### PR TITLE
PSI4 --> Psi4

### DIFF
--- a/include/Z_to_element.h
+++ b/include/Z_to_element.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*! 

--- a/include/chkpt_params.h
+++ b/include/chkpt_params.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef _psi_include_chkpt_params_h_

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef COMPILER_H

--- a/include/cov_radii.h
+++ b/include/cov_radii.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*

--- a/include/element_to_Z.h
+++ b/include/element_to_Z.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*! 

--- a/include/exception.h
+++ b/include/exception.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef _psi4_exception_h_

--- a/include/masses.h
+++ b/include/masses.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*

--- a/include/molecular_system.h
+++ b/include/molecular_system.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef _psi_include_molecular_system_h_

--- a/include/physconst.h
+++ b/include/physconst.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*

--- a/include/process.h
+++ b/include/process.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +22,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
+
 #ifndef PROCESS_H_
 #define PROCESS_H_
 

--- a/include/psi4-config.in
+++ b/include/psi4-config.in
@@ -1,6 +1,33 @@
 #!/usr/bin/env python
 # vim:ft=python
 
+#
+# @BEGIN LICENSE
+#
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# @END LICENSE
+#
+
 import sys
 from collections import OrderedDict
 

--- a/include/psi4-dec.h
+++ b/include/psi4-dec.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef psi_include_psi4_dec_h

--- a/include/psi4-def.h
+++ b/include/psi4-def.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #ifndef psi_include_psi4_def_h

--- a/include/psiconfig.h.cmake.in
+++ b/include/psiconfig.h.cmake.in
@@ -23,7 +23,7 @@
 #define PLUGIN_OBJDIR "@PROJECT_BINARY_DIR@"
 #define PLUGIN_LDFLAGS "@PLUGIN_LDFLAGS@"
 
-/* The PSI4 Datadir */
+/* The Psi4 Datadir */
 #define INSTALLEDPSIDATADIR "@CMAKE_INSTALL_PREFIX@/share/psi4"
 
 /* MPI? */

--- a/include/psifiles.h
+++ b/include/psifiles.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*

--- a/include/psitypes.h
+++ b/include/psitypes.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,9 +22,8 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
-
 
 #ifndef _psi_include_psitypes_h_
 #define _psi_include_psitypes_h_

--- a/include/rgb.h
+++ b/include/rgb.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*------------------------------------------

--- a/include/symmetry.h
+++ b/include/symmetry.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*-------------------------------------------------------

