### PR TITLE
docs and licenses and castup, oh my

### DIFF
--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -83,5 +83,7 @@ A typical input for a Hartree-Fock calculation with PCM would look like the foll
     }
 
 More examples can be found in the directories with PCM tests
-:source:`pcm_scf <samples/pcmsolver/pcm_scf/input.dat>`, :source:`pcm_dft <samples/pcmsolver/pcm_dft/input.dat>`
-and :source:`pcm_dipole <samples/pcmsolver/pcm_dipole/input.dat>`
+:srcsample:`pcmsolver/pcm_scf`, 
+:srcsample:`pcmsolver/pcm_dft`, and
+:srcsample:`pcmsolver/pcm_dipole`. 
+

--- a/doc/sphinxman/source/psithoninput.rst
+++ b/doc/sphinxman/source/psithoninput.rst
@@ -199,8 +199,8 @@ Basis Sets
 
 .. _`sec:psiVariables`:
 
-PSI Variables & Return Values
-=============================
+PSI Variables
+=============
 
 To harness the power of Python, |PSIfour| makes the most pertinent results
 of each computation available to the Python interpreter for
@@ -252,13 +252,54 @@ So if you run in a single input file a STO-3G FCI followed by a
 aug-cc-pVQZ SCF followed by a :py:func:`~psi4.print_variables` command, the
 last will include :psivar:`SCF TOTAL ENERGY <SCFTOTALENERGY>` but not 
 :psivar:`FCI TOTAL ENERGY <FCITOTALENERGY>`.
+The entire dictionary of PSI variables can be obtained through
+:py:func:`~psi4.get_variables`.
+
+.. _`sec:returnvals`:
+
+Return Values
+=============
 
 Most of the usual user computation functions (*i.e.*,
 :py:func:`~driver.energy`, :py:func:`~driver.optimize`, and
 :py:func:`~driver.frequency`) return simply the current total energy.
 Consult the descriptions of other functions in :ref:`sec:psithonFunc` for
 what quantities they return and for what data structures they make
-available for post-processing.
+available for post-processing. Many users need only deal with the simple return
+form for the computation functions. ::
+
+    # E is total energy float
+    # G is gradient array
+    # H is hessian array
+    # wfn is class instance with many computational details
+
+    # simple returns
+    E = energy(...)
+    E = optimize(...)
+    E = frequency(...)
+    G = gradient(...)  # used by optimize()
+    H = hessian(...)  # used by frequency()
+
+For more elaborate post-processing of computations, adding
+``return_wfn=True`` keyword argument additionally returns
+:ref:`Wavefunction<sec:psimod_Wavefunction>`. ::
+
+    # power user returns
+    E, wfn = energy(..., return_wfn=True)
+    E, wfn = optimize(..., return_wfn=True)
+    E, wfn = frequency(..., return_wfn=True)
+    G, wfn = gradient(..., return_wfn=True)  # used by optimize()
+    H, wfn = hessian(..., return_wfn=True)  # used by frequency()
+
+    # print gradient array and its rms
+    wfn.gradient.print_out()
+    print wfn.gradient().rms()
+
+    # format output for other programs
+    molden(wfn, 'mycalc.molden')
+
+    # access array in another format
+    np.array(wfn.hessian())
 
 .. _`sec:loops`:
 

--- a/doc/sphinxman/source/psithonmol.rst
+++ b/doc/sphinxman/source/psithonmol.rst
@@ -267,6 +267,25 @@ ghost atoms.
 Isotopic Substitution
 =====================
 
+.. caution:: Use of isotopic substitution in |PSIfour| is not well
+   developed, and the syntax is subject to change.
+
+At present, isotopes can only be specified at creation-time of the molecule
+
+The syntax for a deuterium- and tritium-substituted water is below. Note
+that asymmetric isotopic substitution such as this *will* change the
+molecule's point group symmetry. ::
+
+    molecule dto {
+      units au
+      O                   0.00000000    0.00000000    0.00000000
+      H@2.014101779       0.00000000    1.93042809   -1.10715266
+      H_label@3.01604927  0.00000000   -1.93042809   -1.10715266
+    }
+
+The masses used by |PSIfour| can be found at
+:source:`include/masses.h`. See :srcsample:`freq-isotope` for about
+the only use to which isotopologs can presently be put in |PSIfour|.
 
 .. index:: 
    single: PubChem
@@ -525,4 +544,126 @@ powerful :ref:`C++ Molecule class <sec:psimod_Molecule>`. Thus, all member
 functions (that have been exported via Boost Python) documented thereat
 are accessible through the handle :samp:`{option_molecule_name}` in
 :samp:`molecule {optional_molecule_name} \\{...\\}`.
