### PR TITLE
Fixes ROHF occupation guess with READ orbitals

### DIFF
--- a/psi4/driver/procedures/proc.py
+++ b/psi4/driver/procedures/proc.py
@@ -1253,11 +1253,11 @@ def scf_helper(name, **kwargs):
             raise ValidationError("Cannot compute projection of different symmetries.")
 
         if basis_name == scf_wfn.basisset().name():
-            core.print_out("  Reading orbitals from file 180, no projection.\n")
+            core.print_out("  Reading orbitals from file 180, no projection.\n\n")
             scf_wfn.guess_Ca(Ca_occ)
             scf_wfn.guess_Cb(Cb_occ)
         else:
-            core.print_out("  Reading orbitals from file 180, projecting to new basis.\n")
+            core.print_out("  Reading orbitals from file 180, projecting to new basis.\n\n")
 
             puream = int(data["BasisSet PUREAM"])
 
@@ -1265,7 +1265,7 @@ def scf_helper(name, **kwargs):
                 basis_name = basis_name.split('/')[-1].replace('.gbs', '')
 
             old_basis = core.BasisSet.build(scf_molecule, "ORBITAL", basis_name, puream=puream)
-            core.print_out("\n  Computing basis projection from %s to %s\n\n" % (basis_name, base_wfn.basisset().name()))
+            core.print_out("  Computing basis projection from %s to %s\n\n" % (basis_name, base_wfn.basisset().name()))
 
             nalphapi = core.Dimension.from_list(data["nalphapi"])
             nbetapi = core.Dimension.from_list(data["nbetapi"])

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1346,13 +1346,13 @@ void HF::guess()
             outfile->Printf( "  SCF Guess: Orbitals guess was supplied from a previous computation.\n\n");
 
         std::string reference = options_.get_str("REFERENCE");
-        bool single_orb = ((reference == "RHF") || (reference == "ROHF"));
+        bool single_orb = (reference == "RHF");
 
         if (single_orb){
             guess_Cb_ = guess_Ca_;
         } else {
             if (!guess_Cb_){
-                throw PSIEXCEPTION("Guess Ca was set, but did not find a matching Cb\n");
+                throw PSIEXCEPTION("Guess Ca was set, but did not find a matching Cb!\n");
             }
         }
 


### PR DESCRIPTION
## Description
Guess READ takes orbital occupations from the READ in orbitals, which are not the same (size wise anyhow).

Fixes cc14 (you will have to trust me on this).