--- a/include/vdw_radii.h
+++ b/include/vdw_radii.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 /*------------------------------------------

--- a/share/plugin/ambit.cc.template
+++ b/share/plugin/ambit.cc.template
@@ -34,7 +34,7 @@
 #include <libpsio/psio.h>
 
 #ifndef HAVE_AMBIT
-#error PSI4 was not compiled with Ambit support.
+#error Psi4 was not compiled with Ambit support.
 #endif
 
 #include <ambit/tensor.h>

--- a/share/python/driver.py
+++ b/share/python/driver.py
@@ -1082,7 +1082,7 @@ def optimize(name, **kwargs):
             # Changing environment to optimized geometry as expected by user
             molecule.set_geometry(moleculeclone.geometry())
             for postcallback in hooks['optimize']['post']:
-                postcallback(lowername, **kwargs)
+                postcallback(lowername, wfn=wfn, **kwargs)
             psi4.clean()
 
             # S/R: Clean up opt input file
@@ -1644,7 +1644,7 @@ def frequency(name, **kwargs):
     psi4.thermo(wfn, wfn.frequencies())
 
     for postcallback in hooks['frequency']['post']:
-        postcallback(lowername, **kwargs)
+        postcallback(lowername, wfn=wfn, **kwargs)
 
     # Reset old global basis if needed
     if not old_global_basis is None:

--- a/share/python/inputparser.py
+++ b/share/python/inputparser.py
@@ -603,7 +603,7 @@ def process_input(raw_input, print_level=1):
 
     """
     # Check if the infile is actually an outfile (yeah we did)
-    psi4_id = re.compile(r'PSI4: An Open-Source Ab Initio Electronic Structure Package')
+    psi4_id = re.compile(r'Psi4: An Open-Source Ab Initio Electronic Structure Package')
     if re.search(psi4_id, raw_input):
         input_lines = raw_input.split("\n")
         input_re = re.compile(r'^\s*?\=\=> Input File <\=\=')

--- a/share/python/p4util/inpsight.py
+++ b/share/python/p4util/inpsight.py
@@ -428,7 +428,7 @@ class InPsight:
 
         # Write the pov.ini file
         fh = open(ini_filename,'w')
-        fh.write('; InPsight: visualization in PSI4\n')
+        fh.write('; InPsight: visualization in Psi4\n')
         fh.write(';  by Rob Parrish\n')
         fh.write('; .pov.ini file\n')
         fh.write('; Created %s\n' % str(date.today()))
@@ -451,7 +451,7 @@ class InPsight:
         # Write the pov file
         fh = open(pov_filename, 'w')
 
-        fh.write('// InPsight: visualization in PSI4\n')
+        fh.write('// InPsight: visualization in Psi4\n')
         fh.write('//  by Rob Parrish\n')
         fh.write('// .pov file (adopted from Jmol)\n')
         fh.write('// Created %s\n' % str(date.today()))
@@ -551,7 +551,7 @@ class InPsight:
 
         # Write the pov.ini file
         fh = open(ini_filename,'w')
-        fh.write('; InPsight: visualization in PSI4\n')
+        fh.write('; InPsight: visualization in Psi4\n')
         fh.write(';  by Rob Parrish\n')
         fh.write('; .pov.ini file\n')
         fh.write('; Created %s\n' % str(date.today()))
@@ -574,7 +574,7 @@ class InPsight:
         # Write the pov file
         fh = open(pov_filename, 'w')
 
-        fh.write('// InPsight: visualization in PSI4\n')
+        fh.write('// InPsight: visualization in Psi4\n')
         fh.write('//  by Rob Parrish\n')
         fh.write('// .pov file (adopted from Jmol)\n')
         fh.write('// Created %s\n' % str(date.today()))

--- a/share/python/procedures/interface_cfour.py
+++ b/share/python/procedures/interface_cfour.py
@@ -164,7 +164,7 @@ def run_cfour(name, **kwargs):
   [1] Supply a GENBAS by placing it in PATH or PSIPATH
       [1a] Use cfour {} block with molecule and basis directives.
       [1b] Use molecule {} block and CFOUR_BASIS keyword.
-  [2] Allow PSI4's internal basis sets to convert to GENBAS
+  [2] Allow Psi4's internal basis sets to convert to GENBAS
       [2a] Use molecule {} block and BASIS keyword.
 
 """
@@ -444,7 +444,7 @@ def write_zmat(name, dertype):
             molecule.reset_point_group('c1')  # need basis printed for *every* atom
             with open('GENBAS', 'w') as cfour_basfile:
                 cfour_basfile.write(psi4.BasisSet.pyconstruct_orbital(molecule, "BASIS", psi4.get_global_option('BASIS')).genbas())
-            psi4.print_out('  GENBAS loaded from PSI4 LibMints for basis %s\n' % (psi4.get_global_option('BASIS')))
+            psi4.print_out('  GENBAS loaded from Psi4 LibMints for basis %s\n' % (psi4.get_global_option('BASIS')))
             molecule.reset_point_group(user_pg)
             molecule.update_geometry()
             bascmd, baskw = qcdbmolecule.format_basis_for_cfour(psi4.MintsHelper().basisset().has_puream())

--- a/share/python/procedures/roa.py
+++ b/share/python/procedures/roa.py
@@ -186,7 +186,7 @@ def roa_stat(db):
                 with open('{}/output.dat'.format(job)) as outfile:
                     outfile.seek(-150,2)
                     for line in outfile:
-                        if 'PSI4 exiting successfully' in line:
+                        if 'Psi4 exiting successfully' in line:
                             db['job_status'][job] = 'finished'
                             n_finished += 1
                             break

--- a/share/python/pubchem.py
+++ b/share/python/pubchem.py
@@ -38,7 +38,7 @@ from __future__ import print_function
            entry["PubChemObj"]  => instance of PubChemObj for this compound
 
            entry["PubChemObj"].getMoleculeString()   => returns a string compatible
-                                                        with PSI4's Molecule creation
+                                                        with Psi4's Molecule creation
 
 """
 from __future__ import absolute_import

--- a/share/python/qcdb/libmintsbasisset.py
+++ b/share/python/qcdb/libmintsbasisset.py
@@ -1131,7 +1131,7 @@ class BasisSet(object):
         for uA in range(self.molecule.nunique()):
             A = self.molecule.unique(uA)
             text += """%s:P4_%d\n""" % (self.molecule.symbol(A), A + 1)
-            text += """PSI4 basis %s for element %s atom %d\n\n""" % \
+            text += """Psi4 basis %s for element %s atom %d\n\n""" % \
                 (self.name.upper(), self.molecule.symbol(A), A + 1)
 
             first_shell = self.center_to_shell[A]

--- a/share/python/qcdb/psi4.py
+++ b/share/python/qcdb/psi4.py
@@ -34,7 +34,7 @@ from .psivarrosetta import useme2psivar
 
 
 def harvest_output(outtext):
-    """Function to separate portions of a PSI4 output file *outtext*.
+    """Function to separate portions of a Psi4 output file *outtext*.
 
     """
     psivar = PreservingDict()
@@ -91,7 +91,7 @@ def harvest_output(outtext):
                 psivar['%s' % (submobj.group(1))] = submobj.group(2)
 
     # Process Completion
-    mobj = re.search(r'PSI4 exiting successfully. Buy a developer a beer!',
+    mobj = re.search(r'Psi4 exiting successfully. Buy a developer a beer!',
         outtext, re.MULTILINE)
     if mobj:
         psivar['SUCCESS'] = True

--- a/share/python/qcdb/qchem.py
+++ b/share/python/qcdb/qchem.py
@@ -34,7 +34,7 @@ from .pdict import PreservingDict
 
 
 def harvest_output(outtext):
-    """Function to separate portions of a PSI4 output file *outtext*.
+    """Function to separate portions of a Psi4 output file *outtext*.
 
     """
     psivar = PreservingDict()

--- a/share/scripts/ixyz2database.py
+++ b/share/scripts/ixyz2database.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
 #
-#@BEGIN LICENSE
+# @BEGIN LICENSE
 #
-# PSI4: an ab initio quantum chemistry software package
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2016 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +24,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#@END LICENSE
+# @END LICENSE
 #
 
 import sys

--- a/share/scripts/ixyz2database.py
+++ b/share/scripts/ixyz2database.py
@@ -445,7 +445,7 @@ if route == 2:
     """
 
 final += """
-       *  Make sure the PSI4 driver can find your new database.
+       *  Make sure the Psi4 driver can find your new database.
           If running from an installed psi4, move %s.py into INSTALLED_DIRECTORY/share/psi/databases .
           If running from source, move %s.py into PSIDATADIR/databases .
           Alternatively, add the directory containing %s.py into PYTHONPATH .

--- a/src/bin/ccdensity/densgrid_RHF.cc
+++ b/src/bin/ccdensity/densgrid_RHF.cc
@@ -213,7 +213,7 @@ y*pc_bohr2angstroms, z*pc_bohr2angstroms, dens/b2a3);
 
   // Prep .dx file
   boost::shared_ptr<OutFile> printer(new OutFile("density.dx",TRUNCATE));
-  printer->Printf( "#  Output from PSI4 calculation\n");
+  printer->Printf( "#  Output from Psi4 calculation\n");
   printer->Printf( "#  Electronic density (in e/ang^3) for: \n");
   printer->Printf( "object 1 class gridpositions counts %d %d %d\n", xsteps, ysteps, zsteps);
   printer->Printf( "origin %8.6E  %8.6E  %8.6E\n", xmin, ymin, zmin);

--- a/src/bin/mrcc/mrcc.cc
+++ b/src/bin/mrcc/mrcc.cc
@@ -577,7 +577,7 @@ PsiReturnType mrcc_load_ccdensities(SharedWavefunction wave, Options& options, c
 {
     tstart();
 
-    outfile->Printf( "  PSI4 interface to MRCC:\n");
+    outfile->Printf( "  Psi4 interface to MRCC:\n");
 
     // Ensure the dict provided has everything we need.
     if (!level.has_key("method") ||
@@ -638,7 +638,7 @@ PsiReturnType mrcc_generate_input(SharedWavefunction ref_wfn, Options& options, 
 {
     tstart();
 
-    outfile->Printf( "  PSI4 interface to MRCC:\n");
+    outfile->Printf( "  Psi4 interface to MRCC:\n");
 
     // Ensure the dict provided has everything we need.
     if (!level.has_key("method") ||

--- a/src/bin/psi4/create_new_plugin.cc
+++ b/src/bin/psi4/create_new_plugin.cc
@@ -121,7 +121,7 @@ class PluginFileManager{
         boost::filesystem::path bf_path;
         bf_path = boost::filesystem::system_complete(psiDataDirWithPlugin);
         if(!boost::filesystem::is_directory(bf_path)) {
-            printf("Unable to read the PSI4 plugin folder - check the PSIDATADIR environmental variable\n"
+            printf("Unable to read the Psi4 plugin folder - check the PSIDATADIR environmental variable\n"
                     "      Current value of PSIDATADIR is %s\n", psiDataDirName.c_str());
             exit(1);
         }

--- a/src/bin/psi4/psi_stop.cc
+++ b/src/bin/psi4/psi_stop.cc
@@ -56,8 +56,8 @@ int psi_stop(FILE* infile, std::string OutFileRMR, char* psi_file_prefix)
   free(psi_file_prefix);
  
   // Success Flag, so a user can tell via grep that the outfile worked (or at least didn't segfault)
-  // With a little PSI4 flavor to it. 
-  outfile->Printf( "\n*** PSI4 exiting successfully. Buy a developer a beer!\n");
+  // With a little Psi4 flavor to it. 
+  outfile->Printf( "\n*** Psi4 exiting successfully. Buy a developer a beer!\n");
 
   
   //if (outfile)

--- a/src/bin/psi4/python.cc
+++ b/src/bin/psi4/python.cc
@@ -209,7 +209,7 @@ void py_reopen_outfile()
     else {
         outfile = boost::shared_ptr<OutFile>(new OutFile(outfile_name, APPEND));
         if (!outfile)
-            throw PSIEXCEPTION("PSI4: Unable to reopen output file.");
+            throw PSIEXCEPTION("Psi4: Unable to reopen output file.");
     }
 }
 
@@ -218,7 +218,7 @@ void py_be_quiet()
     py_close_outfile();
     outfile = boost::shared_ptr<OutFile>(new OutFile("/dev/null", APPEND));
     if (!outfile)
-        throw PSIEXCEPTION("PSI4: Unable to redirect output to /dev/null.");
+        throw PSIEXCEPTION("Psi4: Unable to redirect output to /dev/null.");
 }
 
 std::string py_get_outfile_name()
@@ -1217,14 +1217,14 @@ bool psi4_python_module_initialize()
 
     print_version("stdout");
 
-    // Track down the location of PSI4's python script directory.
+    // Track down the location of Psi4's python script directory.
     std::string psiDataDirName = Process::environment("PSIDATADIR");
     std::string psiDataDirWithPython = psiDataDirName + "/psi4";
     boost::filesystem::path bf_path;
     bf_path = boost::filesystem::system_complete(psiDataDirWithPython);
     // printf("Python dir is at %s\n", psiDataDirName.c_str());
     if(!boost::filesystem::is_directory(bf_path)) {
-        printf("Unable to read the PSI4 Python folder - check the PSIDATADIR environmental variable\n"
+        printf("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable\n"
                 "      Current value of PSIDATADIR is %s\n", psiDataDirName.c_str());
         return false;
     }
@@ -1640,7 +1640,7 @@ void Python::run(FILE *input)
         Py_SetProgramName(s);
 #endif
 
-        // Track down the location of PSI4's auxiliary directories path
+        // Track down the location of Psi4's auxiliary directories path
         std::string psiPath = Process::environment("PSIPATH") + ":./";
         boost::char_separator<char> sep(":");
         typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
@@ -1652,7 +1652,7 @@ void Python::run(FILE *input)
             boost::filesystem::path bf_path2;
             bf_path2 = boost::filesystem::system_complete(*tok_iter);
             if (!boost::filesystem::is_directory(bf_path2)) {
-                printf("Unable to read the PSI4 Auxililary folder - check the PSIPATH environmental variable\n"
+                printf("Unable to read the Psi4 Auxililary folder - check the PSIPATH environmental variable\n"
                                "      Current value of PSIPATH is %s\n", psiPath.c_str());
                 exit(1);
             }
@@ -1667,14 +1667,14 @@ void Python::run(FILE *input)
         Py_DECREF(path);
         Py_DECREF(sysmod);
 
-        // Track down the location of PSI4's python script directory.
+        // Track down the location of Psi4's python script directory.
         std::string psiDataDirName = Process::environment("PSIDATADIR");
         std::string psiDataDirWithPython = psiDataDirName + "/python";
         boost::filesystem::path bf_path;
         bf_path = boost::filesystem::system_complete(psiDataDirWithPython);
         // printf("Python dir is at %s\n", psiDataDirName.c_str());
         if (!boost::filesystem::is_directory(bf_path)) {
-            printf("Unable to read the PSI4 Python folder - check the PSIDATADIR environmental variable\n"
+            printf("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable\n"
                            "      Current value of PSIDATADIR is %s\n", psiDataDirName.c_str());
             exit(1);
         }

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -137,7 +137,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
   describing the origin about which one-electron properties are computed. -*/
   options.add("PROPERTIES_ORIGIN", new ArrayType());
 
