### PR TITLE
Plugin fix

### DIFF
--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -200,4 +200,29 @@ if(${ENABLE_${PLUGIN_NAME}})
 else()
    add_library(${plugin_name} INTERFACE)
 endif()
-endmacro(optional_plugin plugin_name)
+endmacro(optional_plugin plugin_name test_names)
+
+#Macro for adding a skeleton plugin
+macro(add_skeleton_plugin PLUG EXTRA_FLAGS)
+    set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
+    set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
+    set(DIR_2_PASS ${CMAKE_PREFIX_PATH} ${STAGED_INSTALL_PREFIX})
+add_custom_target(plugin_${PLUG}
+    ALL
+    DEPENDS psi4-core
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
+    COMMAND ${PSIEXE} --plugin-name ${PLUG} ${EXTRA_FLAGS}
+    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake "-DCMAKE_PREFIX_PATH=${DIR_2_PASS}" .
+    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
+    COMMENT "Build ${PLUG} example plugin"
+    VERBATIM)
+include(TestingMacros)
+add_regression_test(${PLUG} "${test_names}")
+endmacro(add_skeleton_plugin PLUG EXTRA_FLAGS)
+
+

--- a/plugins/skeleton/CMakeLists.txt
+++ b/plugins/skeleton/CMakeLists.txt
@@ -1,26 +1,7 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
 
-set(PLUG "skeleton")
+add_skeleton_plugin("skeleton" "" "psi;plug")
 
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG}
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
 

--- a/plugins/skeletonambit/CMakeLists.txt
+++ b/plugins/skeletonambit/CMakeLists.txt
@@ -1,26 +1,6 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
 
-set(PLUG "skeletonambit")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template ambit
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
+add_skeleton_plugin("skeletonambit" "--plugin-template ambit" "psi;plug")
 

--- a/plugins/skeletonaointegrals/CMakeLists.txt
+++ b/plugins/skeletonaointegrals/CMakeLists.txt
@@ -1,26 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
-
-set(PLUG "skeletonaointegrals")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template aointegrals
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
+add_skeleton_plugin("skeletonaointegrals" "--plugin-template aointegrals" "psi;plug")
 

--- a/plugins/skeletondfmp2/CMakeLists.txt
+++ b/plugins/skeletondfmp2/CMakeLists.txt
@@ -1,26 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
 
-set(PLUG "skeletondfmp2")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template dfmp2
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug;minitests;quicktests")
-
+add_skeleton_plugin("skeletondfmp2" "--plugin-template dfmp2" "psi;plug;minitests;quicktests")

--- a/plugins/skeletonmointegrals/CMakeLists.txt
+++ b/plugins/skeletonmointegrals/CMakeLists.txt
@@ -1,26 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
-
-set(PLUG "skeletonmointegrals")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template mointegrals
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
+add_skeleton_plugin("skeletonmointegrals" "--plugin-template mointegrals" "psi;plug")
 

--- a/plugins/skeletonscf/CMakeLists.txt
+++ b/plugins/skeletonscf/CMakeLists.txt
@@ -1,26 +1,6 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
 
-set(PLUG "skeletonscf")
 
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template scf
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
-
+add_skeleton_plugin("skeletonscf" "--plugin-template scf")

--- a/plugins/skeletonsointegrals/CMakeLists.txt
+++ b/plugins/skeletonsointegrals/CMakeLists.txt
@@ -1,26 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
-
-set(PLUG "skeletonsointegrals")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template sointegrals
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
+add_skeleton_plugin("skeletonsointegrals" "--plugin-template sointegrals" "psi;plug")
 

--- a/plugins/skeletonwavefunction/CMakeLists.txt
+++ b/plugins/skeletonwavefunction/CMakeLists.txt
@@ -1,26 +1,6 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
-set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
 
-set(PLUG "skeletonwavefunction")
-
-add_custom_target(plugin_${PLUG}
-    ALL
-    DEPENDS psi4-core
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template wavefunction
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH=${STAGED_INSTALL_PREFIX} .
-    COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/__init__.py" "__init__.py"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/pymodule.py" "pymodule.py"
-    COMMENT "Build ${PLUG} example plugin"
-    VERBATIM)
-
-include(TestingMacros)
-add_regression_test(${PLUG} "psi;plug")
+add_skeleton_plugin("skeletonwavefunction" "--plugin-template wavefunction" "psi;plug")
 


### PR DESCRIPTION
## Description
This factors the code in the `CMakeLists.txt` of the various plugin templates into one function to avoid
copy/paste.  Within this function it then ensures that `CMAKE_PREFIX_PATH` is properly passed to each build in turn allowing the user to build plugins and use externally built Psi4 dependencies.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Adding additional plugin templates to the build system is dramatically simplified
* **User-Facing for Release Notes**
  - [x] You can now use external versions of libraries that Psi4 normally compiles with plugins.

## Status
- [x]  Ready to go


