### PR TITLE
AO-CASSCF:  Faster integral transformation for direct/DF CASSCF

### DIFF
--- a/psi4/driver/procedures/mcscf/mcscf_solver.py
+++ b/psi4/driver/procedures/mcscf/mcscf_solver.py
@@ -135,9 +135,13 @@ def mcscf_solver(ref_wfn):
         mtype = "   @MCSCF"
         core.print_out("\n   ==> Starting MCSCF iterations <==\n\n")
         core.print_out("        Iter         Total Energy       Delta E   Orb RMS    CI RMS  NCI NORB\n")
-    else:
+    elif mcscf_type == "DF":
         mtype = "   @DF-MCSCF"
         core.print_out("\n   ==> Starting DF-MCSCF iterations <==\n\n")
+        core.print_out("           Iter         Total Energy       Delta E   Orb RMS    CI RMS  NCI NORB\n")
+    else:
+        mtype = "   @AO-MCSCF"
+        core.print_out("\n   ==> Starting AO-MCSCF iterations <==\n\n")
         core.print_out("           Iter         Total Energy       Delta E   Orb RMS    CI RMS  NCI NORB\n")
 
     # Iterate !

--- a/psi4/driver/procedures/mcscf/mcscf_solver.py
+++ b/psi4/driver/procedures/mcscf/mcscf_solver.py
@@ -89,6 +89,7 @@ def mcscf_solver(ref_wfn):
     converged = False
     ah_step = False
     qc_step = False
+    approx_integrals_only = True
 
     # Fake info to start with the inital diagonalization
     ediff = 1.e-4
@@ -148,7 +149,7 @@ def mcscf_solver(ref_wfn):
     for mcscf_iter in range(1, mcscf_max_macroiteration + 1):
 
         # Transform integrals, diagonalize H
-        ciwfn.transform_mcscf_integrals(mcscf_current_step_type == 'TS')
+        ciwfn.transform_mcscf_integrals(approx_integrals_only)
         nci_iter = ciwfn.diag_h(abs(ediff) * 1.e-2, orb_grad_rms * 1.e-3)
 
         ciwfn.form_opdm()
@@ -235,8 +236,10 @@ def mcscf_solver(ref_wfn):
                 (mcscf_iter >= 2):
 
             if mcscf_target_conv_type == 'AH':
+                approx_integrals_only = False
                 ah_step = True
             elif mcscf_target_conv_type == 'OS':
+                approx_integrals_only = False
                 mcscf_current_step_type = 'OS, Prep'
                 break
             else:

--- a/psi4/driver/procedures/proc.py
+++ b/psi4/driver/procedures/proc.py
@@ -4000,13 +4000,14 @@ def run_detcas(name, **kwargs):
 
         # If RHF get MP2 NO's
         # Why doesnt this work for conv?
-        # if (psi4.get_option('SCF', 'SCF_TYPE') == 'DF') and (user_ref == 'RHF') and\
-        #             (psi4.get_option('DETCI', 'MCSCF_TYPE') == 'DF'):
-        #     psi4.set_global_option('ONEPDM', True)
-        #     psi4.set_global_option('OPDM_RELAX', False)
-        #     ref_wfn = run_dfmp2_gradient(name, **kwargs)
-        # else:
-        ref_wfn = scf_helper(name, **kwargs)
+        if ((core.get_option('SCF', 'SCF_TYPE') == 'DF') and (user_ref == 'RHF') and
+                    (core.get_option('DETCI', 'MCSCF_TYPE') in ['DF', 'AO']) and
+                    (core.get_option("DETCI", "MCSCF_GUESS") == "MP2")):
+            core.set_global_option('ONEPDM', True)
+            core.set_global_option('OPDM_RELAX', False)
+            ref_wfn = run_dfmp2_gradient(name, **kwargs)
+        else:
+            ref_wfn = scf_helper(name, **kwargs)
 
         # Ensure IWL files have been written
         if (core.get_option('DETCI', 'MCSCF_TYPE') == 'CONV'):
@@ -4018,8 +4019,6 @@ def run_detcas(name, **kwargs):
 
     # The DF case
     if core.get_option('DETCI', 'MCSCF_TYPE') == 'DF':
-
-        # Do NOT set global options in general, this is a bit of a hack
         if not core.has_option_changed('SCF', 'SCF_TYPE'):
             core.set_global_option('SCF_TYPE', 'DF')
 
