### PR TITLE
DETCI: thread pool fixed possible hang

### DIFF
--- a/src/bin/detci/tpool.cc
+++ b/src/bin/detci/tpool.cc
@@ -284,10 +284,22 @@ int tpool_destroy(tpool_t          tpool,
 }
 void tpool_queue_open(tpool_t tpool)
 {
-  pthread_mutex_lock(&tpool->queue_lock);
+  int rtn;
+  std::string str;
+
+  if ((rtn = pthread_mutex_lock(&(tpool->queue_lock))) != 0){
+      str = "pthread_mutex_lock ";
+      str += boost::lexical_cast<std::string>( rtn) ;
+      throw PsiException(str,__FILE__,__LINE__);
+  }
+
   tpool->queue_closed = 0;
-  tpool->threads_awake = 0;
-  pthread_mutex_unlock(&tpool->queue_lock);
+
+  if ((rtn = pthread_mutex_unlock(&(tpool->queue_lock))) != 0){
+      str = "pthread_mutex_unlock ";
+      str += boost::lexical_cast<std::string>( rtn) ;
+      throw PsiException(str,__FILE__,__LINE__);
+  }
 }
   
 void tpool_queue_close(tpool_t tpool, int finish)
@@ -295,7 +307,12 @@ void tpool_queue_close(tpool_t tpool, int finish)
   std::string str;
   int rtn;
   
-  pthread_mutex_lock(&tpool->queue_lock);
+  if ((rtn = pthread_mutex_lock(&(tpool->queue_lock))) != 0){
+      str = "pthread_mutex_lock ";
+      str += boost::lexical_cast<std::string>( rtn) ;
+      throw PsiException(str,__FILE__,__LINE__);
+  }
+
   tpool->queue_closed = 1;
   
   if (finish) {
@@ -309,7 +326,11 @@ void tpool_queue_close(tpool_t tpool, int finish)
     
     }
   
-  pthread_mutex_unlock(&tpool->queue_lock);
+  if ((rtn = pthread_mutex_unlock(&(tpool->queue_lock))) != 0){
+      str = "pthread_mutex_unlock ";
+      str += boost::lexical_cast<std::string>( rtn) ;
+      throw PsiException(str,__FILE__,__LINE__);
+  }
   
 }
   


### PR DESCRIPTION
When a thread pool is opend, the number of awake threads should not be
set to zero. If a call to tpool_init() is followed by a call to
tpool_queue_open() and followed by a call to tpool_add_work() while
all threads are still waiting for the mutex queue_lock, the number of
awake thread will go below zero at line tpool.cc:335

The fix in #20 was not enough.
