### PR TITLE
Update .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  max_report_age: off
+  notify:
+    after_n_builds: 1
+    require_ci_to_pass: no
+
 ignore:
  - "tests/"
  - "psi4/driver/qcdb/"


### PR DESCRIPTION
## Description
Per discussion with @dgasmith this pull request fixes the following.

1. Do not ignore python/cobertura reports that have expired
2. Will not wait for CI to complete, nor require it when comparing commits.