### PR TITLE
Added save_xyz() to qcdb.Molecule

### DIFF
--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -321,6 +321,16 @@ class Molecule(LibmintsMolecule):
                     x * factor, y * factor, z * factor)
         return text
 
+    def save_xyz(self, filename, save_ghosts=True, save_natom=False):
+        """Save an XYZ file.
+
+        >>> H2OH2O.save_xyz('h2o.xyz')
+
+        """
+        outfile = open(filename, 'w')
+        outfile.write(self.save_string_xyz(save_ghosts, save_natom))
+        outfile.close()
+
     def format_molecule_for_numpy(self, npobj=True):
         """Returns a NumPy array of the non-dummy atoms of the geometry
         in Cartesian coordinates in Angstroms with element encoded as

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -321,7 +321,7 @@ class Molecule(LibmintsMolecule):
                     x * factor, y * factor, z * factor)
         return text
 
-    def save_xyz(self, filename, save_ghosts=True, save_natom=False):
+    def save_xyz(self, filename, save_ghosts=True, save_natom=True):
         """Save an XYZ file.
 
         >>> H2OH2O.save_xyz('h2o.xyz')


### PR DESCRIPTION
## Description
Added `save_xyz()` function to `qcdb.Molecule` with `save_natom` as additional argument.
Will supersede `LibmintsMolecule.save_xyz()`.  

* **User Interest**
  - [x] Able to save .xyz file of QCDB molecule with (default) or without number of atoms as first line of file.

## Status
- [x]  Ready to go