+
+*  The molecular geometry can be got and set and manipulated as a
+   :ref:`psi4.Matrix <sec:psimod_Matrix>` object. Below shows how to access
+   coordinates in an input file in Python. ::
+
+       molecule formaldehyde {
+       C  0.0 0.0 0.0
+       O  0.0 1.2 0.0
+       H -0.8 -0.3 0.0
+       H  0.8 -0.3 0.0                         # set geometry in angstroms
+       }
+
+       formaldehyde.update_geometry()          # update the molecule internals since pre-energy()-like call
+       formaldehyde.print_out()                # print molecule to output file
+       geom1psi = formaldehyde.geometry()      # get coordinates in bohr as a psi4.Matrix
+
+       geom1psi.print_out()                    # print coordinates array to output file
+       geom1py = mat2arr(geom1psi)             # get coordinates as a Python array
+       print geom1py                           # print coordinates to screen
+
+       geom2py = [[ 0.0,  0.0, 0.0],
+                 [ 0.0,  1.5, 0.0],
+                 [-0.8, -0.3, 0.0],
+                 [ 0.8, -0.3, 0.0]]            # define alternate coordinates in angstroms as Python array
+
+       geom2psi = psi4.Matrix(4, 3)            # initialize psi4.Matrix
+       geom2psi.set(geom2py)                   # load Python array into psi4.Matrix
+       geom2psi.scale(1.0/psi_bohr2angstroms)  # scale into bohr
+       geom2psi.print_out()                    # print alternate coord array to output file
+
+       formaldehyde.set_geometry(geom2psi)     # load alternate coordinates into molecule
+       formaldehyde.update_geometry()          # update the molecule internals
+       formaldehyde.print_out()                # print new molecule to output file
+       compare_values(28.9950517332, formaldehyde.nuclear_repulsion_energy(), 4, "geom2 took")
+
+* Molecules can be initited from XYZ files and fragmented for SAPT computations. ::
+
+       # >>> cat mol1.xyz
+       #7
+       #
+       #O          0.00000000      -0.05786571      -1.47979303
+       #N          0.00000000       0.01436394       1.46454628
+       #H          0.00000000       0.82293384      -1.85541474
+       #H          0.81348351       0.39876776       1.92934049
+       #H          0.00000000       0.07949567      -0.51934253
+       #H          0.00000000      -0.98104857       1.65344779
+       #H         -0.81348351       0.39876776       1.92934049
+
+       # >>> cat mol2.xyz
+       # 6 au
+       # stuff
+       #     C     0.00000000000000     0.00000000000000     5.26601138679877
+       #     C     0.00000000000000     0.00000000000000    -3.15195886530135
+       #     H     0.00000000000000     0.00000000000000     7.28558683837122
+       #     H     0.00000000000000     0.00000000000000    -1.12178201232889
+       #     N     0.00000000000000     0.00000000000000     3.08339310458383
+       #     N     0.00000000000000     0.00000000000000    -5.33865984413460
+
+       sapt = {'mol1': -0.0105313323529,
+               'mol2': -0.00839486625709}
+
+       nre = {'mol1': 38.8138764635,
+              'mol2': 72.3451968428}
+
+       set basis jun-cc-pvdz
+
+       for mol in ['mol1', 'mol2']:
+           filen = mol + '.xyz'
+           p4mol = Molecule.init_with_xyz(filen)           # create molecule from file above
+           fragmentedmol = auto_fragments(molecule=p4mol)  # fragment with BFS algorithm
+           activate(fragmentedmol)                         # activate returned molecule (for sapt)
+
+           e = energy('sapt0')                             # run SAPT that requires 2 fragments
+           compare_values(sapt[mol], e, 5, '%s sapt ok' % mol)
+           compare_values(nre[mol], p4mol.nuclear_repulsion_energy(), 4, '%s ok' % mol)
+           clean()                                         # clean scratch between loop calcs
+
+* The essential element, mass and coordinate information of the molecule is accessible ::
+
+           molecule eneyne {
+           0 1
+           C_ene        0.000000  -0.667578  -2.124659
+           C_ene        0.000000   0.667578  -2.124659
+           H_ene@2.014  0.923621  -1.232253  -2.126185
+           H_ene       -0.923621  -1.232253  -2.126185
+           H_ene       -0.923621   1.232253  -2.126185
+           Gh(H_ene)    0.923621   1.232253  -2.126185
+           --
+           0 1
+           X            9.0        9.0        9.0
+           C_yne        0.000000   0.000000   2.900503
+           C_yne        0.000000   0.000000   1.693240
+           H_yne        0.000000   0.000000   0.627352
+           H_yne        0.000000   0.000000   3.963929
+           }
+
+
+           eneyne.update_geometry()
+
+           for iat in range(eneyne.natom()):
+               print """{:4} {:4} {:12} {:8.4f} {:12.6f} {:12.6f} {:12.6f}   {:12.6f}""".format(
+                                             eneyne.Z(iat),       # atomic number
+                                             eneyne.symbol(iat),  # element symbol
+                                             eneyne.label(iat),   # input element label
+                                             eneyne.charge(iat),  # element charge
+                                             eneyne.x(iat),       # x-coordinate
+                                             eneyne.y(iat),       # y-coordinate
+                                             eneyne.z(iat),       # z-coordinate
+                                             eneyne.mass(iat),    # mass
+           )
+
+
+           # 6.0 C    C_ENE          6.0000    -0.031900    -1.218981    -3.948079      12.000000
+           # 6.0 C    C_ENE          6.0000    -0.031900     1.304098    -3.948079      12.000000
+           # 1.0 H    H_ENE          1.0000     1.713491    -2.286062    -3.950962       2.014000
+           # 1.0 H    H_ENE          1.0000    -1.777290    -2.286062    -3.950962       1.007825
+           # 1.0 H    H_ENE          1.0000    -1.777290     2.371180    -3.950962       1.007825
+           # 0.0 H    H_ENE          0.0000     1.713491     2.371180    -3.950962       1.007825
+           # 6.0 C    C_YNE          6.0000    -0.031900     0.042559     5.548101      12.000000
+           # 6.0 C    C_YNE          6.0000    -0.031900     0.042559     3.266705      12.000000
+           # 1.0 H    H_YNE          1.0000    -0.031900     0.042559     1.252468       1.007825
+           # 1.0 H    H_YNE          1.0000    -0.031900     0.042559     7.557685       1.007825
 

