### PR TITLE
Stops clang CI builds until LLVM hosts their compilers again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,32 +29,34 @@ matrix:
 #    env: CXX_COMPILER='clang++-3.8' C_COMPILER='clang-3.8' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
 # No release version for 3.8 because of a bug in that version of the compiler
 
-  - os: linux
-    compiler: clang
-    addons: &1
-      apt:
-        sources:
-        - llvm-toolchain-precise-3.5
-        - ubuntu-toolchain-r-test
-        - boost-latest
-        - george-edison55-precise-backports
-        packages:
-        - python-numpy
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - clang-3.5
-        - libhdf5-serial-dev
-        - libboost-filesystem1.55-dev
-        - libboost-chrono1.55-dev
-        - libboost-system1.55-dev
-        - libboost-timer1.55-dev
-        - libboost-python1.55-dev
-        - libboost-regex1.55-dev
-        - libboost-serialization1.55-dev
-        - libboost-thread1.55-dev
-        - gfortran
-    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='release' BOOSTSTR=' ' BOOSTBUILD=''
+
+### Close off until clang is fixed on travis
+#  - os: linux
+#    compiler: clang
+#    addons: &1
+#      apt:
+#        sources:
+#        - llvm-toolchain-precise-3.5
+#        - ubuntu-toolchain-r-test
+#        - boost-latest
+#        - george-edison55-precise-backports
+#        packages:
+#        - python-numpy
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - clang-3.5
+#        - libhdf5-serial-dev
+#        - libboost-filesystem1.55-dev
+#        - libboost-chrono1.55-dev
+#        - libboost-system1.55-dev
+#        - libboost-timer1.55-dev
+#        - libboost-python1.55-dev
+#        - libboost-regex1.55-dev
+#        - libboost-serialization1.55-dev
+#        - libboost-thread1.55-dev
+#        - gfortran
+#    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='release' BOOSTSTR=' ' BOOSTBUILD=''
 #  - os: linux
 #    compiler: clang
 #    addons: *1
@@ -89,32 +91,35 @@ matrix:
 #    compiler: clang
 #    addons: *2
 #    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
-  - os: linux
-    compiler: clang
-    addons: &3
-      apt:
-        sources:
-        - llvm-toolchain-precise-3.7
-        - ubuntu-toolchain-r-test
-        - boost-latest
-        - george-edison55-precise-backports
-        packages:
-        - python-numpy
-        - cmake
-        - cmake-data
-        - liblapack-dev
-        - clang-3.7
-        - libhdf5-serial-dev
-        - libboost-filesystem1.55-dev
-        - libboost-chrono1.55-dev
-        - libboost-system1.55-dev
-        - libboost-timer1.55-dev
-        - libboost-python1.55-dev
-        - libboost-regex1.55-dev
-        - libboost-serialization1.55-dev
-        - libboost-thread1.55-dev
-        - gfortran
-    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+
+### Close off until clang is fixed on travis
+#  - os: linux
+#    compiler: clang
+#    addons: &3
+#      apt:
+#        sources:
+#        - llvm-toolchain-precise-3.7
+#        - ubuntu-toolchain-r-test
+#        - boost-latest
+#        - george-edison55-precise-backports
+#        packages:
+#        - python-numpy
+#        - cmake
+#        - cmake-data
+#        - liblapack-dev
+#        - clang-3.7
+#        - libhdf5-serial-dev
+#        - libboost-filesystem1.55-dev
+#        - libboost-chrono1.55-dev
+#        - libboost-system1.55-dev
+#        - libboost-timer1.55-dev
+#        - libboost-python1.55-dev
+#        - libboost-regex1.55-dev
+#        - libboost-serialization1.55-dev
+#        - libboost-thread1.55-dev
+#        - gfortran
+#    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+
 #  - os: linux
 #    compiler: clang
 #    addons: *3


### PR DESCRIPTION
## Description
Turns off clang in Travis CI until the hosting issue is resolved. Useful links:
 - [LLVM mailing list](http://lists.llvm.org/pipermail/llvm-foundation/2016-May/000020.html)
 - [Travis Ticket](https://github.com/travis-ci/travis-ci/issues/6120)

## Questions
- [x] Any objections?

## Status
- [x]  Ready to go


