### PR TITLE
rebased: added option to discard unoccupied MOs in MOLDEN file

### DIFF
--- a/doc/sphinxman/source/molden.rst
+++ b/doc/sphinxman/source/molden.rst
@@ -28,7 +28,9 @@ also used to pass information between |PSIfour| and WebMO, if |PSIfour|
 computations are invoked using the WebMO GUI.  The filename of the 
 Molden file ends in ".molden", and the prefix is determined by 
 |globals__writer_file_label| (if set), or else by the name of the output
-file plus the name of the current molecule.
+file plus the name of the current molecule. If |scf__molden_novirtual|
+is set to true, the unoccupied orbitals are not written to the Molden
+file.
 
 .. autofunction:: driver.molden(wfn, filename)
 
@@ -37,4 +39,5 @@ Options
 
 .. include:: autodir_options_c/scf__molden_write.rst
 .. include:: autodir_options_c/globals__writer_file_label.rst
+.. include:: autodir_options_c/scf__molden_novirtual.rst
 

--- a/doc/sphinxman/source/molden.rst
+++ b/doc/sphinxman/source/molden.rst
@@ -28,8 +28,8 @@ also used to pass information between |PSIfour| and WebMO, if |PSIfour|
 computations are invoked using the WebMO GUI.  The filename of the 
 Molden file ends in ".molden", and the prefix is determined by 
 |globals__writer_file_label| (if set), or else by the name of the output
-file plus the name of the current molecule. If |scf__molden_novirtual|
-is set to true, the unoccupied orbitals are not written to the Molden
+file plus the name of the current molecule. If |scf__molden_with_virtual|
+is set to false, the unoccupied orbitals are not written to the Molden
 file.
 
 .. autofunction:: driver.molden(wfn, filename)
@@ -39,5 +39,5 @@ Options
 
 .. include:: autodir_options_c/scf__molden_write.rst
 .. include:: autodir_options_c/globals__writer_file_label.rst
-.. include:: autodir_options_c/scf__molden_novirtual.rst
+.. include:: autodir_options_c/scf__molden_with_virtual.rst
 

--- a/psi4/share/psi4/python/driver.py
+++ b/psi4/share/psi4/python/driver.py
@@ -1757,7 +1757,7 @@ def fchk(wfn, filename):
     fw.write(filename)
 
 