--- a/share/plugin/Makefile.conda.template
+++ b/share/plugin/Makefile.conda.template
@@ -1,9 +1,14 @@
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
 # @plugin@ by Psi4 Developer, a plugin to:
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 #

--- a/share/plugin/Makefile.template
+++ b/share/plugin/Makefile.template
@@ -1,9 +1,14 @@
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
 # @plugin@ by Psi4 Developer, a plugin to:
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 #

--- a/share/plugin/__init__.py.template
+++ b/share/plugin/__init__.py.template
@@ -1,9 +1,14 @@
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
 # @plugin@ by Psi4 Developer, a plugin to:
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 """Plugin docstring.

--- a/share/plugin/ambit.cc.template
+++ b/share/plugin/ambit.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/aointegrals.cc.template
+++ b/share/plugin/aointegrals.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/doc.rst.template
+++ b/share/plugin/doc.rst.template
@@ -1,26 +1,31 @@
-.. comment 
-.. comment @BEGIN LICENSE
-.. comment 
-.. comment  @plugin@ by Psi4 Developer, a plugin to:
-.. comment 
-.. comment  PSI4: an ab initio quantum chemistry software package
-.. comment 
-.. comment  This program is free software; you can redistribute it and/or modify
-.. comment  it under the terms of the GNU General Public License as published by
-.. comment  the Free Software Foundation; either version 2 of the License, or
-.. comment  (at your option) any later version.
-.. comment 
-.. comment  This program is distributed in the hope that it will be useful,
-.. comment  but WITHOUT ANY WARRANTY; without even the implied warranty of
-.. comment  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-.. comment  GNU General Public License for more details.
-.. comment 
-.. comment  You should have received a copy of the GNU General Public License along
-.. comment  with this program; if not, write to the Free Software Foundation, Inc.,
-.. comment  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-.. comment 
-.. comment @END LICENSE
-.. comment 
+.. comment /*
+.. comment  * @BEGIN LICENSE
+.. comment  *
+.. comment  * @plugin@ by Psi4 Developer, a plugin to:
+.. comment  *
+.. comment  * Psi4: an open-source quantum chemistry software package
+.. comment  *
+.. comment  * Copyright (c) 2007-2016 The Psi4 Developers.
+.. comment  *
+.. comment  * The copyrights for code used from other parties are included in
+.. comment  * the corresponding files.
+.. comment  *
+.. comment  * This program is free software; you can redistribute it and/or modify
+.. comment  * it under the terms of the GNU General Public License as published by
+.. comment  * the Free Software Foundation; either version 2 of the License, or
+.. comment  * (at your option) any later version.
+.. comment  *
+.. comment  * This program is distributed in the hope that it will be useful,
+.. comment  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. comment  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. comment  * GNU General Public License for more details.
+.. comment  *
+.. comment  * You should have received a copy of the GNU General Public License along
+.. comment  * with this program; if not, write to the Free Software Foundation, Inc.,
+.. comment  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. comment  *
+.. comment  * @END LICENSE
+.. comment  */
 
 .. include:: /autodoc_abbr_options_c.rst
 .. include:: /autodoc_abbr_options_plugins.rst

--- a/share/plugin/mointegrals.cc.template
+++ b/share/plugin/mointegrals.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include "psi4-dec.h"

--- a/share/plugin/plugin.cc.template
+++ b/share/plugin/plugin.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/pymodule.py.template
+++ b/share/plugin/pymodule.py.template
@@ -1,9 +1,14 @@
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
 # @plugin@ by Psi4 Developer, a plugin to:
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 import psi4

--- a/share/plugin/scf.cc.template
+++ b/share/plugin/scf.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/scf.pymodule.py.template
+++ b/share/plugin/scf.pymodule.py.template
@@ -1,9 +1,14 @@
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
 # @plugin@ by Psi4 Developer, a plugin to:
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 import psi4

--- a/share/plugin/scf.scf.cc.template
+++ b/share/plugin/scf.scf.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include "liboptions/liboptions.h"

--- a/share/plugin/scf.scf.h.template
+++ b/share/plugin/scf.scf.h.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/sointegrals.cc.template
+++ b/share/plugin/sointegrals.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/plugin/wavefunction.cc.template
+++ b/share/plugin/wavefunction.cc.template
@@ -1,9 +1,14 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
  * @plugin@ by Psi4 Developer, a plugin to:
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include <psi4-dec.h>

--- a/share/python/driver.py
+++ b/share/python/driver.py
@@ -261,7 +261,6 @@ def energy(name, **kwargs):
 
         Binary data files to be renamed for calculation restart.
 
-
     .. _`table:energy_gen`:
 
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -997,6 +996,59 @@ def optimize(name, **kwargs):
 
        * :psivar:`CURRENT ENERGY <CURRENTENERGY>`
 
+    :type name: string
+    :param name: ``'scf'`` || ``'mp2'`` || ``'ci5'`` || etc.
+
+        First argument, usually unlabeled. Indicates the computational method
+        to be applied to the database. May be any valid argument to
+        :py:func:`~driver.energy`.
+
+    :type molecule: :ref:`molecule <op_py_molecule>`
+    :param molecule: ``h2o`` || etc.
+
+        The target molecule, if not the last molecule defined.
+
+    :type return_wfn: :ref:`boolean <op_py_boolean>`
+    :param return_wfn: ``'on'`` || |dl| ``'off'`` |dr|
+
+        Indicate to additionally return the :ref:`Wavefunction<sec:psimod_Wavefunction>`
+        calculation result as the second element (after *float* energy) of a tuple.
+
+    :type func: :ref:`function <op_py_function>`
+    :param func: |dl| ``gradient`` |dr| || ``energy`` || ``cbs``
+
+        Indicates the type of calculation to be performed on the molecule.
+        The default dertype accesses ``'gradient'`` or ``'energy'``, while
+        ``'cbs'`` performs a multistage finite difference calculation.
+        If a nested series of python functions is intended (see :ref:`sec:intercalls`),
+        use keyword ``opt_func`` instead of ``func``.
+
+    :type mode: string
+    :param mode: |dl| ``'continuous'`` |dr| || ``'sow'`` || ``'reap'``
+
+        For a finite difference of energies optimization, indicates whether
+        the calculations required to complete the
+        optimization are to be run in one file (``'continuous'``) or are to be
+        farmed out in an embarrassingly parallel fashion
+        (``'sow'``/``'reap'``). For the latter, run an initial job with
+        ``'sow'`` and follow instructions in its output file. For maximum
+        flexibility, ``return_wfn`` is always on in ``'reap'`` mode.
+
+    :type dertype: :ref:`dertype <op_py_dertype>`
+    :param dertype: ``'gradient'`` || ``'energy'``
+
+        Indicates whether analytic (if available) or finite difference
+        optimization is to be performed.
+
+    :type hessian_with: string
+    :param hessian_with: ``'scf'`` || ``'mp2'`` || etc.
+
+        Indicates the computational method with which to perform a hessian
+        analysis to guide the geometry optimization.
+
+    .. warning:: Optimizations where the molecule is specified in Z-matrix format
+       with dummy atoms will result in the geometry being converted to a Cartesian representation.
+
     .. note:: Analytic gradients area available for all methods in the table
         below. Optimizations with other methods in the energy table proceed
         by finite differences.
@@ -1046,52 +1098,6 @@ def optimize(name, **kwargs):
 
     .. include:: cfour_table_grad.rst
 
-    .. warning:: Optimizations where the molecule is specified in Z-matrix format
-       with dummy atoms will result in the geometry being converted to a Cartesian representation.
-
-    :type name: string
-    :param name: ``'scf'`` || ``'mp2'`` || ``'ci5'`` || etc.
-
-        First argument, usually unlabeled. Indicates the computational method
-        to be applied to the database. May be any valid argument to
-        :py:func:`~driver.energy`.
-
-    :type func: :ref:`function <op_py_function>`
-    :param func: |dl| ``gradient`` |dr| || ``energy`` || ``cbs``
-
-        Indicates the type of calculation to be performed on the molecule.
-        The default dertype accesses ``'gradient'`` or ``'energy'``, while
-        ``'cbs'`` performs a multistage finite difference calculation.
-        If a nested series of python functions is intended (see :ref:`sec:intercalls`),
-        use keyword ``opt_func`` instead of ``func``.
-
-    :type mode: string
-    :param mode: |dl| ``'continuous'`` |dr| || ``'sow'`` || ``'reap'``
-
-        For a finite difference of energies optimization, indicates whether
-        the calculations required to complete the
-        optimization are to be run in one file (``'continuous'``) or are to be
-        farmed out in an embarrassingly parallel fashion
-        (``'sow'``/``'reap'``). For the latter, run an initial job with
-        ``'sow'`` and follow instructions in its output file. For maximum
-        flexibility, ``return_wfn`` is always on in ``'reap'`` mode.
-
-    :type dertype: :ref:`dertype <op_py_dertype>`
-    :param dertype: ``'gradient'`` || ``'energy'``
-
-        Indicates whether analytic (if available) or finite difference
-        optimization is to be performed.
-
-    :type molecule: :ref:`molecule <op_py_molecule>`
-    :param molecule: ``h2o`` || etc.
-
-        The target molecule, if not the last molecule defined.
-
-    :type hessian_with: string
-    :param hessian_with: ``'scf'`` || ``'mp2'`` || etc.
-
-        Indicates the computational method with which to perform a hessian
-        analysis to guide the geometry optimization.
 
     :examples:
 
@@ -1802,11 +1808,6 @@ def frequency(name, **kwargs):
 
     :returns: (*float*, :ref:`Wavefunction<sec:psimod_Wavefunction>`) |w--w| energy and wavefunction when **return_wfn** specified.
 
-    .. note:: Analytic hessians are not available. Frequencies will proceed through
-        finite differences according to availability of gradients or energies.
-
-    .. _`table:freq_gen`:
-
     :type name: string
     :param name: ``'scf'`` || ``'mp2'`` || ``'ci5'`` || etc.
 
@@ -1825,12 +1826,14 @@ def frequency(name, **kwargs):
         calculation result as the second element (after *float* energy) of a tuple.
         Arrays of frequencies and the Hessian can be accessed through the wavefunction.
 
-    :type dertype: :ref:`dertype <op_py_dertype>`
-    :param dertype: |dl| ``'hessian'`` |dr| || ``'gradient'`` || ``'energy'``
+    :type func: :ref:`function <op_py_function>`
+    :param func: |dl| ``gradient`` |dr| || ``energy`` || ``cbs``
 
-        Indicates whether analytic (if available- they're not), finite
-        difference of gradients (if available) or finite difference of
-        energies is to be performed.
+        Indicates the type of calculation to be performed on the molecule.
+        The default dertype accesses ``'gradient'`` or ``'energy'``, while
+        ``'cbs'`` performs a multistage finite difference calculation.
+        If a nested series of python functions is intended (see :ref:`sec:intercalls`),
+        use keyword ``freq_func`` instead of ``func``.
 
     :type mode: string
     :param mode: |dl| ``'continuous'`` |dr| || ``'sow'`` || ``'reap'``
@@ -1842,6 +1845,13 @@ def frequency(name, **kwargs):
         run an initial job with ``'sow'`` and follow instructions in its output file.
         For maximum flexibility, ``return_wfn`` is always on in ``'reap'`` mode.
 
+    :type dertype: :ref:`dertype <op_py_dertype>`
+    :param dertype: |dl| ``'hessian'`` |dr| || ``'gradient'`` || ``'energy'``
+
+        Indicates whether analytic (if available- they're not), finite
+        difference of gradients (if available) or finite difference of
+        energies is to be performed.
+
     :type irrep: int or string
     :param irrep: |dl| ``-1`` |dr| || ``1`` || ``'b2'`` || ``'App'`` || etc.
 
@@ -1849,6 +1859,11 @@ def frequency(name, **kwargs):
         frequencies to be computed. ``1``, ``'1'``, or ``'a1'`` represents
         :math:`a_1`, requesting only the totally symmetric modes.
         ``-1`` indicates a full frequency calculation.
+
+    .. note:: Analytic hessians are not available. Frequencies will proceed through
+        finite differences according to availability of gradients or energies.
+
+    .. _`table:freq_gen`:
 
     :examples:
 
@@ -1901,20 +1916,20 @@ def frequency(name, **kwargs):
 
 
 def gdma(wfn, datafile=""):
-    """Function to write wavefunction information in *wfn* to *filename* in
-    molden format.
+    """Function to use wavefunction information in *wfn* and, if specified,
+    additional commands in *filename* to run GDMA analysis.
 
     .. versionadded:: 0.6
 
     :returns: None
 
+    :type wfn: :ref:`Wavefunction<sec:psimod_Wavefunction>`
+    :param wfn: set of molecule, basis, orbitals from which to generate DMA analysis
+
     :type datafile: string
     :param datafile: optional control file (see GDMA manual) to peform more complicated DMA
                      analyses.  If this option is used, the File keyword must be set to read
                      a filename.fchk, where filename is provided by |globals__writer_file_label| .
-
-    :type wfn: :ref:`Wavefunction<sec:psimod_Wavefunction>`
-    :param wfn: set of molecule, basis, orbitals from which to generate DMA analysis
 
     :examples:
 
@@ -1998,11 +2013,11 @@ def molden(wfn, filename):
 
     :returns: None
 
-    :type filename: string
-    :param filename: destination file name for MOLDEN file
-
     :type wfn: :ref:`Wavefunction<sec:psimod_Wavefunction>`
     :param wfn: set of molecule, basis, orbitals from which to generate cube files
+
+    :type filename: string
+    :param filename: destination file name for MOLDEN file
 
     :examples:
 

--- a/share/python/driver.py
+++ b/share/python/driver.py
@@ -68,7 +68,7 @@ procedures = {
             'sos-pi-omp3'   : run_occ,
             'olccd'         : select_olccd,
             'omp2.5'        : select_omp2p5,
-            'dfocc'         : run_dfocc,
+            'dfocc'         : run_dfocc,  # full control over dfocc
             'qchf'          : run_qchf,
             'ccd'           : run_dfocc,
             'sapt0'         : run_sapt,
@@ -275,15 +275,13 @@ def energy(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | dcft                    | density cumulant functional theory :ref:`[manual] <sec:dcft>`                                                 |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | mcscf                   | multiconfigurational self consistent field (SCF)                                                              |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | mp2                     | 2nd-order Moller-Plesset perturbation theory (MP2) :ref:`[manual] <sec:dfmp2>` :ref:`[details] <tlmp2>`       |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | mp3                     | 3rd-order Moller-Plesset perturbation theory (MP3) :ref:`[details] <tlmp3>`                                   |
+    | mp3                     | 3rd-order Moller-Plesset perturbation theory (MP3) :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tlmp3>`   |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | fno-mp3                 | MP3 with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                                  |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | mp2.5                   | average of MP2 and MP3 :ref:`[details] <tlmp25>`                                                              |
+    | mp2.5                   | average of MP2 and MP3 :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tlmp25>`                              |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | mp4(sdq)                | 4th-order MP perturbation theory (MP4) less triples :ref:`[manual] <sec:fnompn>`                              |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -323,13 +321,11 @@ def energy(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | omp2.5                  | orbital-optimized MP2.5 :ref:`[manual] <sec:occ_oo>`                                                          |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ocepa(0)                | orbital-optimized coupled electron pair approximation :ref:`[manual] <sec:occ_oo>`                            |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | qchf                    | density-fitted QC-HF from DFOCC module :ref:`[manual] <sec:occ_oo>`                                           |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | cepa(0)                 | coupled electron pair approximation variant 0 :ref:`[manual] <sec:fnocepa>` :ref:`[details] <tllccsd>`        |
+    | lccsd, cepa(0)          | coupled electron pair approximation variant 0 :ref:`[manual] <sec:fnocepa>` :ref:`[details] <tllccsd>`        |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | fno-cepa(0)             | CEPA(0) with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                              |
+    | fno-lccsd, fno-cepa(0)  | CEPA(0) with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                              |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | cepa(1)                 | coupled electron pair approximation variant 1 :ref:`[manual] <sec:fnocepa>`                                   |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -351,19 +347,19 @@ def energy(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | fno-qcisd               | QCISD with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                                |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | cc2                     | approximate coupled cluster singles and doubles (CC2) :ref:`[manual] <sec:cc>`                                |
+    | lccd                    | Linear CCD :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tllccd>`                                          |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ccd                     | coupled cluster doubles  (CCD) :ref:`[manual] <sec:cc>`                                                       |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ccsd                    | coupled cluster singles and doubles (CCSD) :ref:`[manual] <sec:cc>` :ref:`[details] <tllccsd>`                |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | bccd                    | Brueckner coupled cluster doubles (BCCD) :ref:`[manual] <sec:cc>`                                             |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | lccd                    | Linear CCD :ref:`[manual] <sec:cc>` :ref:`[details] <tllccd>`                                                 |
+    | fno-lccd                | LCCD with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                                 |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | olccd                   | orbital optimized LCCD :ref:`[manual] <sec:occ_oo>`                                                           |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | fno-lccd                | LCCD with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                                 |
+    | cc2                     | approximate coupled cluster singles and doubles (CC2) :ref:`[manual] <sec:cc>`                                |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | ccd                     | coupled cluster doubles  (CCD) :ref:`[manual] <sec:occ_nonoo>`                                                |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | ccsd                    | coupled cluster singles and doubles (CCSD) :ref:`[manual] <sec:cc>` :ref:`[details] <tlccsd>`                 |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | bccd                    | Brueckner coupled cluster doubles (BCCD) :ref:`[manual] <sec:cc>`                                             |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | fno-ccsd                | CCSD with frozen natural orbitals :ref:`[manual] <sec:fnocc>`                                                 |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -383,7 +379,7 @@ def energy(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | ccenergy                | **expert** full control over ccenergy module                                                                  |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | dfocc                   | orbital optimized CC with density fitting :ref:`[manual] <sec:occ_oo>`                                        |
+    | dfocc                   | **expert** full control over dfocc module                                                                     |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | cisd                    | configuration interaction (CI) singles and doubles (CISD) :ref:`[manual] <sec:ci>` :ref:`[details] <tlcisd>`  |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -402,6 +398,14 @@ def energy(name, **kwargs):
     | casscf                  | complete active space self consistent field (CASSCF)  :ref:`[manual] <sec:ci>`                                |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | rasscf                  | restricted active space self consistent field (RASSCF)  :ref:`[manual] <sec:ci>`                              |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | mcscf                   | multiconfigurational self consistent field (SCF) :ref:`[manual] <sec:psimrcc>`                                |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | psimrcc                 | Mukherjee multireference coupled cluster (Mk-MRCC) :ref:`[manual] <sec:psimrcc>`                              |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | dmrgscf                 | density matrix renormalization group SCF :ref:`[manual] <sec:dmrg>`                                           |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | dmrgci                  | density matrix renormalization group CI :ref:`[manual] <sec:dmrg>`                                            |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | sapt0                   | 0th-order symmetry adapted perturbation theory (SAPT) :ref:`[manual] <sec:sapt>`                              |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -455,10 +459,11 @@ def energy(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | eom-cc3                 | EOM-CC3 :ref:`[manual] <sec:eomcc>`                                                                           |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | dmrgscf                 | density matrix renormalization group SCF :ref:`[manual] <sec:dmrg>`                                           |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | dmrgci                  | density matrix renormalization group CI :ref:`[manual] <sec:dmrg>`                                            |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+
+    .. comment missing and why
+    .. comment a certain isapt --- marginally released
+    .. comment mrcc --- this is handled in its own table
+    .. comment psimrcc_scf --- convenience fn
 
     .. include:: autodoc_dft_energy.rst
 
@@ -1001,35 +1006,37 @@ def optimize(name, **kwargs):
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | name                    | calls method                                                                                                  |
     +=========================+===============================================================================================================+
+    | efp                     | efp-only optimizations                                                                                        |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | scf                     | Hartree--Fock (HF) or density functional theory (DFT) :ref:`[manual] <sec:scf>`                               |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | hf                      | Hartree--Fock (HF)  :ref:`[manual] <sec:scf>`                                                                 |
+    | hf                      | HF self consistent field (SCF) :ref:`[manual] <sec:scf>`                                                      |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | dcft                    | density cumulant functional theory :ref:`[manual] <sec:dcft>`                                                 |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | mp2                     | 2nd-order Moller-Plesset perturbation theory (MP2) :ref:`[manual] <sec:dfmp2>` :ref:`[details] <tlmp2>`       |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | mp2.5                   | MP2.5 :ref:`[manual] <sec:convocc>`                                                                           |
+    | mp3                     | 3rd-order Moller-Plesset perturbation theory (MP3) :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tlmp3>`   |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | mp3                     | third-order MP perturbation theory :ref:`[manual] <sec:convocc>`                                              |
+    | mp2.5                   | average of MP2 and MP3 :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tlmp25>`                              |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | omp2                    | orbital-optimized second-order MP perturbation theory :ref:`[manual] <sec:occ>`                               |
+    | omp2                    | orbital-optimized second-order MP perturbation theory :ref:`[manual] <sec:occ_oo>`                            |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | omp2.5                  | orbital-optimized MP2.5 :ref:`[manual] <sec:occ>`                                                             |
+    | omp3                    | orbital-optimized third-order MP perturbation theory :ref:`[manual] <sec:occ_oo>`                             |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | omp3                    | orbital-optimized third-order MP perturbation theory :ref:`[manual] <sec:occ>`                                |
+    | omp2.5                  | orbital-optimized MP2.5 :ref:`[manual] <sec:occ_oo>`                                                          |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ocepa                   | orbital-optimized coupled electron pair approximation :ref:`[manual] <sec:occ>`                               |
+    | lccd                    | Linear CCD :ref:`[manual] <sec:occ_nonoo>` :ref:`[details] <tllccd>`                                          |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | cepa0                   | coupled electron pair approximation(0) :ref:`[manual] <sec:convocc>`                                          |
+    | olccd                   | orbital optimized LCCD :ref:`[manual] <sec:occ_oo>`                                                           |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ccsd                    | coupled cluster singles and doubles (CCSD) :ref:`[manual] <sec:cc>`                                           |
+    | ccd                     | coupled cluster doubles  (CCD) :ref:`[manual] <sec:occ_nonoo>`                                                |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | ccsd(t)                 | CCSD with perturbative triples (CCSD(T)) :ref:`[manual] <sec:cc>`                                             |
+    | ccsd                    | coupled cluster singles and doubles (CCSD) :ref:`[manual] <sec:cc>` :ref:`[details] <tlccsd>`                 |
+    +-------------------------+---------------------------------------------------------------------------------------------------------------+
+    | ccsd(t)                 | CCSD with perturbative triples (CCSD(T)) :ref:`[manual] <sec:cc>` :ref:`[details] <tlccsdt>`                  |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
     | eom-ccsd                | equation of motion (EOM) CCSD :ref:`[manual] <sec:eomcc>`                                                     |
-    +-------------------------+---------------------------------------------------------------------------------------------------------------+
-    | efp                     | efp-only optimizations                                                                                        |
     +-------------------------+---------------------------------------------------------------------------------------------------------------+
 
     .. _`table:grad_scf`:

--- a/share/python/qcdb/molecule.py
+++ b/share/python/qcdb/molecule.py
@@ -281,7 +281,7 @@ class Molecule(LibmintsMolecule):
         instance.update_geometry()
         return instance
 
-    def save_string_xyz(self, save_ghosts=True):
+    def save_string_xyz(self, save_ghosts=True, save_natom=False):
         """Save a string for a XYZ-style file.
 
         >>> H2OH2O.save_string_xyz()
