### PR TITLE
Making Mulliken and Lowdin charge output more consistent

### DIFF
--- a/src/lib/libmints/oeprop.cc
+++ b/src/lib/libmints/oeprop.cc
@@ -1580,7 +1580,7 @@ void OEProp::compute_mulliken_charges()
 }
 void OEProp::compute_lowdin_charges()
 {
-    outfile->Printf( "\n\n  Lowdin Charges [a.u.]:\n\n");
+    outfile->Printf( "\n\n  Lowdin Charges: (a.u.)\n");
 
     boost::shared_ptr<Molecule> mol = basisset_->molecule();
     boost::shared_ptr<double[]> apcs(new double[mol->natom()]);

--- a/src/lib/libmints/oeprop.cc
+++ b/src/lib/libmints/oeprop.cc
@@ -1580,7 +1580,7 @@ void OEProp::compute_mulliken_charges()
 }
 void OEProp::compute_lowdin_charges()
 {
-    outfile->Printf( "\n\n  Lowdin Charges: (a.u.)\n");
+    outfile->Printf( "  Lowdin Charges: (a.u.)\n");
 
     boost::shared_ptr<Molecule> mol = basisset_->molecule();
     boost::shared_ptr<double[]> apcs(new double[mol->natom()]);


### PR DESCRIPTION
## Description
Minor change to the blank lines and units printed by Lowdin charge calculations. The purpose of this update is to make it easier to parse PSI4 output for different types of charges.

Previous:
```
outfile->Printf( "  Mulliken Charges: (a.u.)\n");

outfile->Printf( "\n\n  Lowdin Charges [a.u.]:\n\n");
```

Updated:
```
outfile->Printf( "  Mulliken Charges: (a.u.)\n");

outfile->Printf( "  Lowdin Charges: (a.u.)\n");
```

## Todos
- [x] Made Lowdin and Mulliken charge output consistent

## Status
- [x]  Ready to go
