### PR TITLE
Makes Psi4 fail gracefully when there are no active virtuals in DF-MP2

### DIFF
--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -189,13 +189,23 @@ double DFMP2::compute_energy()
 {
 
     print_header();
+    if (Ca_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+        if (Cb_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+            throw PSIEXCEPTION("There are no occupied orbitals with alpha or beta spin.");
+        }
+        throw PSIEXCEPTION("There are no occupied orbitals with alpha spin.");
+    }
+    if (Cb_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+        throw PSIEXCEPTION("There are no occupied orbitals with beta spin.");
+    }
     if (Ca_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
-        energies_["Opposite-Spin Energy"] = 0.;
-        energies_["Same-Spin Energy"] = 0.;
-        energies_["Singles Energy"] = 0.;
-        outfile->Printf("No virtual orbitals.\n\n");
-        print_energies();
-        return energies_["Total Energy"];
+        if (Cb_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+            throw PSIEXCEPTION("There are no virtual orbitals with alpha or beta spin.");
+        }
+        throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
+    }
+    if (Cb_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+        throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
     }
     timer_on("DFMP2 Singles");
     form_singles();
@@ -216,6 +226,26 @@ double DFMP2::compute_energy()
 SharedMatrix DFMP2::compute_gradient()
 {
     print_header();
+    
+    if (Ca_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+        if (Cb_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+            throw PSIEXCEPTION("There are no occupied orbitals with alpha or beta spin.");
+        }
+        throw PSIEXCEPTION("There are no occupied orbitals with alpha spin.");
+    }
+    if (Cb_subset("AO","ACTIVE_OCC")->colspi()[0] == 0) {
+        throw PSIEXCEPTION("There are no occupied orbitals with beta spin.");
+    }
+
+    if (Ca_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+        if (Cb_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+            throw PSIEXCEPTION("There are no virtual orbitals with alpha or beta spin.");
+        }
+        throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
+    }
+    if (Cb_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+        throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
+    }
 
     timer_on("DFMP2 Singles");
     form_singles();
@@ -2976,12 +3006,6 @@ void UDFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
     
-    if (avir_a == 0) { 
-      throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
-    }
-    if (avir_b == 0) {
-      throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
-    }
 }
 void UDFMP2::form_Aia()
 {
@@ -3657,12 +3681,6 @@ void RODFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
     
-    if (avir_a == 0) { 
-      throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
-    }
-    if (avir_b == 0) {
-      throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
-    }
 }
 
 }}

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -838,6 +838,10 @@ void RDFMP2::print_header()
     outfile->Printf( "\t %7s %7s %7s %7s %7s %7s %7s\n", "CLASS", "FOCC", "OCC", "AOCC", "AVIR", "VIR", "FVIR");
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "PAIRS", focc, occ, aocc, avir, vir, fvir);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
+    
+    if (avir == 0) {
+      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
+    }
 }
 void RDFMP2::form_Aia()
 {
@@ -2957,6 +2961,7 @@ void UDFMP2::print_header()
     int avir_b = Cavir_b_->colspi()[0];
     int occ_b = focc_b + aocc_b;
     int vir_b = fvir_b + avir_b;
+    
 
     outfile->Printf( "\t --------------------------------------------------------\n");
     outfile->Printf( "\t                 NBF = %5d, NAUX = %5d\n", basisset_->nbf(), ribasis_->nbf());
@@ -2965,6 +2970,10 @@ void UDFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "ALPHA", focc_a, occ_a, aocc_a, avir_a, vir_a, fvir_a);
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
+    
+    if (avir_a == 0 || avir_b == 0) {
+      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
+    }
 }
 void UDFMP2::form_Aia()
 {
@@ -3639,6 +3648,10 @@ void RODFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "ALPHA", focc_a, occ_a, aocc_a, avir_a, vir_a, fvir_a);
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
+    
+    if (avir_a == 0 || avir_b == 0) {
+      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
+    }
 }
 
 }}

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -187,7 +187,16 @@ void DFMP2::common_init()
 }
 double DFMP2::compute_energy()
 {
+
     print_header();
+    if (Ca_subset("AO","ACTIVE_VIR")->colspi()[0] == 0) {
+        energies_["Opposite-Spin Energy"] = 0.;
+        energies_["Same-Spin Energy"] = 0.;
+        energies_["Singles Energy"] = 0.;
+        outfile->Printf("No virtual orbitals.\n\n");
+        print_energies();
+        return energies_["Total Energy"];
+    }
     timer_on("DFMP2 Singles");
     form_singles();
     timer_off("DFMP2 Singles");
@@ -838,10 +847,6 @@ void RDFMP2::print_header()
     outfile->Printf( "\t %7s %7s %7s %7s %7s %7s %7s\n", "CLASS", "FOCC", "OCC", "AOCC", "AVIR", "VIR", "FVIR");
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "PAIRS", focc, occ, aocc, avir, vir, fvir);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
-    
-    if (avir == 0) {
-      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
-    }
 }
 void RDFMP2::form_Aia()
 {
@@ -2971,8 +2976,11 @@ void UDFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
     
-    if (avir_a == 0 || avir_b == 0) {
-      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
+    if (avir_a == 0) { 
+      throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
+    }
+    if (avir_b == 0) {
+      throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
     }
 }
 void UDFMP2::form_Aia()
@@ -3649,8 +3657,11 @@ void RODFMP2::print_header()
     outfile->Printf( "\t %7s %7d %7d %7d %7d %7d %7d\n", "BETA", focc_b, occ_b, aocc_b, avir_b, vir_b, fvir_b);
     outfile->Printf( "\t --------------------------------------------------------\n\n");
     
-    if (avir_a == 0 || avir_b == 0) {
-      throw PSIEXCEPTION("Number of active virtual orbitals is zero. Correlation energy = 0. a.u.");
+    if (avir_a == 0) { 
+      throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
+    }
+    if (avir_b == 0) {
+      throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
     }
 }
 


### PR DESCRIPTION
## Description
Previously, Psi4 was segfaulting when there were no occupied or virtual orbitals in a DF-MP2 computation. Now, it handles this a bit more gracefully by throwing.


## Status
- [X]  Ready to go



