### PR TITLE
more wavefunction-pass for plugins

### DIFF
--- a/share/plugin/aointegrals.cc.template
+++ b/share/plugin/aointegrals.cc.template
@@ -45,14 +45,13 @@ int read_options(std::string name, Options &options)
 }
 
 extern "C"
-PsiReturnType @plugin@(Options &options)
+SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     // Grab options from the options object
     int print = options.get_int("PRINT");
     int doTei = options.get_bool("DO_TEI");
 
-    // Obtain the Wavefunction from globals that we set python-side
-    SharedWavefunction ref_wfn = Process::environment.wavefunction();
+    // Have the Wavefunction from python-side
 
     // Molecule is a member of the wavefunction option
     // Lets print out some molecule information here
@@ -98,7 +97,7 @@ PsiReturnType @plugin@(Options &options)
 
     }
 
-    return Success;
+    return ref_wfn;
 }
 
 }} // End Namespaces

--- a/share/plugin/mointegrals.cc.template
+++ b/share/plugin/mointegrals.cc.template
@@ -47,8 +47,8 @@ read_options(std::string name, Options &options)
 }
 
 
-extern "C" PsiReturnType
-@plugin@(Options &options)
+extern "C"
+SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     /*
      * This plugin shows a simple way of obtaining MO basis integrals, directly from a DPD buffer.  It is also
@@ -59,18 +59,17 @@ extern "C" PsiReturnType
     // Grab the global (default) PSIO object, for file I/O
     boost::shared_ptr<PSIO> psio(_default_psio_lib_);
 
-    // Now we want the reference (SCF) wavefunction
-    boost::shared_ptr<Wavefunction> wfn = Process::environment.wavefunction();
-    if(!wfn) throw PSIEXCEPTION("SCF has not been run yet!");
+    // Have the reference (SCF) wavefunction, ref_wfn
+    if(!ref_wfn) throw PSIEXCEPTION("SCF has not been run yet!");
 
     // Quickly check that there are no open shell orbitals here...
-    int nirrep  = wfn->nirrep();
+    int nirrep  = ref_wfn->nirrep();
 
     // For now, we'll just transform for closed shells and generate all integrals.  For more elaborate use of the
     // LibTrans object, check out the plugin_mp2 example in the test suite.
     std::vector<boost::shared_ptr<MOSpace> > spaces;
     spaces.push_back(MOSpace::all);
-    IntegralTransform ints(wfn, spaces, IntegralTransform::Restricted);
+    IntegralTransform ints(ref_wfn, spaces, IntegralTransform::Restricted);
     ints.transform_tei(MOSpace::all, MOSpace::all, MOSpace::all, MOSpace::all);
     // Use the IntegralTransform object's DPD instance, for convenience
     dpd_set_default(ints.get_dpd_id());
@@ -115,7 +114,7 @@ extern "C" PsiReturnType
     global_dpd_->buf4_close(&K);
     psio->close(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
 
-    return Success;
+    return ref_wfn;
 }
 
 }} // End Namespaces

--- a/share/plugin/sointegrals.cc.template
+++ b/share/plugin/sointegrals.cc.template
@@ -63,20 +63,19 @@ public:
 };
 
 extern "C"
-PsiReturnType @plugin@(Options &options)
+SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     int print = options.get_int("PRINT");
     int doTei = options.get_bool("DO_TEI");
 
     // Get active molecule
-    boost::shared_ptr<Molecule> molecule = Process::environment.molecule();
-    // Create a basis set parser object.
-    boost::shared_ptr<BasisSetParser> parser(new Gaussian94BasisSetParser());
-    // Construct a new basis set.
-    boost::shared_ptr<BasisSet> aoBasis = BasisSet::construct(parser, molecule, "BASIS");
+    boost::shared_ptr<Molecule> molecule = ref_wfn->molecule();
+    // Grab basis object:
+    boost::shared_ptr<BasisSet> aoBasis = ref_wfn->basisset();
 
     // The integral factory oversees the creation of integral objects
-    boost::shared_ptr<IntegralFactory> integral(new IntegralFactory(aoBasis));
+    boost::shared_ptr<IntegralFactory> integral(new IntegralFactory
+            (aoBasis, aoBasis, aoBasis, aoBasis));
 
     // N.B. This should be called after the basis has been built, because
     // the geometry has not been
@@ -149,7 +148,7 @@ PsiReturnType @plugin@(Options &options)
         }
     }
 
-    return Success;
+    return ref_wfn;
 }
 
 }} // End namespaces


### PR DESCRIPTION
## Description
fixed up some plugin templates that escaped the wavefunction pass

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Make [asm]ointegrals plugin templates wavefunction-pass (and basis-building) compliant

## Status
- [x]  Ready to go
