### PR TITLE
Added "ATOM" to list of point groups that does not need "n" replaced. This allows the thermo module to handle atoms.

### DIFF
--- a/src/lib/libmints/molecule.cc
+++ b/src/lib/libmints/molecule.cc
@@ -3561,7 +3561,8 @@ std::string Molecule::full_point_group() const {
   if (pg_with_n == "D_inf_h" || pg_with_n == "C_inf_v" ||
       pg_with_n == "C1"      || pg_with_n == "Cs"      ||
       pg_with_n == "Ci"      || pg_with_n == "Td"      ||
-      pg_with_n == "Oh"      || pg_with_n == "Ih" )
+      pg_with_n == "Oh"      || pg_with_n == "Ih"      ||
+      pg_with_n == "ATOM")
         return pg_with_n;
 
   stringstream n_integer;


### PR DESCRIPTION
## Description
This PR adds "ATOM" to the list of point groups that does not need to be replaced in the point group name. 

## Todos
- [x] The thermo module will no longer crash when handling atoms. 

## Status
- [x] Ready to go



