### PR TITLE
F/I-SAPT section spelling and punctuation typo

### DIFF
--- a/doc/sphinxman/source/fisapt.rst
+++ b/doc/sphinxman/source/fisapt.rst
@@ -45,7 +45,7 @@ F/I-SAPT: Functional Group and/or Intramolecular SAPT
 The FISAPT module provides two extensions to standard SAPT theory to allow for
 (1) an effective two-body partition of the various SAPT terms to localized
 chemical functional groups (F-SAPT) and (2) a means to compute the SAPT
-interaction between two moeities within the embedding field of a third body
+interaction between two moieties within the embedding field of a third body
 (I-SAPT). F-SAPT is designed to provide additional insight into the chemical
 origins of a noncovalent interaction, while I-SAPT allows for one to perform
 a SAPT analysis for intramolecular interactions. F-SAPT and I-SAPT can be
@@ -359,7 +359,7 @@ that permit the customization of the I-SAPT subsystem partition, the convergence
 of the IBO localization procedure, numerical thresholds, etc. We have an entire
 video tutorial devoted to these options `F/I-SAPT Options <https://www.youtube.com/watch?v=KFkPKSUZVfI&index=5&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
 Direct source-code documentation on these options is available :ref:`here
-<apdx:fisapt_psivar>`
+<apdx:fisapt_psivar>`_.
 
 Additional Notes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
Part of the `Documentation Challenge' at the 2016 Psi4 Developers Conference, fixing typo's and other documentation issues.

## Todos
Correct typo's.
- [x] Correct Spelling

## Questions
- [x]  Moiety vs. Moeity? (it's the first one)

## Status
- [x]  Ready to go



`moieties' misspelled in \P1, and missing end punctuation in the final sentence of F/I-SAPT Keywords section.