### PR TITLE
drop some quicktests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: cpp
 sudo: false
 matrix:
-  allow_failures:
-    - compiler: clang
-      env:
-        - CXX_COMPILER='clang++-3.9'
-        - PYTHON_VER='3.5'
-        - C_COMPILER='clang-3.9'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='release'
-        - NAME='clang'
-        - VERSION='3.9'
+  #allow_failures:
+  #  - compiler: clang
+  #    env:
+  #      - CXX_COMPILER='clang++-3.9'
+  #      - PYTHON_VER='3.5'
+  #      - C_COMPILER='clang-3.9'
+  #      - Fortran_COMPILER='gfortran'
+  #      - BUILD_TYPE='release'
+  #      - NAME='clang'
+  #      - VERSION='3.9'
 
   include:
 

--- a/tests/ao-casscf-sp/input.dat
+++ b/tests/ao-casscf-sp/input.dat
@@ -18,5 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/ao-dfcasscf-sp/input.dat
+++ b/tests/ao-dfcasscf-sp/input.dat
@@ -18,5 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073736807922970, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST

--- a/tests/casscf-fzc-sp/input.dat
+++ b/tests/casscf-fzc-sp/input.dat
@@ -18,7 +18,7 @@ set {
 casscf_energy = energy('casscf')
 
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073773094606, casscf_energy, 6, 'FZC CASSCF Energy')  #TEST
 
 
@@ -29,5 +29,5 @@ set {
 casscf_energy = energy('casscf')
 
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073773094606, casscf_energy, 6, 'RSP-FZC CASSCF Energy')  #TEST

