### PR TITLE
Fixed small namespace bug

### DIFF
--- a/src/lib/libparallel/elem.h
+++ b/src/lib/libparallel/elem.h
@@ -140,7 +140,7 @@ public:
             if (receive_buffer == 0) {
                 receive_buffer = new type[nelem];
                 elem::mpi::AllReduce(&data[0], receive_buffer, nelem, elem::mpi::SUM, comm_);
-                ::memcpy(data, receive_buffer, nelem*sizeof(type));
+                std::memcpy(data, receive_buffer, nelem*sizeof(type));
                 delete receive_buffer;
             }
             else

--- a/src/lib/libparallel/local.h
+++ b/src/lib/libparallel/local.h
@@ -137,7 +137,7 @@ public:
     inline void sum(type data, int nelem, type *receive_buffer=0, int target=-1)
     {
         if (receive_buffer != 0)
-            ::memcpy(receive_buffer, data, sizeof(type) * nelem);
+            std::memcpy(receive_buffer, data, sizeof(type) * nelem);
     }
 
     /**

--- a/src/lib/libparallel/mpi_wrapper.h
+++ b/src/lib/libparallel/mpi_wrapper.h
@@ -22,6 +22,7 @@
 
 #if defined(HAVE_MPI)
 
+#include <cstring>
 #include <mpi.h>
 
 namespace psi {
@@ -99,7 +100,7 @@ public:
     void sum(double* data, size_t nelem) {
         double *receive_buffer = new double[nelem];
         MPI_Allreduce(static_cast<void*>(data), static_cast<void*>(receive_buffer), nelem, MPI_DOUBLE, MPI_SUM, comm_);
-        ::memcpy(static_cast<void*>(data), static_cast<void*>(receive_buffer), sizeof(double)*nelem);
+        std::memcpy(static_cast<void*>(data), static_cast<void*>(receive_buffer), sizeof(double)*nelem);
         delete[] receive_buffer;
     }
 
@@ -118,7 +119,7 @@ public:
             MPI_Allreduce(static_cast<void*>(data), static_cast<void*>(receive_buffer), n, M, MPI_SUM, comm_); \
      \
         if (alloc) { \
-            ::memcpy(static_cast<void*>(data), static_cast<void*>(receive_buffer), sizeof(T)*n); \
+            std::memcpy(static_cast<void*>(data), static_cast<void*>(receive_buffer), sizeof(T)*n); \
             delete[] receive_buffer; \
         } \
     }


### PR DESCRIPTION
For some reason, a call for memcpy searches in  the global namespace instead std namespace and the cstring header is missing.
