### PR TITLE
Reduced atom overlap tolerence to 0.1 to fix #195

### DIFF
--- a/src/lib/libmints/petitelist.h
+++ b/src/lib/libmints/petitelist.h
@@ -62,8 +62,8 @@ inline int64_t i_offset64(int64_t i)
  *  \param mol Molecule to form mapping matrix from.
  *  \returns Integer matrix of dimension natoms X nirreps.
  */
-int **compute_atom_map(const boost::shared_ptr<Molecule> &mol, double tol = 0.5);
-int **compute_atom_map(const Molecule* mol, double tol = 0.5);
+int **compute_atom_map(const boost::shared_ptr<Molecule> &mol, double tol = 0.1);
+int **compute_atom_map(const Molecule* mol, double tol = 0.1);
 /// @}
 
 /*! @{


### PR DESCRIPTION
## Description
Reduces the minimum overlap between atoms to fix issue #195. Reductions to this tolerance in the future would likely have to be for ghost atoms only.

A downside to this is linear depends will pop up much more often when two atoms are this close together, especially in highly symmetric molecules.

## Status
- [x]  Ready to go