@@ -4042,7 +4041,7 @@ def run_detcas(name, **kwargs):
         # Ensure IWL files have been written
         proc_util.check_iwl_file_from_scf_type(core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
     else:
-        raise ValidationError("Run DETCAS: MCSCF_TYPE %s not understood." % str(core.get_option('DETCI', 'MCSCF_TYPE'))
+        raise ValidationError("Run DETCAS: MCSCF_TYPE %s not understood." % str(core.get_option('DETCI', 'MCSCF_TYPE')))
 
 
     # Second-order SCF requires non-symmetric density matrix support

--- a/psi4/driver/procedures/proc.py
+++ b/psi4/driver/procedures/proc.py
@@ -4029,7 +4029,12 @@ def run_detcas(name, **kwargs):
                                             puream=ref_wfn.basisset().has_puream())
         ref_wfn.set_basisset("DF_BASIS_SCF", scf_aux_basis)
 
-    # The non-DF case
+    # The AO case
+    elif core.get_option('DETCI', 'MCSCF_TYPE') == 'AO':
+        if not core.has_option_changed('SCF', 'SCF_TYPE'):
+            core.set_global_option('SCF_TYPE', 'DIRECT')
+
+    # The conventional case
     elif core.get_option('DETCI', 'MCSCF_TYPE') == 'CONV':
         if not core.has_option_changed('SCF', 'SCF_TYPE'):
             core.set_global_option('SCF_TYPE', 'PK')
@@ -4037,7 +4042,7 @@ def run_detcas(name, **kwargs):
         # Ensure IWL files have been written
         proc_util.check_iwl_file_from_scf_type(core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
     else:
-        core.print_out("JK object is figuring out the integrals are written to test.")
+        raise ValidationError("Run DETCAS: MCSCF_TYPE %s not understood." % str(core.get_option('DETCI', 'MCSCF_TYPE'))
 
 
     # Second-order SCF requires non-symmetric density matrix support

--- a/psi4/driver/procedures/proc.py
+++ b/psi4/driver/procedures/proc.py
@@ -4030,12 +4030,15 @@ def run_detcas(name, **kwargs):
         ref_wfn.set_basisset("DF_BASIS_SCF", scf_aux_basis)
 
     # The non-DF case
-    else:
+    elif core.get_option('DETCI', 'MCSCF_TYPE') == 'CONV':
         if not core.has_option_changed('SCF', 'SCF_TYPE'):
             core.set_global_option('SCF_TYPE', 'PK')
 
         # Ensure IWL files have been written
         proc_util.check_iwl_file_from_scf_type(core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
+    else:
+        core.print_out("JK object is figuring out the integrals are written to test.")
+
 
     # Second-order SCF requires non-symmetric density matrix support
     if core.get_option('DETCI', 'MCSCF_ALGORITHM') in ['AH', 'OS']:

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -622,7 +622,11 @@ void CIWavefunction::init_mcscf_object(){
     if (Parameters_->mcscf_type == "DF") {
         if (!df_ints_init_) setup_dfmcscf_ints();
         somcscf_ = std::shared_ptr<SOMCSCF>(new DFSOMCSCF(jk_, dferi_, AO2SO_, H_));
-    } else {
+    } else if (Parameters_->mcscf_type == "AO" ){
+        if (!ints_init_) setup_mcscf_ints_ao();
+        somcscf_ = std::shared_ptr<SOMCSCF>(new IncoreSOMCSCF(jk_, AO2SO_, H_));
+    }
+    else {
         if (!ints_init_) setup_mcscf_ints();
         somcscf_ = std::shared_ptr<SOMCSCF>(new DiskSOMCSCF(jk_, ints_, AO2SO_, H_));
     }

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -331,6 +331,13 @@ private:
     void transform_dfmcscf_ints(bool approx_only = false);
     void rotate_dfmcscf_twoel_ints(SharedMatrix K, SharedVector twoel_out);
 
+    /// MO transformation through TeraCHEM-like
+    /// Added in by Kevin Patrick Hannon
+    void transform_mcscf_ints_ao(bool approx_only = false);
+    void setup_mcscf_ints_ao();
+    SharedMatrix tei_raaa_;
+    SharedMatrix tei_aaaa_;
+
     /// => Globals <= //
     struct stringwr **alplist_;
     struct stringwr **betlist_;

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -441,6 +441,11 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only)
     int nmo = this->nmo();
     int nso = this->nso();
     //TODO:  Figure out why frozen core does not work
+    if(CalcInfo_->frozen_docc.sum() > 0)
+    {
+        outfile->Printf("\n AO-CASSCF does not work with frozen core.  ");
+        throw PSIEXCEPTION("Do not have a working AO-CASSCF code with frozen core");
+    }
     int nmo_no_froze = nmo_ - CalcInfo_->frozen_docc.sum() - CalcInfo_->frozen_uocc.sum();
     SharedMatrix Call(new Matrix(nso_, nmo_));
     SharedMatrix Call_no_froze(new Matrix(nso_, nmo_no_froze));

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -149,8 +149,7 @@ void CIWavefunction::transform_mcscf_integrals(bool approx_only) {
         transform_dfmcscf_ints(approx_only);
     } 
     else if (Parameters_->mcscf_type == "AO")
-        ///Have not implemented a compute TS algorithm
-        transform_mcscf_ints_ao(true);
+        transform_mcscf_ints_ao(approx_only);
     else {
         transform_mcscf_ints(approx_only);
     }
@@ -440,13 +439,8 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only)
     {
         setup_mcscf_ints_ao();
     }
-    int nact = CalcInfo_->num_ci_orbs;
 
-    //TODO:  Figure out why frozen core does not work
-    // if(CalcInfo_->frozen_docc.sum() > 0) {
-    //     outfile->Printf("\n AO-CASSCF does not work with frozen core.  ");
-    //     throw PSIEXCEPTION("Do not have a working AO-CASSCF code with frozen core");
-    // }
+    int nact = CalcInfo_->num_ci_orbs;
     int nrot = nmo_ - CalcInfo_->num_fzc_orbs - CalcInfo_->num_fzv_orbs;
 
     // Transform from the SO to the AO basis for the C matrix.

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -500,7 +500,7 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only)
             CAct->set_column(0, v, Call_vec);
     }
 
-    timer_on("Forming Active Psuedo Density");
+    timer_on("CIWave: Forming Active Psuedo Density");
     ///Step 1:  D_{mu nu} ^{tu} = C_{mu t} C_{nu u} forall t, u in active
     std::vector<std::pair<SharedMatrix, std::vector<int> > > D_vec;
     for(size_t i = 0; i < nact; i++){
@@ -516,7 +516,7 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only)
             D_vec.push_back(std::make_pair(D, ij));
         }
     }
-    timer_off("Forming Active Psuedo Density");
+    timer_off("CIWave: Forming Active Psuedo Density");
 
     std::vector<SharedMatrix>  &Cl = jk_->C_left();
     std::vector<SharedMatrix>  &Cr = jk_->C_right();

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -149,7 +149,8 @@ void CIWavefunction::transform_mcscf_integrals(bool approx_only) {
         transform_dfmcscf_ints(approx_only);
     } 
     else if (Parameters_->mcscf_type == "AO")
-        transform_mcscf_ints_ao(approx_only);
+        ///Have not implemented a compute TS algorithm
+        transform_mcscf_ints_ao(true);
     else {
         transform_mcscf_ints(approx_only);
     }

