### PR TITLE
pybind11 2.0.0 update

### DIFF
--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -67,7 +67,7 @@ macro(psi4_add_module binlib libname sources)
     foreach(name_i IN LISTS depend_name)
         target_link_libraries(${libname} PRIVATE ${name_i})
     endforeach()
-    target_link_libraries(${libname} PRIVATE pybind11::pybind11)
+    target_link_libraries(${libname} PRIVATE pybind11::module)
     target_link_libraries(${libname} PRIVATE ${LAPACKBLAS_LIBRARIES})
 endmacro()
 

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(pybind11 CONFIG QUIET)
+find_package(pybind11 2.0.0 CONFIG QUIET)
 
 if(${pybind11_FOUND})
     message(STATUS "${Cyan}Found pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (found version ${pybind11_VERSION})")
@@ -8,7 +8,7 @@ else()
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
         GIT_REPOSITORY https://github.com/pybind/pybind11
-        GIT_TAG c79e435
+        GIT_TAG v2.0.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKECONFIG_INSTALL_DIR "share/cmake/psi4")
 
 #  <<  Pybind11 & Python  >>
 set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
-find_package(pybind11 CONFIG REQUIRED)
+find_package(pybind11 2.0.0 CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")
 message(STATUS "${Cyan}Using Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE}")
 

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(core PRIVATE ${PRE_LIBRARY_OPTION} dpd qt ${POST_LIBRARY_O
 
 target_link_libraries(core PRIVATE ${psi4_binmodules})
 target_link_libraries(core PRIVATE ${LIBC_INTERJECT})
-target_link_libraries(core PUBLIC pybind11::pybind11)
+target_link_libraries(core PUBLIC pybind11::module)
 target_link_libraries(core PRIVATE Threads::Threads)
 # LAPACK & BLAS linking attached to modules in BIN/LIBLIST to maximally defer
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1026,7 +1026,7 @@ void export_mints(py::module& m)
                                             &detci::CIvect::copy;
     void (detci::CIvect::*py_civ_scale)(double, int) = &detci::CIvect::scale;
 
-    py::class_<detci::CIvect, std::shared_ptr<detci::CIvect> >(m, "CIVector", "docstring")
+    py::class_<detci::CIvect, std::shared_ptr<detci::CIvect> >(m, "CIVector", py::buffer_protocol(), "docstring")
         .def("vdot", &detci::CIvect::vdot, "docstring")
         .def("axpy", &detci::CIvect::axpy, "docstring")
         .def("vector_multiply", &detci::CIvect::vector_multiply, "docstring")


### PR DESCRIPTION
## Description
Get Psi4 to a tagged version on pybind11 that's likely to be deployed

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Seeks only >=2.0.0 pybind11. This has the cmake export stuff we need. Note that the current release 2.0.1 has material changes only for Windows.
  - [x] @dgasmith note that I had to add the buffer_protocol flag to your CIVector for runtime functioning. This was part of py11's pypy push. [Details here](https://github.com/pybind/pybind11/commit/1d1f81b278d956445287b3c491125caa11b925bd) if you want to review. I'm a little surprised that neither more nor less was required in the way of changes.
  - [x] `cbs-xtpl-func` broken, but not by this PR.
* **User-Facing for Release Notes**
  - [x] Uses stable 2.0 pybind11 release

## FYI
- @ryanmrichard and @bennybp, shall we agree upon 2.0.0 as our next set point? Not much code adaptation required. Note `pybind11::pybind11` --> `pybind11::module`. There's a one-word patch I'll forward to the pb11 people, but I don't think it'll interfere with you (leftover `::pybind11` in pybind11Config.cmake).

## Status
- [x]  Ready to go