--- a/tests/casscf-sa-sp/input.dat
+++ b/tests/casscf-sa-sp/input.dat
@@ -52,7 +52,7 @@ set detci {
 
 
 casscf_energy = energy('casscf')
-compare_values(-75.375529547673, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-75.375529547673, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-75.604189023004, psi4.get_variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
 compare_values(-75.477044791109, psi4.get_variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
 compare_values(-75.540616907115, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/dfcasscf-fzc-sp/input.dat
+++ b/tests/dfcasscf-fzc-sp/input.dat
@@ -16,5 +16,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.01725998335047, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.01725998335047, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.07373669020915, casscf_energy, 5, 'FZC CASSCF Energy')  #TEST

--- a/tests/dfcasscf-sa-sp/input.dat
+++ b/tests/dfcasscf-sa-sp/input.dat
@@ -27,7 +27,7 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-153.017422024965640, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-153.017422024965640, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-153.103748057296741, psi4.get_variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
 compare_values(-152.826395504293657, psi4.get_variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
 compare_values(-152.965071780795427, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/dfcasscf-sp/input.dat
+++ b/tests/dfcasscf-sp/input.dat
@@ -17,5 +17,5 @@ set {
 
 
 casscf_energy = energy('casscf')
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073828605037164, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/dfrasscf-sp/input.dat
+++ b/tests/dfrasscf-sp/input.dat
@@ -24,5 +24,5 @@ molecule mol {
 
 rasscf_energy = energy('RASSCF')
 
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073028564767768, rasscf_energy, 6, 'RASSCF Energy')  #TEST

--- a/tests/fsapt-diff1/input.dat
+++ b/tests/fsapt-diff1/input.dat
@@ -47,25 +47,25 @@ freeze_core true
 
 energy('fisapt0')
 
-keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot'] # TEST
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 
-Eref = { # TEST
-    'Enuc'  : 805.117733746067756, # TEST
-    'Eelst' :  -0.01449385168,     # TEST
-    'Eexch' :  +0.01572480431,     # TEST
-    'Eind'  :  -0.00445604001,     # TEST
-    'Edisp' :  -0.00815025022,     # TEST
-    'Etot'  :  -0.01137533761,     # TEST
-    } # TEST
+Eref = {  #TEST
+    'Enuc'  : 805.117733746067756,  #TEST
+    'Eelst' :  -0.01449385168,      #TEST
+    'Eexch' :  +0.01572480431,      #TEST
+    'Eind'  :  -0.00445604001,      #TEST
+    'Edisp' :  -0.00815025022,      #TEST
+    'Etot'  :  -0.01137533761,      #TEST
+    }  #TEST
 
-Epsi = { # TEST
-    'Enuc'  : mol.nuclear_repulsion_energy(),          # TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),   # TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),   # TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),    # TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),   # TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"), # TEST   
-    } # TEST
+Epsi = {  #TEST
+    'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
+    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
+    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
+    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
+    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    }  #TEST
 
-for key in keys: # TEST
-    compare_values(Eref[key], Epsi[key], 6, key) # TEST
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST

--- a/tests/fsapt1/input.dat
+++ b/tests/fsapt1/input.dat
@@ -47,25 +47,25 @@ freeze_core true
 
 energy('fisapt0')
 
-keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot'] # TEST
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 
-Eref = { # TEST
-    'Enuc'  : 805.117733746067756, # TEST
-    'Eelst' :  -0.01449385168,     # TEST
-    'Eexch' :  +0.01572480431,     # TEST
-    'Eind'  :  -0.00445604001,     # TEST
-    'Edisp' :  -0.00815025022,     # TEST
-    'Etot'  :  -0.01137533761,     # TEST
-    } # TEST
+Eref = {  #TEST
+    'Enuc'  : 805.117733746067756,  #TEST
+    'Eelst' :  -0.01449385168,      #TEST
+    'Eexch' :  +0.01572480431,      #TEST
+    'Eind'  :  -0.00445604001,      #TEST
+    'Edisp' :  -0.00815025022,      #TEST
+    'Etot'  :  -0.01137533761,      #TEST
+    }  #TEST
 
-Epsi = { # TEST
-    'Enuc'  : mol.nuclear_repulsion_energy(),          # TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),   # TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),   # TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),    # TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),   # TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"), # TEST   
-    } # TEST
+Epsi = {  #TEST
+    'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
+    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
+    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
+    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
+    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    }  #TEST
 
-for key in keys: # TEST
-    compare_values(Eref[key], Epsi[key], 6, key) # TEST
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST

--- a/tests/fsapt2/input.dat
+++ b/tests/fsapt2/input.dat
@@ -26,28 +26,28 @@ freeze_core true
 
 energy('fisapt0')
 
-keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot'] # TEST
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 
-Eref = { # TEST
-    'Enuc'  : 36.662847852755299,  # TEST 
-    'Eelst' :  -0.01407721503,     # TEST
-    'Eexch' :  +0.01136549976,     # TEST
-    'Eind'  :  -0.00336219834,     # TEST
-    'Edisp' :  -0.00202807480,     # TEST
-    'Etot'  :  -0.00810198841,     # TEST
-    } # TEST
+Eref = {  #TEST
+    'Enuc'  : 36.662847852755299,   #TEST 
+    'Eelst' :  -0.01407721503,      #TEST
+    'Eexch' :  +0.01136549976,      #TEST
+    'Eind'  :  -0.00336219834,      #TEST
+    'Edisp' :  -0.00202807480,      #TEST
+    'Etot'  :  -0.00810198841,      #TEST
+    }  #TEST
 
-Epsi = { # TEST
-    'Enuc'  : mol.nuclear_repulsion_energy(),          # TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),   # TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),   # TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),    # TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),   # TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"), # TEST   
-    } # TEST
+Epsi = {  #TEST
+    'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
+    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
+    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
+    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
+    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    }  #TEST
 
-for key in keys: # TEST
-    compare_values(Eref[key], Epsi[key], 6, key) # TEST
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST
 
 
 

--- a/tests/isapt1/input.dat
+++ b/tests/isapt1/input.dat
@@ -46,25 +46,25 @@ fisapt_do_plot true # For extra analysis
 
 energy('fisapt0')
 
-keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot'] # TEST
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 
-Eref = { # TEST
-    'Enuc'  : 338.311173124900847, # TEST
-    'Eelst' :  -0.01408984519,     # TEST
-    'Eexch' :  +0.01776897764,     # TEST
-    'Eind'  :  -0.00520103160,     # TEST
-    'Edisp' :  -0.00254901867,     # TEST
-    'Etot'  :  -0.00407091782,     # TEST
-    } # TEST
+Eref = {  #TEST
+    'Enuc'  : 338.311173124900847,  #TEST
+    'Eelst' :  -0.01408984519,      #TEST
+    'Eexch' :  +0.01776897764,      #TEST
+    'Eind'  :  -0.00520103160,      #TEST
+    'Edisp' :  -0.00254901867,      #TEST
+    'Etot'  :  -0.00407091782,      #TEST
+    }  #TEST
     
-Epsi = { # TEST
-    'Enuc'  : mol.nuclear_repulsion_energy(),          # TEST
-    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),   # TEST
-    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),   # TEST    
-    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),    # TEST   
-    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),   # TEST   
-    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"), # TEST   
-    } # TEST
+Epsi = {  #TEST
+    'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
+    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),    #TEST    
+    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),     #TEST   
+    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),    #TEST   
+    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    }  #TEST
 
-for key in keys: # TEST
-    compare_values(Eref[key], Epsi[key], 6, key) # TEST
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST

--- a/tests/isapt2/input.dat
+++ b/tests/isapt2/input.dat
@@ -43,25 +43,25 @@ freeze_core true
 
 energy('fisapt0')
 
-keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot'] # TEST
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 
-Eref = { # TEST
-    'Enuc'  : 338.311173124900847, # TEST
-    'Eelst' :  -0.01408984519,     # TEST
-    'Eexch' :  +0.01776897764,     # TEST
-    'Eind'  :  -0.00520103160,     # TEST
-    'Edisp' :  -0.00254901867,     # TEST
-    'Etot'  :  -0.00407091782,     # TEST
-    } # TEST
+Eref = {  #TEST
+    'Enuc'  : 338.311173124900847,  #TEST
+    'Eelst' :  -0.01408984519,      #TEST
+    'Eexch' :  +0.01776897764,      #TEST
+    'Eind'  :  -0.00520103160,      #TEST
+    'Edisp' :  -0.00254901867,      #TEST
+    'Etot'  :  -0.00407091782,      #TEST
+    }  #TEST
     
-Epsi = { # TEST
-    'Enuc'  : mol.nuclear_repulsion_energy(),          # TEST
-    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),   # TEST
-    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),   # TEST    
-    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),    # TEST   
-    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),   # TEST   
-    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"), # TEST   
-    } # TEST
+Epsi = {  #TEST
+    'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
+    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),    #TEST    
+    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),     #TEST   
+    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),    #TEST   
+    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    }  #TEST
 
-for key in keys: # TEST
-    compare_values(Eref[key], Epsi[key], 6, key) # TEST
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST

--- a/tests/mints5/input.dat
+++ b/tests/mints5/input.dat
@@ -150,7 +150,7 @@ molecule H2O {
 }
 H2O.update_geometry()
 print_out("\t" + H2O.get_full_point_group() + "\n" )
-compare_strings("C2v", H2O.get_full_point_group(), "C2v point group"); # TEST
+compare_strings("C2v", H2O.get_full_point_group(), "C2v point group");  #TEST
 
 
 molecule CH2F2 {

--- a/tests/mom/input.dat
+++ b/tests/mom/input.dat
@@ -22,7 +22,7 @@ H 1 1.0
 H 1 1.0 2 104.5
 }
 