@@ -303,7 +303,9 @@ class Molecule(LibmintsMolecule):
             for i in range(self.natom()):
                 if self.Z(i):
                     N += 1
-        text = "%d\n" % (N)
+        text = ''
+        if save_natom:
+            text += "%d\n" % (N)
         text += '%d %d %s\n' % (self.molecular_charge(), self.multiplicity(), self.tagline)
 
         for i in range(self.natom()):

--- a/share/python/wrappers.py
+++ b/share/python/wrappers.py
@@ -317,7 +317,7 @@ def auto_fragments(**kwargs):
     White = []
     Black = []
     F = geom.split('\n')
-    for f in range(0, numatoms):
+    for f in range(numatoms):
         A = F[f + 1].split()
         symbol[f] = A[0]
         X[f] = float(A[1])
@@ -353,10 +353,10 @@ def auto_fragments(**kwargs):
             White.remove(White[0])
         frag += 1
 
-    new_geom = """\n0 1\n"""
+    new_geom = """\n"""
     for i in Fragment[0]:
         new_geom = new_geom + F[i].lstrip() + """\n"""
-    new_geom = new_geom + """--\n0 1\n"""
+    new_geom = new_geom + """--\n"""
     for j in Fragment[1]:
         new_geom = new_geom + F[j].lstrip() + """\n"""
     new_geom = new_geom + """units angstrom\n"""

