### PR TITLE
Fixed issue raised by Lori

### DIFF
--- a/src/lib/libmints/sointegral_twobody.h
+++ b/src/lib/libmints/sointegral_twobody.h
@@ -41,8 +41,6 @@
 #include "cdsalclist.h"
 #include "dcd.h"
 
-#include "../libparallel/mpi_wrapper.h"
-#include "../libparallel/local.h"
 
 #include <libqt/qt.h>
 #include <vector>
@@ -72,9 +70,6 @@ public:
 #endif
 
 class TwoBodySOInt
-#if HAVE_MADNESS
-    : public madness::WorldObject<TwoBodySOInt>
-#endif
 {
 protected:
     std::vector<boost::shared_ptr<TwoBodyAOInt> > tb_;
@@ -170,20 +165,6 @@ public:
     // Compute integrals in parallel
     template<typename TwoBodySOIntFunctor>
     void compute_integrals(TwoBodySOIntFunctor &functor);
-
-#if HAVE_MADNESS
-    template<typename TwoBodySOIntFunctor>
-    int compute_pq_pair(const int &p, const int &q, const TwoBodySOIntFunctor &body) {
-
-        boost::shared_ptr<SO_RS_Iterator> shellIter(
-                    new SO_RS_Iterator(p, q,
-                                       b1_, b2_, b3_, b4_));
-
-        this->compute_quartets(shellIter, const_cast<TwoBodySOIntFunctor &>(body));
-
-        return 0;
-    }
-#endif
 
     // Derivative integrals
     // User provides an iterator object and this function will walk through it.


### PR DESCRIPTION
## Description
Removes `sointegral_twobody.h`'s dependence on `mpi_wrapper.h` and `local.h`.  Also removes some MADNESS stuff that was missed originally.

## Status
- [x]  Ready to go



