### PR TITLE
Update PCMSolver to its v1.1.4

### DIFF
--- a/cmake/ConfigPCMSolver.cmake
+++ b/cmake/ConfigPCMSolver.cmake
@@ -52,7 +52,7 @@ if(NOT PCMSolver_FOUND)
       DEPENDS custom_boost
       PREFIX ${CUSTOM_PCMSolver_LOCATION}
       GIT_REPOSITORY https://github.com/PCMSolver/pcmsolver
-      GIT_TAG v1.1.3
+      GIT_TAG v1.1.4
       CMAKE_ARGS "${PCMSolverCMakeArgs}"
       INSTALL_DIR "${CUSTOM_PCMSolver_LOCATION}/install"
       )


### PR DESCRIPTION
## Description
The `GIT_TAG` argument to `ExternalProject_Add` was changed to `v1.1.4` to reflect a version bump in [PCMSolver](https://github.com/PCMSolver/pcmsolver/releases/tag/v1.1.4)
I had introduced a bug with v1.1.3 The polarization charges were computed with a degraded accuracy. This was caught neither by the library own unit tests nor by Psi4 tests, as it becomes apparent only when trying to calculate higher-order response properties (available in DALTON, but I failed to run the PCM tests there...)
I apologize for any inconvenience!

## Todos
- [x] Update the version of PCMSolver shipped with Psi4.

## Questions
- [ ]  @loriab should re-build the conda package

## Status
- [x]  Ready to go