### PR TITLE
Fix SAPT2+(3)dMP2 in proc.py

### DIFF
--- a/share/python/procedures/proc.py
+++ b/share/python/procedures/proc.py
@@ -2803,7 +2803,7 @@ def run_sapt(name, **kwargs):
     elif name in ['sapt2+', 'sapt2+dmp2']:
         psi4.set_local_option('SAPT', 'SAPT_LEVEL', 'SAPT2+')
         psi4.set_local_option('SAPT', 'DO_CCD_DISP', False)
-    elif name in ['sapt2+(3)', 'sapt2+(3)']:
+    elif name in ['sapt2+(3)', 'sapt2+(3)dmp2']:
         psi4.set_local_option('SAPT', 'SAPT_LEVEL', 'SAPT2+3')
         psi4.set_local_option('SAPT', 'DO_THIRD_ORDER', False)
         psi4.set_local_option('SAPT', 'DO_CCD_DISP', False)


### PR DESCRIPTION
## Description
SAPT2+(3)dMP2 was doing SAPT0dMP2 because of a typo in proc.py.

## Status
- [x]  Ready to go



