### PR TITLE
Added disclaimer about 5930

### DIFF
--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -25,10 +25,10 @@ FNOCC: Frozen natural orbitals for CCSD(T), QCISD(T), CEPA, and MP4
 
 *Module:* :ref:`Keywords <apdx:fnocc>`, :ref:`PSI Variables <apdx:fnocc_psivar>`, :source:`FNOCC <src/bin/fnocc>`
 
-.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When
+.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 10.0.2.  When
    |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD 
    correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions
-   are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
+   are running serially, using a different BLAS implementation, or upgrading to Intel 16.0.2 and MKL 11.3.2.
 
 Frozen natural orbitals (FNO)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -450,6 +450,4 @@ Advanced FNOCC Keywords
 .. include:: /autodir_options_c/fnocc__dfcc.rst
 .. include:: /autodir_options_c/fnocc__cepa_level.rst
 
-FNOCC Disclaimer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour] is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
+.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.

--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -25,7 +25,10 @@ FNOCC: Frozen natural orbitals for CCSD(T), QCISD(T), CEPA, and MP4
 
 *Module:* :ref:`Keywords <apdx:fnocc>`, :ref:`PSI Variables <apdx:fnocc_psivar>`, :source:`FNOCC <src/bin/fnocc>`
 
-.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
+.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When
+   |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD 
+   correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions
+   are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
 
 Frozen natural orbitals (FNO)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -25,6 +25,8 @@ FNOCC: Frozen natural orbitals for CCSD(T), QCISD(T), CEPA, and MP4
 
 *Module:* :ref:`Keywords <apdx:fnocc>`, :ref:`PSI Variables <apdx:fnocc_psivar>`, :source:`FNOCC <src/bin/fnocc>`
 
+.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
+
 Frozen natural orbitals (FNO)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -450,4 +452,4 @@ Advanced FNOCC Keywords
 .. include:: /autodir_options_c/fnocc__dfcc.rst
 .. include:: /autodir_options_c/fnocc__cepa_level.rst
 
-.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.
+

--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -25,7 +25,7 @@ FNOCC: Frozen natural orbitals for CCSD(T), QCISD(T), CEPA, and MP4
 
 *Module:* :ref:`Keywords <apdx:fnocc>`, :ref:`PSI Variables <apdx:fnocc_psivar>`, :source:`FNOCC <src/bin/fnocc>`
 
-.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 10.0.2.  When
+.. warning:: There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 11.2.3.  When
    |PsiFour| is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD 
    correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions
    are running serially, using a different BLAS implementation, or upgrading to Intel 16.0.2 and MKL 11.3.2.

--- a/doc/sphinxman/source/fnocc.rst
+++ b/doc/sphinxman/source/fnocc.rst
@@ -449,3 +449,7 @@ Advanced FNOCC Keywords
 .. include:: /autodir_options_c/fnocc__compute_mp4_triples.rst
 .. include:: /autodir_options_c/fnocc__dfcc.rst
 .. include:: /autodir_options_c/fnocc__cepa_level.rst
+
+FNOCC Disclaimer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+There is a known bug concerning the i7-5930 series combined with the Intel 15 compilers and MKL 15.0.2.  When |PsiFour] is compiled under these conditions, parallel runs of the FNOCC code have experienced non-sensical CCSD correlation energies (often several hartrees lower than the starting guess).  At the moment, the only confirmed solutions are running serially, using a different BLAS implementation, or upgrading to Intel 16 and MKL 16.0.2.


### PR DESCRIPTION
## Description
Updates the FNOCC documentation so that it includes a disclaimer about running in parallel on i7-5930 processors when compiling with Intel 15 and MKL 15.0.2

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Has not introduced further Fortran
- [x] Has warned the world of an impending evil lurking in their somewhat homely appearing CCSD correlation energy, caused by an apparent Intel bug

## Questions
- [ ]  Is the placement of the disclaimer satisfactory?

## Status
- [x]  Ready to go



