### PR TITLE
bug fix of prevention of zero target optimization values by the evil atof()

### DIFF
--- a/psi4/src/psi4/optking/molecule_read_coords.cc
+++ b/psi4/src/psi4/optking/molecule_read_coords.cc
@@ -567,12 +567,15 @@ bool stoi(string s, int *a) {
 
 // convert string to float
 bool stof(string s, double *val) {
-  double i = atof(s.c_str());
-  if (i!=0) {
-    *val = i;
+  const char *word = s.c_str();
+  char *check;
+  double f = strtod(word, &check);
+  if (f == 0.0F && word == check)
+    return false;
+  else {
+    *val = f;
     return true;
   }
-  return false;
 }
 
 // convert string to boolean

--- a/psi4/src/psi4/optking/molecule_read_coords.cc
+++ b/psi4/src/psi4/optking/molecule_read_coords.cc
@@ -567,24 +567,15 @@ bool stoi(string s, int *a) {
 
 // convert string to float
 bool stof(string s, double *val) {
-   double d;
-   std::istringstream iss(s);
-   iss >> d;
-   if (iss.bad() || iss.fail())
-     return false;
-   else {
-     *val = d;
-     return true;
-   }
-/* const char *word = s.c_str();
-  char *check;
-  double f = strtod(word, &check);
-  if (f == 0.0F && word == check)
+  double d;
+  try {
+    d = std::stod(s, NULL);
+  }
+  catch(...) {
     return false;
-  else {
-    *val = f;
-    return true;
-  } */
+  }
+  *val = d;
+  return true;
 }
 
 // convert string to boolean

--- a/psi4/src/psi4/optking/molecule_read_coords.cc
+++ b/psi4/src/psi4/optking/molecule_read_coords.cc
@@ -567,7 +567,16 @@ bool stoi(string s, int *a) {
 
 // convert string to float
 bool stof(string s, double *val) {
-  const char *word = s.c_str();
+   double d;
+   std::istringstream iss(s);
+   iss >> d;
+   if (iss.bad() || iss.fail())
+     return false;
+   else {
+     *val = d;
+     return true;
+   }
+/* const char *word = s.c_str();
   char *check;
   double f = strtod(word, &check);
   if (f == 0.0F && word == check)
@@ -575,7 +584,7 @@ bool stof(string s, double *val) {
   else {
     *val = f;
     return true;
-  }
+  } */
 }
 
 // convert string to boolean


### PR DESCRIPTION
## Description
Fixes bug reported [here](http://forum.psicode.org/t/fixed-dihedral-optimization-error/323).  I was sloppy and apparently no one had tried a 0 degree fixed angle before.

* **User-Facing for Release Notes**
  - [ ] Fixes bug preventing fixed (target) values of exactly zero.

## Status
Passed HOOH at 0 degrees.  Still need to run other psi standard tests. 
- [ ] 


