### PR TITLE
ctest for travis in python. compare_values to outfile.

### DIFF
--- a/.scripts/travis_run.py
+++ b/.scripts/travis_run.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import re
+import sys
+import time
+import subprocess
+
+
+# <<<  run ctest  >>>
+retcode = subprocess.Popen(['ctest', '-j2', '-L', 'quick'], bufsize=0,
+                            stdout=subprocess.PIPE, universal_newlines=True)
+ctestout = ''
+while True:
+    data = retcode.stdout.readline()
+    if not data:
+        break
+    sys.stdout.write(data)  # screen
+    #tciout.write(data)  # file
+    #tciout.flush()
+    ctestout += data  # string
+while True:
+    retcode.poll()
+    exstat = retcode.returncode
+    if exstat is not None:
+        ctest_exit_status = exstat
+        break
+    time.sleep(0.1)
+
+# <<<  identify failed tests and cat their output  >>>
+sys.stdout.write("""\n  <<<  CTest complete with status %d. Failing outputs follow.  >>>\n\n""" %
+                 (ctest_exit_status))
+badtests = []
+testfail = re.compile(r'^\s*(?P<num>\d+) - (?P<name>\w+(?:-\w+)*) \(Failed\)\s*$')
+
+for line in ctestout.split('\n'):
+    linematch = testfail.match(line)
+    if linematch:
+        bad = linematch.group('name')
+        sys.stdout.write("""\n%s failed. Here is the output:\n""" % (bad))
+
+        badoutfile = bad
+        for oddity in ['pcmsolver', 'cfour', 'libefp', 'dmrg', 'dftd3', 'mrcc']:
+            if bad.startswith(oddity):
+                badoutfile = oddity + '/' + bad
+        badoutfile = 'tests/' + badoutfile + '/output.dat'
+
+        with open(badoutfile, 'r') as ofile:
+            sys.stdout.write(ofile.read())
+
+# <<<  return ctest error code  >>>
+sys.exit(ctest_exit_status)

--- a/.travis.yml
+++ b/.travis.yml
@@ -238,9 +238,12 @@ before_script:
 - export CXX=${CXX_COMPILER}
 - export CC=${C_COMPILER}
 - export FC=${Fortran_COMPILER}
+- ${CXX_COMPILER} --version
+- ${Fortran_COMPILER} --version
+- ${C_COMPILER} --version
 - ${BOOSTBUILD}
 - python setup --cxx=${CXX_COMPILER} --cc=${C_COMPILER} --fc=${Fortran_COMPILER} --type=${BUILD_TYPE} ${BOOSTSTR} --max-am-eri=4 --chemps2=off objdir
 - cd objdir
 - ../.scripts/travis_build.sh
 script:
-- ../.scripts/travis_run.sh
+- python ../.scripts/travis_run.py

--- a/lib/python/p4util/util.py
+++ b/lib/python/p4util/util.py
@@ -81,8 +81,10 @@ def success(label):
     Used by :py:func:`util.compare_values` family when functions pass.
 
     """
-    print('\t{0:.<66}PASSED'.format(label))
+    msg = '\t{0:.<66}PASSED'.format(label)
+    print(msg)
     sys.stdout.flush()
+    psi4.print_out(msg + '\n')
 
 
 # Test functions


### PR DESCRIPTION
* runs `ctest -L quick -j2` through python rather than bash
* finds the test output files that are in directories a layer deeper than expected, e.g. the pcmsolver that's failing on the wavefunction_pass PR
* writes `compare_values()` output to output.dat (why haven't we done this before?)
* someone who understands how travis deals with run.log should examine this bit: `tciout = open('run.log', 'a')`