### PR TITLE
Fix some issues with ERD

### DIFF
--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -656,10 +656,8 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
         ::memset(target_, 0, sizeof(double)*n1234);
     }
     else if(has_puream_ && !spheric_ && !force_cartesian_) {
-        double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
-        source_ = sourcetmp;
     }
     else {
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -636,23 +636,35 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
     outfile->Printf( "%d integrals were computed\n", nbatch);
 #endif
 
-    if(nbatch == 0){
+    int n1, n2, n3, n4;
+    if (force_cartesian_) {
+        n1 = gs1.ncartesian();
+        n2 = gs2.ncartesian();
+        n3 = gs3.ncartesian();
+        n4 = gs4.ncartesian();
+    } else {
+        n1 = gs1.nfunction();
+        n2 = gs2.nfunction();
+        n3 = gs3.nfunction();
+        n4 = gs4.nfunction();
+    }
+    const int n1234 = n1 * n2 * n3 * n4;
+
+    if(nbatch == 0) {
         // The code should check the return value, and ignore the integrals in the buffer if we get here
         //TODO: LOTS OF CODE DOESN'T DO THIS
-        ::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
-        return 0;
+        ::memset(target_, 0, sizeof(double)*n1234);
     }
-
-    if(has_puream_ && !spheric_){
+    else if(has_puream_ && !spheric_ && !force_cartesian_) {
         double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
         source_ = sourcetmp;
-    }else{
+    }
+    else {
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);
     }
-    return nbatch;
-
+    return n1234;
 }
 
 

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -80,6 +80,12 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory* integral, int deriv,
     bs4_ = original_bs4_;
     same_bs_ = (bs1_ == bs2_ && bs1_ == bs3_ && bs1_ == bs4_);
 
+    has_puream_ = bs1_->has_puream() || bs2_->has_puream() ||
+                  bs3_->has_puream() || bs4_->has_puream();
+
+    spheric_ = 0; //bs1_->has_puream() && bs2_->has_puream() &&
+                  //bs3_->has_puream() && bs4_->has_puream();
+
     size_t max_cart = INT_NCART(basis1()->max_am()) * INT_NCART(basis2()->max_am()) *
                       INT_NCART(basis3()->max_am()) * INT_NCART(basis4()->max_am());
 
@@ -159,7 +165,6 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory* integral, int deriv,
 #endif
 
     screen_ = 0;
-    spheric_ = 0;
 
     // Ask ERD for the maximum amount of scratch it'll need
     compute_scratch_size();
@@ -633,13 +638,16 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
 
     if(nbatch == 0){
         // The code should check the return value, and ignore the integrals in the buffer if we get here
-        //::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
+        //TODO: LOTS OF CODE DOESN'T DO THIS
+        ::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
         return 0;
     }
 
-    if(original_bs1_->has_puream()){
+    if(has_puream_ && !spheric_){
+        double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
+        source_ = sourcetmp;
     }else{
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);
     }

--- a/psi4/src/psi4/libmints/erd_eri.h
+++ b/psi4/src/psi4/libmints/erd_eri.h
@@ -117,6 +117,8 @@ protected:
     F_BOOL screen_;
     /// Whether ERD should use spherical harmonic basis functions
     F_BOOL spheric_;
+    /// Do any of the basis sets have spherical functions
+    bool has_puream_;
     /// Not relating to the monotony of integral computations, but whether the basis sets are all the same
     bool same_bs_;
 

--- a/psi4/src/psi4/libmints/gshell.cc
+++ b/psi4/src/psi4/libmints/gshell.cc
@@ -83,14 +83,14 @@ void ShellInfo::erd_normalize_shell()
 {
     erd_coef_.clear();
     double sum = 0.0;
+    double m = ((double) l_ + 1.5);
     for(int j = 0; j < nprimitive(); j++){
         for(int k = 0; k <= j; k++){
             double a1 = exp_[j];
             double a2 = exp_[k];
             double temp = (original_coef(j) * original_coef(k));
-            double temp2 = ((double) l_ + 1.5);
             double temp3 = (2.0 * sqrt(a1 * a2) / (a1 + a2));
-            temp3 = pow(temp3, temp2);
+            temp3 = pow(temp3, m);
             temp = temp * temp3;
             sum = sum + temp;
             if(j != k)
@@ -102,7 +102,7 @@ void ShellInfo::erd_normalize_shell()
         prefac = pow(2.0, 2*l_) / df[2*l_];
     double norm = sqrt(prefac / sum);
     for(int j = 0; j < nprimitive(); j++){
-        erd_coef_.push_back(original_coef_[j] * norm);
+        erd_coef_.push_back(original_coef_[j] * norm * pow(exp_[j], 0.5*m));
     }
 }
 

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -790,7 +790,8 @@ void FCHKWriter::write(const std::string &filename)
             normfac = sqrt(df[2*am]/pow(2.0, 2.0*am));
         for(int prim = 0; prim < nprim; ++prim){
             exponents.push_back(s.exp(prim));
-            coefficients.push_back(normfac*s.erd_coef(prim));
+            double normfac2 = normfac / pow(s.exp(prim), 0.5*((double)am+1.5));
+            coefficients.push_back(normfac2*s.erd_coef(prim));
         }
     }
 


### PR DESCRIPTION
## Description
Fixes some of the issues with ERD in Psi4

Moves a piece of the normalization from ERD to Psi4. This prevents multiplication by zero inside ERD, which results in incorrect integral values.

Note that the multiplication by zero doesn't happen in Psi4, as the normalization routine doesn't get called for a "zero" basis set (ie, in density fitting).

**Warning** I don't know how well-tested ERD in Psi4 is. I still get some failing tests, although there is certainly an improvement from before. Ideas for why this might be are welcome.

## Status
- [ ]  Ready to go