--- a/psi4/src/psi4/libfock/GTFockJK.cc
+++ b/psi4/src/psi4/libfock/GTFockJK.cc
@@ -44,15 +44,22 @@ struct MinimalInterface{
 #endif
 
 
+#ifdef ENABLE_GTFOCK
 namespace psi {
-GTFockJK::GTFockJK(std::shared_ptr<psi::BasisSet> Primary,
-      size_t NMats,bool AreSymm):
-      JK(Primary),Impl_(new MinimalInterface(NMats,AreSymm)){
+GTFockJK::GTFockJK(std::shared_ptr<psi::BasisSet> Primary) :
+      JK(Primary),Impl_(new MinimalInterface()){
 
 }
 void GTFockJK::compute_JK() {
+
+   NMats_ = C_left_.size();
+   Impl_->create_pfock(NMats_, lr_symmetric_);
    Impl_->SetP(D_ao_);
    Impl_->GetJ(J_ao_);
    Impl_->GetK(K_ao_);
+   Impl_->destroy_gtfock();
 }
+
+
 }
+#endif

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -729,8 +729,9 @@ public:
 class GTFockJK: public JK{
    private:
       ///The actual instance that does the implementing
-
       std::shared_ptr<MinimalInterface> Impl_;
+      int NMats_ = 0;
+      
    protected:
       /// Do we need to backtransform to C1 under the hood?
       virtual bool C1() const { return true; }
@@ -757,9 +758,13 @@ class GTFockJK: public JK{
        *         matrices you'll be passing in are symmetric.
        */
       GTFockJK(std::shared_ptr<psi::BasisSet> Primary,
-            size_t NMats=1,
-            bool AreSymm=true);
-
+            size_t NMats,
+            bool AreSymm);
+      /** \brief Your interface to GTFock that works well with libfock
+      *   GTFock needs number of densities and symmetric at initialization
+      *   This code calls GTFock once the number of densities was read from jk object
+      */
+      GTFockJK(std::shared_ptr<psi::BasisSet> Primary);
 };
 
 /**

--- a/psi4/src/psi4/libfock/soscf.cc
+++ b/psi4/src/psi4/libfock/soscf.cc
@@ -1460,7 +1460,10 @@ SharedMatrix IncoreSOMCSCF::compute_Q(SharedMatrix TPDM)
     int nact3 = nact_ * nact_ * nact_;
     double** TPDMp = TPDM->pointer();
     double** aaaRp = mo_aaar_->pointer();
-    C_DGEMM('N','N',nact_,nmo_,nact3,1.0,TPDMp[0],nact3,aaaRp[0],nact3,1.0,denQp[0],nmo_);
+    ///KPH found that this didn't work for my purpose.  Not sure if it works for anyone else.  No test cases for this.
+    //C_DGEMM('N','N',nact_,nmo_,nact3,1.0,TPDMp[0],nact3,aaaRp[0],nact3,1.0,denQp[0],nmo_);
+    ///TPDM_vwxy G_mwxy -> Q_vm
+    C_DGEMM('N','T',nact_,nmo_,nact3,1.0,TPDMp[0],nact3,aaaRp[0],nact3,1.0,denQp[0],nmo_);
 
     // Symmetry block Q
     SharedMatrix Q(new Matrix("Qvn", nirrep_, nactpi_, nmopi_));

--- a/psi4/src/psi4/libfock/soscf.h
+++ b/psi4/src/psi4/libfock/soscf.h
@@ -337,7 +337,7 @@ protected:
     SharedMatrix mo_aaaa_;
     SharedMatrix mo_aaar_;
 
-}; // DFSOMCSCF class
+};  ///Incore SOMCSCF
 
 
 } // Namespace psi

--- a/psi4/src/psi4/libfock/soscf.h
+++ b/psi4/src/psi4/libfock/soscf.h
@@ -196,6 +196,9 @@ public:
     double current_ci_energy() { return energy_ci_; }
     SharedMatrix current_AFock() { return matrices_["AFock"]; }
     SharedMatrix current_IFock() { return matrices_["IFock"]; }
+    virtual void set_eri_tensors(SharedMatrix, SharedMatrix)
+    {
+    }
 
 protected:
 
@@ -325,6 +328,7 @@ public:
     IncoreSOMCSCF(std::shared_ptr<JK> jk, SharedMatrix AOTOSO, SharedMatrix H);
 
     virtual ~IncoreSOMCSCF();
+    virtual void set_eri_tensors(SharedMatrix aaaa, SharedMatrix aaar);
 
 protected:
 
@@ -332,7 +336,6 @@ protected:
     virtual SharedMatrix compute_Q(SharedMatrix TPDM);
     virtual SharedMatrix compute_Qk(SharedMatrix TPDM, SharedMatrix U, SharedMatrix Uact);
 
-    void set_eri_tensors(SharedMatrix aaaa, SharedMatrix aaar);
     bool eri_tensor_set_;
     SharedMatrix mo_aaaa_;
     SharedMatrix mo_aaar_;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -742,7 +742,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_double("MCSCF_MAX_ROT", 0.5);
 
     /*- Do we run conventional or density fitted? -*/
-    options.add_str("MCSCF_TYPE", "CONV", "DF CONV");
+    options.add_str("MCSCF_TYPE", "CONV", "DF CONV AO");
 
     /*- Apply a list of 2x2 rotation matrices to the orbitals in the form of
     [irrep, orbital1, orbital2, theta] where an angle of 0 would do nothing and an angle
@@ -781,8 +781,6 @@ int read_options(const std::string &name, Options & options, bool suppress_print
 
     /* Cleanup the DPD MCSCF object at the end of a run? */
     options.add_bool("MCSCF_DPD_CLEANUP", true);
-
-
   }
 
 
@@ -1167,7 +1165,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     /*- What algorithm to use for the SCF computation. See Table :ref:`SCF
     Convergence & Algorithm <table:conv_scf>` for default algorithm for
     different calculation types. -*/
-    options.add_str("SCF_TYPE", "PK", "DIRECT DF PK OUT_OF_CORE FAST_DF CD INDEPENDENT");
+    options.add_str("SCF_TYPE", "PK", "DIRECT DF PK OUT_OF_CORE FAST_DF CD INDEPENDENT GTFOCK");
     /*- Maximum numbers of batches to read PK supermatrix. !expert -*/
     options.add_int("PK_MAX_BUCKETS", 500);
     /*- Select the PK algorithm to use. For debug purposes, selection will be automated later. !expert -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -744,6 +744,9 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     /*- Method to handle the two-electron integrals -*/
     options.add_str("MCSCF_TYPE", "CONV", "DF CONV AO");
 
+    /*- Initial MCSCF starting guess, MP2 natural orbitals only available for DF-RHF reference -*/
+    options.add_str("MCSCF_GUESS", "SCF", "MP2 SCF");
+
     /*- Apply a list of 2x2 rotation matrices to the orbitals in the form of
     [irrep, orbital1, orbital2, theta] where an angle of 0 would do nothing and an angle
     of 90 would switch the two orbitals. -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -741,7 +741,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     all values are scaled. -*/
     options.add_double("MCSCF_MAX_ROT", 0.5);
 
-    /*- Do we run conventional or density fitted? -*/
+    /*- Method to handle the two-electron integrals -*/
     options.add_str("MCSCF_TYPE", "CONV", "DF CONV AO");
 
     /*- Apply a list of 2x2 rotation matrices to the orbitals in the form of

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Perl QUIET)
 set(py3_fail_list pywrap-freq-e-sowreap
                   pywrap-freq-g-sowreap pywrap-opt-sowreap
                   pywrap-db2) 
-foreach(test_name adc1 adc2 casscf-fzc-sp casscf-sa-sp casscf-sp castup1 
+foreach(test_name adc1 adc2 casscf-fzc-sp casscf-sa-sp ao-casscf-sp casscf-sp castup1 
                   castup2 castup3 cbs-delta-energy cbs-xtpl-energy 
                   cbs-xtpl-freq cbs-xtpl-gradient cbs-xtpl-opt cbs-xtpl-func 
                   cbs-xtpl-wrapper cc1 cc10 cc11 cc12 cc13 cc13a cc14 cc15 cc16 
@@ -46,7 +46,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-sa-sp casscf-sp castup1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2 
                   ci-property cubeprop decontract dcft-grad1 dcft-grad2 
                   dcft-grad3 dcft-grad4 dcft1 dcft2 dcft3 dcft4 dcft5 dcft6 
-                  dcft7 dcft8 dcft9 dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp 
+                  dcft7 dcft8 dcft9 ao-dfcasscf-sp dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp 
                   dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1 
                   dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-grad1
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfomp2-1 dfomp2-2 dfomp2-3

--- a/tests/ao-casscf-sp/CMakeLists.txt
+++ b/tests/ao-casscf-sp/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(ao-casscf-sp "psi;quicktests;casscf")

--- a/tests/ao-casscf-sp/input.dat
+++ b/tests/ao-casscf-sp/input.dat
@@ -1,0 +1,21 @@
+#! CASSCF/6-31G** energy point
+
+molecule {
+O
+H 1 1.00
+H 1 1.00 2 103.1
+}
+
+set {
+    basis           6-31G**
+    reference       rhf
+    restricted_docc [1, 0, 0, 0]
+    active          [3, 0, 1, 2] 
+    scf_type        direct
+    ints_tolerance  1e-14
+    mcscf_type      ao
+}
+
+casscf_energy = energy('casscf')
+
+compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/ao-casscf-sp/input.dat
+++ b/tests/ao-casscf-sp/input.dat
@@ -18,4 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
+compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/ao-casscf-sp/output.ref
+++ b/tests/ao-casscf-sp/output.ref
@@ -1,0 +1,411 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1a2.dev86 
+
+                         Git: Rev {ao_casscf} e7601e1 
+
+
+    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
+    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
+    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
+    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
+    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
+    (doi: 10.1002/wcms.93)
+
+
+                         Additional Contributions by
+    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
+    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
+    B. P. Pritchard
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 16 November 2016 02:41PM
+
+    Process ID:  16815
+    PSIDATADIR: /Users/kevinhannon/Programs/psi4/psi4src/share
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! CASSCF/6-31G** energy point
+
+molecule {
+O
+H 1 1.00
+H 1 1.00 2 103.1
+}
+
+set {
+    basis           6-31G**
+    reference       rhf
+    restricted_docc [1, 0, 0, 0]
+    active          [3, 0, 1, 2] 
+    scf_type        direct
+    ints_tolerance  1e-14
+    mcscf_type      ao
+}
+
+casscf_energy = energy('casscf')
+
+compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')  #TEST
+--------------------------------------------------------------------------
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    524 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.069592187390    15.994914619560
+           H          0.000000000000    -0.783151105291     0.552239257844     1.007825032070
+           H          0.000000000000     0.783151105291     0.552239257844     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     24.35462  B =     13.63610  C =      8.74166 [cm^-1]
+  Rotational constants: A = 730133.20983  B = 408800.03934  C = 262068.46197 [MHz]
+  Nuclear repulsion =    8.804686618639057
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-14
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/kevinhannon/Programs/psi4/psi4src/share/basis/6-31gss.gbs
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-14
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/kevinhannon/Programs/psi4/psi4src/share/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3361254517E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.91131636997139   -7.59113e+01   1.07844e-01 
+   @DF-RHF iter   1:   -75.97781077166562   -6.64944e-02   2.01717e-02 
+   @DF-RHF iter   2:   -76.00796714618964   -3.01564e-02   1.08745e-02 DIIS
+   @DF-RHF iter   3:   -76.01665151268321   -8.68437e-03   1.63084e-03 DIIS
+   @DF-RHF iter   4:   -76.01718741124949   -5.35899e-04   5.16989e-04 DIIS
+   @DF-RHF iter   5:   -76.01725653383969   -6.91226e-05   1.01491e-04 DIIS
+   @DF-RHF iter   6:   -76.01725988347586   -3.34964e-06   1.73768e-05 DIIS
+   @DF-RHF iter   7:   -76.01725998100528   -9.75294e-08   2.98600e-06 DIIS
+   @DF-RHF iter   8:   -76.01725998332289   -2.31761e-09   3.45426e-07 DIIS
+   @DF-RHF iter   9:   -76.01725998334720   -2.43148e-11   2.92801e-08 DIIS
+   @DF-RHF iter  10:   -76.01725998334724   -4.26326e-14   2.86550e-09 DIIS
+
+  DF guess converged.
+
+  ==> Integral Setup <==
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-14
+
+   @RHF iter  11:   -76.01729654369264   -3.65603e-05   1.19915e-05 DIIS
+   @RHF iter  12:   -76.01729655497029   -1.12776e-08   1.64017e-06 DIIS
+   @RHF iter  13:   -76.01729655525889   -2.88608e-10   4.89627e-07 DIIS
+   @RHF iter  14:   -76.01729655527991   -2.10179e-11   1.68501e-07 DIIS
+   @RHF iter  15:   -76.01729655528283   -2.91323e-12   4.58662e-08 DIIS
+   @RHF iter  16:   -76.01729655528311   -2.84217e-13   5.21119e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.569000     2A1    -1.320609     1B2    -0.678724  
+       3A1    -0.563930     1B1    -0.495004  
+
+    Virtual:                                                              
+
+       4A1     0.202466     2B2     0.292719     3B2     0.981164  
+       5A1     1.056318     6A1     1.129179     2B1     1.168639  
+       4B2     1.294985     7A1     1.413596     1A2     1.802875  
+       8A1     1.806916     3B1     1.918871     9A1     2.513248  
+       5B2     2.537822     6B2     2.713577     2A2     2.921065  
+       4B1     2.947486    10A1     3.291755    11A1     3.620730  
+       7B2     3.874917    12A1     4.077740  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -76.01729655528311
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8046866186390567
+    One-Electron Energy =                -122.3894315046534871
+    Two-Electron Energy =                  37.5674483307313167
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0172965552831101
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0351
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1532
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8819     Total:     0.8819
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.2414     Total:     2.2414
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of SO shells:               9
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Number of irreps:                  4
+      Integral cutoff                 1.00e-14
+      Number of functions per irrep: [  12    2    4    7 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 13617 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+         ---------------------------------------------------------
+                Multi-Configurational Self-Consistent Field
+                            (a 'D E T C I' module)
+
+                 Daniel G. A. Smith, C. David Sherrill, and
+                              Matt L. Leininger
+         ---------------------------------------------------------
+
+
+   ==> Parameters <==
+
+    EX LEVEL       =        8      H0 BLOCKSIZE  =     1000
+    VAL EX LEVEL   =        0      H0 GUESS SIZE =     1000
+    H0COUPLINGSIZE =        0      H0 COUPLING   =       NO
+    MAXITER        =       12      NUM PRINT     =       20
+    NUM ROOTS      =        1      ICORE         =        1
+    PRINT LVL      =        1      FCI           =      YES
+    R CONV         = 1.00e-07      MIXED         =      YES
+    E CONV         = 1.00e-06      MIXED4        =      YES
+    R4S            =       NO      REPL OTF      =       NO
+    DIAG METHOD    =      SEM      FOLLOW ROOT   =        0
+    PRECONDITIONER = DAVIDSON      UPDATE        = DAVIDSON
+    S              =   0.0000      Ms0           =      YES
+    GUESS VECTOR   =   D FILE      OPENTYPE      =     NONE
+    COLLAPSE SIZE  =        1      HD AVG        = EVANGELISTI
+    MAX NUM VECS   =       13      REF SYM       =     AUTO
+    IOPEN        =       NO
+
+    EX ALLOW       =  1  1  1  1  1  1  1  1 
+    STATE AVERAGE  =  1(1.00) 
+
+   ==> CI Orbital and Space information <==
+
+   ------------------------------------------------------
+               Space    Total    A1    A2    B1    B2
+   ------------------------------------------------------
+                 Nso       25    12     2     4     7
+                 Nmo       25    12     2     4     7
+               Ndocc        5     3     0     1     1
+               Nsocc        0     0     0     0     0
+   ------------------------------------------------------
+                        MCSCF Spaces
+   ------------------------------------------------------
+         Frozen DOCC        0     0     0     0     0
+     Restricted DOCC        1     1     0     0     0
+              Active        6     3     0     1     2
+     Restricted DOCC       18     8     2     3     5
+         Frozen UOCC        0     0     0     0     0
+   ------------------------------------------------------
+
+   ==> Setting up CI strings <==
+
+    There are 15 alpha and 15 beta strings
+    The CI space requires 65 (6.50E+01) determinants and 4 blocks
+
+
+   ==> Setting up MCSCF integrals <==
+
+
+   ==> Starting AO-MCSCF iterations <==
+
+           Iter         Total Energy       Delta E   Orb RMS    CI RMS  NCI NORB
+   @AO-MCSCF  1:    -76.029934009734   -1.2637e-02  9.04e-03  8.60e-13    1    1  Initial CI
+      Warning! Maxstep = 0.55, scaling to 0.50
+   @AO-MCSCF  2:    -76.068885953821   -3.8952e-02  1.23e-02  4.32e-06    6    1  TS
+   @AO-MCSCF  3:    -76.072990329991   -4.1044e-03  4.09e-03  4.42e-06    5    1  TS
+   @AO-MCSCF  4:    -76.073632977986   -6.4265e-04  1.61e-03  2.36e-06    5    1  TS, DIIS
+   @AO-MCSCF  5:    -76.073771244723   -1.3827e-04  8.79e-04  1.31e-06    5    1  TS, DIIS
+   @AO-MCSCF  6:    -76.073819048240   -4.7804e-05  5.84e-04  1.31e-07    6    1  TS, DIIS
+   @AO-MCSCF  7:    -76.073838798945   -1.9751e-05  4.15e-04  1.25e-07    6    1  TS, DIIS
+   @AO-MCSCF  8:    -76.073846139702   -7.3408e-06  2.61e-04  2.80e-07    5    1  TS, DIIS
+   @AO-MCSCF  9:    -76.073854681746   -8.5420e-06  2.06e-04  2.31e-07    5    1  TS, DIIS
+   @AO-MCSCF 10:    -76.073862541191   -7.8594e-06  1.64e-04  3.02e-08    6    1  TS, DIIS
+   @AO-MCSCF 11:    -76.073864806278   -2.2651e-06  5.13e-05  3.88e-08    6    1  TS, DIIS
+   @AO-MCSCF 12:    -76.073864822813   -1.6535e-08  3.07e-05  1.50e-08    6    1  TS, DIIS
+   @AO-MCSCF 13:    -76.073864971379   -1.4857e-07  1.02e-05  6.43e-09    6    1  TS, DIIS
+   @AO-MCSCF 14:    -76.073864995330   -2.3950e-08  3.74e-06  5.02e-09    6    1  TS, DIIS
+
+          @AO-MCSCF has converged!
+
+   @AO-MCSCF Final Energy:  -76.073864995329600
+
+   ==> Energetics <==
+
+    SCF energy =          -76.017296555283110
+    Total CI energy =     -76.073864995329600
+
+
+   ==> CI root 1 information <==
+
+    CI Root  1 energy =   -76.073864995329600
+
+   Natural occupation numbers:
+
+        B1   1.999341        A1   1.998802        A1   1.976077
+        B2   1.973937        B2   0.026628        A1   0.025216
+
+   The 20 most important determinants:
+
+    *   1   -0.986840  (    3,    3)  2A1X  3A1X  1B1X  1B2X  
+    *   2    0.080304  (    6,    6)  2A1X  3A1X  1B1X  2B2X  
+    *   3    0.052774  (    4,    4)  2A1X  4A1X  1B1X  1B2X  
+    *   4   -0.051070  (    4,    6)  2A1X  3A1B  4A1A  1B1X  1B2A  2B2B  
+    *   5   -0.051070  (    6,    4)  2A1X  3A1A  4A1B  1B1X  1B2B  2B2A  
+    *   6    0.032189  (    4,    5)  2A1A  3A1B  4A1X  1B1X  1B2X  
+    *   7    0.032189  (    5,    4)  2A1B  3A1A  4A1X  1B1X  1B2X  
+    *   8   -0.031041  (    5,    6)  2A1B  3A1X  4A1A  1B1X  1B2A  2B2B  
+    *   9   -0.031041  (    6,    5)  2A1A  3A1X  4A1B  1B1X  1B2B  2B2A  
+    *  10    0.030843  (    9,    9)  2A1X  3A1X  4A1X  1B1X  
+    *  11    0.030047  (    5,    5)  3A1X  4A1X  1B1X  1B2X  
+    *  12    0.028950  (   10,   10)  2A1X  1B1X  1B2X  2B2X  
+    *  13    0.026536  (    9,   10)  2A1X  3A1A  4A1A  1B1X  1B2B  2B2B  
+    *  14    0.026536  (   10,    9)  2A1X  3A1B  4A1B  1B1X  1B2A  2B2A  
+    *  15   -0.024535  (    3,    7)  2A1X  3A1A  4A1B  1B1X  1B2A  2B2B  
+    *  16   -0.024535  (    7,    3)  2A1X  3A1B  4A1A  1B1X  1B2B  2B2A  
+    *  17    0.019860  (    9,   11)  2A1A  3A1X  4A1A  1B1X  1B2B  2B2B  
+    *  18    0.019860  (   11,    9)  2A1B  3A1X  4A1B  1B1X  1B2A  2B2A  
+    *  19    0.017608  (   11,   11)  3A1X  1B1X  1B2X  2B2X  
+    *  20    0.015802  (   13,   13)  2A1X  3A1X  4A1X  1B2X  
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the CASSCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0351
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.2208
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8142     Total:     0.8142
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.0696     Total:     2.0696
+
+	CASSCF Energy.....................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/ao-dfcasscf-sp/CMakeLists.txt
+++ b/tests/ao-dfcasscf-sp/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(ao-dfcasscf-sp "psi;quicktests;casscf")

--- a/tests/ao-dfcasscf-sp/input.dat
+++ b/tests/ao-dfcasscf-sp/input.dat
@@ -10,7 +10,7 @@ set {
     basis           6-31G**
     df_basis_scf    cc-pvdz-jkfit
     reference       rhf
-    restricted_docc [1, 0, 0, 0]
+    frozen_docc     [1, 0, 0, 0]
     active          [3, 0, 1, 2] 
     scf_type        df
     mcscf_type      ao
@@ -18,4 +18,4 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.0738286, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST
+compare_values(-76.073736807922970, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST

--- a/tests/ao-dfcasscf-sp/input.dat
+++ b/tests/ao-dfcasscf-sp/input.dat
@@ -1,0 +1,21 @@
+#! CASSCF/6-31G** energy point
+
+molecule {
+O
+H 1 1.00
+H 1 1.00 2 103.1
+}
+
+set {
+    basis           6-31G**
+    df_basis_scf    cc-pvdz-jkfit
+    reference       rhf
+    restricted_docc [1, 0, 0, 0]
+    active          [3, 0, 1, 2] 
+    scf_type        df
+    mcscf_type      ao
+}
+
+casscf_energy = energy('casscf')
+
+compare_values(-76.0738286, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST

--- a/tests/ao-dfcasscf-sp/input.dat
+++ b/tests/ao-dfcasscf-sp/input.dat
@@ -18,4 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-76.073736807922970, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST

--- a/tests/ao-dfcasscf-sp/output.ref
+++ b/tests/ao-dfcasscf-sp/output.ref
@@ -1,0 +1,390 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1a2.dev86 
+
+                         Git: Rev {ao_casscf} e7601e1 
+
+
+    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
+    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
+    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
+    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
+    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
+    (doi: 10.1002/wcms.93)
+
+
+                         Additional Contributions by
+    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
+    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
+    B. P. Pritchard
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 16 November 2016 02:41PM
+
+    Process ID:  16827
+    PSIDATADIR: /Users/kevinhannon/Programs/psi4/psi4src/share
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! CASSCF/6-31G** energy point
+
+molecule {
+O
+H 1 1.00
+H 1 1.00 2 103.1
+}
+
+set {
+    basis           6-31G**
+    df_basis_scf    cc-pvdz-jkfit
+    reference       rhf
+    restricted_docc [1, 0, 0, 0]
+    active          [3, 0, 1, 2] 
+    scf_type        df
+    mcscf_type      ao
+}
+
+casscf_energy = energy('casscf')
+
+compare_values(-76.0738286, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST
+--------------------------------------------------------------------------
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    524 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.069592187390    15.994914619560
+           H          0.000000000000    -0.783151105291     0.552239257844     1.007825032070
+           H          0.000000000000     0.783151105291     0.552239257844     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     24.35462  B =     13.63610  C =      8.74166 [cm^-1]
+  Rotational constants: A = 730133.20983  B = 408800.03934  C = 262068.46197 [MHz]
+  Nuclear repulsion =    8.804686618639057
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/kevinhannon/Programs/psi4/psi4src/share/basis/6-31gss.gbs
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/kevinhannon/Programs/psi4/psi4src/share/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3361254517E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.91131636997136   -7.59113e+01   1.07844e-01 
+   @DF-RHF iter   1:   -75.97781077166553   -6.64944e-02   2.01717e-02 
+   @DF-RHF iter   2:   -76.00796714618963   -3.01564e-02   1.08745e-02 DIIS
+   @DF-RHF iter   3:   -76.01665151268307   -8.68437e-03   1.63084e-03 DIIS
+   @DF-RHF iter   4:   -76.01718741124941   -5.35899e-04   5.16989e-04 DIIS
+   @DF-RHF iter   5:   -76.01725653383957   -6.91226e-05   1.01491e-04 DIIS
+   @DF-RHF iter   6:   -76.01725988347579   -3.34964e-06   1.73768e-05 DIIS
+   @DF-RHF iter   7:   -76.01725998100520   -9.75294e-08   2.98600e-06 DIIS
+   @DF-RHF iter   8:   -76.01725998332282   -2.31762e-09   3.45426e-07 DIIS
+   @DF-RHF iter   9:   -76.01725998334710   -2.42864e-11   2.92801e-08 DIIS
+   @DF-RHF iter  10:   -76.01725998334716   -5.68434e-14   2.86550e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.569001     2A1    -1.320617     1B2    -0.678724  
+       3A1    -0.563921     1B1    -0.494994  
+
+    Virtual:                                                              
+
+       4A1     0.202464     2B2     0.292735     3B2     0.981214  
+       5A1     1.056373     6A1     1.129238     2B1     1.168666  
+       4B2     1.295134     7A1     1.413717     1A2     1.803418  
+       8A1     1.807591     3B1     1.919544     9A1     2.513656  
+       5B2     2.538563     6B2     2.713724     2A2     2.921723  
+       4B1     2.948260    10A1     3.292263    11A1     3.621690  
+       7B2     3.876039    12A1     4.078097  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01725998334716
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8046866186390567
+    One-Electron Energy =                -122.3893793479470276
+    Two-Electron Energy =                  37.5674327459608079
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0172599833471736
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0351
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1531
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8820     Total:     0.8820
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.2417     Total:     2.2417
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of SO shells:               9
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  12    2    4    7 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 13773 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+         ---------------------------------------------------------
+                Multi-Configurational Self-Consistent Field
+                            (a 'D E T C I' module)
+
+                 Daniel G. A. Smith, C. David Sherrill, and
+                              Matt L. Leininger
+         ---------------------------------------------------------
+
+
+   ==> Parameters <==
+
+    EX LEVEL       =        8      H0 BLOCKSIZE  =     1000
+    VAL EX LEVEL   =        0      H0 GUESS SIZE =     1000
+    H0COUPLINGSIZE =        0      H0 COUPLING   =       NO
+    MAXITER        =       12      NUM PRINT     =       20
+    NUM ROOTS      =        1      ICORE         =        1
+    PRINT LVL      =        1      FCI           =      YES
+    R CONV         = 1.00e-07      MIXED         =      YES
+    E CONV         = 1.00e-06      MIXED4        =      YES
+    R4S            =       NO      REPL OTF      =       NO
+    DIAG METHOD    =      SEM      FOLLOW ROOT   =        0
+    PRECONDITIONER = DAVIDSON      UPDATE        = DAVIDSON
+    S              =   0.0000      Ms0           =      YES
+    GUESS VECTOR   =   D FILE      OPENTYPE      =     NONE
+    COLLAPSE SIZE  =        1      HD AVG        = EVANGELISTI
+    MAX NUM VECS   =       13      REF SYM       =     AUTO
+    IOPEN        =       NO
+
+    EX ALLOW       =  1  1  1  1  1  1  1  1 
+    STATE AVERAGE  =  1(1.00) 
+
+   ==> CI Orbital and Space information <==
+
+   ------------------------------------------------------
+               Space    Total    A1    A2    B1    B2
+   ------------------------------------------------------
+                 Nso       25    12     2     4     7
+                 Nmo       25    12     2     4     7
+               Ndocc        5     3     0     1     1
+               Nsocc        0     0     0     0     0
+   ------------------------------------------------------
+                        MCSCF Spaces
+   ------------------------------------------------------
+         Frozen DOCC        0     0     0     0     0
+     Restricted DOCC        1     1     0     0     0
+              Active        6     3     0     1     2
+     Restricted DOCC       18     8     2     3     5
+         Frozen UOCC        0     0     0     0     0
+   ------------------------------------------------------
+
+   ==> Setting up CI strings <==
+
+    There are 15 alpha and 15 beta strings
+    The CI space requires 65 (6.50E+01) determinants and 4 blocks
+
+
+   ==> Setting up MCSCF integrals <==
+
+
+   ==> Starting AO-MCSCF iterations <==
+
+           Iter         Total Energy       Delta E   Orb RMS    CI RMS  NCI NORB
+   @AO-MCSCF  1:    -76.029899529419   -1.2640e-02  9.04e-03  5.66e-13    1    1  Initial CI
+      Warning! Maxstep = 0.55, scaling to 0.50
+   @AO-MCSCF  2:    -76.068848788943   -3.8949e-02  1.23e-02  4.32e-06    6    1  TS
+   @AO-MCSCF  3:    -76.072954159272   -4.1054e-03  4.09e-03  4.42e-06    5    1  TS
+   @AO-MCSCF  4:    -76.073596827920   -6.4267e-04  1.61e-03  2.36e-06    5    1  TS, DIIS
+   @AO-MCSCF  5:    -76.073735035240   -1.3821e-04  8.79e-04  1.31e-06    5    1  TS, DIIS
+   @AO-MCSCF  6:    -76.073782796392   -4.7761e-05  5.84e-04  1.31e-07    6    1  TS, DIIS
+   @AO-MCSCF  7:    -76.073802520380   -1.9724e-05  4.15e-04  1.25e-07    6    1  TS, DIIS
+   @AO-MCSCF  8:    -76.073809859812   -7.3394e-06  2.61e-04  2.80e-07    5    1  TS, DIIS
+   @AO-MCSCF  9:    -76.073818403837   -8.5440e-06  2.06e-04  2.31e-07    5    1  TS, DIIS
+   @AO-MCSCF 10:    -76.073826267886   -7.8640e-06  1.64e-04  3.02e-08    6    1  TS, DIIS
+   @AO-MCSCF 11:    -76.073828530164   -2.2623e-06  5.11e-05  3.88e-08    6    1  TS, DIIS
+   @AO-MCSCF 12:    -76.073828546682   -1.6519e-08  3.06e-05  1.50e-08    6    1  TS, DIIS
+   @AO-MCSCF 13:    -76.073828694622   -1.4794e-07  1.02e-05  6.42e-09    6    1  TS, DIIS
+   @AO-MCSCF 14:    -76.073828718340   -2.3717e-08  3.72e-06  4.99e-09    6    1  TS, DIIS
+
+          @AO-MCSCF has converged!
+
+   @AO-MCSCF Final Energy:  -76.073828718339868
+
+   ==> Energetics <==
+
+    SCF energy =          -76.017259983347174
+    Total CI energy =     -76.073828718339868
+
+
+   ==> CI root 1 information <==
+
+    CI Root  1 energy =   -76.073828718339868
+
+   Natural occupation numbers:
+
+        B1   1.999341        A1   1.998802        A1   1.976076
+        B2   1.973936        B2   0.026629        A1   0.025217
+
+   The 20 most important determinants:
+
+    *   1    0.986839  (    3,    3)  2A1X  3A1X  1B1X  1B2X  
+    *   2   -0.080306  (    6,    6)  2A1X  3A1X  1B1X  2B2X  
+    *   3   -0.052774  (    4,    4)  2A1X  4A1X  1B1X  1B2X  
+    *   4    0.051072  (    4,    6)  2A1X  3A1B  4A1A  1B1X  1B2A  2B2B  
+    *   5    0.051072  (    6,    4)  2A1X  3A1A  4A1B  1B1X  1B2B  2B2A  
+    *   6   -0.032191  (    4,    5)  2A1A  3A1B  4A1X  1B1X  1B2X  
+    *   7   -0.032191  (    5,    4)  2A1B  3A1A  4A1X  1B1X  1B2X  
+    *   8    0.031043  (    5,    6)  2A1B  3A1X  4A1A  1B1X  1B2A  2B2B  
+    *   9    0.031043  (    6,    5)  2A1A  3A1X  4A1B  1B1X  1B2B  2B2A  
+    *  10   -0.030843  (    9,    9)  2A1X  3A1X  4A1X  1B1X  
+    *  11   -0.030049  (    5,    5)  3A1X  4A1X  1B1X  1B2X  
+    *  12   -0.028946  (   10,   10)  2A1X  1B1X  1B2X  2B2X  
+    *  13   -0.026539  (    9,   10)  2A1X  3A1A  4A1A  1B1X  1B2B  2B2B  
+    *  14   -0.026539  (   10,    9)  2A1X  3A1B  4A1B  1B1X  1B2A  2B2A  
+    *  15    0.024533  (    3,    7)  2A1X  3A1A  4A1B  1B1X  1B2A  2B2B  
+    *  16    0.024533  (    7,    3)  2A1X  3A1B  4A1A  1B1X  1B2B  2B2A  
+    *  17   -0.019861  (    9,   11)  2A1A  3A1X  4A1A  1B1X  1B2B  2B2B  
+    *  18   -0.019861  (   11,    9)  2A1B  3A1X  4A1B  1B1X  1B2A  2B2A  
+    *  19   -0.017608  (   11,   11)  3A1X  1B1X  1B2X  2B2X  
+    *  20   -0.015797  (   13,   13)  2A1X  3A1X  4A1X  1B2X  
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the CASSCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0351
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.2208
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8143     Total:     0.8143
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.0698     Total:     2.0698
+
+	AO-DFCASSCF Energy................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/casscf-fzc-sp/input.dat
+++ b/tests/casscf-fzc-sp/input.dat
@@ -18,4 +18,5 @@ set {
 casscf_energy = energy('casscf')
 
 
+compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-76.073773094606, casscf_energy, 6, 'FZC CASSCF Energy')  #TEST

--- a/tests/casscf-sa-sp/input.dat
+++ b/tests/casscf-sa-sp/input.dat
@@ -52,6 +52,6 @@ set detci {
 
 
 casscf_energy = energy('casscf')
-
+compare_values(-75.375529547673, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-75.604189247182, casscf_energy, 6, 'CASSCF Energy')  #TEST
 

--- a/tests/dfcasscf-fzc-sp/input.dat
+++ b/tests/dfcasscf-fzc-sp/input.dat
@@ -16,4 +16,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.073736690209159, casscf_energy, 5, 'FZC CASSCF Energy')  #TEST
+compare_values(-76.01725998335047, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.07373669020915, casscf_energy, 5, 'FZC CASSCF Energy')  #TEST

--- a/tests/dfcasscf-sa-sp/input.dat
+++ b/tests/dfcasscf-sa-sp/input.dat
@@ -27,5 +27,6 @@ set {
 
 casscf_energy = energy('casscf')
 
+compare_values(-153.017422024965640, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-153.103747672024809, casscf_energy, 6, 'CASSCF Energy')  #TEST
 

--- a/tests/dfcasscf-sp/input.dat
+++ b/tests/dfcasscf-sp/input.dat
@@ -17,5 +17,5 @@ set {
 
 
 casscf_energy = energy('casscf')
-ref_casscf_energy = -76.073828605037164
-compare_values(ref_casscf_energy, casscf_energy, 6, 'CASSCF Energy')  #TEST
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.073828605037164, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/dfrasscf-sp/input.dat
+++ b/tests/dfrasscf-sp/input.dat
@@ -24,4 +24,5 @@ molecule mol {
 
 rasscf_energy = energy('RASSCF')
 
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-76.073028564767768, rasscf_energy, 6, 'RASSCF Energy')  #TEST

--- a/tests/rasscf-sp/input.dat
+++ b/tests/rasscf-sp/input.dat
@@ -23,5 +23,5 @@ molecule mol {
 
 rasscf_energy = energy('RASSCF')
 
-
+compare_values(-76.017259983350, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
 compare_values(-76.073064815921, rasscf_energy, 6, 'RASSCF Energy')  #TEST


### PR DESCRIPTION
## Description
I added a new integral transformation for CASSCF.  This PR does the integral transformation as a series of J builds rather than actually carrying out an N^5 integral transformation.  For direct, DF, gtfock, this can provide some significant savings.  

For example, a system with 3248 basis functions, the AO-DF-CASSCF performs the CASSCF procedure in 7054 second while the DF-CASSCF performs the CASSCF procedure in 14800 seconds.  

This is a serial version of the AO-CASSCF procedure.  It is possible to implement this in parallel by using a distributed Fock builder.  I will make another PR once I can get GTFock to compile, but this code works without GTFock and MPI.   

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x]  Corrected a call to build Q in IncoreSOMCSCF
  - [x]  Allowing GTFockJK to work better with libfock (can initialize GTFockJK and compute later on)
  - [x]  Added two test cases for this feature: ao-casscf-sp and ao-dfcasscf-sp
 -  [x]   I don't understand how the CI ordering works for frozen core.  Might need a little guidance for this.  
 ## Questions
- [x]  @dgasmith, 
Could you take a look at how to add frozen core to the integral transformation?
I can show you how I have frozen core in my CASSCF, but I don't understand how the CI ordering changes with frozen core.
- [x] I tried to add test cases, but I am not sure if I followed the right way to add test cases. Please take a look to make sure I added those correctly.  

## Status
- [x]  If you are fine with no frozen core, this is ready to go.  