-  /*- PSI4 dies if energy does not converge. !expert -*/
+  /*- Psi4 dies if energy does not converge. !expert -*/
   options.add_bool("DIE_IF_NOT_CONVERGED", true);
   /*- Integral package to use. If compiled with ERD support, ERD is used where possible; LibInt is used otherwise. -*/
   options.add_str("INTEGRAL_PACKAGE", "ERD", "ERD LIBINT");
@@ -2810,7 +2810,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- MODULEDESCRIPTION Interface to MRCC program written by Mih\ |a_acute|\ ly K\ |a_acute|\ llay. -*/
 
       /*- Sets the OMP_NUM_THREADS environment variable before calling MRCC.
-          If the environment variable :envvar:`OMP_NUM_THREADS` is set prior to calling PSI4 then
+          If the environment variable :envvar:`OMP_NUM_THREADS` is set prior to calling Psi4 then
           that value is used. When set, this option overrides everything. Be aware
           the ``-n`` command-line option described in section :ref:`sec:threading`
           does not affect MRCC.
@@ -2988,10 +2988,10 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       `CFOUR Website <http://slater.chemie.uni-mainz.de/cfour/index.php?n=Main.ListOfKeywordsInAlphabeticalOrder>`_
       and extended by interface comments. -*/
 
-      /*- SUBSECTION PSI4 Control of CFOUR -*/
+      /*- SUBSECTION Psi4 Control of CFOUR -*/
 
       /*- Sets the OMP_NUM_THREADS environment variable before calling CFOUR.
-          If the environment variable :envvar:`OMP_NUM_THREADS` is set prior to calling PSI4 then
+          If the environment variable :envvar:`OMP_NUM_THREADS` is set prior to calling Psi4 then
           that value is used. When set, this option overrides everything. Be aware
           the ``-n`` command-line option described in section :ref:`sec:threading`
           does not affect CFOUR.
@@ -3117,7 +3117,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       arbitrary basis (see non-standard basis-set input). However, the
       latter must be available in the supplied GENBAS file. As standard
       basis sets, currently the following are available.
-      **PSI4 Interface:** Recommended to use instead |mints__basis| for
+      **Psi4 Interface:** Recommended to use instead |mints__basis| for
       larger basis set selection and greater flexibility. When |mints__basis|
       used, |cfour__cfour_spherical| is set appropriately. -*/
       options.add_str("CFOUR_BASIS", "SPECIAL", "STO-3G 3-21G 4-31G 6-31G 6-31G* 6-31G** 6-311G 6-311G* 6-311G** DZ DZP TZ TZP TZ2P PVDZ PVTZ PVQZ PV5Z PV6Z PCVDZ PCVTZ PCVQZ PCV5Z PCV6Z AUG-PVDZ AUG-PVTZ AUG-PVTZ AUG-PVQZ AUG-PV5Z AUG-PV6Z D-AUG-PVDZ D-AUG-PVTZ D-AUG-PVQZ D-AUG-PV5Z D-AUG-PV6Z cc-pVDZ cc-pVTZ cc-pVQZ cc-pV5Z cc-pV6Z cc-pCVDZ cc-pCVTZ cc-pCVQZ cc-pCV5Z cc-pCV6Z PWCVDZ PWCVTZ PWCVQZ PWCV5Z PWCV6Z PwCVDZ PwCVTZ PwCVQZ PwCV5Z PwCV6Z svp dzp tzp tzp2p qz2p pz3d2f 13s9p4d3f WMR ANO0 ANO1 ANO2 EVEN_TEMPERED SPECIAL");
