### PR TITLE
plugins testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,7 @@ before_script:
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
     -DENABLE_gdma=ON
+    -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ option_with_print(BUILD_SHARED_LIBS "Build internally built Psi4 add-on librarie
 option_with_print(ENABLE_OPENMP "Enables OpenMP parallelization" ON)
 option_with_print(ENABLE_AUTO_BLAS "Enables CMake to auto-detect BLAS" ON)
 option_with_print(ENABLE_AUTO_LAPACK "Enables CMake to auto-detect LAPACK" ON)
+option_with_print(ENABLE_PLUGIN_TESTING "Test the plugin templates build and run" OFF)
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization" ON
                   "-xHost" "-march=native")
 option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF

--- a/cmake/ConfigTesting.cmake
+++ b/cmake/ConfigTesting.cmake
@@ -24,4 +24,6 @@ set(DART_TESTING_TIMEOUT
 
 # This must come last!!
 add_subdirectory(tests)
-add_subdirectory(plugins)
+if(ENABLE_PLUGIN_TESTING)
+    add_subdirectory(plugins)
+endif()


### PR DESCRIPTION
## Description
Turn off plugin testing by default. Turn on for Travis.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] enable plugin testing to be turned off (needed for conda packages)
  - [x] explicitly turn on plugin testing for Travis CI to keep plugins in working order

## Status
- [x]  Ready to go


