### PR TITLE
Minor Psi4 fixes for v1.1

### DIFF
--- a/psi4/driver/procedures/proc.py
+++ b/psi4/driver/procedures/proc.py
@@ -3081,6 +3081,8 @@ def run_sapt(name, **kwargs):
         core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
         sapt_dimer = ref_wfn.molecule()
     sapt_dimer.update_geometry()  # make sure since mol from wfn, kwarg, or P::e
+    sapt_dimer.fix_orientation(True)
+    sapt_dimer.fix_com(True)
 
     # Shifting to C1 so we need to copy the active molecule
     if sapt_dimer.schoenflies_symbol() != 'c1':
@@ -3259,6 +3261,8 @@ def run_sapt_ct(name, **kwargs):
         core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
         sapt_dimer = ref_wfn.molecule()
     sapt_dimer.update_geometry()  # make sure since mol from wfn, kwarg, or P::e
+    sapt_dimer.fix_orientation(True)
+    sapt_dimer.fix_com(True)
 
     # Shifting to C1 so we need to copy the active molecule
     if sapt_dimer.schoenflies_symbol() != 'c1':

--- a/psi4/driver/procedures/proc_util.py
+++ b/psi4/driver/procedures/proc_util.py
@@ -129,8 +129,16 @@ def check_iwl_file_from_scf_type(scf_type, wfn):
     Ensures that a IWL file has been written based on input SCF type.
     """
 
+
     if scf_type in ['DF', 'CD', 'PK', 'DIRECT']:
         mints = core.MintsHelper(wfn.basisset())
+        if core.get_global_option("RELATIVISTIC") in ["X2C", "DKH"]:
+            rel_bas = core.BasisSet.build(wfn.molecule(), "BASIS_RELATIVISTIC",
+                                          core.get_option("SCF", "BASIS_RELATIVISTIC"),
+                                          "DECON", core.get_global_option('BASIS'),
+                                          puream=wfn.basisset().has_puream())
+            mints.set_rel_basisset(rel_bas)
+
         mints.set_print(1)
         mints.integrals()
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -568,6 +568,7 @@ void export_mints(py::module& m)
             def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "docstring").
             def("mo_spin_eri", &MintsHelper::mo_spin_eri, "docstring").
             def("mo_transform", &MintsHelper::mo_transform, "docstring").
+            def("set_rel_basisset", &MintsHelper::set_rel_basisset, "docstring").
 
             def("play", &MintsHelper::play, "docstring");
 

--- a/tests/x2c1/input.dat
+++ b/tests/x2c1/input.dat
@@ -2,8 +2,10 @@
 #! The reference numbers are from Lan Cheng's implementation in Cfour
 
 ref_nuc_energy =  8.316179709840201 #TEST
-ref_nr_energy  = -76.00770336258013 #TEST 
-ref_rel_energy = -76.059287839660001 #TEST
+scf_ref_nr_energy  = -76.00770336258013 #TEST 
+scf_ref_rel_energy = -76.059287839660001 #TEST
+ccsd_ref_nr_energy =  -76.280731819537309 # TEST
+ccsd_ref_rel_energy = -76.332592039115724 # TEST
 
 molecule h2o {
 O
@@ -66,11 +68,15 @@ D   1   1.00
 ****
 }
 
-testnr = energy('scf')
+ccsd_nr_energy = energy('ccsd')
+scf_nr_energy = psi4.get_variable("HF TOTAL ENERGY")
 set relativistic x2c
 set basis_relativistic adecon  # shouldn't need to specify
-testrel = energy('scf')
+ccsd_rel_energy = energy('ccsd')
+scf_rel_energy = psi4.get_variable("HF TOTAL ENERGY")
 
 compare_values(ref_nuc_energy, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
-compare_values(ref_nr_energy,testnr, 9, "Non-relativistic SCF energy")                  #TEST
-compare_values(ref_rel_energy,testrel, 9, "X2C relativistic SCF energy")                #TEST
+compare_values(scf_ref_nr_energy, scf_nr_energy, 9, "Non-relativistic SCF energy")            #TEST
+compare_values(ccsd_ref_nr_energy, ccsd_nr_energy, 9, "Non-relativistic CCSD energy")         #TEST
+compare_values(scf_ref_rel_energy, scf_rel_energy, 9, "X2C relativistic SCF energy")          #TEST
+compare_values(ccsd_ref_rel_energy, ccsd_rel_energy, 9, "X2C relativistic CCSD energy")       #TEST


### PR DESCRIPTION
## Description
Fixes a few issues with Psi4 brought up on the forum.

## Features
- [x] SAPT-CT no longer fails for molecules in C1 symmetry.
- [x] Allows X2C and DKH corrections for post-SCF methods.

## Status
- [x]  Ready to go