@@ -3140,7 +3140,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       //BUFFERSIZE
 
       /*- Defines the level of calculation to be performed.
-      **PSI4 Interface:** Keyword set from argument of computation
+      **Psi4 Interface:** Keyword set from argument of computation
       command: CCSD if ``energy('c4-ccsd')``, *etc.* See :ref:`Energy
       (CFOUR) <table:energy_cfour>` and :ref:`Gradient (CFOUR)
       <table:grad_cfour>`. for all available. -*/
@@ -3189,7 +3189,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       gradients. That is, if you are doing a geometry optimization with
       ROHF as your reference wave function then it is safe to use the
       option VCC.
-      **PSI4 Interface:** Keyword set according to best practice for the
+      **Psi4 Interface:** Keyword set according to best practice for the
       computational method |cfour__cfour_calc_level|, reference
       |cfour__cfour_reference| (NYI) and derivative level
       |cfour__cfour_deriv_level| according to Table :ref:`Best Practices
@@ -3200,7 +3200,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       options.add_str("CFOUR_CC_PROGRAM", "VCC", "VCC ECC MRCC EXTERNAL");
 
       /*- Specifies the molecular charge.
-      **PSI4 Interface:** Keyword set from active molecule. -*/
+      **Psi4 Interface:** Keyword set from active molecule. -*/
       options.add_int("CFOUR_CHARGE", 0);
 
       /*- Specifies the convergence threshold as :math:`10^{-N}` for CIS
@@ -3236,7 +3236,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       internal coordinates defined implicitly by supplying Cartesian
       coordinates. Note that geometry optimizations are currently only
       possible for INTERNAL and XYZ2INT.
-      **PSI4 Interface:** Keyword set from active molecule, always CARTESIAN.
+      **Psi4 Interface:** Keyword set from active molecule, always CARTESIAN.
       Above restrictions on geometry optimizations no longer apply. -*/
       options.add_str("CFOUR_COORDINATES", "INTERNAL", "INTERNAL CARTESIAN XYZINT");
 
@@ -3286,7 +3286,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       that this keyword usually needs not be set in any calculation since
       it is automatically set if the appropriate other options in the
       CFOUR namelist are turned on.
-      **PSI4 Interface:** Keyword set from type of computation command:
+      **Psi4 Interface:** Keyword set from type of computation command:
       ZERO if :py:func:`~driver.energy`, FIRST if
       :py:func:`~driver.gradient` or :py:func:`~driver.optimization`,
       *etc.* -*/
@@ -3443,7 +3443,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Tells the program, in the course of a geometry optimization, to
       calculate the Hessian explicitly every N cycles. 0 means never
       calculated explicitly.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead,
       particularly |optking__full_hess_every|. -*/
@@ -3615,7 +3615,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Specifies the convergence criterion for geometry optimization.
       The optimization terminates when the RMS gradient is below $10^{-N}$
       Hartree/bohr, where $N$ is the specified value.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead,
       particularly |optking__g_convergence| =CFOUR, which should be equivalent
@@ -3624,7 +3624,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
 
       /*- Specifies largest step (in millibohr) which is allowed in
       geometry optimizations.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead,
       particularly |optking__intrafrag_step_limit|. -*/
@@ -3646,7 +3646,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       options.add_str("CFOUR_GEO_METHOD", "SINGLE_POINT", "NR RFA TS MANR SINGLE_POINT ENERONLY");
 
       /*- Specifies the maximum allowed number of geometry optimization cycles.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead,
       particularly |optking__geom_maxiter|. -*/
@@ -3772,14 +3772,14 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       (default) or in the units specified via the keyword |cfour__cfour_mem_unit|.
       Default: 100 000 000 (approximately 381 or 762 MB for 32 or 64 bit
       machines, respectively).
-      **PSI4 Interface:** Keyword set in MB from memory input command when
+      **Psi4 Interface:** Keyword set in MB from memory input command when
       given. -*/
       options.add_int("CFOUR_MEMORY_SIZE", 100000000);
 
       /*- Specifies the units in which the amount of requested core memory
       is given. Possible choices are INTEGERWORDS (default), kB, MB, GB,
       and TB.
-      **PSI4 Interface:** Keyword set from memory input command when
+      **Psi4 Interface:** Keyword set from memory input command when
       given, always MB. -*/
       options.add_str("CFOUR_MEM_UNIT", "INTEGERWORDS", "INTEGERWORDS KB MB GB TB");
 
@@ -3794,7 +3794,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       for minimum (very efficient minimization scheme, particularly if the
       Hessian is available); 4 is currently unavailable;
       SINGLE_POINT (=5) is a single point calculation.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead,
       particularly |optking__opt_type| and |optking__step_type|. -*/
@@ -3805,7 +3805,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       options.add_bool("CFOUR_MRCC", false);
 
       /*- Specifies the spin multiplicity.
-      **PSI4 Interface:** Keyword set from active molecule. -*/
+      **Psi4 Interface:** Keyword set from active molecule. -*/
       options.add_int("CFOUR_MULTIPLICITY", 1);
 
       /*- Calculation of non-adiabatic coupling. In case of ON (=1) the
@@ -3826,7 +3826,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       plugging away (this is strongly discouraged!); and if RFA
       (=2), the keyword |cfour__cfour_geo_method| is switched to RFA internally and the
       optimization is continued.
-      **PSI4 Interface:** Geometry optimizations run through PSI (except in
+      **Psi4 Interface:** Geometry optimizations run through PSI (except in
       sandwich mode) use PSI's optimizer and so this keyword has no effect.
       Use :ref:`optking <apdx:optking>` keywords instead. -*/
       options.add_str("CFOUR_NEGEVAL", "ABORT", "ABORT SWITCH RFA");
@@ -3874,7 +3874,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       usually converge to the lowest energy HF-SCF solution, but this
       should not be blindly assumed.  (Default: The occupation is given
       by the core Hamiltonian initial guess).
-      **PSI4 Interface:** The arrays above are specified in PSI as
+      **Psi4 Interface:** The arrays above are specified in PSI as
       (whitespace-tolerant) [3,1,1,0] and [[3,1,1,0],[3,0,1,0]]. -*/
       options.add("CFOUR_OCCUPATION", new ArrayType());
 
@@ -4056,7 +4056,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       open-shell Hartree-Fock calculation; TCSCF (=3) a
       two-configurational SCF calculation, and CASSCF (=4) a
       complete-active space SCF calculations (currently not implemented).
-      **PSI4 Interface:** Keyword subject to translation from value of
+      **Psi4 Interface:** Keyword subject to translation from value of
       |scf__reference| unless set explicitly. -*/
       options.add_str("CFOUR_REFERENCE", "RHF", "RHF UHF ROHF TCSCF CASSCF");
 
@@ -4133,7 +4133,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Specifies the convergence criterion for the HF-SCF equations.
       Equations are considered converged when the maximum change in
       density matrix elements is less than $10^{-N}$.
-      **PSI4 Interface:** Keyword subject to translation from value of
+      **Psi4 Interface:** Keyword subject to translation from value of
       |scf__d_convergence| unless set explicitly. -*/
       options.add_int("CFOUR_SCF_CONV", 7);
 
@@ -4144,7 +4144,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       currently 1000 (no damping), but a value of 500 is recommended in
       particular for transition metal compounds where the SCF convergence
       is often troublesome.
-      **PSI4 Interface:** Keyword subject to translation from value of
+      **Psi4 Interface:** Keyword subject to translation from value of
       |scf__damping_percentage| unless set explicitly. -*/
       options.add_int("CFOUR_SCF_DAMPING", 1000);
 
@@ -4162,7 +4162,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       options.add_bool("CFOUR_SCF_EXTRAPOLATION", true);
 
       /*- Specifies the maximum number of SCF iterations.
-      **PSI4 Interface:** Keyword subject to translation from value of
+      **Psi4 Interface:** Keyword subject to translation from value of
       |scf__maxiter| unless set explicitly.-*/
       options.add_int("CFOUR_SCF_MAXCYC", 150);
 
@@ -4187,7 +4187,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Specifies whether spherical harmonic (5d, 7f, 9g, etc.) or
       Cartesian (6d, 10f, 15g, etc.) basis functions are to be used. ON (=
       1) uses spherical harmonics, OFF (= 0) uses Cartesians.
-      **PSI4 Interface:** Keyword set according to basis design when
+      **Psi4 Interface:** Keyword set according to basis design when
       |mints__basis| is used instead of |cfour__cfour_basis|. Keyword
       subject to translation from value of |globals__puream| unless set
       explicitly. -*/
@@ -4323,7 +4323,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
 
       /*- Specifies the units used for molecular geometry input. ANGSTROM
       (= 0) uses Angstrom units, BOHR (= 1) specifies atomic units.
-      **PSI4 Interface:** Keyword set from active molecule, always ANGSTROM. -*/
+      **Psi4 Interface:** Keyword set from active molecule, always ANGSTROM. -*/
       options.add_str("CFOUR_UNITS", "ANGSTROM", "ANGSTROM BOHR");
 
       //UNOS
@@ -4529,7 +4529,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
         /*- The DMRG wavefunction multiplicity in the form (2S+1) -*/
         options.add_int("DMRG_WFN_MULTP", -1);
 
-        /*- The DMRG wavefunction irrep uses the same conventions as PSI4. How convenient :-).
+        /*- The DMRG wavefunction irrep uses the same conventions as Psi4. How convenient :-).
             Just to avoid confusion, it's copied here. It can also be found on
             http://sebwouters.github.io/CheMPS2/classCheMPS2_1_1Irreps.html .
 

--- a/src/lib/libJKFactory/CifiedFxns.cc
+++ b/src/lib/libJKFactory/CifiedFxns.cc
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +22,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
+
 #include <omp.h>
 extern "C" {
 #include "CifiedFxns.h"

--- a/src/lib/libJKFactory/CifiedFxns.h
+++ b/src/lib/libJKFactory/CifiedFxns.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +22,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
+
 #ifndef SRC_LIB_LIBJKFACTORY_CIFIEDFXNS_H_
 #define SRC_LIB_LIBJKFACTORY_CIFIEDFXNS_H_
 

--- a/src/lib/libJKFactory/MinimalInterface.cpp
+++ b/src/lib/libJKFactory/MinimalInterface.cpp
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +22,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
 
 #include "MinimalInterface.h"

--- a/src/lib/libJKFactory/MinimalInterface.h
+++ b/src/lib/libJKFactory/MinimalInterface.h
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +22,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
+
 #ifndef SRC_LIB_LIBJKFACTORY_SRC_MINIMALINTERFACE_H_
 #define SRC_LIB_LIBJKFACTORY_SRC_MINIMALINTERFACE_H_
 #include <vector>

--- a/src/lib/libcubeprop/csg.cc
+++ b/src/lib/libcubeprop/csg.cc
@@ -283,7 +283,7 @@ void CubicScalarGrid::write_cube_file(double* v, const std::string& name)
 
     FILE* fh = fopen(ss.str().c_str(), "w");
     // Two comment lines
-    fprintf(fh, "PSI4 Gaussian Cube File.\n");
+    fprintf(fh, "Psi4 Gaussian Cube File.\n");
     fprintf(fh, "Property: %s\n", name.c_str());
 
     // Number of atoms plus origin of data

--- a/src/lib/libfock/cubature.cc
+++ b/src/lib/libfock/cubature.cc
@@ -2317,7 +2317,7 @@ void RadialGridMgr::getMultiExpRoots(int n, double r[], double w[])
     };
 
     if (n > TABSIZE)
-        throw PSIEXCEPTION("PSI4 does not support MultiExp radial grids for n > 200.");
+        throw PSIEXCEPTION("Psi4 does not support MultiExp radial grids for n > 200.");
 
     double a[n], bhack[n+1];
     double *const b = &bhack[1]; // Note that b[n-1] is unused.

--- a/src/lib/libmints/basisset.cc
+++ b/src/lib/libmints/basisset.cc
@@ -326,7 +326,7 @@ std::string BasisSet::print_detail_cfour() const
 
         sprintf(buffer, "%s:P4_%d\n", molecule_->symbol(A).c_str(), A+1);
         ss << buffer;
-        sprintf(buffer, "PSI4 basis %s for element %s atom %d\n\n",
+        sprintf(buffer, "Psi4 basis %s for element %s atom %d\n\n",
                 boost::to_upper_copy(name_).c_str(), molecule_->symbol(A).c_str(), A+1);
         ss << buffer;
 

--- a/src/lib/libparallel/TableSpecs.common
+++ b/src/lib/libparallel/TableSpecs.common
@@ -1,7 +1,12 @@
 /*
- *@BEGIN LICENSE
+ * @BEGIN LICENSE
  *
- * PSI4: an ab initio quantum chemistry software package
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2016 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +22,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *@END LICENSE
+ * @END LICENSE
  */
+
 /* This file is the common implementation of the TableSpecs class
  * it is not meant to be included anywhere else.  Please use TableSpecs.h
  */

--- a/src/lib/libpsio/error.cc
+++ b/src/lib/libpsio/error.cc
@@ -80,7 +80,7 @@ namespace psi {
         fprintf(stderr, "PSIO_ERROR: the $HOME/.psi4rc file.\n");
         fprintf(stderr, "PSIO_ERROR:\n");
         fprintf(stderr, "PSIO_ERROR: Please note that the scratch directory must exist and be\n");
-        fprintf(stderr, "PSIO_ERROR: writable by PSI4\n");
+        fprintf(stderr, "PSIO_ERROR: writable by Psi4\n");
         break;
       case PSIO_ERROR_REOPEN:
         fprintf(stderr, "PSIO_ERROR: %d (file is already open)\n", PSIO_ERROR_REOPEN);

--- a/src/lib/libpsio/filemanager.cc
+++ b/src/lib/libpsio/filemanager.cc
@@ -138,7 +138,7 @@ void PSIOManager::print(std::string out)
    boost::shared_ptr<psi::PsiOutStream> printer=(out=="outfile"?outfile:
             boost::shared_ptr<OutFile>(new OutFile(out)));
     printer->Printf("                    --------------------------------\n");
-    printer->Printf("                    ==> PSI4 Current File Status <==\n");
+    printer->Printf("                    ==> Psi4 Current File Status <==\n");
     printer->Printf( "                    --------------------------------\n");
     printer->Printf( "\n");
 

--- a/src/lib/libqt/dx_write.cc
+++ b/src/lib/libqt/dx_write.cc
@@ -192,7 +192,7 @@ y*pc_bohr2angstroms, z*pc_bohr2angstroms, dens/b2a3);
 
   // Prep .dx file
   boost::shared_ptr<OutFile> printer(new OutFile("density.dx",APPEND));
-  printer->Printf( "#  Output from PSI4 calculation\n");
+  printer->Printf( "#  Output from Psi4 calculation\n");
   printer->Printf( "#  Electronic density (in e/ang^3) for: \n");
   printer->Printf( "object 1 class gridpositions counts %d %d %d\n", xsteps, ysteps, zsteps);
   printer->Printf( "origin %8.6E  %8.6E  %8.6E\n", xmin, ymin, zmin);

--- a/src/lib/libscf_solver/frac.cc
+++ b/src/lib/libscf_solver/frac.cc
@@ -115,7 +115,7 @@ void HF::frac()
 
             // Throw if the user is insane
             if (val < 0.0)
-                throw PSIEXCEPTION("Fractional Occupation SCF: PSI4 is not configured for positrons. Please annihilate and start again");             
+                throw PSIEXCEPTION("Fractional Occupation SCF: Psi4 is not configured for positrons. Please annihilate and start again");
 
             outfile->Printf( "    %-5s orbital %4d will contain %11.3E electron.\n", (i > 0 ? "Alpha" : "Beta"), abs(i), val);
         }


### PR DESCRIPTION
## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Unless in a comment, `PSI4` becomes `Psi4`. This will break everyone's "is it done" scripts unless they were only grepping on "beer"
- [x] pass a few more `wfn=wfn` and license a few more files

## Questions
- [ ]  Everyone ok w/ PSI4 --> Psi4?

## Status
- [ ]  Ready to go


