### PR TITLE
added the molden_novirtual option to scf - discard unoccupied MOs

### DIFF
--- a/doc/sphinxman/source/molden.rst
+++ b/doc/sphinxman/source/molden.rst
@@ -28,7 +28,9 @@ also used to pass information between |PSIfour| and WebMO, if |PSIfour|
 computations are invoked using the WebMO GUI.  The filename of the 
 Molden file ends in ".molden", and the prefix is determined by 
 |globals__writer_file_label| (if set), or else by the name of the output
-file plus the name of the current molecule.
+file plus the name of the current molecule. If |scf__molden_novirtual|
+is set to true, the unoccupied orbitals are not written to the Molden
+file.
 
 .. autofunction:: driver.molden(wfn, filename)
 
@@ -37,4 +39,5 @@ Options
 
 .. include:: autodir_options_c/scf__molden_write.rst
 .. include:: autodir_options_c/globals__writer_file_label.rst
+.. include:: autodir_options_c/scf__molden_novirtual.rst
 

--- a/doc/sphinxman/source/molden.rst
+++ b/doc/sphinxman/source/molden.rst
@@ -28,8 +28,8 @@ also used to pass information between |PSIfour| and WebMO, if |PSIfour|
 computations are invoked using the WebMO GUI.  The filename of the 
 Molden file ends in ".molden", and the prefix is determined by 
 |globals__writer_file_label| (if set), or else by the name of the output
-file plus the name of the current molecule. If |scf__molden_novirtual|
-is set to true, the unoccupied orbitals are not written to the Molden
+file plus the name of the current molecule. If |scf__molden_with_virtual|
+is set to false, the unoccupied orbitals are not written to the Molden
 file.
 
 .. autofunction:: driver.molden(wfn, filename)
@@ -39,5 +39,5 @@ Options
 
 .. include:: autodir_options_c/scf__molden_write.rst
 .. include:: autodir_options_c/globals__writer_file_label.rst
-.. include:: autodir_options_c/scf__molden_novirtual.rst
+.. include:: autodir_options_c/scf__molden_with_virtual.rst
 

--- a/share/python/driver.py
+++ b/share/python/driver.py
@@ -1822,7 +1822,7 @@ def molden(wfn, filename, density_a=None, density_b=None):
 
         # At this point occupation number will be difficult to build, lets set them to zero
         mw = psi4.MoldenWriter(wfn)
-        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb)
+        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb, True)
 
 
 # Aliases

--- a/src/bin/dcft/dcft_density_UHF.cc
+++ b/src/bin/dcft/dcft_density_UHF.cc
@@ -2166,7 +2166,7 @@ DCFTSolver::write_molden_file() {
     SharedVector dummy_a(new Vector("Dummy Vector Alpha", nirrep_, nmopi_));
     SharedVector dummy_b(new Vector("Dummy Vector Beta", nirrep_, nmopi_));
 
-    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals);
+    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
 
 }
 

--- a/src/bin/dcft/dcft_density_UHF.cc
+++ b/src/bin/dcft/dcft_density_UHF.cc
@@ -2166,7 +2166,7 @@ DCFTSolver::write_molden_file() {
     SharedVector dummy_a(new Vector("Dummy Vector Alpha", nirrep_, nmopi_));
     SharedVector dummy_b(new Vector("Dummy Vector Beta", nirrep_, nmopi_));
 
-    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
+    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, true);
 
 }
 

--- a/src/bin/dfocc/occ_iterations.cc
+++ b/src/bin/dfocc/occ_iterations.cc
@@ -331,7 +331,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbA->to_shared_vector(dummy_a);
 
 	// write
-	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, false);
+	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, true);
 
 	//free
 	aAONO.reset();
@@ -386,7 +386,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbB->to_shared_vector(dummy_b);
 
 	// write
-	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
+	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, true);
 
 	// free
 	aAONO.reset();

--- a/src/bin/dfocc/occ_iterations.cc
+++ b/src/bin/dfocc/occ_iterations.cc
@@ -331,7 +331,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbA->to_shared_vector(dummy_a);
 
 	// write
-	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals);
+	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, false);
 
 	//free
 	aAONO.reset();
@@ -386,7 +386,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbB->to_shared_vector(dummy_b);
 
 	// write
-	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals);
+	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
 
 	// free
 	aAONO.reset();

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -1210,7 +1210,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
-    /* Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). */
+    /*- Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). -*/
     options.add_bool("MOLDEN_NOVIRTUAL", false);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -1210,8 +1210,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
-    /*- Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). -*/
-    options.add_bool("MOLDEN_NOVIRTUAL", false);
+    /*- Write all the MOs to the MOLDEN file (true) or discard the unoccupied MOs (false). -*/
+    options.add_bool("MOLDEN_WITH_VIRTUAL", true);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/
     options.add_bool("GUESS_PERSIST", false);

--- a/src/bin/psi4/read_options.cc
+++ b/src/bin/psi4/read_options.cc
@@ -1210,6 +1210,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
+    /* Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). */
+    options.add_bool("MOLDEN_NOVIRTUAL", false);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/
     options.add_bool("GUESS_PERSIST", false);

--- a/src/bin/scf/main.cc
+++ b/src/bin/scf/main.cc
@@ -115,7 +115,7 @@ SharedWavefunction scf(SharedWavefunction ref_wfn, Options & options, PyObject* 
        HF* hf = (HF*)scf.get();
        SharedVector occA = hf->occupation_a();
        SharedVector occB = hf->occupation_b();
-       molden->write(filename, scf->Ca(), scf->Cb(), scf->epsilon_a(), scf->epsilon_b(),occA,occB,options.get_bool("MOLDEN_NOVIRTUAL"));
+       molden->write(filename, scf->Ca(), scf->Cb(), scf->epsilon_a(), scf->epsilon_b(),occA,occB,options.get_bool("MOLDEN_WITH_VIRTUAL"));
     }
 
     // Print molecular orbitals

