### PR TITLE
FJT Recursion Change

### DIFF
--- a/psi4/src/psi4/libmints/eri.cc
+++ b/psi4/src/psi4/libmints/eri.cc
@@ -41,11 +41,11 @@ ERI::ERI(const IntegralFactory *integral, int deriv, bool use_shell_pairs)
     : TwoElectronInt(integral, deriv, use_shell_pairs)
 {
     // The +1 is needed for derivatives to work.
-    fjt_ = new Taylor_Fjt(basis1()->max_am() +
-                          basis2()->max_am() +
-                          basis3()->max_am() +
-                          basis4()->max_am() +
-                          deriv_+1, 1e-15);
+    fjt_ = new Split_Fjt(basis1()->max_am() +
+                         basis2()->max_am() +
+                         basis3()->max_am() +
+                         basis4()->max_am() +
+                         deriv_+1);
 }
 
 ERI::~ERI()

--- a/psi4/src/psi4/libmints/eribase.cc
+++ b/psi4/src/psi4/libmints/eribase.cc
@@ -1670,7 +1670,8 @@ static size_t fill_primitive_data(prim_data *PrimQuartet, Fjt *fjt,
                                   int nprim1, int nprim2, int nprim3, int nprim4,
                                   bool sh1eqsh2, bool sh3eqsh4, int deriv_lvl)
 {
-    double zeta, eta, ooze, rho, poz, coef1, PQx, PQy, PQz, PQ2, Wx, Wy, Wz, o12, o34, T, *F;
+    double F[am+deriv_lvl+1];
+    double zeta, eta, ooze, rho, poz, coef1, PQx, PQy, PQz, PQ2, Wx, Wy, Wz, o12, o34, T;
     double a1, a2, a3, a4;
     int p1, p2, p3, p4, i;
     size_t nprim = 0L;
@@ -1774,7 +1775,7 @@ static size_t fill_primitive_data(prim_data *PrimQuartet, Fjt *fjt,
 
                     T = rho * PQ2;
                     fjt->set_rho(rho);
-                    F = fjt->values(am + deriv_lvl, T);
+                    fjt->calculate(F, am + deriv_lvl, T);
 
                     for (i = 0; i <= am + deriv_lvl; ++i)
                         PrimQuartet[nprim].F[i] = F[i] * coef1;
@@ -2392,6 +2393,7 @@ size_t TwoElectronInt::compute_quartet(int sh1, int sh2, int sh3, int sh4)
     int nprim3;
     int nprim4;
     double A[3], B[3], C[3], D[3];
+    double F[am+1];
 
     A[0] = s1.center()[0];
     A[1] = s1.center()[1];
@@ -2550,7 +2552,7 @@ size_t TwoElectronInt::compute_quartet(int sh1, int sh2, int sh3, int sh4)
 
                         double T = rho * PQ2;
                         fjt_->set_rho(rho);
-                        double *F = fjt_->values(am, T);
+                        fjt_->calculate(F, am, T);
 
                         // Modify F to include overlap of ab and cd, eqs 14, 15, 16 of libint manual
                         double Scd = pow(M_PI * oon, 3.0 / 2.0) * exp(-a3 * a4 * oon * CD2) * c3 * c4;
@@ -2765,6 +2767,7 @@ size_t TwoElectronInt::compute_quartet_deriv1(int sh1, int sh2, int sh3, int sh4
     int nprim4 = s4.nprimitive();
     size_t nprim;
 
+    double F[am+2];
     double A[3], B[3], C[3], D[3];
     A[0] = s1.center()[0];
     A[1] = s1.center()[1];
@@ -2902,7 +2905,7 @@ size_t TwoElectronInt::compute_quartet_deriv1(int sh1, int sh2, int sh3, int sh4
                         libderiv_.PrimQuartet[nprim].twozeta_d = 2.0 * a4;
 
                         double T = rho * PQ2;
-                        double *F = fjt_->values(am + 1, T);
+                        fjt_->calculate(F, am + 1, T);
 
                         // Modify F to include overlap of ab and cd, eqs 14, 15, 16 of libint manual
                         double Scd = pow(M_PI * oon, 3.0 / 2.0) * exp(-a3 * a4 * oon * CD2) * c3 * c4;
@@ -3103,6 +3106,7 @@ size_t TwoElectronInt::compute_quartet_deriv2(int sh1, int sh2, int sh3, int sh4
     int nprim4 = s4.nprimitive();
     size_t nprim = 0;
 
+    double F[am+3];
     double A[3], B[3], C[3], D[3];
     A[0] = s1.center()[0];
     A[1] = s1.center()[1];
@@ -3238,7 +3242,7 @@ size_t TwoElectronInt::compute_quartet_deriv2(int sh1, int sh2, int sh3, int sh4
                         libderiv_.PrimQuartet[nprim].twozeta_d = 2.0 * a4;
 
                         double T = rho * PQ2;
-                        double *F = fjt_->values(am + 2, T);
+                        fjt_->calculate(F, am + 2, T);
 
                         // Modify F to include overlap of ab and cd, eqs 14, 15, 16 of libint manual
                         double Scd = pow(M_PI * oon, 3.0 / 2.0) * exp(-a3 * a4 * oon * CD2) * c3 * c4;

--- a/psi4/src/psi4/libmints/fjt.cc
+++ b/psi4/src/psi4/libmints/fjt.cc
@@ -130,8 +130,8 @@ Split_Fjt::Split_Fjt(unsigned int maxJ)
     // initialize the grid if we have to
     if(!grid_)
     {
-        max_Tval_ = 43.0; // rough
-        max_T_ = 430;
+        max_Tval_ = 40.0; // rough
+        max_T_ = 400;
         max_J_ = maxJ;
 
         nrow_ = max_T_+1;
@@ -162,9 +162,8 @@ void Split_Fjt::calculate(double * F, int J, double T)
     if(T > max_Tval_)
     {
         // long range asymptotic formula
-        const double p = -(2*J+1);
-        const double T2 = std::pow(T, p);
-        F[J] = boys_longfac[J] * std::sqrt(T2);
+        const double p = static_cast<double>(-J) - 0.5;
+        F[J] = boys_longfac[J] * std::pow(T, p);
     }
     else
     {

--- a/psi4/src/psi4/libmints/fjt.h
+++ b/psi4/src/psi4/libmints/fjt.h
@@ -99,23 +99,26 @@ class CorrelationFactor;
 /// Evaluates the Boys function F_j(T)
 class Fjt {
 public:
-    Fjt();
-    virtual ~Fjt();
+    Fjt() { };
+
+    virtual ~Fjt() { };
+
     /** Computed F_j(T) for every 0 <= j <= J (total of J+1 doubles).
-        The user may read/write these values.
-        The values will be overwritten with the next call to this functions.
-        The pointer will be invalidated after the call to ~Fjt. */
-    virtual double *values(int J, double T) =0;
+     *  Output is to F
+     */
+    virtual void calculate(double * F, int J, double T) =0;
     virtual void set_rho(double /*rho*/) { }
 };
 
 /// Uses Taylor interpolation of up to 8-th order to compute the Boys function
 class Split_Fjt : public Fjt {
 public:
-    Split_Fjt(unsigned int jmax);
+    Split_Fjt(unsigned int maxJ);
+
     virtual ~Split_Fjt();
-    /// Implements Fjt::values()
-    double *values(int J, double T);
+
+    void calculate(double * F, int J, double T);
+
 private:
 
     bool initialized_;  /* Has the table been initialized */
@@ -124,33 +127,30 @@ private:
                            of m (max_m+1 columns) */
 	int max_T_;         /* Maximum T index stored (10*max T value) */
 	double max_Tval_;   /* Maximum T value stored */
-    int max_m_;         /* Maximum value of m in the table, depends on cutoff
-                                  and the number of terms in Taylor interpolation */
-    double *F_;         /* Here computed values of Fj(T) are stored */
+    int max_J_;         /* Maximum value of J in the table */
 };
 
 class GaussianFundamental : public Fjt {
 protected:
     std::shared_ptr<CorrelationFactor> cf_;
     double rho_;
-    double* value_;
 
 public:
     GaussianFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~GaussianFundamental();
 
-    virtual double* values(int J, double T) = 0;
+    virtual void calculate(double * F, int J, double T) = 0;
     void set_rho(double rho);
 };
 
-    /**
-     *  Solves \scp -\gamma r_{12}
-     */
+/**
+ *  Solves \scp -\gamma r_{12}
+ */
 class F12Fundamental : public GaussianFundamental {
 public:
     F12Fundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~F12Fundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
 };
 
 /**
@@ -160,51 +160,51 @@ class F12ScaledFundamental : public GaussianFundamental {
 public:
     F12ScaledFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~F12ScaledFundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
 };
 
 class F12SquaredFundamental : public GaussianFundamental {
 public:
     F12SquaredFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~F12SquaredFundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
 };
 
 class F12G12Fundamental : public GaussianFundamental {
 private:
-    std::shared_ptr<Split_Fjt> Fm_;
+    Split_Fjt Fm_;
 public:
     F12G12Fundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~F12G12Fundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
 };
 
 class F12DoubleCommutatorFundamental : public GaussianFundamental {
 public:
     F12DoubleCommutatorFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
     virtual ~F12DoubleCommutatorFundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
 };
 
 class ErfFundamental : public GaussianFundamental {
 private:
     double omega_;
-    std::shared_ptr<Split_Fjt> boys_;
+    Split_Fjt boys_;
 public:
     ErfFundamental(double omega, int max);
     virtual ~ErfFundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
     void setOmega(double omega) { omega_ = omega; }
 };
 
 class ErfComplementFundamental : public GaussianFundamental {
 private:
     double omega_;
-    std::shared_ptr<Split_Fjt> boys_;
+    Split_Fjt boys_;
 public:
     ErfComplementFundamental(double omega, int max);
     virtual ~ErfComplementFundamental();
-    double* values(int J, double T);
+    virtual void calculate(double * F, int J, double T);
     void setOmega(double omega) { omega_ = omega; }
 };
 

--- a/psi4/src/psi4/libmints/fjt.h
+++ b/psi4/src/psi4/libmints/fjt.h
@@ -56,6 +56,8 @@
 #ifndef _chemistry_qc_basis_fjt_h
 #define _chemistry_qc_basis_fjt_h
 
+#include <memory>
+
 // This table stores some common factors for the boys function
 // asymptotic form
 #define BOYS_LONGFAC_MAXN 50 // maximum value of nu stored
@@ -121,13 +123,14 @@ public:
 
 private:
 
-    bool initialized_;  /* Has the table been initialized */
-    double **grid_;     /* Table of "exact" Fm(T) values. Row index corresponds to
-                           values of T (max_T_+1 rows), column index to values
-                           of m (max_m+1 columns) */
-	int max_T_;         /* Maximum T index stored (10*max T value) */
-	double max_Tval_;   /* Maximum T value stored */
-    int max_J_;         /* Maximum value of J in the table */
+    static std::unique_ptr<double[]> grid_; /* Table of "exact" Fm(T) values. Row index corresponds to
+                                               values of T (max_T_+1 rows), column index to values
+                                               of m (max_m+1 columns) */
+    static int nrow_;       /* number of rows in the grid */
+    static int ncol_;       /* number of columns in the grid */
+    static int max_T_;        /* Maximum T index stored (10*max T value) */
+    static double max_Tval_;  /* Maximum T value stored */
+    static int max_J_;        /* Maximum value of J in the table */
 };
 
 class GaussianFundamental : public Fjt {

--- a/psi4/src/psi4/libmints/osrecur.cc
+++ b/psi4/src/psi4/libmints/osrecur.cc
@@ -32,7 +32,6 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/wavefunction.h"   // for df
 #include "psi4/libmints/osrecur.h"
-#include "psi4/libmints/fjt.h"
 #include "psi4/libpsi4util/exception.h"
 
 using namespace psi;
@@ -171,7 +170,8 @@ void ObaraSaikaTwoCenterMIRecursion::compute(double PA[3], double PB[3], double 
 }
 
 ObaraSaikaTwoCenterEFPRecursion::ObaraSaikaTwoCenterEFPRecursion(int max_am1, int max_am2):
-    max_am1_(max_am1), max_am2_(max_am2)
+    max_am1_(max_am1), max_am2_(max_am2),
+    boys_(max_am1+max_am2)
 {
     if (max_am1 < 0)
         throw SanityCheckError("ERROR: ObaraSaikaTwoCenterMVIRecursion -- max_am1 must be nonnegative", __FILE__, __LINE__);
@@ -245,14 +245,13 @@ void ObaraSaikaTwoCenterEFPRecursion::compute(double PA[3], double PB[3], double
     double tmp = sqrt(zeta) * M_2_SQRTPI;
     // U from A21
     double u = zeta * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1]; // TODO: Move this allocation into constructor
+    double F[mmax+1];
 
     // Zero out F
     memset(F, 0, sizeof(double) * (mmax+1));
 
     // Form Fm(U) from A20
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Perform recursion in m for (a|A(0)|s) using A20
     for (m=0; m<=mmax; ++m) {
@@ -775,7 +774,6 @@ void ObaraSaikaTwoCenterEFPRecursion::compute(double PA[3], double PB[3], double
             }
         }
     }
-    delete[] F;
 }
 
 
@@ -876,7 +874,8 @@ void ObaraSaikaTwoCenterRecursion::compute(double PA[3], double PB[3], double ga
 }
 
 ObaraSaikaTwoCenterVIRecursion::ObaraSaikaTwoCenterVIRecursion(int max_am1, int max_am2):
-    max_am1_(max_am1), max_am2_(max_am2)
+    max_am1_(max_am1), max_am2_(max_am2),
+    boys_(max_am1 + max_am2_)
 {
     if (max_am1 < 0)
         throw SanityCheckError("ERROR: ObaraSaikaTwoCenterVIRecursion -- max_am1 must be nonnegative", __FILE__, __LINE__);
@@ -912,11 +911,10 @@ void ObaraSaikaTwoCenterVIRecursion::compute(double PA[3], double PB[3], double 
     double tmp = sqrt(zeta) * M_2_SQRTPI;
     // U from A21
     double u = zeta * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1];
+    double F[mmax+1];
 
     // Form Fm(U) from A20
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Think we're having problems with values being left over.
     //zero_box(vi_, size_, size_, mmax + 1);
@@ -1040,9 +1038,6 @@ void ObaraSaikaTwoCenterVIRecursion::compute(double PA[3], double PB[3], double 
             }
         }
     }
-
-    delete[] F;
-
 }
 
 void ObaraSaikaTwoCenterVIRecursion::compute_erf(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2, double zetam)
@@ -1063,10 +1058,9 @@ void ObaraSaikaTwoCenterVIRecursion::compute_erf(double PA[3], double PB[3], dou
     double tmp = sqrt(zetam) * M_2_SQRTPI;
     // U from A21
     double u = zetam * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1];
+    double F[mmax+1];
 
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Think we're having problems with values being left over.
     //zero_box(vi_, size_, size_, mmax + 1);
@@ -1195,9 +1189,6 @@ void ObaraSaikaTwoCenterVIRecursion::compute_erf(double PA[3], double PB[3], dou
             }
         }
     }
-
-    delete[] F;
-
 }
 
 ObaraSaikaTwoCenterVIDerivRecursion::ObaraSaikaTwoCenterVIDerivRecursion(int max_am1, int max_am2)
@@ -1233,14 +1224,13 @@ void ObaraSaikaTwoCenterVIDerivRecursion::compute(double PA[3], double PB[3], do
     double tmp = sqrt(zeta) * M_2_SQRTPI;
     // U from A21
     double u = zeta * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1];
+    double F[mmax+1];
 
     // Zero out F
     memset(F, 0, sizeof(double) * (mmax+1));
 
     // Form Fm(U) from A20
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Perform recursion in m for (a|A(0)|s) using A20
     for (m=0; m<=mmax; ++m) {
@@ -1441,7 +1431,6 @@ void ObaraSaikaTwoCenterVIDerivRecursion::compute(double PA[3], double PB[3], do
             }
         }
     }
-    delete[] F;
 }
 
 ObaraSaikaTwoCenterVIDeriv2Recursion::ObaraSaikaTwoCenterVIDeriv2Recursion(int max_am1, int max_am2)