--- a/src/bin/psi4/export_mints.cc
+++ b/src/bin/psi4/export_mints.cc
@@ -784,7 +784,7 @@ void export_mints()
             def("symmetrize", &Molecule::symmetrize_to_abelian_group, "Finds the highest point Abelian point group within the specified tolerance, and forces the geometry to have that symmetry.").
             def("create_molecule_from_string", &Molecule::create_molecule_from_string, "Returns a new Molecule with member data from the geometry string arg1 in psi4 format").
             staticmethod("create_molecule_from_string").
-                def("is_variable", &Molecule::is_variable, "Checks if variable arg2 is in the list, returns true if it is, and returns false if not").
+            def("is_variable", &Molecule::is_variable, "Checks if variable arg2 is in the list, returns true if it is, and returns false if not").
             def("set_variable", &Molecule::set_variable, "Assigns the value arg3 to the variable arg2 in the list of geometry variables, then calls update_geometry()").
             def("get_variable", &Molecule::get_variable, "Checks if variable arg2 is in the list, sets it to val and returns true if it is, and returns false if not").
             def("update_geometry", &Molecule::update_geometry, "Reevaluates the geometry with current variable values, orientation directives, etc. Must be called after initial Molecule definition by string.").

--- a/src/lib/libsapt_solver/ind20.cc
+++ b/src/lib/libsapt_solver/ind20.cc
@@ -143,7 +143,7 @@ void SAPT0::ind20rA_B()
   }
 
   if (print_)