-def molden(wfn, filename=None, density_a=None, density_b=None):
+def molden(wfn, filename=None, density_a=None, density_b=None, dovirtual=None):
     """Function to write wavefunction information in *wfn* to *filename* in
     molden format. Will write natural orbitals from *density* (MO basis) if supplied.
 
@@ -1778,6 +1778,9 @@ def molden(wfn, filename=None, density_a=None, density_b=None):
     :type density_b: psi4.Matrix
     :param density_b: density in the MO basis to build beta NO's from, assumes restricted if not supplied (optional)
 
+    :type dovirtual: bool
+    :param dovirtual: do write all the MOs to the MOLDEN file (true) or discard the unoccupied MOs (false) (optional)
+
     :examples:
 
     >>> # [1] Molden file for DFT calculation
@@ -1792,6 +1795,9 @@ def molden(wfn, filename=None, density_a=None, density_b=None):
 
     if filename is None:
         filename = psi4.get_writer_file_prefix(wfn.molecule().name()) + ".molden"
+
+    if dovirtual is None:
+        dovirt = bool(psi4.get_option("SCF", "MOLDEN_WITH_VIRTUAL"))
 
     if density_a:
         nmopi = wfn.nmopi()
@@ -1828,7 +1834,7 @@ def molden(wfn, filename=None, density_a=None, density_b=None):
             occb = psi4.Vector(wfn.nmopi())
 
         mw = psi4.MoldenWriter(wfn)
-        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb, True)
+        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb, dovirt)
 
 
 # Aliases

--- a/psi4/share/psi4/python/driver.py
+++ b/psi4/share/psi4/python/driver.py
@@ -1826,7 +1826,7 @@ def molden(wfn, filename=None, density_a=None, density_b=None, dovirtual=None):
     else:
         try:
             occa = wfn.occupation_a()
-            occb = wfn.occupation_a()
+            occb = wfn.occupation_b()
         except AttributeError:
             psi4.print_out("\n!Molden warning: This wavefunction does not have occupation numbers.\n"
                            "Writing zero's for occupation numbers\n\n")

--- a/psi4/share/psi4/python/driver.py
+++ b/psi4/share/psi4/python/driver.py
@@ -1828,7 +1828,7 @@ def molden(wfn, filename=None, density_a=None, density_b=None):
             occb = psi4.Vector(wfn.nmopi())
 
         mw = psi4.MoldenWriter(wfn)
-        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb)
+        mw.write(filename, wfn.Ca(), wfn.Cb(), wfn.epsilon_a(), wfn.epsilon_b(), occa, occb, True)
 
 
 # Aliases

--- a/psi4/share/psi4/python/procedures/proc.py
+++ b/psi4/share/psi4/python/procedures/proc.py
@@ -1217,6 +1217,24 @@ def scf_helper(name, **kwargs):
         psi4.set_variable("CURRENT DIPOLE Y", psi4.get_variable("SCF DIPOLE Y"))
         psi4.set_variable("CURRENT DIPOLE Z", psi4.get_variable("SCF DIPOLE Z"))
 
+    # Write out MO's
+    if psi4.get_option("SCF", "PRINT_MOS"):
+        mowriter = psi4.MOWriter(scf_wfn)
+        mowriter.write()
+
+    # Write out a molden file
+    if psi4.get_option("SCF", "MOLDEN_WRITE"):
+        filename = psi4.get_writer_file_prefix(scf_wfn.molecule().name()) + ".molden"
+        dovirt = bool(psi4.get_option("SCF", "MOLDEN_WITH_VIRTUAL"))
+
+        occa = scf_wfn.occupation_a()
+        occb = scf_wfn.occupation_a()
+
+        mw = psi4.MoldenWriter(scf_wfn)
+        mw.write(filename, scf_wfn.Ca(), scf_wfn.Cb(), scf_wfn.epsilon_a(),
+                 scf_wfn.epsilon_b(), scf_wfn.occupation_a(),
+                 scf_wfn.occupation_b(), dovirt)
+
     psi4.tstop()
 
     optstash.restore()

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -890,7 +890,7 @@ void export_mints(py::module& m)
 
     py::class_<MOWriter, std::shared_ptr<MOWriter> >(m, "MOWriter", "docstring").
             def(py::init<std::shared_ptr<Wavefunction> >()).
-            def("write", &NBOWriter::write, "docstring");
+            def("write", &MOWriter::write, "docstring");
 
     py::class_<OperatorSymmetry, std::shared_ptr<OperatorSymmetry> >(m, "MultipoleSymmetry", "docstring").
             def(py::init<int, const std::shared_ptr<Molecule>&,

--- a/psi4/src/psi4/dcft/dcft_density_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_density_UHF.cc
@@ -2167,7 +2167,7 @@ DCFTSolver::write_molden_file() {
     SharedVector dummy_a(new Vector("Dummy Vector Alpha", nirrep_, nmopi_));
     SharedVector dummy_b(new Vector("Dummy Vector Beta", nirrep_, nmopi_));
 
-    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
+    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, true);
 
 }
 

--- a/psi4/src/psi4/dcft/dcft_density_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_density_UHF.cc
@@ -2167,7 +2167,7 @@ DCFTSolver::write_molden_file() {
     SharedVector dummy_a(new Vector("Dummy Vector Alpha", nirrep_, nmopi_));
     SharedVector dummy_b(new Vector("Dummy Vector Beta", nirrep_, nmopi_));
 
-    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals);
+    molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
 
 }
 

--- a/psi4/src/psi4/dfocc/occ_iterations.cc
+++ b/psi4/src/psi4/dfocc/occ_iterations.cc
@@ -332,7 +332,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbA->to_shared_vector(dummy_a);
 
 	// write
-	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals);
+	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, false);
 
 	//free
 	aAONO.reset();
@@ -387,7 +387,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbB->to_shared_vector(dummy_b);
 
 	// write
-	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals);
+	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
 
 	// free
 	aAONO.reset();

--- a/psi4/src/psi4/dfocc/occ_iterations.cc
+++ b/psi4/src/psi4/dfocc/occ_iterations.cc
@@ -332,7 +332,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbA->to_shared_vector(dummy_a);
 
 	// write
-	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, false);
+	molden->write(filename, aAONO, aAONO, dummy_a, dummy_a, aevals, aevals, true);
 
 	//free
 	aAONO.reset();
@@ -387,7 +387,7 @@ void DFOCC::save_mo_to_wfn()
 	eps_orbB->to_shared_vector(dummy_b);
 
 	// write
-	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, false);
+	molden->write(filename, aAONO, bAONO, dummy_a, dummy_b, aevals, bevals, true);
 
 	// free
 	aAONO.reset();

--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -950,7 +950,7 @@ SharedWavefunction dmrg(SharedWavefunction wfn, Options& options)
         std::shared_ptr<MoldenWriter> molden( new MoldenWriter( wfn ) );
         std::string filename = get_writer_file_prefix( wfn->molecule()->name() ) + ".pseudocanonical.molden";
         outfile->Printf( "Write molden file to %s. \n", filename.c_str() );
-        molden->write( filename, wfn->Ca(), wfn->Ca(), sp_energies, sp_energies, occupation, occupation );
+        molden->write( filename, wfn->Ca(), wfn->Ca(), sp_energies, sp_energies, occupation, occupation, true );
 
     }
 

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -271,7 +271,7 @@ void MoldenWriter::writeNO(const std::string &filename, std::shared_ptr<Matrix> 
 }
 
 
-void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB, bool novirtual)
+void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB, bool dovirtual)
 {
     std::shared_ptr<OutFile> printer(new OutFile(filename,APPEND));
 
@@ -404,10 +404,10 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
     // Number of MOs to write
     int nmoh[wavefunction_->nirrep()];
     for (int h=0; h<wavefunction_->nirrep(); ++h) {
-	if (novirtual)
-	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
-	else
+	if (dovirtual)
 	    nmoh[h] = wavefunction_->nmopi()[h];
+	else
+	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
     }
 
     // do alpha's

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -271,7 +271,7 @@ void MoldenWriter::writeNO(const std::string &filename, std::shared_ptr<Matrix> 
 }
 
 
-void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB)
+void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB, bool novirtual)
 {
     std::shared_ptr<OutFile> printer(new OutFile(filename,APPEND));
 
@@ -401,10 +401,19 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
 
     std::vector<std::pair<double, std::pair<int, int> > > mos;
 
+    // Number of MOs to write
+    int nmoh[wavefunction_->nirrep()];
+    for (int h=0; h<wavefunction_->nirrep(); ++h) {
+	if (novirtual)
+	    nmoh[h] = wavefunction_->doccpi()[h]+wavefunction_->soccpi()[h];
+	else
+	    nmoh[h] = wavefunction_->nmopi()[h];
+    }
+
     // do alpha's
     bool SameOcc = true;
     for (int h=0; h<wavefunction_->nirrep(); ++h) {
-        for (int n=0; n<wavefunction_->nmopi()[h]; ++n) {
+        for (int n=0; n<nmoh[h]; ++n) {
             mos.push_back(make_pair(Ea->get(h, n), make_pair(h, n)));
             if(fabs(OccA->get(h,n) - OccB->get(h,n)) > 1e-10)
                 SameOcc = false;
@@ -431,7 +440,7 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
     mos.clear();
     if (Ca != Cb || Ea != Eb || !SameOcc) {
         for (int h=0; h<wavefunction_->nirrep(); ++h) {
-            for (int n=0; n<wavefunction_->nmopi()[h]; ++n) {
+            for (int n=0; n<nmoh[h]; ++n) {
                 mos.push_back(make_pair(Eb->get(h, n), make_pair(h, n)));
             }
         }

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -80,7 +80,7 @@ class MoldenWriter
     std::shared_ptr<Wavefunction> wavefunction_;
 
 public:
-    void write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB);
+    void write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB, bool dovirtual);
     void writeNO(const std::string &filename, std::shared_ptr<Matrix> Na, std::shared_ptr<Matrix> Nb, std::shared_ptr<Vector> Oa, std::shared_ptr<Vector> Ob);
     MoldenWriter(std::shared_ptr<Wavefunction> wavefunction);
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1210,7 +1210,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
-    /* Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). */
+    /*- Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). -*/
     options.add_bool("MOLDEN_NOVIRTUAL", false);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1210,8 +1210,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
-    /*- Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). -*/
-    options.add_bool("MOLDEN_NOVIRTUAL", false);
+    /*- Write all the MOs to the MOLDEN file (true) or discard the unoccupied MOs (false). -*/
+    options.add_bool("MOLDEN_WITH_VIRTUAL", true);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/
     options.add_bool("GUESS_PERSIST", false);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1210,6 +1210,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (if set), or else by the name of the output file plus the name of
     the current molecule. -*/
     options.add_bool("MOLDEN_WRITE", false);
+    /* Write all the MOs to the MOLDEN file (false) or discard the unoccupied MOs (true). */
+    options.add_bool("MOLDEN_NOVIRTUAL", false);
     /*- If true, then repeat the specified guess procedure for the orbitals every time -
     even during a geometry optimization. -*/
     options.add_bool("GUESS_PERSIST", false);


### PR DESCRIPTION
## Description
The MOLDEN file written by psi4, which can be used by our external programs, is HUGE when a reasonably-sized molecule is calculated using a large basis set. Since for many post-processing purposes the virtual orbitals are unnecessary, it would be interesting to have an option to drop writing most virtual MOs to the file, dramatically cutting down its size. This PR implements the molden_novirtual option to SCF. If true (it is false by default to preserve the original behavior), only the occupied orbitals are written to the molden file in a closed-shell molecule. In an open-shell system, 2*max(nocca,noccb) orbitals are written.

## Questions
- [x]  @dgasmith, input file seems unresponsive to `set MOLDEN_WRITE true`. Instead have to keep Wfn and call `molden(Wfn)`. Does that sound right for the new scheme? Otherwise, can just have `molden()` called at end of `energy()` if kw is on. The PR's molden writing was in `src/bin/scf` which is now gone. Is the driver `molden()` the replacement location or did I miss it? Currently set up to be sensitive to `MOLDEN_WITH_VIRTUAL` but whatever's decided about `MOLDEN_WRTIE`, should probably go the same way.

## Status
- [x]  Ready to go


