### PR TITLE
Clarification in libdpd

### DIFF
--- a/psi4/src/psi4/libdpd/buf4_init.cc
+++ b/psi4/src/psi4/libdpd/buf4_init.cc
@@ -53,6 +53,13 @@ namespace psi {
 **   int anti: Boolean flag which indicates whether the data needs to
 **             be antisymmetrized as it is read from disk.
 **   char *label: The string labelling the PSIO TOC entry on disk.
+**
+**   Note: Make sure that you use the correct label and inputfile combination.
+**      If you intend to read from or write to an existing quantity on disk be sure
+**      that the label string/file number point to that quantity. If you intend to
+**      create and populate a new quantity on disk, ensure that the label is not
+**      already used in the file.  PSIO::tocprint(int filenum) can be used to print
+**      the labels currently used in in filenum and is quite useful for debugging.
 */
 
 int DPD::buf4_init(dpdbuf4 *Buf, int inputfile, int irrep, int pqnum, int rsnum,

--- a/psi4/src/psi4/libdpd/file2_init.cc
+++ b/psi4/src/psi4/libdpd/file2_init.cc
@@ -49,8 +49,12 @@ namespace psi {
 **   int qnum: The orbital subspace number for the right index [see
 **             dpd_init()].
 **   char *label: A string labelling for this buffer.
-**   int print_flag: A boolean for the print routines.
-**   std::string OutFileRMR: The formatted output file stream.
+**   Note: Make sure that you use the correct label and inputfile combination.
+**      If you intend to read from or write to an existing quantity on disk be sure
+**      that the label string/file number point to that quantity. If you intend to
+**      create and populate a new quantity on disk, ensure that the label is not
+**      already used in the file.  PSIO::tocprint(int filenum) can be used to print
+**      the labels currently used in in filenum and is quite useful for debugging.
 */
 
 int DPD::file2_init(dpdfile2 *File, int filenum, int irrep, int pnum,


### PR DESCRIPTION
See discussion in #550.

## Description
Commonly, new users of libdpd will think that DPD::buf4_init() and DPD::file2_init() are initializing blank (zeroed out) tensors to be manipulated.  The note added to the comments above these functions should help some from making this mistake. 

I also removed comments from the file2_init() that describe arguments that do not exist. 
## Status
- [x]  Ready to go

