### PR TITLE
fix short-term CheMPS2 outage

### DIFF
--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -94,10 +94,14 @@ int chemps2_groupnumber(const string SymmLabel){
 void buildJK(SharedMatrix MO_RDM, SharedMatrix MO_JK, SharedMatrix Cmat, std::shared_ptr<JK> myJK, std::shared_ptr<Wavefunction> wfn){
 
     const int nso    = wfn->nso();
-    int * nsopi      = wfn->nsopi();
     const int nmo    = wfn->nmo();
-    int * nmopi      = wfn->nmopi();
     const int nirrep = wfn->nirrep();
+    int * nmopi = init_int_array(nirrep);
+    int * nsopi = init_int_array(nirrep);
+    for ( int h = 0; h < nirrep; ++h ){
+        nmopi[h] = wfn->nmopi()[h];
+        nsopi[h] = wfn->nsopi()[h];
+    }
 
     // nso can be different from nmo
     SharedMatrix SO_RDM;     SO_RDM = SharedMatrix( new Matrix( "SO RDM",   nirrep, nsopi, nsopi ) );
@@ -217,8 +221,13 @@ SharedMatrix print_rdm_ao( CheMPS2::DMRGSCFindices * idx, double * DMRG1DM, Shar
         }
     }
 
-    int * nmopi = wfn->nmopi();
-    int * nsopi = wfn->nsopi();
+    const int nirrep = wfn->nirrep();
+    int * nmopi = init_int_array(nirrep);
+    int * nsopi = init_int_array(nirrep);
+    for ( int h = 0; h < nirrep; ++h ){
+        nmopi[h] = wfn->nmopi()[h];
+        nsopi[h] = wfn->nsopi()[h];
+    }
     const int nao = wfn->aotoso()->rowspi( 0 );
 
     SharedMatrix tfo;       tfo = SharedMatrix( new Matrix( num_irreps, nao, nmopi ) );
@@ -300,8 +309,12 @@ void buildTmatrix( CheMPS2::DMRGSCFmatrix * theTmatrix, CheMPS2::DMRGSCFindices 
     const int nTriMo = nmo * (nmo + 1) / 2;
     const int nso    = wfn->nso();
     const int nTriSo = nso * (nso + 1) / 2;
-    int * mopi       = wfn->nmopi();
-    int * sopi       = wfn->nsopi();
+    int * mopi       = init_int_array(nirrep);
+    int * sopi       = init_int_array(nirrep);
+    for ( int h = 0; h < nirrep; ++h ){
+        mopi[h] = wfn->nmopi()[h];
+        sopi[h] = wfn->nsopi()[h];
+    }
     double * work1   = new double[ nTriSo ];
     double * work2   = new double[ nTriSo ];
     IWL::read_one(psio.get(), PSIF_OEI, PSIF_SO_T, work1, nTriSo, 0, 0, "outfile");
@@ -488,9 +501,14 @@ SharedWavefunction dmrg(SharedWavefunction wfn, Options& options)
     const int SyGroup= chemps2_groupnumber( wfn->molecule()->sym_label() );
     const int nmo    = wfn->nmo();
     const int nirrep = wfn->nirrep();
-    int * orbspi     = wfn->nmopi();
-    int * docc       = wfn->doccpi();
-    int * socc       = wfn->soccpi();
+    int * orbspi     = init_int_array(nirrep);
+    int * docc       = init_int_array(nirrep);
+    int * socc       = init_int_array(nirrep);
+    for ( int h = 0; h < nirrep; ++h ){
+        orbspi[h] = wfn->nmopi()[h];
+        docc[h] = wfn->doccpi()[h];
+        socc[h] = wfn->soccpi()[h];
+    }
     if ( wfn_irrep<0 )                            { throw PSIEXCEPTION("Option DMRG_IRREP (integer) may not be smaller than zero!"); }
     if ( wfn_multp<1 )                            { throw PSIEXCEPTION("Option DMRG_MULTIPLICITY (integer) should be larger or equal to one: DMRG_MULTIPLICITY = (2S+1) >= 1 !"); }
     if ( ndmrg_states==0 )                        { throw PSIEXCEPTION("Option DMRG_SWEEP_STATES (integer array) should be set!"); }

--- a/psi4/src/psi4/mrcc/mrcc.cc
+++ b/psi4/src/psi4/mrcc/mrcc.cc
@@ -601,7 +601,7 @@ bool has_key(const py::dict &data, const std::string &key)
 {
     bool found = false;
     for (auto item : data) {
-        if (item.first == py::str(key)) {
+        if (std::string(py::str(item.first)) == key) {
             found = true;
             break;
         }

--- a/tests/cbs-xtpl-func/input.dat
+++ b/tests/cbs-xtpl-func/input.dat
@@ -15,25 +15,28 @@ set g_convergence gau_verytight
 
 E1 = energy(cbs, corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g')
 E2 = energy(sherrill_gold_standard, scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
-compare_values(E1, E2, 5, 'Match gold_standard energy')  #TEST
+compare_values(E1, E2, 5, '[1] Match gold_standard energy')  #TEST
 
-G1 = gradient(cbs, corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g')
+G1 = gradient(cbs, corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g', dertype='energy')
 G2 = gradient(sherrill_gold_standard, scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
-compare_matrices(G1, G2, 5, 'Match gold_standard gradient')  #TEST
+compare_matrices(G1, G2, 5, '[2] Match gold_standard gradient')  #TEST
 
 # Reset mol geometries
 mol.R = 1.0
 mol.A = 100.0
-E = optimize(cbs, corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g')
-compare_values(-76.3707500218, E, 5, '[1a] opt(cbs, sherrill) energy')  #TEST
-compare_values(0.960940174888, mol.R, 3, '[1b] opt(cbs, sherrill) bond')  #TEST
-compare_values(103.436972667, mol.A, 2, '[1c] opt(cbs, sherrill) angle')  #TEST
+E = optimize(cbs, corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g', dertype=0)
+compare_values(-76.3707500218, E, 5, '[3a] opt(cbs, sherrill) energy')  #TEST
+compare_values(0.960940174888, mol.R, 3, '[3b] opt(cbs, sherrill) bond')  #TEST
+compare_values(103.436972667, mol.A, 2, '[3c] opt(cbs, sherrill) angle')  #TEST
 
 # Reset mol geometries
 mol.R = 1.0
 mol.A = 100.0
 E = optimize(sherrill_gold_standard, scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
-compare_values(-76.3707500218, E, 5, '[2a] opt(sherrill) energy')  #TEST
-compare_values(0.960940174888, mol.R, 3, '[2b] opt(sherrill) bond')  #TEST
-compare_values(103.436972667, mol.A, 2, '[2c] opt(sherrill) angle')  #TEST
+compare_values(-76.3707500218, E, 5, '[4a] opt(sherrill) energy')  #TEST
+compare_values(0.960940174888, mol.R, 3, '[4b] opt(sherrill) bond')  #TEST
+compare_values(103.436972667, mol.A, 2, '[4c] opt(sherrill) angle')  #TEST
 
+# Note: with new analytical ccsd(t) gradients, calcs G1 and 3 default  #TEST
+#   to sum-of-analytic. Want to compare with custom_func values that are  #TEST
+#   always findif, so force findif on grad(cbs and opt(cbs counterparts.  #TEST

--- a/tests/mrcc/ccsd_t_/CMakeLists.txt
+++ b/tests/mrcc/ccsd_t_/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(mrcc-ccsd_t_ "psi;quicktests;smoketests;mrcc;addon;cc")
+add_regression_test(mrcc-ccsd_t_ "psi;quicktests;mrcc;addon;cc")

--- a/tests/mrcc/ccsdt/CMakeLists.txt
+++ b/tests/mrcc/ccsdt/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(mrcc-ccsdt "psi;quicktests;mrcc;addon;cc")
+add_regression_test(mrcc-ccsdt "psi;quicktests;smoketests;mrcc;addon;cc")


### PR DESCRIPTION
## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] The Dimension C++ updating of #574 / #571 needed to be done for the CheMPS2 interface code also. This does it.
  - [x] test `cbs-xtpl-func` was unsuccessfully comparing analytic- and findif-computed values (as found by Daniel) after analytic ccsd(t) grads available. This forces findif comparison.
  - [x] fixed MRCC interface probably broken since CMR-KtB-INV. Looks like we don't have to close and reopen outfile anymore, so simplified procedure func. tested with normal and `-o stdout` operation under py27 and py35.
* **User-Facing for Release Notes**

## Status
- [x]  Ready to go
