### PR TITLE
python 3.5 travis

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,10 @@ Provide a brief description of the PR's purpose here.
 
 ## Todos
 Notable points that this PR has either accomplished or will accomplish.
-- [ ] Feature1
+* **Developer Interest**
+  - [ ] Feature1
+* **User-Facing for Release Notes**
+  - [ ] Feature2
 
 ## Questions
 - [ ]  Question1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - compiler: clang
       env:
         - CXX_COMPILER='clang++-3.9'
-        - PYTHON_VER='2.7'
+        - PYTHON_VER='3.5'
         - C_COMPILER='clang-3.9'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='release'
@@ -29,7 +29,7 @@ matrix:
         - gfortran
     env:
       - CXX_COMPILER='clang++-3.6'
-      - PYTHON_VER='2.7'
+      - PYTHON_VER='3.5'
       - C_COMPILER='clang-3.6'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
@@ -73,7 +73,7 @@ matrix:
         - gfortran
     env:
       - CXX_COMPILER='clang++-3.9'
-      - PYTHON_VER='2.7'
+      - PYTHON_VER='3.5'
       - C_COMPILER='clang-3.9'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
@@ -123,7 +123,7 @@ matrix:
         - gfortran-6
     env:
       - CXX_COMPILER='g++-6'
-      - PYTHON_VER='2.7'
+      - PYTHON_VER='3.5'
       - C_COMPILER='gcc-6'
       - Fortran_COMPILER='gfortran-6'
       - BUILD_TYPE='release'
@@ -148,7 +148,7 @@ matrix:
 #        - gfortran-6
 #    env:
 #      - CXX_COMPILER='g++-6'
-#      - PYTHON_VER='2.7'
+#      - PYTHON_VER='3.5'
 #      - C_COMPILER='gcc-6'
 #      - Fortran_COMPILER='gfortran-6'
 #      - BUILD_TYPE='release'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - compiler: clang
       env:
         - CXX_COMPILER='clang++-3.9'
+        - PYTHON_VER='2.7'
         - C_COMPILER='clang-3.9'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='release'
@@ -22,15 +23,13 @@ matrix:
         - ubuntu-toolchain-r-test
         - george-edison55-precise-backports
         packages:
-        - python-numpy
-        - cmake
-        - cmake-data
         - liblapack-dev
         - clang-3.6
         - libhdf5-serial-dev
         - gfortran
     env:
       - CXX_COMPILER='clang++-3.6'
+      - PYTHON_VER='2.7'
       - C_COMPILER='clang-3.6'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
@@ -42,29 +41,48 @@ matrix:
     addons: &2
       apt:
         sources:
+        - llvm-toolchain-precise-3.6
+        - ubuntu-toolchain-r-test
+        - george-edison55-precise-backports
+        packages:
+        - liblapack-dev
+        - clang-3.6
+        - libhdf5-serial-dev
+        - gfortran
+    env:
+      - CXX_COMPILER='clang++-3.6'
+      - PYTHON_VER='3.5'
+      - C_COMPILER='clang-3.6'
+      - Fortran_COMPILER='gfortran'
+      - BUILD_TYPE='release'
+      - NAME='clang'
+      - VERSION='3.6'
+
+  - os: linux
+    compiler: clang
+    addons: &3
+      apt:
+        sources:
         - llvm-toolchain-precise-3.9
         - ubuntu-toolchain-r-test
         - george-edison55-precise-backports
         packages:
-        - python-numpy
-        - cmake
-        - cmake-data
         - liblapack-dev
         - clang-3.9
         - libhdf5-serial-dev
         - gfortran
     env:
       - CXX_COMPILER='clang++-3.9'
+      - PYTHON_VER='2.7'
       - C_COMPILER='clang-3.9'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
       - NAME='clang'
       - VERSION='3.9'
 
-
   - os: linux
     compiler: gcc
-    addons: &3
+    addons: &4
       apt:
         sources:
         - ubuntu-toolchain-r-test
@@ -80,6 +98,7 @@ matrix:
         - gfortran-4.9
     env:
       - CXX_COMPILER='g++-4.9'