-water.update_geometry() # TEST
+water.update_geometry()  #TEST
 compare_values(Enuc, water.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy") #TEST
 
 # => Ground state SCF <= #

--- a/tests/nbody-he-cluster/CMakeLists.txt
+++ b/tests/nbody-he-cluster/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(nbody-he-cluster "psi;quicktests;nbody")
+add_regression_test(nbody-he-cluster "psi;nbody")

--- a/tests/opt-multi-dimer-c1/input.dat
+++ b/tests/opt-multi-dimer-c1/input.dat
@@ -1,5 +1,5 @@
 #! Multi-fragment opt of C2h methane dimer with user-combined reference points.
-OPT_ENERGY = -80.7431166 # TEST
+OPT_ENERGY = -80.7431166  #TEST
 
 memory 1 gb
 

--- a/tests/opt-multi-dimer-c2h/input.dat
+++ b/tests/opt-multi-dimer-c2h/input.dat
@@ -1,5 +1,5 @@
 #! Multi-fragment opt of C2h methane dimer with user-combined reference points.
-OPT_ENERGY = -80.7431166 # TEST
+OPT_ENERGY = -80.7431166  #TEST
 
 memory 1 gb
 

--- a/tests/opt-multi-frozen-dimer-c2h/input.dat
+++ b/tests/opt-multi-frozen-dimer-c2h/input.dat
@@ -1,5 +1,5 @@
 #! Frozen-fragment opt of C2h methane dimer with user-combined reference points.
-FROZEN_OPT_ENERGY = -80.7427781 # TEST
+FROZEN_OPT_ENERGY = -80.7427781  #TEST
 
 memory 1 gb
 

--- a/tests/opt10/input.dat
+++ b/tests/opt10/input.dat
@@ -1,5 +1,5 @@
 #! 6-31G MP2 transition-state optimization with initial, computed Hessian.
-TS_ENERGY = -303.30622629    # TEST
+TS_ENERGY = -303.30622629     #TEST
 
 memory 1 gb
 

--- a/tests/opt5/input.dat
+++ b/tests/opt5/input.dat
@@ -2,8 +2,8 @@
 
 memory 250 mb
 
-nucenergy = 6.197322440574482    # TEST
-refenergy = -38.925486977153     # TEST
+nucenergy = 6.197322440574482     #TEST
+refenergy = -38.925486977153      #TEST
 
 molecule ch2 {
 0 3
@@ -26,5 +26,5 @@ set {
 
 thisenergy = optimize('scf')
   
-compare_values(nucenergy, ch2.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy") # TEST
-compare_values(refenergy, thisenergy, 6, "Reference energy") # TEST
+compare_values(nucenergy, ch2.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")  #TEST
+compare_values(refenergy, thisenergy, 6, "Reference energy")  #TEST

--- a/tests/opt6/input.dat
+++ b/tests/opt6/input.dat
@@ -3,9 +3,9 @@
 
 memory 250 mb
 
-OH_frozen_stre_rhf       = -150.78104113  # TEST
-OOH_frozen_bend_rhf      = -150.78628057  # TEST
-HOOH_frozen_dihedral_rhf = -150.78667424  # TEST
+OH_frozen_stre_rhf       = -150.78104113   #TEST
+OOH_frozen_bend_rhf      = -150.78628057   #TEST
+HOOH_frozen_dihedral_rhf = -150.78667424   #TEST
 
 set {
   diis false

--- a/tests/opt7/input.dat
+++ b/tests/opt7/input.dat
@@ -1,12 +1,12 @@
 #! Various constrained energy minimizations of HOOH with cc-pvdz RHF.
 #! For "fixed" coordinates, the final value is provided by the user.
 
-# Minimized energy with OH bonds at 0.950 Angstroms. # TEST
-OH_950_stre       = -150.78666731                    # TEST
-# Minimized energy with OOH angles at 105.0 degrees. # TEST
-OOH_105_bend      = -150.78617685                    # TEST
-# Minimized energy with HOOH torsion at 120.0 degrees. # TEST
-HOOH_120_dihedral = -150.78664695                      # TEST
+# Minimized energy with OH bonds at 0.950 Angstroms.  #TEST
+OH_950_stre       = -150.78666731                     #TEST
+# Minimized energy with OOH angles at 105.0 degrees.  #TEST
+OOH_105_bend      = -150.78617685                     #TEST
+# Minimized energy with HOOH torsion at 120.0 degrees.  #TEST
+HOOH_120_dihedral = -150.78664695                       #TEST
 
 set {
   diis false

--- a/tests/opt8/input.dat
+++ b/tests/opt8/input.dat
@@ -1,9 +1,9 @@
 #! Various constrained energy minimizations of HOOH with cc-pvdz RHF.
 #! Cartesian-coordinate constrained optimizations of HOOH in Cartesians.
 
-HOOH_E_fixed_H_xyz = -150.7866490998188     # TEST
-HOOH_E_fixed_O_xyz = -150.7866389583059     # TEST
-HOOH_E             = -150.7866739753094     # TEST
+HOOH_E_fixed_H_xyz = -150.7866490998188      #TEST
+HOOH_E_fixed_O_xyz = -150.7866389583059      #TEST
+HOOH_E             = -150.7866739753094      #TEST
 
 set {
   basis cc-pvdz

--- a/tests/opt9/input.dat
+++ b/tests/opt9/input.dat
@@ -1,7 +1,7 @@
 #! Various constrained energy minimizations of HOOH with cc-pvdz RHF.
 #! Cartesian-coordinate constrained optimizations of HOOH in internals.
-HOOH_E_fixed_H_xyz = -150.7866490998188     # TEST
-HOOH_E_fixed_O_xyz = -150.7866389583059     # TEST
+HOOH_E_fixed_H_xyz = -150.7866490998188      #TEST
+HOOH_E_fixed_O_xyz = -150.7866389583059      #TEST
 
 set { basis cc-pvdz }
 

--- a/tests/rasscf-sp/input.dat
+++ b/tests/rasscf-sp/input.dat
@@ -23,5 +23,5 @@ molecule mol {
 
 rasscf_energy = energy('RASSCF')
 
-compare_values(-76.017259983350, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(-76.017259983350, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073064815921, rasscf_energy, 6, 'RASSCF Energy')  #TEST

--- a/tests/sapt6/CMakeLists.txt
+++ b/tests/sapt6/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(sapt6 "psi;quicktests;sapt")
+add_regression_test(sapt6 "psi;sapt")

--- a/tests/x2c1/input.dat
+++ b/tests/x2c1/input.dat
@@ -4,8 +4,8 @@
 ref_nuc_energy =  8.316179709840201 #TEST
 scf_ref_nr_energy  = -76.00770336258013 #TEST 
 scf_ref_rel_energy = -76.059287839660001 #TEST
-ccsd_ref_nr_energy =  -76.280731819537309 # TEST
-ccsd_ref_rel_energy = -76.332592039115724 # TEST
+ccsd_ref_nr_energy =  -76.280731819537309  #TEST
+ccsd_ref_rel_energy = -76.332592039115724  #TEST
 
 molecule h2o {
 O


### PR DESCRIPTION
## Description
shorten quicktests for Travis' sake

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] moved `sapt6` and `nbody-he-cluster` out of quicktests
  - in tests, make sure you say `#TEST`, not `# TEST`
* **User-Facing for Release Notes**

## Status
- [x]  Ready to go