### PR TITLE
BCCD with ROHF starting orbitals now works, fixes #294

### DIFF
--- a/share/python/driver.py
+++ b/share/python/driver.py
@@ -98,7 +98,7 @@ procedures = {
             'cc3'           : run_ccenergy,
             'mrcc'          : run_mrcc,  # interface to Kallay's MRCC program
             'bccd'          : run_bccd,
-            'bccd(t)'       : run_bccd_t,
+            'bccd(t)'       : run_bccd,
             'eom-ccsd'      : run_eom_cc,
             'eom-cc2'       : run_eom_cc,
             'eom-cc3'       : run_eom_cc,

--- a/src/bin/ccenergy/get_params.cc
+++ b/src/bin/ccenergy/get_params.cc
@@ -64,7 +64,8 @@ void CCEnergyWavefunction::get_params(Options &options)
   else if(junk == "ROHF" &&
     (params_.wfn == "MP2" || params_.wfn == "CCSD_T" || params_.wfn == "CCSD_AT" ||
     params_.wfn == "CC3" || params_.wfn == "EOM_CC3" ||
-    params_.wfn == "CC2" || params_.wfn == "EOM_CC2")) {
+    params_.wfn == "CC2" || params_.wfn == "EOM_CC2" ||
+    params_.wfn == "BCCD" || params_.wfn == "BCCD_T")) {
     params_.ref = 2;
     params_.semicanonical = 1;
   }

--- a/src/bin/cctransort/cctransort.cc
+++ b/src/bin/cctransort/cctransort.cc
@@ -83,7 +83,8 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
   else if(options.get_str("REFERENCE") =="ROHF" &&
           (options.get_str("WFN")=="MP2" || options.get_str("WFN")=="CCSD_T" || options.get_str("WFN")=="CCSD_AT" ||
            options.get_str("WFN")=="CC3" || options.get_str("WFN")=="EOM_CC3" ||
-           options.get_str("WFN")=="CC2" || options.get_str("WFN")=="EOM_CC2")) {
+           options.get_str("WFN")=="CC2" || options.get_str("WFN")=="EOM_CC2" ||
+           options.get_str("WFN")=="BCCD" || options.get_str("WFN")=="BCCD_T")) {
     reference = 2;
     semicanonical = true;
   }
@@ -97,7 +98,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
   // Allow user to force semicanonical
   if(options["SEMICANONICAL"].has_changed()) {
    semicanonical = options.get_bool("SEMICANONICAL");
-   reference = 2;
+   if (semicanonical) reference = 2;
   }
 
   int nirreps = ref->nirrep();

--- a/src/bin/cctriples/get_moinfo.cc
+++ b/src/bin/cctriples/get_moinfo.cc
@@ -84,7 +84,7 @@ void get_moinfo(boost::shared_ptr<Wavefunction> wfn, Options &options)
     junk = options.get_str("REFERENCE");
     /* if no reference is given, assume rhf */
     if(junk == "RHF") params.ref = 0;
-    else if(junk == "ROHF" && params.wfn == "CCSD_T") {
+    else if(junk == "ROHF" && (params.wfn == "CCSD_T" || params.wfn == "BCCD_T")) {
         params.ref = 2;
         params.semicanonical = 1;
     }

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -2194,6 +2194,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_double("CC_SS_SCALE",1.13);
     /*- Convert ROHF MOs to semicanonical MOs -*/
     options.add_bool("SEMICANONICAL", true);
+    /*- Convert ROHF MOs to semicanonical MOs -*/
+    options.add_int("BCCD_MAXITER", 50);
   }
   if(name == "DFMP2"|| options.read_globals()) {
     /*- MODULEDESCRIPTION Performs density-fitted MP2 computations for RHF/UHF/ROHF reference wavefunctions. -*/

--- a/src/bin/transqt2/get_params.cc
+++ b/src/bin/transqt2/get_params.cc
@@ -58,7 +58,8 @@ void get_params(Options & options)
   else if((reference == "ROHF") and
      ((params.wfn == "MP2") or (params.wfn == "CCSD_T") or (params.wfn == "CCSD_AT") or
      (params.wfn == "CC3") or (params.wfn == "EOM_CC3") or
-     (params.wfn == "CC2") or (params.wfn == "EOM_CC2"))) {
+     (params.wfn == "CC2") or (params.wfn == "EOM_CC2") or
+     (params.wfn == "BCCD") or (params.wfn == "BCCD_T"))) {
       params.ref = 2;
       params.semicanonical = 1;
     }

--- a/tests/cc16/input.dat
+++ b/tests/cc16/input.dat
@@ -1,4 +1,4 @@
-#! UHF-B-CCD(T)/cc-pVDZ $^{3}B@@1$ CH2 single-point energy (fzc, MO-basis $\langle ab|cd \rangle$ )
+#! ROHF and UHF-B-CCD(T)/cc-pVDZ $^{3}B@@1$ CH2 single-point energy (fzc, MO-basis $\langle ab|cd \rangle$ )
 
 memory 250 mb
 
@@ -12,9 +12,9 @@ molecule ch2 {
 }
 
 set {
-   reference = uhf
-   basis cc-pVDZ
-   freeze_core true
+   reference    uhf
+   basis        cc-pVDZ
+   freeze_core  true
 }
 
 energy("bccd(t)")
@@ -22,6 +22,21 @@ energy("bccd(t)")
 escf = -38.917378694797030 #TEST
 ebccd = -39.030833895315020 #TEST
 ebccd_t = -39.032691827829460 #TEST
+compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+
+
+# We should obtain the same result as above, but start with different orbitals
+# Energy will be slightly different as the core is frozen 
+set {
+   reference    rohf
+}
+
+energy("bccd(t)")
+escf = -38.91341670976116 #TEST
+ebccd = -39.030807046983838 #TEST
+ebccd_t = -39.032665163463861 #TEST
 compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
 compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
 compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST


### PR DESCRIPTION
## Description
Allows BCCD with ROHF starting orbitals.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Added BCCD and BCCD_T to the list of ROHF semicanonicalize cases in `src/bin/cc*`.
- [x] Added a BCCD ROHF test case
- [x] Added a BCCD_MAXITER keyword instead of using an arbitrary value
- [x] Removed redundant `proc.py:run_bccdt`

## Status
- [x]  Ready to go


