### PR TITLE
SOSCF: Now correctly throws an error for RKS/UKS SOSOCF updates

### DIFF
--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -1075,9 +1075,13 @@ void HF::form_Shalf()
 
         // Refreshes twice in RHF, no big deal
         epsilon_a_->init(nmopi_);
-        Ca_->init(nirrep_,nsopi_,nmopi_,"MO coefficients");
+        Ca_->init(nirrep_,nsopi_,nmopi_,"Alpha MO coefficients");
         epsilon_b_->init(nmopi_);
-        Cb_->init(nirrep_,nsopi_,nmopi_,"MO coefficients");
+        Cb_->init(nirrep_,nsopi_,nmopi_,"Beta MO coefficients");
+
+        // Extra matrix dimension changes for specific derived classes
+        prepare_canonical_orthogonalization();
+
     }
 
     // Temporary variables needed by diagonalize_F

--- a/src/lib/libscf_solver/hf.h
+++ b/src/lib/libscf_solver/hf.h
@@ -227,8 +227,12 @@ protected:
     // Temporarily converting to virtual function for testing embedding
     // potentials.  TDC, 5/23/12.
     virtual void form_H();
+
     /// Formation of S^+1/2 and S^-1/2 are the same
     void form_Shalf();
+
+    /// Edit matrices if we are doing canonical orthogonalization
+    virtual void prepare_canonical_orthogonalization() { return; }
 
     /// Prints the orbital occupation
     void print_occupation();

--- a/src/lib/libscf_solver/ks.cc
+++ b/src/lib/libscf_solver/ks.cc
@@ -225,6 +225,11 @@ void RKS::finalize()
 {
     RHF::finalize();
 }
+int RKS::soscf_update()
+{
+    throw PSIEXCEPTION("Sorry, second-order convergence has not been implemented for this "
+                       "type of SCF wavefunction yet.");
+}
 bool RKS::stability_analysis()
 {
     throw PSIEXCEPTION("DFT stabilty analysis has not been implemented yet.  Sorry :(");
@@ -401,6 +406,11 @@ double UKS::compute_E()
 void UKS::finalize()
 {
     UHF::finalize();
+}
+int UKS::soscf_update()
+{
+    throw PSIEXCEPTION("Sorry, second-order convergence has not been implemented for this "
+                       "type of SCF wavefunction yet.");
 }
 bool UKS::stability_analysis()
 {

--- a/src/lib/libscf_solver/ks.h
+++ b/src/lib/libscf_solver/ks.h
@@ -96,6 +96,7 @@ protected:
     virtual bool stability_analysis();
     virtual void integrals();
     virtual void finalize();
+    virtual int soscf_update();
 
     void common_init();
 public:
@@ -121,6 +122,7 @@ protected:
     virtual bool stability_analysis();
     virtual void integrals();
     virtual void finalize();
+    virtual int soscf_update();
 
     void common_init();
 public:

--- a/src/lib/libscf_solver/rhf.cc
+++ b/src/lib/libscf_solver/rhf.cc
@@ -368,7 +368,7 @@ int RHF::soscf_update()
         double** fp = IFock->pointer(h);
 
         for (size_t i=0, target=0; i<doccpi_[h]; i++){
-            for (size_t a=doccpi_[h]; a < nsopi_[h]; a++){
+            for (size_t a=doccpi_[h]; a < nmopi_[h]; a++){
                 gp[target] = -4.0 * fp[i][a];
                 denomp[target++] = -4.0 * (fp[i][i] - fp[a][a]);
             }

--- a/src/lib/libscf_solver/rohf.h
+++ b/src/lib/libscf_solver/rohf.h
@@ -35,7 +35,7 @@ namespace psi { namespace scf {
 
 class ROHF : public HF {
 protected:
-    SharedMatrix Feff_;
+    SharedMatrix moFeff_;
     SharedMatrix soFeff_;
     SharedMatrix Dt_old_;
     SharedMatrix Dt_;
@@ -54,6 +54,7 @@ protected:
     double compute_initial_E();
     double compute_E();
     virtual bool stability_analysis();
+    virtual void prepare_canonical_orthogonalization();
     void semicanonicalize();
 
     void form_G();
@@ -79,7 +80,7 @@ public:
     ROHF(SharedWavefunction ref_wfn, Options& options, boost::shared_ptr<PSIO> psio);
     virtual ~ROHF();
 
-    SharedMatrix moFeff() const {return Feff_; }
+    SharedMatrix moFeff() const {return moFeff_; }
     SharedMatrix moFa() const {return moFa_; }
     SharedMatrix moFb() const {return moFb_; }
 

--- a/src/lib/libscf_solver/uhf.cc
+++ b/src/lib/libscf_solver/uhf.cc
@@ -404,7 +404,7 @@ int UHF::soscf_update(void)
             double** fp = IFock_a->pointer(h);
 
             for (size_t i=0, target=0; i<nalphapi_[h]; i++){
-                for (size_t a=nalphapi_[h]; a < nsopi_[h]; a++){
+                for (size_t a=nalphapi_[h]; a < nmopi_[h]; a++){
                     gp[target] = -4.0 * fp[i][a];
                     denomp[target++] = -4.0 * (fp[i][i] - fp[a][a]);
                 }
@@ -416,7 +416,7 @@ int UHF::soscf_update(void)
             double** fp = IFock_b->pointer(h);
 
             for (size_t i=0, target=0; i<nbetapi_[h]; i++){
-                for (size_t a=nbetapi_[h]; a < nsopi_[h]; a++){
+                for (size_t a=nbetapi_[h]; a < nmopi_[h]; a++){
                     gp[target] = -4.0 * fp[i][a];
                     denomp[target++] = -4.0 * (fp[i][i] - fp[a][a]);
                 }


### PR DESCRIPTION
Added virtual functions to UKS and RKS to override the soscf_update of UHF and RKS. The result is that calling soscf_update on these functions will now fail with an error message instead of a set fault.

Also cleaned up the SOSCF logic a bit.

This PR is ready to be merged if everything passes. Fixes #256.