### PR TITLE
PSI4 now compiles correctly with HAVE_JK_FACTORY flag enabled.  

### DIFF
--- a/src/lib/libfock/GTFockJK.cc
+++ b/src/lib/libfock/GTFockJK.cc
@@ -29,8 +29,8 @@ GTFockJK::GTFockJK(boost::shared_ptr<psi::BasisSet> Primary,
 
 }
 void GTFockJK::compute_JK() {
-   Impl_->SetP(D_);
-   Impl_->GetJ(J_);
-   Impl_->GetK(K_);
+   Impl_->SetP(D_ao_);
+   Impl_->GetJ(J_ao_);
+   Impl_->GetK(K_ao_);
 }
 }

--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -410,10 +410,10 @@ void HF::integrals()
                 jk_ = boost::shared_ptr<JK>(new GTFockJK(basisset_,2,false));
             else
                 jk_ = boost::shared_ptr<JK>(new GTFockJK(basisset_,2,true));
+            Process::environment.set_legacy_molecule(other_legacy);
           #else
             throw PSIEXCEPTION("GTFock was not compiled in this version.\n");
           #endif
-            Process::environment.set_legacy_molecule(other_legacy);
         } else {
             jk_ = JK::build_JK(basisset_, options_);
         }

--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -405,15 +405,15 @@ void HF::integrals()
           #ifdef HAVE_JK_FACTORY
             //DGAS is adding to the ghetto, this Python -> C++ -> C -> C++ -> back to C is FUBAR
             boost::shared_ptr<Molecule> other_legacy = Process::environment.legacy_molecule();
-            Process::environment.set_legacy_wavefunction(molecule_);
+            Process::environment.set_legacy_molecule(molecule_);
             if(options_.get_bool("SOSCF"))
                 jk_ = boost::shared_ptr<JK>(new GTFockJK(basisset_,2,false));
             else
                 jk_ = boost::shared_ptr<JK>(new GTFockJK(basisset_,2,true));
-            Process::environment.set_legacy_molecule(other_legacy);
           #else
             throw PSIEXCEPTION("GTFock was not compiled in this version.\n");
           #endif
+            Process::environment.set_legacy_molecule(other_legacy);
         } else {
             jk_ = JK::build_JK(basisset_, options_);
         }


### PR DESCRIPTION
## Description
PSI4 compiles when HAVE_JK_FACTORY is enabled and GTFock works with symmetry.  

## Todos

- [x] PSI4 compiles with HAVE_JK_FACTORY
- [x] GTFock works with symmetry.  

## Status
- [x]  Ready to go


