### PR TITLE
Resolved potential syntax error

### DIFF
--- a/doc/sphinxman/source/numpy.rst
+++ b/doc/sphinxman/source/numpy.rst
@@ -84,7 +84,7 @@ views.  Views can be created in two ways::
     # Access the NumPy object and set all values to 1 through broadcasting
     >>> numpy_mat_view[:] = 1
     
-    >>> print(np.array(mat)
+    >>> print(np.array(mat))
     [[ 1.  1.  1.]
      [ 1.  1.  1.]
      [ 1.  1.  1.]]


### PR DESCRIPTION
## Description
Resolved typo in code which would have given syntax error if copied verbatim.

## Todos
- [x] Fix typo

## Status
- [x]  Ready to go



Corrected print statement in NumPy Views section that was missing a `)'.