### PR TITLE
CIWave: Fixes memory leak

### DIFF
--- a/src/bin/detci/ciwave.cc
+++ b/src/bin/detci/ciwave.cc
@@ -449,6 +449,11 @@ void CIWavefunction::cleanup(void) {
     for (int i = 0, cnt = 0; i < 4; i++) {
         free_int_matrix(CalcInfo_->ras_orbs[i]);
     };
+
+
+    if (Parameters_->mcscf) {
+        ints_.reset();
+    }
     // delete CalcInfo_;
     // delete MCSCF_Parameters_;
 

--- a/src/bin/detci/diag_h.cc
+++ b/src/bin/detci/diag_h.cc
@@ -518,8 +518,8 @@ void CIWavefunction::diag_h() {
                          Parameters_->maxnvect, "outfile",
                          Parameters_->print_lvl);
 
-            H0block_free();
         }
+        H0block_free();
 
     } /* end the Davidson-Liu/Mitrushenkov-Olsen-Davidson section */
 

--- a/src/bin/detci/h0block.cc
+++ b/src/bin/detci/h0block.cc
@@ -112,6 +112,11 @@ void CIWavefunction::H0block_free(void)
    int i;
 
    if (H0block_->osize) {
+      free_matrix(H0block_->H0b, H0block_->osize);
+      if (Parameters_->precon == PRECON_GEN_DAVIDSON)
+         free(H0block_->H0b_diag_transpose);
+      free_matrix(H0block_->H0b_diag, H0block_->osize);
+      free_matrix(H0block_->tmp1, H0block_->osize);
       free(H0block_->H00);
       free(H0block_->c0b);
       free(H0block_->c0bp);
@@ -122,15 +127,13 @@ void CIWavefunction::H0block_free(void)
       free(H0block_->alpidx);
       free(H0block_->betidx);
       free(H0block_->blknum);
-      if (Parameters_->precon == PRECON_GEN_DAVIDSON)
-        free(H0block_->H0b_diag_transpose);
-      free_matrix(H0block_->H0b, H0block_->osize);
-      if (Parameters_->precon == PRECON_H0BLOCK_INVERT)
-        free_matrix(H0block_->H0b_inv, H0block_->osize);
-    /*  if (Parameters_->precon == PRECON_H0BLOCK_INVERT ||
-          Parameters_->precon == PRECON_H0BLOCK_ITER_INVERT) */
-        free_matrix(H0block_->tmp1, H0block_->osize);
       free(H0block_->pair);
+      if (Parameters_->precon == PRECON_H0BLOCK_INVERT)
+         free_matrix(H0block_->H0b_inv, H0block_->osize);
+      if (Parameters_->h0block_coupling) {
+         free(H0block_->tmp_array1);
+         free(H0block_->tmp_array2);
+         }
       if (H0block_->nbuf) {
          free(H0block_->buf_num);
          for (i=0; i<H0block_->nbuf; i++) free(H0block_->buf_member[i]);
@@ -692,9 +695,6 @@ void CIWavefunction::H0block_fill()
 
    /* fill upper triangle */
    fill_sym_matrix(H0block_->H0b, H0block_->size);
-
-   evals = init_array(H0block_->guess_size);
-   evecs = init_matrix(H0block_->guess_size, H0block_->guess_size);
 
    if (Parameters_->precon == PRECON_GEN_DAVIDSON)
      size = H0block_->size;

--- a/src/bin/detci/sem.cc
+++ b/src/bin/detci/sem.cc
@@ -1219,12 +1219,45 @@ void CIWavefunction::sem_iter(CIvect &Hd, struct stringwr **alplist, struct stri
    Sigma.close_io_files(1);
    if (Parameters_->nodfile == FALSE) Dvec.close_io_files(1);
 
-   free(mi_iac); free(mi_ibc); free(mi_iaidx); free(mi_ibidx); free(mi_coeff);
-   free(dvecnorm);  free(lastroot);  free(root_converged);
-   free(clpse_norm);  free(did_root);  free_matrix(clpse_dot, nroots);
-   free_matrix(tmpmat, maxnvect);  free(Lvec);
+   // Free N-D arrays
+   for (i=0; i<maxnvect; i++)
+      free_matrix(m_lambda[i], nroots);
+   free(m_lambda);
+
+   for (i=0; i<nroots; i++)
+        free_matrix(M[i], maxnvect);
+   free(M);
+
+   for (i=0; i<maxnvect; i++) {
+      free_matrix(alpha[i], maxnvect);
+      }
+   free(alpha);
+
+   for (i=0; i<maxiter; i++) {
+      for (j=0; j<nroots; j++) {
+         free_matrix(m_alpha[i][j], maxnvect);
+      }
+     free(m_alpha[i]);
+   }
+   free(m_alpha);
+
+   // Free buffers
    free(buffer1);
    free(buffer2);
+
+   // Free arrays
+   free(lastroot);  free(dvecnorm);     free(root_converged);
+   free(did_root);  free(clpse_norm);   free(lse_do_arr);
+   free(renorm_c);  free(x);            free(y);
+   free(E_est);     free(mi_iac);       free(Lvec);
+   free(mi_ibc);    free(mi_iaidx);     free(mi_ibidx);
+   free(mi_coeff);
+
+   // Free matrices
+   free_matrix(clpse_dot, maxnvect);    free_matrix(G, maxnvect);
+   free_matrix(tmpmat, maxnvect);       free_matrix(cmp_cncoe, maxnvect);
+   free_matrix(tr_cmp_cncoe, maxnvect); free_matrix(sigma_overlap, maxnvect);
+   free_matrix(lambda, maxnvect);
 }
 
 }} // namespace psi::detci


### PR DESCRIPTION
## Description
Fixes a memory leak in the CI code where a matrix that scaled like `maxiter^3` was not being freed. This only effected computations where the maximum number of iterations was set to a very large value (100+, default 12).

## Todos
- [x] Fixes CI memory leak
- [x] Ensures the DPD object is freed upon CI exit

## Status
- [x]  Ready to go