### PR TITLE
attempt to stop double travis-ci-ing our PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -179,3 +179,10 @@ before_script:
 script:
 - python ../.scripts/travis_run_test.py
 - python ../.scripts/travis_print_failing.py
+
+# safelist
+branches:
+  only:
+  - master
+  - 1.0.x
+  - libxc


### PR DESCRIPTION
Most of the developers have Travis turned on in our psi4 forks (esp. as we each hosted _the_ Psi4 for a different phase over the summer). So every time we push a branch and make a PR back to psi4/psi4, Travis is running twice. According to [this](https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches), we can turn on/off travis for certain branches. So this PR hopefully keeps Travis running on all the psi4/psi4 PRs and any long-term non-PR branches you add, while turning it off for the branches that are covered under psi4/psi4 master testing. At least I think that's how this works.
