### PR TITLE
WIP: Adds compiler flags from Psi4 to plugins.

### DIFF
--- a/psi4/config.py
+++ b/psi4/config.py
@@ -49,3 +49,8 @@ psidatadir = share_dir = _join_path(psi4_root, "psi4", "share", "psi4")
 cxx_compiler = "(unknown C++ compiler)"
 c_compiler = "(unknown C compiler)"
 fortran_compiler = "(unknown Fortran compiler)"
+
+cxx_flags = ""
+c_flags = ""
+fortran_flags = ""
+

--- a/psi4/config.py.in
+++ b/psi4/config.py.in
@@ -42,3 +42,7 @@ psidatadir = share_dir = _data_dir
 cxx_compiler = "@CMAKE_CXX_COMPILER@"
 c_compiler = "@CMAKE_C_COMPILER@"
 fortran_compiler = "@CMAKE_Fortran_COMPILER@"
+
+cxx_flags = "@CMAKE_CXX_FLAGS@"
+c_flags = "@CMAKE_C_FLAGS@"
+fortran_flags = "@CMAKE_Fortran_FLAGS@"

--- a/psi4/driver/plugin.py
+++ b/psi4/driver/plugin.py
@@ -148,6 +148,9 @@ def create_plugin(args):
         contents = contents.replace('@C@', config.c_compiler)
         contents = contents.replace('@CXX@', config.cxx_compiler)
         contents = contents.replace('@Fortran@', config.fortran_compiler)
+        contents = contents.replace('@C_FLAGS@', config.c_flags)
+        contents = contents.replace('@CXX_FLAGS@', config.cxx_flags)
+        contents = contents.replace('@Fortran_FLAGS@', config.fortran_flags)
 
         try:
             with open(join_path(name, target_file), 'w') as temp_file:

--- a/psi4/share/cmake/psi4/psi4Config.cmake.in
+++ b/psi4/share/cmake/psi4/psi4Config.cmake.in
@@ -74,7 +74,7 @@ set(psi4_FOUND TRUE)
 set(PSI4_FOUND TRUE)
 
 function(add_psi4_plugin TARGET SOURCES)
-    # remove ${TARGET} from ${ARGV} to use ${ARGV} as ${SOURCES}
+    # remove ${TARGET} from ${ARGV} to use ${ARGV} as SOURCES
     list(REMOVE_AT ARGV 0)
 
     add_library(${TARGET} MODULE ${ARGV})
@@ -86,8 +86,5 @@ function(add_psi4_plugin TARGET SOURCES)
     if (APPLE)
         set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     endif()
-
-    # Add additional properties to the "make clean" to delete *.pyc
-    set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "*.pyc")
 endfunction(add_psi4_plugin)
 

--- a/psi4/share/psi4/plugin/aointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/aointegrals/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/basic/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/basic/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/dfmp2/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/dfmp2/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/mointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/mointegrals/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/scf/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/scf/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/sointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/sointegrals/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/wavefunction/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/wavefunction/CMakeLists.txt.template
@@ -29,11 +29,16 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-# These were the compilers used to compile Psi4. They may or may not be
-# required to successfully run your plugin.
+# These were the compilers used to compile Psi4 along with the additional
+# compiler flags used. Edit as needed.
 set(CMAKE_C_COMPILER @C@)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} @C_FLAGS@")
+
 set(CMAKE_CXX_COMPILER @CXX@)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @CXX_FLAGS@")
+
 set(CMAKE_Fortran_COMPILER @Fortran@)
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} @Fortran_FLAGS@")
 
 project(@plugin@ CXX)
 


### PR DESCRIPTION
## Description
Pulls in the C, CXX, and Fortran compiler flags from Psi4, this includes additional compiler flags the user provided in their initial cmake call, and passes them to the new plugin's CMakeLists.txt file.

Need people to test to ensure all the needed flags are being obtained.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [ ] User provided Psi4 compiler flags are passed to new plugins.

## Status
- [ ]  Ready to go



