### PR TITLE
externals and plugins prep for 1.0rc2

### DIFF
--- a/cmake/ConfigAmbit.cmake
+++ b/cmake/ConfigAmbit.cmake
@@ -55,10 +55,8 @@ if (NOT Ambit_FOUND)
 
     ExternalProject_Add(interface_ambit
             PREFIX ${CUSTOM_Ambit_LOCATION}
-            GIT_REPOSITORY https://github.com/loriab/ambit
-            GIT_TAG boost61fix
-            #GIT_REPOSITORY https://github.com/jturney/ambit
-            #GIT_TAG v0.1.1-alpha
+            GIT_REPOSITORY https://github.com/jturney/ambit
+            GIT_TAG 17a3b1e
             CMAKE_ARGS "${AmbitCMakeArgs}"
             INSTALL_DIR "${CUSTOM_Ambit_LOCATION}/install"
             )

--- a/cmake/ConfigChemps2.cmake
+++ b/cmake/ConfigChemps2.cmake
@@ -18,7 +18,7 @@ if(NOT CHEMPS2_FOUND)
     ExternalProject_Add(interface_chemps2
         PREFIX ${CUSTOM_CHEMPS2_LOCATION}
         GIT_REPOSITORY https://github.com/SebWouters/CheMPS2
-        GIT_TAG v1.7
+        GIT_TAG v1.7.1
         CMAKE_ARGS 
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                    -DEXTRA_C_FLAGS=${CMAKE_EXTRA_C_FLAGS}

--- a/plugins/skeletonambit/CMakeLists.txt
+++ b/plugins/skeletonambit/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +ambit
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/plugins/skeletonaointegrals/CMakeLists.txt
+++ b/plugins/skeletonaointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +aointegrals
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/plugins/skeletonmointegrals/CMakeLists.txt
+++ b/plugins/skeletonmointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +mointegrals
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/plugins/skeletonscf/CMakeLists.txt
+++ b/plugins/skeletonscf/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +scf
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/plugins/skeletonsointegrals/CMakeLists.txt
+++ b/plugins/skeletonsointegrals/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +sointegrals
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/plugins/skeletonwavefunction/CMakeLists.txt
+++ b/plugins/skeletonwavefunction/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS ${PSIEXE}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG}
+    COMMAND ${PSIEXE} -l ${PROJECT_SOURCE_DIR}/share --new-plugin ${PLUG} +wavefunction
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CCBD}/${PLUG} ${CCBD}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
     COMMAND $(MAKE)

--- a/share/plugin/ambit.cc.template
+++ b/share/plugin/ambit.cc.template
@@ -69,8 +69,6 @@ SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options &options)
     boost::shared_ptr<BasisSet> aoBasis = ref_wfn->basisset();
 
     //   2. Auxiliary basis set
-    // Create a basis set parser object.
-    boost::shared_ptr<BasisSetParser> parser(new Gaussian94BasisSetParser());
     // Construct a new basis set.
     boost::shared_ptr<BasisSet> auxBasis= BasisSet::pyconstruct_auxiliary(molecule,
                                                  "DF_BASIS_MP2", options.get_str("DF_BASIS_MP2"),

--- a/share/plugin/ambit.input.dat.template
+++ b/share/plugin/ambit.input.dat.template
@@ -1,0 +1,27 @@
+
+# PYTHONPATH must include directory above plugin directory.
+#     Define either externally or here, then import plugin.
+sys.path.insert(0, './..')
+import @plugin@
+
+molecule {
+O
+H 1 R
+H 1 R 2 A
+
+R = .9
+A = 104.5
+symmetry c1
+}
+
+set {
+  basis sto-3g
+}
+
+set @plugin@ {
+  print 1
+}
+
+energy('@plugin@')
+
+@plugin@.exampleFN()

--- a/src/bin/psi4/create_new_plugin.cc
+++ b/src/bin/psi4/create_new_plugin.cc
@@ -247,6 +247,9 @@ void create_new_plugin(std::string name, const std::string& template_name)
         // Overwrite the existing pymodule file with a more appropriate one
         file_manager.add_file("scf.pymodule.py.template", "pymodule.py");
     }
+    if(template_name_lower == "ambit"){
+        file_manager.add_file("ambit.input.dat.template", "input.dat");
+    }
     file_manager.process();
 }
 

--- a/src/bin/psi4/gitversion.py
+++ b/src/bin/psi4/gitversion.py
@@ -102,6 +102,9 @@ try:
     if len(fields) == 2:
         if fields[0].endswith('rc'):
             mmp = ''.join(fields)
+        elif fields[0] == '1.0rc2':
+            # special case. choose offset to allow monotonic versioning
+            mmp = '1.0rc' + str(200 + int(fields[1]))
         else:
             mmp = '.'.join(fields)
     else:


### PR DESCRIPTION
## Description
`1.0rc2` prep

## Todones
- [x] pull ambit and chemps repos from proper upstream
- [x] bump chemps to `1.7.1`
- [x] fix that +something plugins weren't actually getting their specialized code. ambit couldn't run with default (c2v) input file
- [x] prep version computer for `1.0rc2`

## Status
- [x]  Ready to go. curious about travis and scf5