--- a/src/bin/scf/main.cc
+++ b/src/bin/scf/main.cc
@@ -115,7 +115,7 @@ SharedWavefunction scf(SharedWavefunction ref_wfn, Options & options, PyObject* 
        HF* hf = (HF*)scf.get();
        SharedVector occA = hf->occupation_a();
        SharedVector occB = hf->occupation_b();
-       molden->write(filename, scf->Ca(), scf->Cb(), scf->epsilon_a(), scf->epsilon_b(),occA,occB);
+       molden->write(filename, scf->Ca(), scf->Cb(), scf->epsilon_a(), scf->epsilon_b(),occA,occB,options.get_bool("MOLDEN_NOVIRTUAL"));
     }
 
     // Print molecular orbitals

--- a/src/lib/libmints/writer.cc
+++ b/src/lib/libmints/writer.cc
@@ -265,7 +265,7 @@ void MoldenWriter::writeNO(const std::string &filename, boost::shared_ptr<Matrix
 }
 
 
-void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool novirtual)
+void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool dovirtual)
 {
     boost::shared_ptr<OutFile> printer(new OutFile(filename,APPEND));
 
@@ -398,10 +398,10 @@ void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> 
     // Number of MOs to write
     int nmoh[wavefunction_->nirrep()];
     for (int h=0; h<wavefunction_->nirrep(); ++h) {
-	if (novirtual)
-	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
-	else
+	if (dovirtual)
 	    nmoh[h] = wavefunction_->nmopi()[h];
+	else
+	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
     }
 
     // do alpha's

--- a/src/lib/libmints/writer.cc
+++ b/src/lib/libmints/writer.cc
@@ -265,7 +265,7 @@ void MoldenWriter::writeNO(const std::string &filename, boost::shared_ptr<Matrix
 }
 
 
-void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB)
+void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool novirtual)
 {
     boost::shared_ptr<OutFile> printer(new OutFile(filename,APPEND));
 
@@ -395,10 +395,19 @@ void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> 
 
     std::vector<std::pair<double, std::pair<int, int> > > mos;
 
+    // Number of MOs to write
+    int nmoh[wavefunction_->nirrep()];
+    for (int h=0; h<wavefunction_->nirrep(); ++h) {
+	if (novirtual)
+	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
+	else
+	    nmoh[h] = wavefunction_->nmopi()[h];
+    }
+
     // do alpha's
     bool SameOcc = true;
     for (int h=0; h<wavefunction_->nirrep(); ++h) {
-        for (int n=0; n<wavefunction_->nmopi()[h]; ++n) {
+        for (int n=0; n<nmoh[h]; ++n) {
             mos.push_back(make_pair(Ea->get(h, n), make_pair(h, n)));
             if(fabs(OccA->get(h,n) - OccB->get(h,n)) > 1e-10)
                 SameOcc = false;
@@ -425,7 +434,7 @@ void MoldenWriter::write(const std::string &filename, boost::shared_ptr<Matrix> 
     mos.clear();
     if (Ca != Cb || Ea != Eb || !SameOcc) {
         for (int h=0; h<wavefunction_->nirrep(); ++h) {
-            for (int n=0; n<wavefunction_->nmopi()[h]; ++n) {
+            for (int n=0; n<nmoh[h]; ++n) {
                 mos.push_back(make_pair(Eb->get(h, n), make_pair(h, n)));
             }
         }

--- a/src/lib/libmints/writer.h
+++ b/src/lib/libmints/writer.h
@@ -76,7 +76,7 @@ class MoldenWriter
     boost::shared_ptr<Wavefunction> wavefunction_;
 
 public:
-    void write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB);
+    void write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool novirtual);
     void writeNO(const std::string &filename, boost::shared_ptr<Matrix> Na, boost::shared_ptr<Matrix> Nb, boost::shared_ptr<Vector> Oa, boost::shared_ptr<Vector> Ob);
     MoldenWriter(boost::shared_ptr<Wavefunction> wavefunction);
 

--- a/src/lib/libmints/writer.h
+++ b/src/lib/libmints/writer.h
@@ -76,7 +76,7 @@ class MoldenWriter
     boost::shared_ptr<Wavefunction> wavefunction_;
 
 public:
-    void write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool novirtual);
+    void write(const std::string &filename, boost::shared_ptr<Matrix> Ca, boost::shared_ptr<Matrix> Cb, boost::shared_ptr<Vector> Ea, boost::shared_ptr<Vector> Eb, boost::shared_ptr<Vector> OccA, boost::shared_ptr<Vector> OccB, bool dovirtual);
     void writeNO(const std::string &filename, boost::shared_ptr<Matrix> Na, boost::shared_ptr<Matrix> Nb, boost::shared_ptr<Vector> Oa, boost::shared_ptr<Vector> Ob);
     MoldenWriter(boost::shared_ptr<Wavefunction> wavefunction);
 


### PR DESCRIPTION
## Description
The MOLDEN file written by psi4, which can be used by our external programs, is HUGE when a reasonably-sized molecule is calculated using a large basis set. Since for many post-processing purposes the virtual orbitals are unnecessary, it would be interesting to have an option to drop writing most virtual MOs to the file, dramatically cutting down its size. This PR implements the molden_novirtual option to SCF. If true (it is false by default to preserve the original behavior), only the occupied orbitals are written to the molden file in a closed-shell molecule. In an open-shell system, 2*max(nocca,noccb) orbitals are written.