@@ -1485,14 +1474,13 @@ void ObaraSaikaTwoCenterVIDeriv2Recursion::compute(double PA[3], double PB[3], d
     double tmp = sqrt(zeta) * M_2_SQRTPI;
     // U from A21
     double u = zeta * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1]; // TODO: Move this allocation into constructor
+    double F[mmax+1];
 
     // Zero out F
     memset(F, 0, sizeof(double) * (mmax+1));
 
     // Form Fm(U) from A20
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Perform recursion in m for (a|A(0)|s) using A20
     for (m=0; m<=mmax; ++m) {
@@ -1824,7 +1812,6 @@ void ObaraSaikaTwoCenterVIDeriv2Recursion::compute(double PA[3], double PB[3], d
             }
         }
     }
-    delete[] F;
 }
 
 ObaraSaikaTwoCenterElectricField::ObaraSaikaTwoCenterElectricField(int max_am1, int max_am2)
@@ -1861,14 +1848,13 @@ void ObaraSaikaTwoCenterElectricField::compute(double PA[3], double PB[3], doubl
     double tmp = sqrt(zeta) * M_2_SQRTPI;
     // U from A21
     double u = zeta * (PC[0] * PC[0] + PC[1] * PC[1] + PC[2] * PC[2]);
-    double *F = new double[mmax+1]; // TODO: Move this allocation into constructor
+    double F[mmax+1];
 
     // Zero out F
     memset(F, 0, sizeof(double) * (mmax+1));
 
     // Form Fm(U) from A20
-    Split_Fjt fjt(mmax);
-    fjt.calculate(F, mmax, u);
+    boys_.calculate(F, mmax, u);
 
     // Perform recursion in m for (a|A(0)|s) using A20
     for (m=0; m<=mmax; ++m) {
@@ -2071,7 +2057,6 @@ void ObaraSaikaTwoCenterElectricField::compute(double PA[3], double PB[3], doubl
             }
         }
     }