-    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time (s)\n");
+    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time [s]\n");
 
   SAPTDFInts C_p_AA = set_C_AA();
   SAPTDFInts C_p_AR = set_C_AR();
@@ -338,7 +338,7 @@ void SAPT0::ind20rB_A()
   }
 
   if (print_)
-    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time (s)\n");
+    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time [s]\n");
 
   SAPTDFInts C_p_BB = set_C_BB();
   SAPTDFInts C_p_BS = set_C_BS();
@@ -533,7 +533,7 @@ void SAPT0::ind20rA_B_aio()
   }
 
   if (print_)
-    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time (s)\n");
+    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time [s]\n");
 
   SAPTDFInts C_p_AR = set_C_AR();
 
@@ -772,7 +772,7 @@ void SAPT0::ind20rB_A_aio()
   }
 
   if (print_)
-    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time (s)\n");
+    outfile->Printf("\n    Iter     Energy [mEh]          dE [mEh]         Residual      Time [s]\n");
 
   SAPTDFInts C_p_BS = set_C_BS();
 

--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -1529,9 +1529,11 @@ void HF::load_orbitals()
 
     boost::shared_ptr<BasisSet> dual_basis;
     if (basisname != options_.get_str("BASIS")) {
-        boost::shared_ptr<BasisSetParser> parser(new Gaussian94BasisSetParser(old_forced_puream));
-        molecule_->set_basis_all_atoms(basisname, "DUAL_BASIS_SCF");
-        dual_basis = BasisSet::construct(parser, molecule_, "DUAL_BASIS_SCF");
+        //boost::shared_ptr<BasisSetParser> parser(new Gaussian94BasisSetParser(old_forced_puream));
+        //molecule_->set_basis_all_atoms(basisname, "DUAL_BASIS_SCF");
+        //dual_basis = BasisSet::construct(parser, molecule_, "DUAL_BASIS_SCF");
+        dual_basis = BasisSet::pyconstruct_orbital(molecule_,
+        "BASIS", basisname, old_forced_puream);
     } else {
         dual_basis = BasisSet::pyconstruct_orbital(molecule_,
         "BASIS", options_.get_str("BASIS"));

--- a/src/lib/libscf_solver/hf.cc
+++ b/src/lib/libscf_solver/hf.cc
@@ -1533,7 +1533,7 @@ void HF::load_orbitals()
         //molecule_->set_basis_all_atoms(basisname, "DUAL_BASIS_SCF");
         //dual_basis = BasisSet::construct(parser, molecule_, "DUAL_BASIS_SCF");
         dual_basis = BasisSet::pyconstruct_orbital(molecule_,
-        "BASIS", basisname, old_forced_puream);
+        "DUAL_BASIS_SCF", basisname, old_forced_puream);
     } else {
         dual_basis = BasisSet::pyconstruct_orbital(molecule_,
         "BASIS", options_.get_str("BASIS"));


### PR DESCRIPTION
## Description
docs and licenses and castup, oh my

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] few tweaks to the energy/grad docstring tables, #249 
- [x] improve molecule and fn return docs, #351 & #352 
- [x] update licenses in plugin template dir, since those are mixed py/c++ and awkward to do by script
- [x] hesitant replacement of cast-up with pyconstruct basis machinery. no differences detected in relevant output files (castup1/2/3, sapt2/4/5, pywrap-all), #285 
- [x] do `[s]` on seconds in sapt


## Status
- [x]  Ready to go


