### PR TITLE
Improved fixed-coordinate optimizations, PES scans.

### DIFF
--- a/src/bin/optking/frag_apply_frozen_constraints.cc
+++ b/src/bin/optking/frag_apply_frozen_constraints.cc
@@ -290,8 +290,13 @@ bool FRAG::apply_fixed_constraints(string R_string, string B_string, string D_st
       throw(INTCO_EXCEPT("Impossibly large index for atom in fixed dihedral string."));
 
     TORS *one_tors = new TORS(a, b, c, d, 0);
-    // Insist on user-specified fixed coordinates to be given in Angstroms/radians
-    one_tors->set_fixed_eq_val(D[i].eq_val/180.0*_pi);
+    // Insist on user-specified fixed coordinates to be given in Angstroms/degrees
+    double user_val = D[i].eq_val/180.0*_pi;
+    if (user_val <= -_pi)
+      user_val += 2*_pi;
+    else if (user_val > _pi)
+      user_val -= 2*_pi;
+    one_tors->set_fixed_eq_val(user_val);
 
     // check if coord is already present; returns 1 past the end if not found
     int index = find(one_tors);
@@ -299,7 +304,7 @@ bool FRAG::apply_fixed_constraints(string R_string, string B_string, string D_st
     if ((std::size_t) index == coords.simples.size())
       coords.simples.push_back(one_tors);// add it
     else {
-      coords.simples[index]->set_fixed_eq_val(D[i].eq_val/180.0*_pi); // it's there already, add the fixed value
+      coords.simples[index]->set_fixed_eq_val(user_val); // it's there already, add the fixed value
       delete one_tors;
     }
   }

--- a/src/bin/optking/molecule.cc
+++ b/src/bin/optking/molecule.cc
@@ -187,28 +187,18 @@ void MOLECULE::apply_constraint_forces(void) {
         double eq_val = fragments[f]->coord_fixed_eq_val(i);
         double val = fragments[f]->coord_value(i);
 
-        k = H[cnt][cnt];
-        if (iter > 10) { // this works OK
-          k = abs(k);
-          k += 0.05;
-          H[cnt][cnt] = k;
-        }
+        // Increase force constant by 5% of initial value per iteration
+        k = (1 + 0.05 * (iter-1)) * Opt_params.fixed_coord_force_constant;
+        H[cnt][cnt] = k;
 
-        // haven't tested this
-/* INTCO_TYPE it = fragments[f]->get_simple_type(i);
-        if (it == stre_type) k = 0.5;
-        else if (it == bend_type) k = 0.2;
-        else k = 0.1; */
-
-        double force = (eq_val - val) * fabs(k);
-        oprintf_out("\tAdding user-defined constraint: Fragment %d; Coordinate %d; Force constant %8.4e.\n",
-           f+1, i+1, k);
-        oprintf_out("\tValue=%8.4e; Fixed value=%8.4e; Force=%8.4e.\n", val, eq_val, force);
-        oprintf_out("\tRemoving off-diagonal coupling of this coordinate with others.\n");
+        double force = (eq_val - val) * k;
+        oprintf_out("\tAdding user-defined constraint: Fragment %d; Coordinate %d:\n", f+1, i+1);
+        oprintf_out("\t\tValue = %12.6f; Fixed value    = %12.6f\n", val, eq_val);
+        oprintf_out("\t\tForce = %12.6f; Force constant = %12.6f\n", force, k);
         f_q[cnt] = force;
 
         // If user eq. value is specified delete coupling between this coordinate and others.
-        if (iter > 10)
+        oprintf_out("\tRemoving off-diagonal coupling between coordinate %d and others.\n", cnt+1);
         for (int j=0; j<N; ++j)
           if (j != cnt)
             H[j][cnt] = H[cnt][j] = 0;

--- a/src/bin/optking/opt_params.h
+++ b/src/bin/optking/opt_params.h
@@ -192,8 +192,8 @@ struct OPT_PARAMS {
   double IRC_step_size;
   bool keep_intcos; // don't delete intco.dat
 
-  // for coordinates with user-specified equilibrium values - this is the force constant
-  //double fixed_coord_force_constant;
+  // for coordinates with user-specified equilibrium values - this is the starting force constant
+  double fixed_coord_force_constant;
 
   // If a static line search is being done (which currently just outputs N geometries)
   // these control the min and the max of the largest internal coordinate displacement.

--- a/src/bin/optking/set_params.cc
+++ b/src/bin/optking/set_params.cc
@@ -91,6 +91,7 @@ void set_params(void)
      Opt_params.coordinates = OPT_PARAMS::BOTH;
 
 // Maximum step size in bohr or radian along an internal coordinate {double}
+   // For fixed coordinate optimizations, also see below.
 //  Opt_params.intrafragment_step_limit = 0.4;
     Opt_params.intrafragment_step_limit = options.get_double("INTRAFRAG_STEP_LIMIT");
     Opt_params.intrafragment_step_limit_min = options.get_double("INTRAFRAG_STEP_LIMIT_MIN");
@@ -393,7 +394,7 @@ void set_params(void)
     Opt_params.keep_intcos = true;
 
   // for coordinates with user-specified equilibrium values - this is the force constant
-  //Opt_params.fixed_coord_force_constant = options.get_double("FIXED_COORD_FORCE_CONSTANT");
+  Opt_params.fixed_coord_force_constant = options.get_double("FIXED_COORD_FORCE_CONSTANT");
 
   // Currently, a static line search merely displaces along the gradient in internal
   // coordinates generating LINESEARCH_STATIC_N geometries.  The other two keywords
@@ -614,6 +615,15 @@ void set_params(void)
   Opt_params.fixed_distance_str = options.get_str("FIXED_DISTANCE");
   Opt_params.fixed_bend_str     = options.get_str("FIXED_BEND");
   Opt_params.fixed_dihedral_str = options.get_str("FIXED_DIHEDRAL");
+
+  if (!Opt_params.fixed_distance_str.empty() ||
+      !Opt_params.fixed_bend_str.empty()     ||
+      !Opt_params.fixed_dihedral_str.empty()) {
+    if (!options["INTRAFRAG_STEP_LIMIT"].has_changed())     Opt_params.intrafragment_step_limit = 0.1;
+    if (!options["INTRAFRAG_STEP_LIMIT_MIN"].has_changed()) Opt_params.intrafragment_step_limit_min = 0.1;
+    if (!options["INTRAFRAG_STEP_LIMIT_MAX"].has_changed()) Opt_params.intrafragment_step_limit_max = 0.1;
+  }
+
 #elif defined(OPTKING_PACKAGE_QCHEM)
   // Read QChem input and write all the frozen distances into a string
   if (rem_read(REM_GEOM_OPT2_FROZEN_DISTANCES) > 0) {

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -2517,11 +2517,10 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       options.add_bool("TEST_DERIVATIVE_B", false);
       /*- Keep internal coordinate definition file. -*/
       options.add_bool("KEEP_INTCOS", false);
-      /*In constrained optimizations, for coordinates with user-specified
-      equilibrium values, this is the force constant (in au) used to apply an additional
-      force to each coordinate.  If the user is only concerned to satisfy the desired constraint,
-      then the user need only ensure that this value is sufficiently large. */
-      //options.add_double("FIXED_COORD_FORCE_CONSTANT", 2.0);
+      /*- In constrained optimizations, for coordinates with user-specified
+      equilibrium values, this is the initial force constant (in au) used to apply an
+      additional force to each coordinate. -*/
+      options.add_double("FIXED_COORD_FORCE_CONSTANT", 1.0);
       /*- If doing a static line search, scan this many points. -*/
       options.add_int("LINESEARCH_STATIC_N", 8);
       /*- If doing a static line search, this fixes the shortest step, whose largest

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -2520,7 +2520,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- In constrained optimizations, for coordinates with user-specified
       equilibrium values, this is the initial force constant (in au) used to apply an
       additional force to each coordinate. -*/
-      options.add_double("FIXED_COORD_FORCE_CONSTANT", 1.0);
+      options.add_double("FIXED_COORD_FORCE_CONSTANT", 0.5);
       /*- If doing a static line search, scan this many points. -*/
       options.add_int("LINESEARCH_STATIC_N", 8);
       /*- If doing a static line search, this fixes the shortest step, whose largest


### PR DESCRIPTION
## Description
Improved fixed-coordinate optimizations.  Test opt7 still works, as does a full dihedral scan of HOOH in C2 symmetry.  Resolves issue #10 (there are no longer any nonsymmetric displacements).  A new keyword `FIXED_COORD_FORCE_CONSTANT` allows tweaking for softer or firmer constraints, if necessary.

The code does interpret fixed dihedrals <-180 or >180.  However, the code does NOT currently deduce the most direct way through the dihedral discontinuity at 180.  So it's a bad idea to give an input geometry with a dihedral of, say 178, and assign a target value of -178.

Also, I've turned off dynamic trust radius sizing for optimizations with fixed coordinate targets by default.

## Status
- [x] Ready to go