-    delete[] F;
 }
 
 ObaraSaikaTwoCenterElectricFieldGradient::ObaraSaikaTwoCenterElectricFieldGradient(int max_am1, int max_am2)

--- a/psi4/src/psi4/libmints/osrecur.h
+++ b/psi4/src/psi4/libmints/osrecur.h
@@ -29,6 +29,8 @@
 #ifndef _psi_src_lib_libmints_osrecur_h
 #define _psi_src_lib_libmints_osrecur_h
 
+#include "psi4/libmints/fjt.h"
+
 namespace psi {
 
 /*! \ingroup MINTS
@@ -109,8 +111,7 @@ protected:
 
     double ***vi_;
 
-    // Forms Fm(U) from A20 (OS 1986)
-    void calculate_f(double *F, int n, double t);
+    Split_Fjt boys_;
 
 private:
     // No default constructor
@@ -300,8 +301,7 @@ protected:
     double*** yzz_;
     double*** zzz_;
 
-    // Forms Fm(U) from A20 (OS 1986)
-    void calculate_f(double *F, int n, double t);
+    Split_Fjt boys_;
 
 private:
     // No default constructor


### PR DESCRIPTION
## Description
Adds threading to the MintsHelper object. Notably we no longer build SO integrals directly in the SO basis, but build AO and transform AO->MO. This appears to be about as efficient as the former when threading, we can revisit this if the potential integrals can be improved.

Benchmark is a carbon chain in the cc-pvdz basis set, tuned to compute about a million basis functions per row.

```
# Original - 1 thread
   nbf  ntrial  ao_overlap  ao_kinetic  ao_potential  so_overlap  so_kinetic  so_potential
0   28    1275    0.002474    0.000240      0.000936    0.000253    0.000311      0.001072
1   98     104    0.005268    0.002996      0.031417    0.002182    0.002873      0.031835
2  168      35    0.007805    0.007087      0.149304    0.005561    0.007733      0.150582
3  238      17    0.019714    0.014981      0.415791    0.010558    0.014752      0.418562
4  308      10    0.029242    0.023728      0.890593    0.017159    0.023903      0.938164
5  378       6    0.038581    0.034306      1.624236    0.023958    0.034886      1.637466
6  448       4    0.058684    0.050234      2.687780    0.033669    0.048659      2.867169
7  518       3    0.073995    0.067988      4.212363    0.043464    0.063137      4.170965

# New algorithm - 1 thread
   nbf  ntrial  ao_overlap  ao_kinetic  ao_potential  so_overlap  so_kinetic  so_potential
0   28    1275    0.002221    0.000152      0.000583    0.002632    0.000274      0.000731
1   98     104    0.004644    0.001872      0.016447    0.004653    0.002240      0.016920
2  168      35    0.005474    0.004001      0.076230    0.006461    0.004780      0.078292
3  238      17    0.007382    0.006899      0.210317    0.010013    0.008758      0.214130
4  308      10    0.011478    0.011354      0.449083    0.015937    0.015050      0.452936
5  378       6    0.017539    0.016836      0.817148    0.025508    0.022129      0.825095
6  448       4    0.022457    0.023191      1.350382    0.028970    0.031135      1.363716
7  518       3    0.029087    0.030661      2.079129    0.040195    0.042085      2.086033

# New algorithm -  6 threads
   nbf  ntrial  ao_overlap  ao_kinetic  ao_potential  so_overlap  so_kinetic  so_potential
0   28    1275    0.001724    0.000046      0.001282    0.001815    0.000171      0.001468
1   98     104    0.001922    0.000262      0.004997    0.002548    0.000852      0.005569
2  168      35    0.002558    0.000697      0.019184    0.003850    0.001897      0.020388
3  238      17    0.003629    0.001342      0.049260    0.005645    0.003470      0.051254
4  308      10    0.004355    0.003332      0.120245    0.009402    0.006256      0.109358
5  378       6    0.008223    0.004361      0.190977    0.014398    0.009077      0.192586
6  448       4    0.011751    0.006664      0.311692    0.017004    0.012781      0.312895
7  518       3    0.017167    0.007853      0.475830    0.023663    0.018094      0.481414
```

As you can see efficiency is not great. We are spending about 99% of the time inside `compute_shell` however. So, if we want better efficiency were going to have to run this through `vtune` and find out whats happening in `OneBodyAOInt`. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
 - [x] Moves Wavefunction classes out of `export_mints.cc`.
 - [x] Threads several common Matrix functions.
 - [x] Adds add/subtract/axpy/rms/sum_of_squares to the Vector object.
* **Developer Interest**
  - [x] MintsHelper is now threaded for one-body integrals.
  - [ ] Switch FJT to the LibInt version.

## Questions
- [ ]  It looks like `Vector::norm` actually returns sum of squares. Anyone know why that is?

## Status
- [ ]  Ready to go