+      - PYTHON_VER='2.7'
       - C_COMPILER='gcc-4.9'
       - Fortran_COMPILER='gfortran-4.9'
       - BUILD_TYPE='release'
@@ -88,7 +107,7 @@ matrix:
 
   - os: linux
     compiler: gcc
-    addons: &4
+    addons: &5
       apt:
         sources:
         - ubuntu-toolchain-r-test
@@ -104,6 +123,7 @@ matrix:
         - gfortran-6
     env:
       - CXX_COMPILER='g++-6'
+      - PYTHON_VER='2.7'
       - C_COMPILER='gcc-6'
       - Fortran_COMPILER='gfortran-6'
       - BUILD_TYPE='release'
@@ -112,7 +132,7 @@ matrix:
 
 #  - os: linux
 #    compiler: gcc
-#    addons: &5
+#    addons: &6
 #      apt:
 #        sources:
 #        - ubuntu-toolchain-r-test
@@ -128,6 +148,7 @@ matrix:
 #        - gfortran-6
 #    env:
 #      - CXX_COMPILER='g++-6'
+#      - PYTHON_VER='2.7'
 #      - C_COMPILER='gcc-6'
 #      - Fortran_COMPILER='gfortran-6'
 #      - BUILD_TYPE='release'
@@ -139,21 +160,24 @@ before_install:
   - free -m
   - df -h
   - ulimit -a
-  - python -V
 install:
-- DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-- mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-- |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-    brew install cmake python
+- if [[ "$PYTHON_VER" == "2.7" ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  else
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   fi
-- |
-  val=`python -c "import sys; print(sys.version[0])"`
-  if [[ $val == "3" ]]; then
-      pip install numpy
-  fi
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+- conda update -q conda
+- conda info -a
+- conda create -q -n p4env python=$PYTHON_VER numpy cmake dftd3 libint libxc gdma libefp -c psi4/label/test -c psi4
+- source activate p4env
+- conda list
 before_script:
-- python -c 'import numpy; print numpy.version.version'
+- python -V
+- python -c 'import numpy; print(numpy.version.version)'
 - cd ${TRAVIS_BUILD_DIR}
 - export CXX=${CXX_COMPILER}
 - export CC=${C_COMPILER}
@@ -162,16 +186,14 @@ before_script:
 - ${CXX_COMPILER} --version
 - ${Fortran_COMPILER} --version
 - ${C_COMPILER} --version
-- mkdir ${TRAVIS_BUILD_DIR}/libint
-- wget http://vergil.chemistry.gatech.edu/test_sphinxman/libint_x86_64.tgz
-- tar -xzvf libint_x86_64.tgz -C ${TRAVIS_BUILD_DIR}/libint
 - > 
     cmake -Bbuild -H. 
     -DCMAKE_CXX_COMPILER=${CXX_COMPILER} 
     -DCMAKE_C_COMPILER=${C_COMPILER} 
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
-    -DCMAKE_PREFIX_PATH=${TRAVIS_BUILD_DIR}/libint
-    -DENABLE_CHEMPS2=off 
+    -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
+    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
+    -DENABLE_gdma=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,28 +41,6 @@ matrix:
     addons: &2
       apt:
         sources:
-        - llvm-toolchain-precise-3.6
-        - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
-        packages:
-        - liblapack-dev
-        - clang-3.6
-        - libhdf5-serial-dev
-        - gfortran
-    env:
-      - CXX_COMPILER='clang++-3.6'
-      - PYTHON_VER='3.5'
-      - C_COMPILER='clang-3.6'
-      - Fortran_COMPILER='gfortran'
-      - BUILD_TYPE='release'
-      - NAME='clang'
-      - VERSION='3.6'
-
-  - os: linux
-    compiler: clang
-    addons: &3
-      apt:
-        sources:
         - llvm-toolchain-precise-3.9
         - ubuntu-toolchain-r-test
         - george-edison55-precise-backports
@@ -82,7 +60,7 @@ matrix:
 
   - os: linux
     compiler: gcc
-    addons: &4
+    addons: &3
       apt:
         sources:
         - ubuntu-toolchain-r-test
@@ -107,7 +85,7 @@ matrix:
 
   - os: linux
     compiler: gcc
-    addons: &5
+    addons: &4
       apt:
         sources:
         - ubuntu-toolchain-r-test
@@ -132,7 +110,7 @@ matrix:
 
 #  - os: linux
 #    compiler: gcc
-#    addons: &6
+#    addons: &5
 #      apt:
 #        sources:
 #        - ubuntu-toolchain-r-test

--- a/doc/sphinxman/document_cfour.py
+++ b/doc/sphinxman/document_cfour.py
@@ -41,7 +41,7 @@ if (len(sys.argv) == 2):
 
 
 def pts(category, pyfile):
-    print 'Auto-documenting %s module %s' % (category, pyfile)
+    print('Auto-documenting %s module %s' % (category, pyfile))
 
 
 # Available psi variables in psi4/driver/qcdb/cfour.py

--- a/doc/sphinxman/document_databases.py
+++ b/doc/sphinxman/document_databases.py
@@ -40,7 +40,7 @@ if (len(sys.argv) == 2):
 
 
 def pts(category, pyfile):
-    print 'Auto-documenting %s file %s' % (category, pyfile)
+    print('Auto-documenting %s file %s' % (category, pyfile))
 
 
 # Available databases in psi4/share/psi4/databases

--- a/doc/sphinxman/document_driver.py
+++ b/doc/sphinxman/document_driver.py
@@ -41,7 +41,7 @@ if (len(sys.argv) == 2):
 
 
 def pts(category, pyfile):
-    print 'Auto-documenting %s file %s' % (category, pyfile)
+    print('Auto-documenting %s file %s' % (category, pyfile))
 
 
 # Main driver modules in psi4/driver

--- a/doc/sphinxman/document_efpfrag.py
+++ b/doc/sphinxman/document_efpfrag.py
@@ -41,7 +41,7 @@ if (len(sys.argv) == 2):
 
 
 def pts(category, pyfile):
-    print 'Auto-documenting %s file %s' % (category, pyfile)
+    print('Auto-documenting %s file %s' % (category, pyfile))
 
 
 def extract_xyz(pyfile):

--- a/doc/sphinxman/document_plugins.py
+++ b/doc/sphinxman/document_plugins.py
@@ -43,7 +43,7 @@ if (len(sys.argv) == 2):
 
 
 def pts(category, pyfile):
-    print 'Auto-documenting %s file %s' % (category, pyfile)
+    print('Auto-documenting %s file %s' % (category, pyfile))
 
 
 # helper fn
@@ -222,7 +222,7 @@ def determine_options(cfilename):
                 elif kw_type == 'PythonDataType':
                     kw_type = 'python'
                 else:
-                    print 'ERROR: unrecognized type %s for %s' % (kw_type, kw_name)
+                    print('ERROR: unrecognized type %s for %s' % (kw_type, kw_name))
                     sys.exit()
 
             if   kw_type == 'str':    kw_type = 'string'
@@ -233,7 +233,7 @@ def determine_options(cfilename):
             elif kw_type == 'map':    pass
             elif kw_type == 'python': pass
             else:
-                print 'ERROR: unrecognized type2 %s for %s' % (kw_type, kw_name)
+                print('ERROR: unrecognized type2 %s for %s' % (kw_type, kw_name))
                 sys.exit()
 
             #print 'kw_name = \t', kw_name

--- a/doc/sphinxman/source/psi4doc/themes/psi4doc/theme.conf
+++ b/doc/sphinxman/source/psi4doc/themes/psi4doc/theme.conf
@@ -60,7 +60,6 @@ sidebar_next_title =
 link_hover_text_color = #1a4162
 link_hover_bg_color   = #d0d3d9
 link_hover_trim_color =
-highlightcolor        = #aacc99
 highlightcolor        = #b9cde4
 
 codebgcolor           = #f2f2f2

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -32,7 +32,7 @@ import os
 import json
 import argparse
 
-parser = argparse.ArgumentParser(description="A hybrid C++/Python quantum chemistry module.")
+parser = argparse.ArgumentParser(description="Psi4: Open-Source Quantum Chemistry")
 parser.add_argument("-i", "--input", default="input.dat", help="Input file name. Default input.dat.")
 parser.add_argument("-o", "--output", help="Redirect output elsewhere.\n"
                                            "Default: when input filename is 'input.dat', then defaults to 'output.dat'. "

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1215,7 +1215,7 @@ void psi4_python_module_finalize()
 
 
 PYBIND11_PLUGIN(core) {
-    py::module core("core", "Psi4: An Open-Source Ab Initio Electronic Structure Package");
+    py::module core("core", "C++ Innards of Psi4: Open-Source Quantum Chemistry");
 //    py::module core("core", R"pbdoc(
 //
 //        Psi4: An Open-Source Ab Initio Electronic Structure Package

--- a/samples/numpy-array-interface/input.dat
+++ b/samples/numpy-array-interface/input.dat
@@ -53,6 +53,9 @@ vec2.set(0, 0, 13)
 
 
 
+dim1_match = list(dim1) == list(dim1.to_tuple())
+dim2_match = list(dim2) == list(dim2.to_tuple())
+
 
 
 
@@ -114,6 +117,14 @@ for n in range(1000):
     tmp.append(np.asarray(Matrix(3, 3)))
 residual = sum(np.sum(x) for x in tmp)
 
+
+
+# Try out JSON serialization
+json_data = irreped_vec.to_serial()
+json_vec = psi4.Vector.from_serial(json_data)
+
+json_data = irreped_mat.to_serial()
+json_vec = psi4.Matrix.from_serial(json_data)
 
 
 

--- a/samples/numpy-array-interface/test.in
+++ b/samples/numpy-array-interface/test.in
@@ -77,8 +77,13 @@ dim2[2] = 2     #TEST
 
 dim1_match = dim1.to_tuple() == (3, 0, 0)     #TEST
 dim2_match = dim2.to_tuple() == (3, 0, 2)     #TEST
-compare_values(dim1_match, True, 9, "Dimension to list test 1")     #TEST
-compare_values(dim2_match, True, 9, "Dimension to list test 1")     #TEST
+compare_values(True, dim1_match, 9, "Dimension to tuple test 1")     #TEST
+compare_values(True, dim2_match, 9, "Dimension to tuple test 2")     #TEST
+
+dim1_match = list(dim1) == list(dim1.to_tuple())
+dim2_match = list(dim2) == list(dim2.to_tuple())
+compare_values(True, dim1_match, 9, "Dimension to list test 1")     #TEST
+compare_values(True, dim2_match, 9, "Dimension to list test 2")     #TEST
 
 dim1_test = Dimension.from_list((3, 0, 0))     #TEST
 dim2_test = Dimension.from_list((3, 0, 2))     #TEST
@@ -184,6 +189,16 @@ for n in range(1000):
 residual = sum(np.sum(x) for x in tmp)
 
 compare_values(0, residual, 9, "View pointers are correctly assigned.")     #TEST
+
+
+# Try out JSON serialization
+json_data = irreped_vec.to_serial()
+json_vec = psi4.Vector.from_serial(json_data)
+compare_vectors(json_vec, irreped_vec, 9, "Irreped psi4.Vector serialized read/write.")     #TEST
+
+json_data = irreped_mat.to_serial()
+json_vec = psi4.Matrix.from_serial(json_data)
+compare_matrices(json_vec, irreped_mat, 9, "Irreped psi4.Vector serialized read/write.")     #TEST
 
 
 


### PR DESCRIPTION
## Description
improve CI testing

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Use miniconda as a source for cmake, python, numpy, libint, libefp, gdma, libxc
- [x] Add a build case with python 3.5 (the clang 3.6, since it's the shortest)
- [x] No more AM<=4 restrictions on quicktests. We should probably continue to keep tests runable w/default (AM=5) integrals, but Travis now using AM=7.
- [x] solicit Release Notes through PR template
- [x] fix up tagline
- [x] make docs build, and thus conda package, py3 compatible

## Status
- [x]  Ready to go



