### PR TITLE
CIWave: Fixes strange ICC 2015 compiler error with certain vectorization options

### DIFF
--- a/src/bin/detci/ints.cc
+++ b/src/bin/detci/ints.cc
@@ -70,7 +70,7 @@ namespace psi { namespace detci {
 void CIWavefunction::transform_ci_integrals()
 {
 
-  outfile->Printf("\n   ==> Transforming CI integrals <==\n");
+  outfile->Printf("\n   ==> Transforming CI integrals <==\n\n");
   // Grab orbitals
   SharedMatrix Cdrc = get_orbitals("DRC");
   SharedMatrix Cact = get_orbitals("ACT");

--- a/src/lib/libfock/soscf.cc
+++ b/src/lib/libfock/soscf.cc
@@ -417,6 +417,11 @@ SharedMatrix SOMCSCF::H_approx_diag()
             double** IFp = matrices_["IFock"]->pointer(h);
             double** OPDMp = matrices_["OPDM"]->pointer(h);
 
+            // We need to do these completely flat, some compilers vectorize this incorrectly
+            double* actMO_fp = matrices_["actMO"]->pointer()[0];
+            double* TPDM_fp = matrices_["TPDM"]->pointer()[0];
+
+            int nact2 = nact_ * nact_;
             int offset_col = 0;
             int offset_row = 0;
 
@@ -450,20 +455,21 @@ SharedMatrix SOMCSCF::H_approx_diag()
                     int pp = p * nact_ + p;
                     int pq = p * nact_ + q;
                     int qq = q * nact_ + q;
-                    // int end = offset_act + nactpi_[h];
                     for (int u=0; u<nact_; u++){
                         int pu = p * nact_ + u;
                         int qu = q * nact_ + u;
+
+                        // Unrolling this to prevent some strange vectorization error
                         for (int v=0; v<nact_; v++){
                             int pv = p * nact_ + v;
                             int qv = q * nact_ + v;
                             int uv = u * nact_ + v;
-                            value += 2.0 * TPDMp[pu][pv] * actMOp[qu][qv];
-                            value += 2.0 * TPDMp[qu][qv] * actMOp[pu][pv];
-                            value += TPDMp[pp][uv] * actMOp[qq][uv];
-                            value += TPDMp[qq][uv] * actMOp[pp][uv];
-                            value -= 4.0 * TPDMp[pv][qu] * actMOp[pu][qv];
-                            value -= 2.0 * TPDMp[pq][uv] * actMOp[pq][uv];
+                            value += 2.0 * TPDM_fp[pu * nact2 + pv] * actMO_fp[qu * nact2 + qv];
+                            value += 2.0 * TPDM_fp[qu * nact2 + qv] * actMO_fp[pu * nact2 + pv];
+                            value +=       TPDM_fp[pp * nact2 + uv] * actMO_fp[qq * nact2 + uv];
+                            value +=       TPDM_fp[qq * nact2 + uv] * actMO_fp[pp * nact2 + uv];
+                            value -= 4.0 * TPDM_fp[pv * nact2 + qu] * actMO_fp[pu * nact2 + qv];
+                            value -= 2.0 * TPDM_fp[pq * nact2 + uv] * actMO_fp[pq * nact2 + uv];
                         }
                     }
                     // outfile->Printf("%d %d | %d %d : %lf %lf\n", h, nras, i, a, Hp[oi][a], value);


### PR DESCRIPTION
## Description
With ICC 2015 and `XHOST` turned off the changed loop will fail. You can either turn `XHOST` on, set `#prama novector` for the inner loops, or unroll the loop as shown to fix the problem. I would consider this a compiler bug, but I was curious if anyone had other opinions. A bit scary that we are running into this kind of thing.

A few details:
- `TPDMp` and `actMOp` are both `double**`'s with shapes of `nact*nact` by `nact*nact`.
- All indices are within bounds.
- Very excited for everyone to review the most neglected piece of code in the MCSCF orbital optimization.

## Status
- [X]  Ready to go

