### PR TITLE
add intel RTL Fortran threading initialization/finalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,27 +36,27 @@ matrix:
       - NAME='clang'
       - VERSION='3.6'
 
-  - os: linux
-    compiler: clang
-    addons: &2
-      apt:
-        sources:
-        - llvm-toolchain-precise-3.9
-        - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
-        packages:
-        - liblapack-dev
-        - clang-3.9
-        - libhdf5-serial-dev
-        - gfortran
-    env:
-      - CXX_COMPILER='clang++-3.9'
-      - PYTHON_VER='3.5'
-      - C_COMPILER='clang-3.9'
-      - Fortran_COMPILER='gfortran'
-      - BUILD_TYPE='release'
-      - NAME='clang'
-      - VERSION='3.9'
+  #- os: linux
+  #  compiler: clang
+  #  addons: &2
+  #    apt:
+  #      sources:
+  #      - llvm-toolchain-precise-3.9
+  #      - ubuntu-toolchain-r-test
+  #      - george-edison55-precise-backports
+  #      packages:
+  #      - liblapack-dev
+  #      - clang-3.9
+  #      - libhdf5-serial-dev
+  #      - gfortran
+  #  env:
+  #    - CXX_COMPILER='clang++-3.9'
+  #    - PYTHON_VER='3.5'
+  #    - C_COMPILER='clang-3.9'
+  #    - Fortran_COMPILER='gfortran'
+  #    - BUILD_TYPE='release'
+  #    - NAME='clang'
+  #    - VERSION='3.9'
 
   - os: linux
     compiler: gcc

--- a/external/upstream/dkh/CMakeLists.txt
+++ b/external/upstream/dkh/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${ENABLE_dkh})
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                       # OpenMP irrelevant
+                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
                        -DENABLE_XHOST=${ENABLE_XHOST}
                        -DBUILD_FPIC=${BUILD_FPIC}
                        -DENABLE_GENERIC=${ENABLE_GENERIC}

--- a/external/upstream/gdma/CMakeLists.txt
+++ b/external/upstream/gdma/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${ENABLE_gdma})
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                       # OpenMP irrelevant
+                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
                        -DENABLE_XHOST=${ENABLE_XHOST}
                        -DBUILD_FPIC=${BUILD_FPIC}
                        -DENABLE_GENERIC=${ENABLE_GENERIC}

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -32,7 +32,7 @@ if(${ENABLE_PCMSolver})
                        -DCMAKE_INSTALL_DATADIR=${CMAKE_INSTALL_DATADIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DSTATIC_LIBRARY_ONLY=${_a_only}
-#                       -DENABLE_OPENMP=???
+                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
                        #-DENABLE_XHOST=???  # option missing
                        #-DENABLE_XHOST=${ENABLE_XHOST}  # option missing
                        #-DBUILD_FPIC=${BUILD_FPIC}  # always fpic'd

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -57,6 +57,13 @@
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
+// definitions for Fortran Runtime library init/finalize
+extern "C" {
+    void for_rtl_init_(int *, char **);
+    int for_rtl_finish_();
+    int for_set_reentrancy(int *);
+}
+
 using namespace psi;
 
 // Python helper wrappers
@@ -1177,6 +1184,8 @@ bool psi4_python_module_initialize()
     read_options("", Process::environment.options, true);
     Process::environment.options.set_read_globals(false);
 
+    for_rtl_init_(NULL, NULL);
+
     initialized = true;
 
     return true;
@@ -1184,6 +1193,8 @@ bool psi4_python_module_initialize()
 
 void psi4_python_module_finalize()
 {
+    for_rtl_finish_();
+
     py_psi_plugin_close_all();
 
     // Shut things down:

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1184,7 +1184,9 @@ bool psi4_python_module_initialize()
     read_options("", Process::environment.options, true);
     Process::environment.options.set_read_globals(false);
 
+#ifdef __INTEL_COMPILER
     for_rtl_init_(NULL, NULL);
+#endif
 
     initialized = true;
 
@@ -1193,7 +1195,9 @@ bool psi4_python_module_initialize()
 
 void psi4_python_module_finalize()
 {
+#ifdef __INTEL_COMPILER
     for_rtl_finish_();
+#endif
 
     py_psi_plugin_close_all();
 


### PR DESCRIPTION
## Description
@bennybp pointed out [here](https://github.com/psi4/erd/pull/5) that we need to be paying attention to thread safety in called libraries, even if they don't have OpenMP, because Psi4 does. This is trying to follow the guidance in [the venerable document (search `ifcoremt`)](https://software.intel.com/en-us/articles/threading-fortran-applications-for-parallel-performance-on-multi-core-systems)

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Adds rtl_init and rtl_finalize calls. According to the sample code below, also supposed to set reentrancy, but I don't know what to do about that.
  - [x] Drops clang-3.9 travis test that's a little slow. I'm told that clang 3.9 is the same as Mac/Distelli is running anyways.
* **User-Facing for Release Notes**

## Questions
- [x]  I don't know much about this, but it appears harmless, at least for Intel compilers. Going to let Travis test other build systems. Any thoughts?

## Status
- [x]  Ready to go

```
/*
 * Multithreaded C-Fortran mixed language test program
 */

#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <pthread.h>
#include <errno.h>
#include "threadpool.h"

#include "forreent.h"

#define NUM_THREADS 12
#define NUM_JOBS 10

/* definitions for Fortran Runtime library init/finalize */
extern void for_rtl_init_ (int *, char **);
extern int for_rtl_finish_ ( );
extern int for_set_reentrancy (int *);

/* declare the external Fortran function 'fpa' */
extern void fpa(int io, char *filename);  

void job_thread(void *arg1, void *arg2);

int main(int argc, char **argv)
{
    threadpool tp;
    int i;
    int *reent ;
    int fstat;

    char filenames[NUM_JOBS][100];
    int io[NUM_JOBS];

    int io_status;
    /* Call the Fortran Runtime library for initialization */
    for_rtl_init_ (&argc, argv);
    *reent = FOR_K_REENTRANCY_THREADED;
    fstat = for_set_reentrancy( reent );
    printf ("fstat %i \n", fstat);

    /* Create a thread pool of 12 threads */
    tp = create_threadpool(NUM_THREADS);

    for (i = 0; i < NUM_JOBS; i++)
    {
        /* Create a unique file name i.e. "./Files/file1.txt" */
        sprintf(&filenames[i][0], "/home/spd/rwgreen/quad/rwgreen/forums/81088/file%d.txt", i+1);

        /* Create a unique file I/O unit */
        io[i] = 10+i;

        /* Add file name and I/O unit to threadpool job queue */
        printf("Main: queueing %s\n", &filenames[i][0]);
        dispatch_job(tp, job_thread, (void *) &filenames[i][0], &io[i]);
    }

    /* Wait a while for all the threads to do their thing */
    printf("Main: sleeping 20 secs...\n");
    sleep(20);
    printf("Main: waking up and destroying threadpool...\n");

    /* Clean up threadpool */
    destroy_threadpool(tp);

    /* close the Fortran Runtime */
    io_status = for_rtl_finish_ () ;

    printf("Main: exiting...\n");
    return 0;
}

/* Thread job function */
void job_thread(void *arg1, void *arg2)
{
    char *filename = (char *) arg1;
    int *io = (int *) arg2;
    unsigned int len = strlen(filename);

    char string[len+1];
    sprintf(string, "%s", filename);

    fpa(*io, string); 

    printf("->Thread %ld: Opened %s (len=%d) on I/O unit %d\n", pthread_self(), filename, len, *io);
}
```
