### PR TITLE
DF_SCF_GUESS with PK integrals

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -37,15 +37,15 @@ An illustrative example of using the SCF module is as follows::
     basis cc-pvdz
     guess sad
     reference uhf
-    scf_type pk
+    scf_type direct
     }
     
     energy('scf')
 
 This will run a UHF computation for triplet molecular oxygen (the ground state)
-using a PK algorithm for the Electron Repulsion Integrals (ERI) and starting
+using a Direct algorithm for the Electron Repulsion Integrals (ERI) and starting
 from a Superposition of Atomic Densities (SAD) guess. DF integrals are
-automatically used to converge the DF-SCF solution before the PK algorithm is
+automatically used to converge the DF-SCF solution before the Direct algorithm is
 activated.  After printing all manner of titles, geometries, sizings, and
 algorithm choices, the SCF finally reaches the iterations::
 
@@ -71,7 +71,7 @@ algorithm choices, the SCF finally reaches the iterations::
    @UHF iter  12:  -149.62730738624032   -8.69250e-10   7.06690e-07 DIIS
 
 The first set of iterations are from the DF portion of the computation, the
-second set use the exact (but much slower) PK algorithm. Within the DF portion
+second set uses the exact (but much slower) Direct algorithm. Within the DF portion
 of the computation, the zeroth-iteration uses a non-idempotent density matrix
 obtained from the SAD guess, so the energy is unphysically low. However, the
 first true iteration is quite close to the final DF energy, highlighting the
@@ -80,11 +80,10 @@ SCF convergence, with the DF phase reaching convergence in eight true
 iterations. When used together, SAD and DIIS are usually sufficient to converge
 the SCF for all but the most difficult systems. Additional convergence
 techniques are available for more difficult cases, and are detailed below. At
-this point, the code switches on the requested PK integrals technology, which
+this point, the code switches on the requested Direct integrals technology, which
 requires only four full iterations to reach convergence, starting from the DF
-guess. This hybrid DF/conventional procedure can significantly accelerate SCF
-computations requiring exact integrals, especially when used in concert with the
-integral-direct conventional algorithm.
+guess. This hybrid DF/Direct procedure can significantly accelerate SCF
+computations requiring exact integrals.
 
 After the iterations are completed, a number of one-electron properties are
 printed, and some bookkeeping is performed to set up possible correlated
@@ -537,8 +536,8 @@ sieving, set the |scf__ints_tolerance| keyword to your desired cutoff
 (1.0E-12 is recommended for most applications).
 
 Recently, we have added the automatic capability to use the extremely fast DF
-code for intermediate convergence of the orbitals, for |scf__scf_type| other
-than ``DF``. At the moment, the code defaults to cc-pVDZ-JKFIT as the
+code for intermediate convergence of the orbitals, for |scf__scf_type| 
+``DIRECT``. At the moment, the code defaults to cc-pVDZ-JKFIT as the
 auxiliary basis, unless the user specifies |scf__df_basis_scf| manually. For
 some atoms, cc-pVDZ-JKFIT is not defined, so this procedure will fail. In these
 cases, you will see an error message of the form::

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -1158,7 +1158,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_str("INDEPENDENT_K_TYPE", "DIRECT_SCREENING", "DIRECT_SCREENING LINK");
     /*- Tolerance for Cholesky decomposition of the ERI tensor -*/
     options.add_double("CHOLESKY_TOLERANCE",1e-4);
-    /*- Use DF integrals tech to converge the SCF before switching to a conventional tech -*/
+    /*- Use DF integrals tech to converge the SCF before switching to a conventional tech 
+        in a |scf__scf_type| ``DIRECT`` calculation -*/
     options.add_bool("DF_SCF_GUESS", true);
     /*- Keep JK object for later use? -*/
     options.add_bool("SAVE_JK", false);

--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -419,12 +419,19 @@ void HF::integrals()
         }
     }
     catch(const BasisSetNotFound& e) {
-        if (options_.get_str("SCF_TYPE") == "DF" || options_.get_int("DF_SCF_GUESS") == 1) {
+        if (options_.get_str("SCF_TYPE") == "DF") {
             outfile->Printf( "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
             outfile->Printf( "%s\n", e.what());
             outfile->Printf( "   Turning off DF and switching to PK method.\n");
             outfile->Printf( "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
             options_.set_str("SCF", "SCF_TYPE", "PK");
+            options_.set_bool("SCF", "DF_SCF_GUESS", false);
+            jk_ = JK::build_JK(basisset_, options_);
+        } else if ( (options_.get_int("DF_SCF_GUESS") == 1) && (options_.get_str("SCF_TYPE") == "DIRECT") ) {
+            outfile->Printf( "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+            outfile->Printf( "%s\n", e.what());
+            outfile->Printf( "   Turning off DF guess, performing only DIRECT SCF\n");
+            outfile->Printf( "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
             options_.set_bool("SCF", "DF_SCF_GUESS", false);
             jk_ = JK::build_JK(basisset_, options_);
         }
@@ -1711,7 +1718,7 @@ void HF::initialize()
 
     // Andy trick 2.0
     old_scf_type_ = options_.get_str("SCF_TYPE");
-    if (options_.get_bool("DF_SCF_GUESS") && !(old_scf_type_ == "DF" || old_scf_type_ == "CD" || old_scf_type_ == "PK" || old_scf_type_ == "OUT_OF_CORE")) {
+    if (options_.get_bool("DF_SCF_GUESS") && (old_scf_type_ == "DIRECT") ) {
          outfile->Printf( "  Starting with a DF guess...\n\n");
          if(!options_["DF_BASIS_SCF"].has_changed()) {
              // TODO: Match Dunning basis sets
@@ -1966,7 +1973,7 @@ void HF::iterations()
         if (frac_enabled_ && !frac_performed_) converged_ = false;
 
         // If a DF Guess environment, reset the JK object, and keep running
-        if (converged_ && options_.get_bool("DF_SCF_GUESS") && !(old_scf_type_ == "DF" || old_scf_type_ == "CD")) {
+        if (converged_ && options_.get_bool("DF_SCF_GUESS") && (old_scf_type_ == "DIRECT")) {
             outfile->Printf( "\n  DF guess converged.\n\n"); // Be cool dude.
             converged_ = false;
             if(initialized_diis_manager_)


### PR DESCRIPTION
## Description
DF_SCF_GUESS was not completely suppressed for PK integrals. The code is now cleaned up and the documentation updated.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Clean up DF_SCF_GUESS so that it only acts on integral direct computations
- [x] Update the documentation

## Status
- [x]  Ready to go



