### PR TITLE
Update base compiler version detection with Intel compiler and clang.

### DIFF
--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -15,7 +15,11 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
     #include <stdio.h>
     
     int main() {
+        #ifdef __clang__
+        printf(\"%d.%d.%d\", __clang_major__, __clang_minor__, __clang_patchlevel__);
+        #else
         printf(\"%d.%d.%d\", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+        #endif
         return 0;
     }
     ")
@@ -23,7 +27,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
             GCCV_RUNS
             ${CMAKE_BINARY_DIR} ${_testfl}
             RUN_OUTPUT_VARIABLE GCC_VERSION)
-    message(STATUS "Found GCC ${GCC_VERSION}")
+    message(STATUS "Found base compiler version ${GCC_VERSION}")
     file(REMOVE ${_testfl})
 
     if (APPLE)

--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -13,7 +13,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
     set(_testfl ${CMAKE_BINARY_DIR}/test_gcc_version.cc)
     file(WRITE  ${_testfl} "
     #include <stdio.h>
-    
+
     int main() {
         #ifdef __clang__
         printf(\"%d.%d.%d\", __clang_major__, __clang_minor__, __clang_patchlevel__);
@@ -32,7 +32,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
 
     if (APPLE)
         if (${GCC_VERSION} VERSION_LESS 6.1)
-            message(FATAL_ERROR "Intel ICPC makes use of CLANG (detected: ${GCC_VERSION}; required for C++11: 6.1) so this build won't work without GCC intervention: http://psicode.org/psi4manual/master/build_planning.html#faq-modgcc")
+            message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of CLANG (detected: ${GCC_VERSION}; required for C++11: 6.1) so this build won't work without CLANG intervention: http://psicode.org/psi4manual/master/build_planning.html\n${ColourReset}")
         endif()
     else ()
         if (${GCC_VERSION} VERSION_LESS 4.9)


### PR DESCRIPTION
## Description
According to [clang source](http://llvm.org/svn/llvm-project/cfe/trunk/lib/Frontend/InitPreprocessor.cpp) (about half way down the page), clang always reports version 4.2.1 when using ```__GNUC__```, ```__GNUC_MINOR__```, ```__GNUC_PATCHLEVEL__```. This PR updates the version tester to use ```__clang_major__```, ```__clang_minor__```, ```__clang_patchlevel__``` when clang is detected.

This issue appeared when using Intel compilers on a Mac.

## Status
- [x]  Ready to go

