### PR TITLE
dft printing

### DIFF
--- a/src/lib/libdisp/dispersion.cc
+++ b/src/lib/libdisp/dispersion.cc
@@ -201,7 +201,6 @@ boost::shared_ptr<Dispersion> Dispersion::build(const std::string & name, double
         disp->a2_ = p3;
         return disp;
     } else {
-        printf("cant find %s", boost::to_upper_copy(name).c_str());
         throw PSIEXCEPTION("Dispersion: Unknown -D type specified");
     }
 }

--- a/src/lib/libfunctional/functional.cc
+++ b/src/lib/libfunctional/functional.cc
@@ -38,8 +38,8 @@ void Functional::common_init()
     gga_ = false;
     meta_ = false;
     name_ = "";
-    description_ = "";
-    citation_ = "";
+    description_ = "    ";
+    citation_ = "    ";
     alpha_ = 1.0;
     omega_ = 0.0;
     
@@ -62,7 +62,7 @@ void Functional::print(std::string out, int level) const
     
     printer->Printf( "%s", citation_.c_str());
     printer->Printf( "\n");
-    
+
     printer->Printf( "    GGA   = %14s\n", (gga_ ? "TRUE" : "FALSE"));
     printer->Printf( "    Meta  = %14s\n", (meta_ ? "TRUE" : "FALSE"));
     printer->Printf( "    LRC   = %14s\n", (lrc_ ? "TRUE" : "FALSE"));

--- a/src/lib/libfunctional/superfunctional.cc
+++ b/src/lib/libfunctional/superfunctional.cc
@@ -41,8 +41,8 @@ void SuperFunctional::common_init()
     max_points_ = 0;
     deriv_ = 0;
     name_ = "";
-    description_ = "";
-    citation_ = "";
+    description_ = "    ";
+    citation_ = "    ";
     x_omega_ = 0.0;
     c_omega_ = 0.0;
     x_alpha_ = 0.0;


### PR DESCRIPTION
## Description
So `name_`, `description_`, and `citation_` for functionals and superfunctionals default to empty std::string s, `""`. Something about the mpi printing changeover did not like empty strings one bit, so the printing gave up whenever description & citation weren't set in functional.py . This occurs for the functionals B97-D (Grimme's) and HTCH and DLDF superfunctional. But that printing only gets called when print level >=2 (which it is for the dft1, dft1-alt, and dft2 test cases). Thus certain dft jobs have been giving not much output for a year and a half. A string with standard indentation fixes the problem. Kudos to @dgasmith for actually looking at a test case output and noticing.

## Status
- [x]  Ready to go