### PR TITLE
ERD progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ENABLE_gdma OR ENABLE_dkh OR ENABLE_erd OR ENABLE_PCMSolver) # OR ENABLE_JKFA
 endif()
 
 if(ENABLE_erd)
-    message(WARNING "ERD will build, link, and run in Psi4 just fine. However, it has not been hooked into Psi4 in all roles, so upon activating through ``set integral_package erd``, it will give *wrong* answers for density-fitting (default) calculations, indeed all except for ``set scf_type direct`` will be wrong. Consider this your warning.")
+    message(WARNING "ERD will build, link, and run in Psi4 just fine. However, it has not been hooked into Psi4 in all roles, notably gradients, LRC DFT energies, and ESP. So upon activating through ``set integral_package erd``, gradients will be caught and halted, but LRC DFT, ESP, and perhaps other types not tested and identified will give *wrong* answers. Consider this your warning.")
 endif()
 
 ############################  Options: Build How?  #############################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ENABLE_gdma OR ENABLE_dkh OR ENABLE_erd OR ENABLE_PCMSolver) # OR ENABLE_JKFA
 endif()
 
 if(ENABLE_erd)
-    message(WARNING "ERD will build, link, and run in Psi4 just fine. However, it has not been hooked into Psi4 in all roles, notably gradients, LRC DFT energies, and ESP. So upon activating through ``set integral_package erd``, gradients will be caught and halted, but LRC DFT, ESP, and perhaps other types not tested and identified will give *wrong* answers. Consider this your warning.")
+    message(WARNING "ERD will build, link, and run in Psi4 just fine. However, it has not been hooked into Psi4 in all roles, notably gradients, LRC DFT energies, and ESP. So upon activating through ``set integral_package erd``, known failures will be caught and halted, but perhaps other types not tested and identified will give *wrong* answers. Consider this your warning.")
 endif()
 
 ############################  Options: Build How?  #############################

--- a/doc/sphinxman/source/erd.rst
+++ b/doc/sphinxman/source/erd.rst
@@ -33,7 +33,7 @@
 Interface to ERD by N. Flocke and V. Lotrich
 ============================================
 
-.. codeauthor:: Andrew C. Simmonett
+.. codeauthor:: Andrew C. Simmonett and Benjamin P. Pritchard
 .. sectionauthor:: Lori A. Burns
 
 .. *Module:* :ref:`Keywords <apdx:dkh>`, :ref:`Samples <apdx:testSuitedkh>`
@@ -50,11 +50,19 @@ Interface to ERD by N. Flocke and V. Lotrich
 
 .. _`sec:erdinstall`:
 
-These are the AcesIII electron repulsion integrals that have been
-partially interfaced into libmints. Only conventional (no density-fitted)
-integrals are accessible, so enabling erd and adding ``set
-integral_package erd``, essentially breaks |PSIfour| for all SCF except
-direct.
+These are the AcesIII electron repulsion integrals that have
+been partially interfaced into libmints. Enabling erd and adding
+``set integral_package erd`` (do this in ``~/.psi4rc`` for universal
+effect) runs libderiv from libint for derivative integrals and erd for
+non-derivative integrals.
+
+.. warning:: The interface between erd and libderiv is not fully
+   debugged. So analytic gradients, particularly density-fitted ones,
+   are wrong; |PSIfour| will throw an error if you try to compute *any*
+   analytic gradient with |globals__integral_package| ``erd``. However,
+   ESP calculations and *energies* for long-range-corrected ("omega")
+   functionals are also wrong with erd, and these errors are *not* trapped.
+   So use with caution.
 
 Installation
 ~~~~~~~~~~~~

--- a/doc/sphinxman/source/erd.rst
+++ b/doc/sphinxman/source/erd.rst
@@ -58,11 +58,11 @@ non-derivative integrals.
 
 .. warning:: The interface between erd and libderiv is not fully
    debugged. So analytic gradients, particularly density-fitted ones,
-   are wrong; |PSIfour| will throw an error if you try to compute *any*
-   analytic gradient with |globals__integral_package| ``erd``. However,
-   ESP calculations and *energies* for long-range-corrected ("omega")
-   functionals are also wrong with erd, and these errors are *not* trapped.
-   So use with caution.
+   are wrong, as are ESP calculations and some energies for long-range
+   corrected ("omega") functionals. Insofar as faulty answers are
+   anticipated with |globals__integral_package| ``erd``, |PSIfour| will
+   throw an error if you try to execute that class of computation. But
+   there may be more, so use with caution.
 
 Installation
 ~~~~~~~~~~~~

--- a/external/upstream/erd/CMakeLists.txt
+++ b/external/upstream/erd/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${ENABLE_erd})
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                       # OpenMP irrelevant
+                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
                        -DENABLE_XHOST=${ENABLE_XHOST}
                        -DBUILD_FPIC=${BUILD_FPIC}
                        -DENABLE_GENERIC=${ENABLE_GENERIC}

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -82,6 +82,9 @@ def _find_derivative_type(ptype, method_name, user_dertype):
             raise ValidationError("_find_derivative_type: user_dertype should only be None or int!")
         dertype = user_dertype
 
+    if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (dertype != 0):
+        raise ValidationError("INTEGRAL_PACKAGE ERD does not play nicely with gradients, so stopping.")
+
     # Summary validation
     if (dertype == 2) and (method_name in procedures['hessian']):
         pass

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -83,7 +83,7 @@ def _find_derivative_type(ptype, method_name, user_dertype):
         dertype = user_dertype
 
     if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (dertype != 0):
-        raise ValidationError("INTEGRAL_PACKAGE ERD does not play nicely with gradients, so stopping.")
+        raise ValidationError('INTEGRAL_PACKAGE ERD does not play nicely with derivatives, so stopping.')
 
     # Summary validation
     if (dertype == 2) and (method_name in procedures['hessian']):

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -90,6 +90,10 @@ def cubeprop(wfn, **kwargs):
     if not core.has_global_option_changed('CUBEPROP_TASKS'):
         core.set_global_option('CUBEPROP_TASKS',['ORBITALS'])
 
+    if ((core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and
+        ('ESP' in core.get_global_option('CUBEPROP_TASKS'))):
+        raise ValidationError('INTEGRAL_PACKAGE ERD does not play nicely with electrostatic potential, so stopping.')
+
     cp = core.CubeProperties(wfn)
     cp.compute_properties()
 

--- a/psi4/driver/procedures/dft_functional.py
+++ b/psi4/driver/procedures/dft_functional.py
@@ -34,6 +34,7 @@ import os
 import math
 from psi4 import core
 from psi4.driver.qcdb import interface_dftd3 as dftd3
+from psi4.driver.p4util.exceptions import *
 
 ## ==> Functionals <== ##
 

--- a/psi4/driver/procedures/dft_functional.py
+++ b/psi4/driver/procedures/dft_functional.py
@@ -3079,6 +3079,9 @@ def build_superfunctional(alias):
         raise KeyError("SCF: SCF_TYPE (%s) not supported for range-seperated functionals."
                         % core.get_option("SCF", "SCF_TYPE"))
 
+    if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (sup[0].is_x_lrc()):
+        raise ValidationError('INTEGRAL_PACKAGE ERD does not play nicely with LRC DFT functionals, so stopping.')
+
     return sup
 
 def test_ccl_functional(functional, ccl_functional):

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -656,10 +656,8 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
         ::memset(target_, 0, sizeof(double)*n1234);
     }
     else if(has_puream_ && !spheric_ && !force_cartesian_) {
-        double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
-        source_ = sourcetmp;
     }
     else {
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -636,23 +636,35 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
     outfile->Printf( "%d integrals were computed\n", nbatch);
 #endif
 
-    if(nbatch == 0){
+    int n1, n2, n3, n4;
+    if (force_cartesian_) {
+        n1 = gs1.ncartesian();
+        n2 = gs2.ncartesian();
+        n3 = gs3.ncartesian();
+        n4 = gs4.ncartesian();
+    } else {
+        n1 = gs1.nfunction();
+        n2 = gs2.nfunction();
+        n3 = gs3.nfunction();
+        n4 = gs4.nfunction();
+    }
+    const int n1234 = n1 * n2 * n3 * n4;
+
+    if(nbatch == 0) {
         // The code should check the return value, and ignore the integrals in the buffer if we get here
         //TODO: LOTS OF CODE DOESN'T DO THIS
-        ::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
-        return 0;
+        ::memset(target_, 0, sizeof(double)*n1234);
     }
-
-    if(has_puream_ && !spheric_){
+    else if(has_puream_ && !spheric_ && !force_cartesian_) {
         double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
         source_ = sourcetmp;
-    }else{
+    }
+    else {
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);
     }
-    return nbatch;
-
+    return n1234;
 }
 
 

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -80,6 +80,12 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory* integral, int deriv,
     bs4_ = original_bs4_;
     same_bs_ = (bs1_ == bs2_ && bs1_ == bs3_ && bs1_ == bs4_);
 
+    has_puream_ = bs1_->has_puream() || bs2_->has_puream() ||
+                  bs3_->has_puream() || bs4_->has_puream();
+
+    spheric_ = 0; //bs1_->has_puream() && bs2_->has_puream() &&
+                  //bs3_->has_puream() && bs4_->has_puream();
+
     size_t max_cart = INT_NCART(basis1()->max_am()) * INT_NCART(basis2()->max_am()) *
                       INT_NCART(basis3()->max_am()) * INT_NCART(basis4()->max_am());
 
@@ -159,7 +165,6 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory* integral, int deriv,
 #endif
 
     screen_ = 0;
-    spheric_ = 0;
 
     // Ask ERD for the maximum amount of scratch it'll need
     compute_scratch_size();
@@ -633,13 +638,16 @@ size_t ERDTwoElectronInt::compute_shell(int shell_i, int shell_j, int shell_k, i
 
     if(nbatch == 0){
         // The code should check the return value, and ignore the integrals in the buffer if we get here
-        //::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
+        //TODO: LOTS OF CODE DOESN'T DO THIS
+        ::memset(target_, 0, sizeof(double)*gs1.nfunction() *gs2.nfunction() *gs3.nfunction() *gs4.nfunction());
         return 0;
     }
 
-    if(original_bs1_->has_puream()){
+    if(has_puream_ && !spheric_){
+        double * sourcetmp = source_;
         source_ = &(dscratch_[buffer_offset_-1]);
         pure_transform(shell_i, shell_j, shell_k, shell_l, 1);
+        source_ = sourcetmp;
     }else{
         ::memcpy(target_, &(dscratch_[buffer_offset_-1]), sizeof(double)*nbatch);
     }

--- a/psi4/src/psi4/libmints/erd_eri.h
+++ b/psi4/src/psi4/libmints/erd_eri.h
@@ -117,6 +117,8 @@ protected:
     F_BOOL screen_;
     /// Whether ERD should use spherical harmonic basis functions
     F_BOOL spheric_;
+    /// Do any of the basis sets have spherical functions
+    bool has_puream_;
     /// Not relating to the monotony of integral computations, but whether the basis sets are all the same
     bool same_bs_;
 

--- a/psi4/src/psi4/libmints/gshell.cc
+++ b/psi4/src/psi4/libmints/gshell.cc
@@ -83,14 +83,14 @@ void ShellInfo::erd_normalize_shell()
 {
     erd_coef_.clear();
     double sum = 0.0;
+    double m = ((double) l_ + 1.5);
     for(int j = 0; j < nprimitive(); j++){
         for(int k = 0; k <= j; k++){
             double a1 = exp_[j];
             double a2 = exp_[k];
             double temp = (original_coef(j) * original_coef(k));
-            double temp2 = ((double) l_ + 1.5);
             double temp3 = (2.0 * sqrt(a1 * a2) / (a1 + a2));
-            temp3 = pow(temp3, temp2);
+            temp3 = pow(temp3, m);
             temp = temp * temp3;
             sum = sum + temp;
             if(j != k)
@@ -102,7 +102,7 @@ void ShellInfo::erd_normalize_shell()
         prefac = pow(2.0, 2*l_) / df[2*l_];
     double norm = sqrt(prefac / sum);
     for(int j = 0; j < nprimitive(); j++){
-        erd_coef_.push_back(original_coef_[j] * norm);
+        erd_coef_.push_back(original_coef_[j] * norm * pow(exp_[j], 0.5*m));
     }
 }
 

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -790,7 +790,8 @@ void FCHKWriter::write(const std::string &filename)
             normfac = sqrt(df[2*am]/pow(2.0, 2.0*am));
         for(int prim = 0; prim < nprim; ++prim){
             exponents.push_back(s.exp(prim));
-            coefficients.push_back(normfac*s.erd_coef(prim));
+            double normfac2 = normfac / pow(s.exp(prim), 0.5*((double)am+1.5));
+            coefficients.push_back(normfac2*s.erd_coef(prim));
         }
     }
 

--- a/tests/erd/CMakeLists.txt
+++ b/tests/erd/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(scf5)
+add_subdirectory(mp2-module)
 

--- a/tests/erd/mp2-module/CMakeLists.txt
+++ b/tests/erd/mp2-module/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(erd-mp2-module "psi;df;mp2;erd;addon")

--- a/tests/erd/mp2-module/input.dat
+++ b/tests/erd/mp2-module/input.dat
@@ -1,0 +1,492 @@
+#! OMP2 cc-pVDZ energy for the H2O molecule and using ERD integrals.
+
+refnuc      =  9.18738642147759 #TEST
+refscf      = -76.02674017978704 #TEST
+refomp2     = -76.22932767439706 #TEST
+
+
+memory 256 mb
+
+set integral_package ERD
+
+molecule hf {
+H
+F 1 0.917
+}
+
+molecule bh_h2p {
+1 2
+B     0.10369114     0.00000000     0.00000000
+H    -1.13269886     0.00000000     0.00000000
+H     3.00000000     0.37149000     0.00000000
+H     3.00000000    -0.37149000     0.00000000
+}
+
+molecule interloper {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776
+}
+
+set basis cc-pvdz
+set scf_type df
+set guess sad
+set freeze_core true
+set e_convergence 8
+set d_convergence 7
+
+# <<<  RHF CONV  >>>
+
+scftot =   -100.019400605629
+mp2corl =    -0.201612517228
+mp2tot =   -100.221013122857
+
+set reference rhf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf conv: 3 occ*')  #TEST
+clean_variables()
+clean()
+
+set qc_module fnocc
+eugene = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, eugene, 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+clean_variables()
+clean()
+
+set qc_module detci
+david = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rhf conv: 3 detci')  #TEST
+clean_variables()
+clean()
+
+## <<<  RHF DF  >>>
+
+mp2corl =    -0.201610660387
+mp2tot =   -100.221011266016
+
+set reference rhf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+print_variables()
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+rob = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, rob, 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  RHF CD  >>>
+
+mp2corl =     -0.201609396752
+mp2tot =    -100.221010002381
+
+set reference rhf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF CONV  >>>
+
+scftot =    -25.945130559147
+mp2corl =    -0.058421122206
+mp2tot =    -26.003551681354
+
+set reference uhf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf conv: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF DF  >>>
+
+mp2corl =    -0.058390006825
+mp2tot =    -26.003520565972
+
+
+set reference uhf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF CD  >>>
+
+mp2corl =    -0.058409837177
+mp2tot =    -26.003540396324
+
+set reference uhf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF CONV  >>>
+
+scftot =     -25.943606522029
+mp2corl =     -0.060939211739
+mp2tot =     -26.004545733768
+
+set reference rohf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, ugur, 6, 'mp2 rohf conv: 2 occ*')  #TEST
+clean_variables()
+clean()
+
+set qc_module detci
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rohf conv: 2 detci')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF DF  >>>
+
+mp2corl =    -0.059372748391
+mp2tot =    -26.002979270420
+
+set reference rohf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rohf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF CD  >>>
+
+mp2corl =      -0.059393510962
+mp2tot =      -26.003000032991
+
+set reference rohf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rohf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+#
+# <<<  commencing gradients  >>>
+#
+
+set scf_type pk
+psi4.revoke_global_option_changed('SCF_TYPE')
+
+# <<<  RHF CONV gradient  >>>
+
+set reference rhf
+set mp2_type conv
+
+# fnocc findif-5 fc pk+conv
+scftot =   -100.01941126902270
+mp2corl =    -0.201627516796
+mp2tot =   -100.221038785818
+mp2totg = psi4.Matrix(2, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.00317450456474],
+               [     0.00000000000000,     0.00000000000000,    -0.00317450456474]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+# test ready in case ever implemented
+#set qc_module occ
+#theme = 'mp2 grad rhf conv fc: 1 occ*'
+#retG = gradient('mp2', molecule=hf)
+#compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+#compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+#compare_matrices(mp2totg, retG, 6, theme)  #TEST
+#clean_variables()
+#clean()
+
+# fnocc findif-5 nfc pk+conv
+scftot =   -100.019411269023  # different from sp above which were df/conv
+mp2corl =    -0.203781911950
+mp2tot =   -100.223193180973
+mp2tot_vals = [[   0.0000000000,       0.0000000000,       0.0028193375],
+               [   0.0000000000,       0.0000000000,      -0.0028193375]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad rhf conv nfc: 1 occ*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  RHF DF gradient  >>>
+
+set reference rhf
+set mp2_type df
+
+# dfmp2 findif-5 fc df+df
+scftot =   -100.0194006056297411
+mp2corl =    -0.2016106599354766
+mp2tot =   -100.2210112655652239
+mp2tot_vals = [[    0.00000000000000,    0.00000000000000,    0.00314716362539],
+               [    0.00000000000000,    0.00000000000000,   -0.00314716362539]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+### set qc_module occ
+### theme = 'mp2 grad rhf df fc: 2 occ'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+### set qc_module dfmp2
+### theme = 'mp2 grad rhf df fc: 2 dfmp2*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# dfmp2 findif-5 nfc df+df
+scftot =   -100.0194006056297695
+mp2corl =    -0.2037649370559149
+mp2tot =   -100.2231655426856776
+mp2tot_vals = [[    0.00000000000000,     0.00000000000000,     0.00279211492833],
+               [    0.00000000000000,     0.00000000000000,    -0.00279211492833]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad rhf df nfc: 2 occ'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+### set qc_module dfmp2
+### theme = 'mp2 grad rhf df nfc: 2 dfmp2*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  RHF CD gradient  >>>
+
+# <<<  UHF CONV gradient  >>>
+
+set reference uhf
+set mp2_type conv
+
+# occ findif-5 nfc pk+conv
+scftot =    -25.94513842869638
+mp2corl =  -0.05948928003552
+mp2tot =  -26.00462770873190
+mp2totg = psi4.Matrix(4, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01250561195911],
+               [     0.00000000000000,     0.00000000000000,    -0.01206536529299],
+               [     0.00000000000000,     0.01033165380573,    -0.00022012333306],
+               [     0.00000000000000,    -0.01033165380573,    -0.00022012333306]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad uhf conv nfc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  UHF DF gradient  >>>
+
+set reference uhf
+set mp2_type df
+
+# dfmp2 findif-5 fc df+df
+scftot =   -25.9451305591489998
+mp2corl =   -0.0583900033598046
+mp2tot =   -26.0035205625088039
+mp2tot_vals = [[    0.00000000000000,     0.00000000000000,     0.01231996225662],
+               [    0.00000000000000,     0.00000000000000,    -0.01186374280678],
+               [    0.00000000000000,     0.01031743020277,    -0.00022810972492],
+               [    0.00000000000000,    -0.01031743020277,    -0.00022810972492]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+### set qc_module occ
+### theme = 'mp2 grad uhf df fc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# dfmp2 findif-5 nfc df+df
+scftot =    -25.9451305591489998
+mp2corl =    -0.0594557966607590
+mp2tot =    -26.0045863558097601
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01252024755551],
+               [     0.00000000000000,     0.00000000000000,    -0.01207773525598],
+               [     0.00000000000000,     0.01032204616770,    -0.00022125614977],
+               [     0.00000000000000,    -0.01032204616770,    -0.00022125614977]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad uhf df nfc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  UHF CD gradient  >>>
+
+# <<<  ROHF CONV gradient  >>>
+
+# <<<  ROHF DF gradient  >>>
+
+# <<<  ROHF CD gradient  >>>
+
+#
+# <<<  commencing findif routing test  >>>
+#
+
+# For gradients, this method would be found in the procedures table but
+#   would return a ManagedMethodError from proc.py. Normally, this would
+#   confuse the analytic-or-findif logic in gradient(). This scenario is
+#   now managed, and this test case makes sure it stays managed.
+
+scftot =  -25.9436065220297998
+mp2corl =  -0.0604436327328384
+mp2tot =  -26.0040501547626377
+mp2totg = psi4.Matrix(4, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01361287313486],
+               [     0.00000000000000,     0.00000000000000,    -0.01314329502424],
+               [     0.00000000000000,     0.01029838165151,    -0.00023478905531],
+               [     0.00000000000000,    -0.01029838165151,    -0.00023478905531]]
+mp2totg.set(mp2tot_vals)
+
+set reference rohf
+set mp2_type df
+set freeze_core false
+psi4.revoke_global_option_changed('SCF_TYPE')
+psi4.revoke_global_option_changed('QC_MODULE')
+set qc_module occ
+set points 5
+
+retG = gradient('mp2', molecule=bh_h2p)
+theme = 'mp2 grad rohf df nfc: findif'
+compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 6, theme)  #TEST
+clean_variables()
+clean()
+

--- a/tests/erd/mp2-module/output.ref
+++ b/tests/erd/mp2-module/output.ref
@@ -1,0 +1,9704 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1a2.dev229 
+
+                         Git: Rev {erd2} 2e8c416 dirty
+
+
+    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
+    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
+    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
+    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
+    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
+    (doi: 10.1002/wcms.93)
+
+
+                         Additional Contributions by
+    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
+    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
+    B. P. Pritchard
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Friday, 03 February 2017 07:05PM
+
+    Process ID:  24826
+    PSIDATADIR: /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! OMP2 cc-pVDZ energy for the H2O molecule and using ERD integrals.
+
+refnuc      =  9.18738642147759 #TEST
+refscf      = -76.02674017978704 #TEST
+refomp2     = -76.22932767439706 #TEST
+
+
+memory 256 mb
+
+set integral_package ERD
+
+molecule hf {
+H
+F 1 0.917
+}
+
+molecule bh_h2p {
+1 2
+B     0.10369114     0.00000000     0.00000000
+H    -1.13269886     0.00000000     0.00000000
+H     3.00000000     0.37149000     0.00000000
+H     3.00000000    -0.37149000     0.00000000
+}
+
+molecule interloper {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776
+}
+
+set basis cc-pvdz
+set scf_type df
+set guess sad
+set freeze_core true
+set e_convergence 8
+set d_convergence 7
+
+# <<<  RHF CONV  >>>
+
+scftot =   -100.019400605629
+mp2corl =    -0.201612517228
+mp2tot =   -100.221013122857
+
+set reference rhf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf conv: 3 occ*')  #TEST
+clean_variables()
+clean()
+
+set qc_module fnocc
+eugene = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, eugene, 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+clean_variables()
+clean()
+
+set qc_module detci
+david = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rhf conv: 3 detci')  #TEST
+clean_variables()
+clean()
+
+## <<<  RHF DF  >>>
+
+mp2corl =    -0.201610660387
+mp2tot =   -100.221011266016
+
+set reference rhf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+print_variables()
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+rob = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, rob, 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  RHF CD  >>>
+
+mp2corl =     -0.201609396752
+mp2tot =    -100.221010002381
+
+set reference rhf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=hf)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rhf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF CONV  >>>
+
+scftot =    -25.945130559147
+mp2corl =    -0.058421122206
+mp2tot =    -26.003551681354
+
+set reference uhf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf conv: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF DF  >>>
+
+mp2corl =    -0.058390006825
+mp2tot =    -26.003520565972
+
+
+set reference uhf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  UHF CD  >>>
+
+mp2corl =    -0.058409837177
+mp2tot =    -26.003540396324
+
+set reference uhf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 uhf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF CONV  >>>
+
+scftot =     -25.943606522029
+mp2corl =     -0.060939211739
+mp2tot =     -26.004545733768
+
+set reference rohf
+set mp2_type conv
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, ugur, 6, 'mp2 rohf conv: 2 occ*')  #TEST
+clean_variables()
+clean()
+
+set qc_module detci
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rohf conv: 2 detci')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF DF  >>>
+
+mp2corl =    -0.059372748391
+mp2tot =    -26.002979270420
+
+set reference rohf
+set mp2_type df
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rohf df: 2 occ')  #TEST
+clean_variables()
+clean()
+
+set qc_module dfmp2
+david = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, david, 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+clean_variables()
+clean()
+
+# <<<  ROHF CD  >>>
+
+mp2corl =      -0.059393510962
+mp2tot =      -26.003000032991
+
+set reference rohf
+set mp2_type cd
+
+set qc_module occ
+ugur = energy('mp2', molecule=bh_h2p)
+compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, ugur, 6, 'mp2 rohf cd: 1 occ*')  #TEST
+clean_variables()
+clean()
+
+#
+# <<<  commencing gradients  >>>
+#
+
+set scf_type pk
+psi4.revoke_global_option_changed('SCF_TYPE')
+
+# <<<  RHF CONV gradient  >>>
+
+set reference rhf
+set mp2_type conv
+
+# fnocc findif-5 fc pk+conv
+scftot =   -100.01941126902270
+mp2corl =    -0.201627516796
+mp2tot =   -100.221038785818
+mp2totg = psi4.Matrix(2, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.00317450456474],
+               [     0.00000000000000,     0.00000000000000,    -0.00317450456474]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+# test ready in case ever implemented
+#set qc_module occ
+#theme = 'mp2 grad rhf conv fc: 1 occ*'
+#retG = gradient('mp2', molecule=hf)
+#compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+#compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+#compare_matrices(mp2totg, retG, 6, theme)  #TEST
+#clean_variables()
+#clean()
+
+# fnocc findif-5 nfc pk+conv
+scftot =   -100.019411269023  # different from sp above which were df/conv
+mp2corl =    -0.203781911950
+mp2tot =   -100.223193180973
+mp2tot_vals = [[   0.0000000000,       0.0000000000,       0.0028193375],
+               [   0.0000000000,       0.0000000000,      -0.0028193375]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad rhf conv nfc: 1 occ*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  RHF DF gradient  >>>
+
+set reference rhf
+set mp2_type df
+
+# dfmp2 findif-5 fc df+df
+scftot =   -100.0194006056297411
+mp2corl =    -0.2016106599354766
+mp2tot =   -100.2210112655652239
+mp2tot_vals = [[    0.00000000000000,    0.00000000000000,    0.00314716362539],
+               [    0.00000000000000,    0.00000000000000,   -0.00314716362539]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+### set qc_module occ
+### theme = 'mp2 grad rhf df fc: 2 occ'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+### set qc_module dfmp2
+### theme = 'mp2 grad rhf df fc: 2 dfmp2*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# dfmp2 findif-5 nfc df+df
+scftot =   -100.0194006056297695
+mp2corl =    -0.2037649370559149
+mp2tot =   -100.2231655426856776
+mp2tot_vals = [[    0.00000000000000,     0.00000000000000,     0.00279211492833],
+               [    0.00000000000000,     0.00000000000000,    -0.00279211492833]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad rhf df nfc: 2 occ'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+### set qc_module dfmp2
+### theme = 'mp2 grad rhf df nfc: 2 dfmp2*'
+### retG = gradient('mp2', molecule=hf)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  RHF CD gradient  >>>
+
+# <<<  UHF CONV gradient  >>>
+
+set reference uhf
+set mp2_type conv
+
+# occ findif-5 nfc pk+conv
+scftot =    -25.94513842869638
+mp2corl =  -0.05948928003552
+mp2tot =  -26.00462770873190
+mp2totg = psi4.Matrix(4, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01250561195911],
+               [     0.00000000000000,     0.00000000000000,    -0.01206536529299],
+               [     0.00000000000000,     0.01033165380573,    -0.00022012333306],
+               [     0.00000000000000,    -0.01033165380573,    -0.00022012333306]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad uhf conv nfc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  UHF DF gradient  >>>
+
+set reference uhf
+set mp2_type df
+
+# dfmp2 findif-5 fc df+df
+scftot =   -25.9451305591489998
+mp2corl =   -0.0583900033598046
+mp2tot =   -26.0035205625088039
+mp2tot_vals = [[    0.00000000000000,     0.00000000000000,     0.01231996225662],
+               [    0.00000000000000,     0.00000000000000,    -0.01186374280678],
+               [    0.00000000000000,     0.01031743020277,    -0.00022810972492],
+               [    0.00000000000000,    -0.01031743020277,    -0.00022810972492]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core true
+
+### set qc_module occ
+### theme = 'mp2 grad uhf df fc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# dfmp2 findif-5 nfc df+df
+scftot =    -25.9451305591489998
+mp2corl =    -0.0594557966607590
+mp2tot =    -26.0045863558097601
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01252024755551],
+               [     0.00000000000000,     0.00000000000000,    -0.01207773525598],
+               [     0.00000000000000,     0.01032204616770,    -0.00022125614977],
+               [     0.00000000000000,    -0.01032204616770,    -0.00022125614977]]
+mp2totg.set(mp2tot_vals)
+
+set freeze_core false
+
+### set qc_module occ
+### theme = 'mp2 grad uhf df nfc: 1 occ*'
+### retG = gradient('mp2', molecule=bh_h2p)
+### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_matrices(mp2totg, retG, 6, theme)  #TEST
+### clean_variables()
+### clean()
+
+# <<<  UHF CD gradient  >>>
+
+# <<<  ROHF CONV gradient  >>>
+
+# <<<  ROHF DF gradient  >>>
+
+# <<<  ROHF CD gradient  >>>
+
+#
+# <<<  commencing findif routing test  >>>
+#
+
+# For gradients, this method would be found in the procedures table but
+#   would return a ManagedMethodError from proc.py. Normally, this would
+#   confuse the analytic-or-findif logic in gradient(). This scenario is
+#   now managed, and this test case makes sure it stays managed.
+
+scftot =  -25.9436065220297998
+mp2corl =  -0.0604436327328384
+mp2tot =  -26.0040501547626377
+mp2totg = psi4.Matrix(4, 3)
+mp2tot_vals = [[     0.00000000000000,     0.00000000000000,     0.01361287313486],
+               [     0.00000000000000,     0.00000000000000,    -0.01314329502424],
+               [     0.00000000000000,     0.01029838165151,    -0.00023478905531],
+               [     0.00000000000000,    -0.01029838165151,    -0.00023478905531]]
+mp2totg.set(mp2tot_vals)
+
+set reference rohf
+set mp2_type df
+set freeze_core false
+psi4.revoke_global_option_changed('SCF_TYPE')
+psi4.revoke_global_option_changed('QC_MODULE')
+set qc_module occ
+set points 5
+
+retG = gradient('mp2', molecule=bh_h2p)
+theme = 'mp2 grad rohf df nfc: findif'
+compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 6, theme)  #TEST
+clean_variables()
+clean()
+
+--------------------------------------------------------------------------
+
+  Memory set to 256.000 MiB by Python script.
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -99.90072566896721   -9.99007e+01   1.03631e-01 
+   @DF-RHF iter   1:   -99.98858327983388   -8.78576e-02   2.39156e-02 
+   @DF-RHF iter   2:  -100.01377496960880   -2.51917e-02   1.18552e-02 DIIS
+   @DF-RHF iter   3:  -100.01910110147952   -5.32613e-03   1.73073e-03 DIIS
+   @DF-RHF iter   4:  -100.01937121769200   -2.70116e-04   5.21555e-04 DIIS
+   @DF-RHF iter   5:  -100.01939971505494   -2.84974e-05   7.96441e-05 DIIS
+   @DF-RHF iter   6:  -100.01940059442471   -8.79370e-07   9.13869e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060555118   -1.11265e-08   8.65130e-07 DIIS
+   @DF-RHF iter   8:  -100.01940060562649   -7.53033e-11   1.21832e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562789   -1.40687e-12   1.33338e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.278131     2A1    -1.583457     3A1    -0.747199  
+       1B1    -0.628887     1B2    -0.628887  
+
+    Virtual:                                                              
+
+       4A1     0.183841     5A1     0.810057     2B1     1.412047  
+       2B2     1.412047     6A1     1.415770     3B1     1.604670  
+       3B2     1.604670     7A1     2.134266     8A1     2.499125  
+       9A1     4.004800     1A2     4.004800     4B1     4.280975  
+       4B2     4.280975    10A1     5.056529  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562789
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930204455973126
+    Two-Electron Energy =                  45.4799503990643075
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056278795
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -1.9499     Total:     1.9499
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               9
+      Number of SO shells:               9
+      Number of primitives:             27
+      Number of atomic orbitals:        20
+      Number of basis functions:        19
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  10    1    4    4 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 4515 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:12 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CACHELEVEL                  => 2                
+  CCL_ENERGY                  => FALSE            
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CEPA_OS_SCALE               => 1.27             
+  CEPA_SOS_SCALE              => 1.3              
+  CEPA_SS_SCALE               => 1.13             
+  CEPA_TYPE                   => CEPA0            
+  CI_TYPE                     => CONV             
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 14               
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EA_POLES                    => FALSE            
+  EKT_EA                      => FALSE            
+  EKT_IP                      => FALSE            
+  EP_EA_POLES                 => FALSE            
+  EP_IP_POLES                 => FALSE            
+  EP_MAXITER                  => 30               
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  INTEGRAL_PACKAGE            => ERD             !
+  IP_POLES                    => FALSE            
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOGRAD_DAMPING              => 1                
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_READ                     => FALSE            
+  MO_STEP_MAX                 => 0.5              
+  MO_WRITE                    => FALSE            
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => CONV            !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OPT_METHOD                  => ORB_RESP         
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 30               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  RELATIVISTIC                => NO               
+  RELAXED                     => TRUE             
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  SYMMETRIZE                  => TRUE             
+  TPDM_ABCD_TYPE              => DIRECT           
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => OMP2            !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       MP2   
+              Program Written by Ugur Bozkaya,
+              Latest Revision June 25, 2014.
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	RMS orbital gradient is changed to :     1.00e-06
+	MAX orbital gradient is changed to :     1.00e-04
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	  A1     1     2     7    0
+	  A2     0     0     1    0
+	  B1     0     1     3    0
+	  B2     0     1     3    0
+	==============================
+
+	Memory is    256 MB 
+	Cost of iabc is      0 MB 
+	Cost of abcd is      0 MB 
+	Switching to the incore algoritm for iabc..
+	Switching to the incore algoritm for abcd..
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     5.19366944090513
+	SCF Energy (a.u.)                  :  -100.01940060562789
+	REF Energy (a.u.)                  :  -100.01940060562789
+	Alpha-Alpha Contribution (a.u.)    :    -0.02674253674112
+	Alpha-Beta Contribution (a.u.)     :    -0.14812744401523
+	Beta-Beta Contribution (a.u.)      :    -0.02674253674112
+	Scaled_SS Correlation Energy (a.u.):    -0.01782835782742
+	Scaled_OS Correlation Energy (a.u.):    -0.17775293281828
+	SCS-MP2 Total Energy (a.u.)        :  -100.21498189627360
+	SOS-MP2 Total Energy (a.u.)        :  -100.01940060562789
+	SCSN-MP2 Total Energy (a.u.)       :  -100.11353433495664
+	SCS-MP2-VDW Total Energy (a.u.)    :  -100.23574627070852
+	SOS-PI-MP2 Total Energy (a.u.)     :  -100.22677902724922
+	MP2 Correlation Energy (a.u.)      :    -0.20161251749748
+	MP2 Total Energy (a.u.)            :  -100.22101312312537
+	============================================================================== 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:12 2017
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	mp2 rhf conv: 3 occ*..............................................PASSED
+	mp2 rhf conv: 3 occ*..............................................PASSED
+	mp2 rhf conv: 3 occ*..............................................PASSED
+	mp2 rhf conv: 3 occ*..............................................PASSED
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -99.90072566896721   -9.99007e+01   1.03631e-01 
+   @DF-RHF iter   1:   -99.98858327983388   -8.78576e-02   2.39156e-02 
+   @DF-RHF iter   2:  -100.01377496960880   -2.51917e-02   1.18552e-02 DIIS
+   @DF-RHF iter   3:  -100.01910110147952   -5.32613e-03   1.73073e-03 DIIS
+   @DF-RHF iter   4:  -100.01937121769200   -2.70116e-04   5.21555e-04 DIIS
+   @DF-RHF iter   5:  -100.01939971505494   -2.84974e-05   7.96441e-05 DIIS
+   @DF-RHF iter   6:  -100.01940059442471   -8.79370e-07   9.13869e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060555118   -1.11265e-08   8.65130e-07 DIIS
+   @DF-RHF iter   8:  -100.01940060562649   -7.53033e-11   1.21832e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562789   -1.40687e-12   1.33338e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.278131     2A1    -1.583457     3A1    -0.747199  
+       1B1    -0.628887     1B2    -0.628887  
+
+    Virtual:                                                              
+
+       4A1     0.183841     5A1     0.810057     2B1     1.412047  
+       2B2     1.412047     6A1     1.415770     3B1     1.604670  
+       3B2     1.604670     7A1     2.134266     8A1     2.499125  
+       9A1     4.004800     1A2     4.004800     4B1     4.280975  
+       4B2     4.280975    10A1     5.056529  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562789
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930204455973126
+    Two-Electron Energy =                  45.4799503990643075
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056278795
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -1.9499     Total:     1.9499
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               9
+      Number of SO shells:               9
+      Number of primitives:             27
+      Number of atomic orbitals:        20
+      Number of basis functions:        19
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  10    1    4    4 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 4515 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:12 2017
+
+        ==> Transform all two-electron integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+*** tstop() called on psinet at Fri Feb  3 19:05:12 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:12 2017
+
+
+
+        *****************************************************
+        *                                                   *
+        *                        MP2                        *
+        *                  Eugene DePrince                  *
+        *                                                   *
+        *****************************************************
+
+
+
+  ==> Input parameters <==
+
+        Freeze core orbitals?                 yes
+        Use frozen natural orbitals?           no
+        r_convergence:                  1.000e-07
+        e_convergence:                  1.000e-08
+        Number of DIIS vectors:                 8
+        Number of frozen core orbitals:         1
+        Number of active occupied orbitals:     4
+        Number of active virtual orbitals:     14
+        Number of frozen virtual orbitals:      0
+
+        ==> Transform (OV|OV) integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+        ==> Sort (OV|OV) integrals <==
+
+        CC integral sort will use    0.02 mb
+        Sort (IA|JB)........done.
+
+        OS MP2 correlation energy:            -0.148127444015
+        SS MP2 correlation energy:            -0.053485073482
+        MP2 correlation energy:               -0.201612517497
+      * MP2 total energy:                   -100.221013123125
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:12 2017
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	mp2 rhf conv: 3 fnocc.............................................PASSED
+	mp2 rhf conv: 3 fnocc.............................................PASSED
+	mp2 rhf conv: 3 fnocc.............................................PASSED
+	mp2 rhf conv: 3 fnocc.............................................PASSED
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -99.90072566896721   -9.99007e+01   1.03631e-01 
+   @DF-RHF iter   1:   -99.98858327983388   -8.78576e-02   2.39156e-02 
+   @DF-RHF iter   2:  -100.01377496960880   -2.51917e-02   1.18552e-02 DIIS
+   @DF-RHF iter   3:  -100.01910110147952   -5.32613e-03   1.73073e-03 DIIS
+   @DF-RHF iter   4:  -100.01937121769200   -2.70116e-04   5.21555e-04 DIIS
+   @DF-RHF iter   5:  -100.01939971505494   -2.84974e-05   7.96441e-05 DIIS
+   @DF-RHF iter   6:  -100.01940059442471   -8.79370e-07   9.13869e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060555118   -1.11265e-08   8.65130e-07 DIIS
+   @DF-RHF iter   8:  -100.01940060562649   -7.53033e-11   1.21832e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562789   -1.40687e-12   1.33338e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.278131     2A1    -1.583457     3A1    -0.747199  
+       1B1    -0.628887     1B2    -0.628887  
+
+    Virtual:                                                              
+
+       4A1     0.183841     5A1     0.810057     2B1     1.412047  
+       2B2     1.412047     6A1     1.415770     3B1     1.604670  
+       3B2     1.604670     7A1     2.134266     8A1     2.499125  
+       9A1     4.004800     1A2     4.004800     4B1     4.280975  
+       4B2     4.280975    10A1     5.056529  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562789
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930204455973126
+    Two-Electron Energy =                  45.4799503990643075
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056278795
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -1.9499     Total:     1.9499
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               9
+      Number of SO shells:               9
+      Number of primitives:             27
+      Number of atomic orbitals:        20
+      Number of basis functions:        19
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  10    1    4    4 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 4515 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+         ---------------------------------------------------------
+                          Configuration Interaction
+                            (a 'D E T C I' module)
+
+                 C. David Sherrill, Daniel G. A. Smith, and
+                              Matt L. Leininger
+         ---------------------------------------------------------
+
+
+   ==> Parameters <==
+
+    EX LEVEL       =        8      H0 BLOCKSIZE  =        1
+    VAL EX LEVEL   =        0      H0 GUESS SIZE =        1
+    H0COUPLINGSIZE =        0      H0 COUPLING   =       NO
+    MAXITER        =       24      NUM PRINT     =       20
+    NUM ROOTS      =        1      ICORE         =        1
+    PRINT LVL      =        1      FCI           =      YES
+    R CONV         = 1.00e-04      MIXED         =      YES
+    E CONV         = 1.00e-08      MIXED4        =      YES
+    R4S            =       NO      REPL OTF      =       NO
+    DIAG METHOD    =      SEM      FOLLOW ROOT   =        0
+    PRECONDITIONER = DAVIDSON      UPDATE        = DAVIDSON
+    S              =   0.0000      Ms0           =      YES
+    GUESS VECTOR   =     UNIT      OPENTYPE      =     NONE
+    COLLAPSE SIZE  =        1      HD AVG        = ORB_ENER
+MPN options:
+    MPN            =      YES      MPN SCHMIDT   =       NO
+    ZAPTN          =       NO      MPN WIGNER    =      YES
+    PERT Z         =   1.0000
+    MAX NUM VECS   =        2      REF SYM       =     AUTO
+    IOPEN        =       NO
+
+    EX ALLOW       =  1  1  1  1  1  1  1  1 
+    STATE AVERAGE  =  0(1.00) 
+
+   ==> CI Orbital and Space information <==
+
+   ------------------------------------------------------
+               Space    Total    A1    A2    B1    B2
+   ------------------------------------------------------
+                 Nso       19    10     1     4     4
+                 Nmo       19    10     1     4     4
+               Ndocc        5     3     0     1     1
+               Nsocc        0     0     0     0     0
+   ------------------------------------------------------
+                       CI Spaces
+   ------------------------------------------------------
+        Dropped DOCC        1     1     0     0     0
+              Active       18     9     1     4     4
+        Dropped UOCC        0     0     0     0     0
+   ------------------------------------------------------
+
+   ==> Setting up CI strings <==
+
+    There are 3060 alpha and 3060 beta strings
+    The CI space requires 2342800 (2.34E+06) determinants and 73 blocks
+
+   ==> Transforming CI integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+   ==> Starting MPn CI Computation <==
+
+ orb_energy[0] = -26.278131
+   CalcInfo_->escf =      -100.019400605627894
+   CalcInfo_->e0   =       -59.733119552154214
+   CalcInfo_->enuc =         5.193669440905126
+   CalcInfo_->e1   =       -45.479950494378805
+
+   n         Corr. Energy                  E(MPn)               n         Corr. Energy                  E(MPn)
+
+   0          0.000000000000000       -54.539450111249089
+   1        -45.479950494378805      -100.019400605627894
+   1        -45.479961146671691      -100.019411257920780
+   2         -0.201612527292624      -100.221013132920518       2        -0.201612527292624      -100.221013132920518
+                                                                3        -0.002923614909289      -100.223936747829811
+
+    MP2 energy saved
+
+    EMPn = -100.2210131329205
+
+
+   ==> Energetics <==
+
+    SCF energy =         -100.019400605627879
+    Total MP energy =    -100.221013132920518
+
+		 "A good bug is a dead bug" 
+
+			 - Starship Troopers
+
+		 "I didn't write FORTRAN.  That's the problem."
+
+			 - Edward Valeev
+	mp2 rhf conv: 3 detci.............................................PASSED
+	mp2 rhf conv: 3 detci.............................................PASSED
+	mp2 rhf conv: 3 detci.............................................PASSED
+	mp2 rhf conv: 3 detci.............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:  -100.02002712800405   -1.00020e+02   6.33905e-02 
+   @DF-RHF iter   1:   -99.98154312793520    3.84840e-02   1.53121e-02 
+   @DF-RHF iter   2:  -100.01297271654619   -3.14296e-02   7.41736e-03 DIIS
+   @DF-RHF iter   3:  -100.01883834610834   -5.86563e-03   1.41933e-03 DIIS
+   @DF-RHF iter   4:  -100.01935947373728   -5.21128e-04   3.82690e-04 DIIS
+   @DF-RHF iter   5:  -100.01939957249122   -4.00988e-05   5.17440e-05 DIIS
+   @DF-RHF iter   6:  -100.01940058080362   -1.00831e-06   8.01605e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060511922   -2.43156e-08   1.16170e-06 DIIS
+   @DF-RHF iter   8:  -100.01940060559923   -4.80014e-10   2.34495e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562642   -2.71854e-11   5.29085e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -26.278131     2A     -1.583457     3A     -0.747199  
+       4A     -0.628887     5A     -0.628887  
+
+    Virtual:                                                              
+
+       6A      0.183841     7A      0.810057     8A      1.412047  
+       9A      1.412047    10A      1.415770    11A      1.604670  
+      12A      1.604670    13A      2.134266    14A      2.499125  
+      15A      4.004800    16A      4.004800    17A      4.280975  
+      18A      4.280975    19A      5.056528  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562642
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930202434502917
+    Two-Electron Energy =                  45.4799501969187503
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056264158
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:    -0.0000      Z:    -1.9499     Total:     1.9499
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:13 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  1    4    14    0
+	Number of basis functions in the DF-CC basis:  70
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.11 MB 
+	Memory requirement for B-CC (Q|mu nu) :      0.19 MB 
+	Memory requirement for B-CC (Q|ab)    :      0.10 MB 
+	Memory requirement for DF-CC int trans:      0.44 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     5.19366944090513
+	DF-HF Energy (a.u.)                :  -100.01940060562642
+	REF Energy (a.u.)                  :  -100.01940060562642
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20161066414203
+	DF-MP2 Total Energy (a.u.)         :  -100.22101126976844
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:13 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+  Variable Map:
+  ----------------------------------------------------------------------------
+  "CURRENT CORRELATION ENERGY"           =>      -0.201610664142
+  "CURRENT DIPOLE X"                     =>       0.000000011863
+  "CURRENT DIPOLE Y"                     =>      -0.000000230772
+  "CURRENT DIPOLE Z"                     =>      -1.949925325638
+  "CURRENT ENERGY"                       =>    -100.221011269768
+  "CURRENT REFERENCE ENERGY"             =>    -100.019400605626
+  "HF TOTAL ENERGY"                      =>    -100.019400605626
+  "MP2 CORRELATION ENERGY"               =>      -0.201610664142
+  "MP2 OPPOSITE-SPIN CORRELATION ENERGY" =>       0.000000000000
+  "MP2 SAME-SPIN CORRELATION ENERGY"     =>       0.000000000000
+  "MP2 TOTAL ENERGY"                     =>    -100.221011269768
+  "NUCLEAR REPULSION ENERGY"             =>       5.193669440905
+  "ONE-ELECTRON ENERGY"                  =>    -150.693020243450
+  "SCF DIPOLE X"                         =>       0.000000011863
+  "SCF DIPOLE Y"                         =>      -0.000000230772
+  "SCF DIPOLE Z"                         =>      -1.949925325638
+  "SCF ITERATION ENERGY"                 =>    -100.019400605626
+  "SCF ITERATIONS"                       =>       9.000000000000
+  "SCF TOTAL ENERGY"                     =>    -100.019400605626
+  "SCS-MP2 CORRELATION ENERGY"           =>     100.019400605626
+  "SCS-MP2 TOTAL ENERGY"                 =>       0.000000000000
+  "SCSN-MP2 CORRELATION ENERGY"          =>     100.019400605626
+  "SCSN-MP2 TOTAL ENERGY"                =>       0.000000000000
+  "SOS-MP2 CORRELATION ENERGY"           =>     100.019400605626
+  "SOS-MP2 TOTAL ENERGY"                 =>       0.000000000000
+  "TWO-ELECTRON ENERGY"                  =>      45.479950196919
+
+
+	mp2 rhf df: 2 occ.................................................PASSED
+	mp2 rhf df: 2 occ.................................................PASSED
+	mp2 rhf df: 2 occ.................................................PASSED
+	mp2 rhf df: 2 occ.................................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:13 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -99.90072566896721   -9.99007e+01   1.03631e-01 
+   @DF-RHF iter   1:   -99.98858327983388   -8.78576e-02   2.39156e-02 
+   @DF-RHF iter   2:  -100.01377496960880   -2.51917e-02   1.18552e-02 DIIS
+   @DF-RHF iter   3:  -100.01910110147952   -5.32613e-03   1.73073e-03 DIIS
+   @DF-RHF iter   4:  -100.01937121769200   -2.70116e-04   5.21555e-04 DIIS
+   @DF-RHF iter   5:  -100.01939971505494   -2.84974e-05   7.96441e-05 DIIS
+   @DF-RHF iter   6:  -100.01940059442471   -8.79370e-07   9.13869e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060555118   -1.11265e-08   8.65130e-07 DIIS
+   @DF-RHF iter   8:  -100.01940060562649   -7.53033e-11   1.21832e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562789   -1.40687e-12   1.33338e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.278131     2A1    -1.583457     3A1    -0.747199  
+       1B1    -0.628887     1B2    -0.628887  
+
+    Virtual:                                                              
+
+       4A1     0.183841     5A1     0.810057     2B1     1.412047  
+       2B2     1.412047     6A1     1.415770     3B1     1.604670  
+       3B2     1.604670     7A1     2.134266     8A1     2.499125  
+       9A1     4.004800     1A2     4.004800     4B1     4.280975  
+       4B2     4.280975    10A1     5.056529  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562789
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930204455973126
+    Two-Electron Energy =                  45.4799503990643075
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056278795
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -1.9499     Total:     1.9499
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 24
+    Number of basis function: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    70
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =    -100.0194006056278937 [Eh]
+	 Singles Energy            =      -0.0000000000000013 [Eh]
+	 Same-Spin Energy          =      -0.0535212490030915 [Eh]
+	 Opposite-Spin Energy      =      -0.1480894116525460 [Eh]
+	 Correlation Energy        =      -0.2016106606556387 [Eh]
+	 Total Energy              =    -100.2210112662835257 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0178404163343638 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1777072939830552 [Eh]
+	 SCS Correlation Energy    =      -0.1955477103174202 [Eh]
+	 SCS Total Energy          =    -100.2149483159453069 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:13 2017
+Module time:
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.88 seconds =       0.01 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	mp2 rhf df: 2 dfmp2*..............................................PASSED
+	mp2 rhf df: 2 dfmp2*..............................................PASSED
+	mp2 rhf df: 2 dfmp2*..............................................PASSED
+	mp2 rhf df: 2 dfmp2*..............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H          0.000000000000     0.000000000000    -0.870805607805     1.007825032070
+           F          0.000000000000     0.000000000000     0.046194392195    18.998403224000
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =     20.94695  C =     20.94695 [cm^-1]
+  Rotational constants: A = ************  B = 627973.76742  C = 627973.76742 [MHz]
+  Nuclear repulsion =    5.193669440905126
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.9118010066E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:  -100.02002712800405   -1.00020e+02   6.33905e-02 
+   @DF-RHF iter   1:   -99.98154312793520    3.84840e-02   1.53121e-02 
+   @DF-RHF iter   2:  -100.01297271654619   -3.14296e-02   7.41736e-03 DIIS
+   @DF-RHF iter   3:  -100.01883834610834   -5.86563e-03   1.41933e-03 DIIS
+   @DF-RHF iter   4:  -100.01935947373728   -5.21128e-04   3.82690e-04 DIIS
+   @DF-RHF iter   5:  -100.01939957249122   -4.00988e-05   5.17440e-05 DIIS
+   @DF-RHF iter   6:  -100.01940058080362   -1.00831e-06   8.01605e-06 DIIS
+   @DF-RHF iter   7:  -100.01940060511922   -2.43156e-08   1.16170e-06 DIIS
+   @DF-RHF iter   8:  -100.01940060559923   -4.80014e-10   2.34495e-07 DIIS
+   @DF-RHF iter   9:  -100.01940060562642   -2.71854e-11   5.29085e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -26.278131     2A     -1.583457     3A     -0.747199  
+       4A     -0.628887     5A     -0.628887  
+
+    Virtual:                                                              
+
+       6A      0.183841     7A      0.810057     8A      1.412047  
+       9A      1.412047    10A      1.415770    11A      1.604670  
+      12A      1.604670    13A      2.134266    14A      2.499125  
+      15A      4.004800    16A      4.004800    17A      4.280975  
+      18A      4.280975    19A      5.056528  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -100.01940060562642
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.1936694409051256
+    One-Electron Energy =                -150.6930202434502917
+    Two-Electron Energy =                  45.4799501969187503
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -100.0194006056264158
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8599
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:     0.0928
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:    -0.7672     Total:     0.7672
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:    -0.0000      Z:    -1.9499     Total:     1.9499
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => TRUE            !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => CD              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => FALSE           !
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       CD-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  1    4    14    0
+	Generating Cholesky vectors ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:      98
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     5.19366944090513
+	CD-HF Energy (a.u.)                :  -100.01940060562642
+	REF Energy (a.u.)                  :  -100.01940060562642
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20160940243769
+	CD-MP2 Total Energy (a.u.)         :  -100.22101000806410
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.07 seconds =       0.02 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	mp2 rhf cd: 1 occ*................................................PASSED
+	mp2 rhf cd: 1 occ*................................................PASSED
+	mp2 rhf cd: 1 occ*................................................PASSED
+	mp2 rhf cd: 1 occ*................................................PASSED
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         5       5       0       0       0       0
+     B2         8       8       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   0:   -23.55827872794868   -2.35583e+01   3.02707e-02 
+   @DF-UHF iter   1:   -25.92005297507478   -2.36177e+00   7.67473e-03 
+   @DF-UHF iter   2:   -25.94056219591508   -2.05092e-02   2.47544e-03 DIIS
+   @DF-UHF iter   3:   -25.94429700140951   -3.73481e-03   1.01606e-03 DIIS
+   @DF-UHF iter   4:   -25.94507561889526   -7.78617e-04   2.62479e-04 DIIS
+   @DF-UHF iter   5:   -25.94512210594932   -4.64871e-05   9.89875e-05 DIIS
+   @DF-UHF iter   6:   -25.94512978482777   -7.67888e-06   3.19775e-05 DIIS
+   @DF-UHF iter   7:   -25.94513047710574   -6.92278e-07   1.00835e-05 DIIS
+   @DF-UHF iter   8:   -25.94513055839589   -8.12902e-08   1.19266e-06 DIIS
+   @DF-UHF iter   9:   -25.94513055910935   -7.13463e-10   2.76024e-07 DIIS
+   @DF-UHF iter  10:   -25.94513055914784   -3.84901e-11   5.55069e-08 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.079773169E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560797732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1A1    -8.125181     2A1    -1.002799     3A1    -0.814851  
+       4A1    -0.752664  
+
+    Alpha Virtual:                                                        
+
+       1B2    -0.265824     1B1    -0.265313     5A1    -0.003286  
+       2B2     0.034624     6A1     0.137479     2B1     0.173814  
+       3B2     0.185321     7A1     0.187042     8A1     0.375565  
+       9A1     0.482405     3B1     0.503426     4B2     0.507365  
+       1A2     0.557078    10A1     0.557084     5B2     0.785180  
+      11A1     0.991295     4B1     1.123636    12A1     1.223805  
+       5B1     1.501174     6B2     1.501933    13A1     1.802185  
+       2A2     1.871410     7B2     1.871594    14A1     2.079553  
+       8B2     3.423362  
+
+    Beta Occupied:                                                        
+
+       1A1    -8.099302     2A1    -0.942276     3A1    -0.760723  
+
+    Beta Virtual:                                                         
+
+       4A1    -0.271858     1B2    -0.226623     1B1    -0.226065  
+       5A1     0.029985     2B2     0.035701     6A1     0.156155  
+       2B1     0.193111     3B2     0.205308     7A1     0.279192  
+       8A1     0.385142     9A1     0.523594     3B1     0.557780  
+       4B2     0.559520     1A2     0.576482    10A1     0.576488  
+       5B2     0.789064    11A1     1.037817     4B1     1.125981  
+      12A1     1.230020     5B1     1.528295     6B2     1.529007  
+      13A1     1.803917     2A2     1.872335     7B2     1.872511  
+      14A1     2.104591     8B2     3.425018  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:   -25.94513055914784
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2315423779711097
+    Two-Electron Energy =                  10.3668736312765777
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9451305591478416
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998982
+  HONO-1 :    3 A1 1.9970579
+  HONO-0 :    4 A1 1.0000000
+  LUNO+0 :    5 A1 0.0029421
+  LUNO+1 :    6 A1 0.0001018
+  LUNO+2 :    7 A1 0.0000003
+  LUNO+3 :    8 A1 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4727
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8096     Total:     0.8096
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0579     Total:     2.0579
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   4
+      Number of AO shells:              15
+      Number of SO shells:              12
+      Number of primitives:             37
+      Number of atomic orbitals:        30
+      Number of basis functions:        29
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  14    2    5    8 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 25380 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       MP2   
+              Program Written by Ugur Bozkaya,
+              Latest Revision June 25, 2014.
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	RMS orbital gradient is changed to :     1.00e-06
+	MAX orbital gradient is changed to :     1.00e-04
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	  A1     1     3     2    10     11     0
+	  A2     0     0     0     2      2     0
+	  B1     0     0     0     5      5     0
+	  B2     0     0     0     8      8     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	SCF Energy (a.u.)                  :   -25.94513055914784
+	REF Energy (a.u.)                  :   -25.94513055914784
+	Alpha-Alpha Contribution (a.u.)    :    -0.00171203863612
+	Alpha-Beta Contribution (a.u.)     :    -0.05665374780557
+	Beta-Beta Contribution (a.u.)      :    -0.00005533573784
+	Scaled_SS Correlation Energy (a.u.):    -0.00058912479132
+	Scaled_OS Correlation Energy (a.u.):    -0.06798449736668
+	SCS-MP2 Total Energy (a.u.)        :   -26.01370418130584
+	SOS-MP2 Total Energy (a.u.)        :   -25.94513055914784
+	SCSN-MP2 Total Energy (a.u.)       :   -25.94824113804601
+	SCS-MP2-VDW Total Energy (a.u.)    :   -26.01853104352595
+	SOS-PI-MP2 Total Energy (a.u.)     :   -26.02444580607563
+	MP2 Correlation Energy (a.u.)      :    -0.05842112217952
+	MP2 Total Energy (a.u.)            :   -26.00355168132736
+	============================================================================== 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	mp2 uhf conv: 1 occ*..............................................PASSED
+	mp2 uhf conv: 1 occ*..............................................PASSED
+	mp2 uhf conv: 1 occ*..............................................PASSED
+	mp2 uhf conv: 1 occ*..............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   0:   -23.55875413083328   -2.35588e+01   1.77494e-02 
+   @DF-UHF iter   1:   -25.91992088068058   -2.36117e+00   4.50410e-03 
+   @DF-UHF iter   2:   -25.94050345957620   -2.05826e-02   1.45454e-03 DIIS
+   @DF-UHF iter   3:   -25.94426407667235   -3.76062e-03   6.00397e-04 DIIS
+   @DF-UHF iter   4:   -25.94506203145991   -7.97955e-04   1.60359e-04 DIIS
+   @DF-UHF iter   5:   -25.94511624978175   -5.42183e-05   6.45237e-05 DIIS
+   @DF-UHF iter   6:   -25.94512789665452   -1.16469e-05   2.45007e-05 DIIS
+   @DF-UHF iter   7:   -25.94512982839310   -1.93174e-06   1.07231e-05 DIIS
+   @DF-UHF iter   8:   -25.94513039019937   -5.61806e-07   5.17731e-06 DIIS
+   @DF-UHF iter   9:   -25.94513052922304   -1.39024e-07   2.32025e-06 DIIS
+   @DF-UHF iter  10:   -25.94513055888650   -2.96635e-08   3.42443e-07 DIIS
+   @DF-UHF iter  11:   -25.94513055913719   -2.50697e-10   7.67806e-08 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.079824820E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560798248E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1A     -8.125180     2A     -1.002798     3A     -0.814851  
+       4A     -0.752665  
+
+    Alpha Virtual:                                                        
+
+       5A     -0.265823     6A     -0.265313     7A     -0.003286  
+       8A      0.034624     9A      0.137479    10A      0.173814  
+      11A      0.185321    12A      0.187042    13A      0.375564  
+      14A      0.482405    15A      0.503426    16A      0.507365  
+      17A      0.557078    18A      0.557085    19A      0.785180  
+      20A      0.991295    21A      1.123636    22A      1.223805  
+      23A      1.501175    24A      1.501934    25A      1.802185  
+      26A      1.871410    27A      1.871594    28A      2.079554  
+      29A      3.423361  
+
+    Beta Occupied:                                                        
+
+       1A     -8.099302     2A     -0.942276     3A     -0.760723  
+
+    Beta Virtual:                                                         
+
+       4A     -0.271858     5A     -0.226622     6A     -0.226065  
+       7A      0.029986     8A      0.035701     9A      0.156155  
+      10A      0.193111    11A      0.205308    12A      0.279192  
+      13A      0.385142    14A      0.523594    15A      0.557780  
+      16A      0.559520    17A      0.576483    18A      0.576488  
+      19A      0.789064    20A      1.037817    21A      1.125981  
+      22A      1.230019    23A      1.528295    24A      1.529007  
+      25A      1.803917    26A      1.872334    27A      1.872511  
+      28A      2.104592    29A      3.425017  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:   -25.94513055913719
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2315415437411161
+    Two-Electron Energy =                  10.3668727970572299
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9451305591371941
+
+
+  UHF NO Occupations:
+  HONO-2 :    2  A 1.9998982
+  HONO-1 :    3  A 1.9970578
+  HONO-0 :    4  A 1.0000000
+  LUNO+0 :    5  A 0.0029422
+  LUNO+1 :    6  A 0.0001018
+  LUNO+2 :    7  A 0.0000003
+  LUNO+3 :    8  A 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4727
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8096     Total:     0.8096
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0579     Total:     2.0579
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     3     2    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	DF-HF Energy (a.u.)                :   -25.94513055913719
+	REF Energy (a.u.)                  :   -25.94513055913719
+	Alpha-Alpha Contribution (a.u.)    :    -0.00171345419773
+	Alpha-Beta Contribution (a.u.)     :    -0.05662108331443
+	Beta-Beta Contribution (a.u.)      :    -0.00005546571939
+	Scaled_SS Correlation Energy (a.u.):    -0.00058963997237
+	Scaled_OS Correlation Energy (a.u.):    -0.06794529997731
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01366549908688
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01873796744595
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94824385819133
+	DF-MP2 Correlation Energy (a.u.)   :    -0.05839000323155
+	DF-MP2 Total Energy (a.u.)         :   -26.00352056236875
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.65 seconds =       0.03 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	mp2 uhf df: 2 occ.................................................PASSED
+	mp2 uhf df: 2 occ.................................................PASSED
+	mp2 uhf df: 2 occ.................................................PASSED
+	mp2 uhf df: 2 occ.................................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         5       5       0       0       0       0
+     B2         8       8       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   0:   -23.55827872794868   -2.35583e+01   3.02707e-02 
+   @DF-UHF iter   1:   -25.92005297507478   -2.36177e+00   7.67473e-03 
+   @DF-UHF iter   2:   -25.94056219591508   -2.05092e-02   2.47544e-03 DIIS
+   @DF-UHF iter   3:   -25.94429700140951   -3.73481e-03   1.01606e-03 DIIS
+   @DF-UHF iter   4:   -25.94507561889526   -7.78617e-04   2.62479e-04 DIIS
+   @DF-UHF iter   5:   -25.94512210594932   -4.64871e-05   9.89875e-05 DIIS
+   @DF-UHF iter   6:   -25.94512978482777   -7.67888e-06   3.19775e-05 DIIS
+   @DF-UHF iter   7:   -25.94513047710574   -6.92278e-07   1.00835e-05 DIIS
+   @DF-UHF iter   8:   -25.94513055839589   -8.12902e-08   1.19266e-06 DIIS
+   @DF-UHF iter   9:   -25.94513055910935   -7.13463e-10   2.76024e-07 DIIS
+   @DF-UHF iter  10:   -25.94513055914784   -3.84901e-11   5.55069e-08 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.079773169E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560797732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1A1    -8.125181     2A1    -1.002799     3A1    -0.814851  
+       4A1    -0.752664  
+
+    Alpha Virtual:                                                        
+
+       1B2    -0.265824     1B1    -0.265313     5A1    -0.003286  
+       2B2     0.034624     6A1     0.137479     2B1     0.173814  
+       3B2     0.185321     7A1     0.187042     8A1     0.375565  
+       9A1     0.482405     3B1     0.503426     4B2     0.507365  
+       1A2     0.557078    10A1     0.557084     5B2     0.785180  
+      11A1     0.991295     4B1     1.123636    12A1     1.223805  
+       5B1     1.501174     6B2     1.501933    13A1     1.802185  
+       2A2     1.871410     7B2     1.871594    14A1     2.079553  
+       8B2     3.423362  
+
+    Beta Occupied:                                                        
+
+       1A1    -8.099302     2A1    -0.942276     3A1    -0.760723  
+
+    Beta Virtual:                                                         
+
+       4A1    -0.271858     1B2    -0.226623     1B1    -0.226065  
+       5A1     0.029985     2B2     0.035701     6A1     0.156155  
+       2B1     0.193111     3B2     0.205308     7A1     0.279192  
+       8A1     0.385142     9A1     0.523594     3B1     0.557780  
+       4B2     0.559520     1A2     0.576482    10A1     0.576488  
+       5B2     0.789064    11A1     1.037817     4B1     1.125981  
+      12A1     1.230020     5B1     1.528295     6B2     1.529007  
+      13A1     1.803917     2A2     1.872335     7B2     1.872511  
+      14A1     2.104591     8B2     3.425018  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:   -25.94513055914784
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2315423779711097
+    Two-Electron Energy =                  10.3668736312765777
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9451305591478416
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998982
+  HONO-1 :    3 A1 1.9970579
+  HONO-0 :    4 A1 1.0000000
+  LUNO+0 :    5 A1 0.0029421
+  LUNO+1 :    6 A1 0.0001018
+  LUNO+2 :    7 A1 0.0000003
+  LUNO+3 :    8 A1 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4727
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8096     Total:     0.8096
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0579     Total:     2.0579
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              UMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+	 --------------------------------------------------------
+	                 NBF =    29, NAUX =    98
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   ALPHA       1       4       3      25      25       0
+	    BETA       1       3       2      26      26       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -25.9451305591478416 [Eh]
+	 Singles Energy            =      -0.0000000000005724 [Eh]
+	 Same-Spin Energy          =      -0.0017689187155575 [Eh]
+	 Opposite-Spin Energy      =      -0.0566210880817505 [Eh]
+	 Correlation Energy        =      -0.0583900067978804 [Eh]
+	 Total Energy              =     -26.0035205659457205 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0005896395718525 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.0679453056981006 [Eh]
+	 SCS Correlation Energy    =      -0.0685349452705256 [Eh]
+	 SCS Total Energy          =     -26.0136655044183662 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:15 2017
+Module time:
+	user time   =       0.30 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+	mp2 uhf df: 2 dfmp2*..............................................PASSED
+	mp2 uhf df: 2 dfmp2*..............................................PASSED
+	mp2 uhf df: 2 dfmp2*..............................................PASSED
+	mp2 uhf df: 2 dfmp2*..............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   0:   -23.55875413083328   -2.35588e+01   1.77494e-02 
+   @DF-UHF iter   1:   -25.91992088068066   -2.36117e+00   4.50410e-03 
+   @DF-UHF iter   2:   -25.94050345957627   -2.05826e-02   1.45454e-03 DIIS
+   @DF-UHF iter   3:   -25.94426407667241   -3.76062e-03   6.00397e-04 DIIS
+   @DF-UHF iter   4:   -25.94506203146001   -7.97955e-04   1.60359e-04 DIIS
+   @DF-UHF iter   5:   -25.94511624978180   -5.42183e-05   6.45237e-05 DIIS
+   @DF-UHF iter   6:   -25.94512789665459   -1.16469e-05   2.45007e-05 DIIS
+   @DF-UHF iter   7:   -25.94512982839319   -1.93174e-06   1.07231e-05 DIIS
+   @DF-UHF iter   8:   -25.94513039019942   -5.61806e-07   5.17731e-06 DIIS
+   @DF-UHF iter   9:   -25.94513052922309   -1.39024e-07   2.32025e-06 DIIS
+   @DF-UHF iter  10:   -25.94513055888654   -2.96635e-08   3.42443e-07 DIIS
+   @DF-UHF iter  11:   -25.94513055913726   -2.50722e-10   7.67806e-08 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.079824820E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560798248E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1A     -8.125180     2A     -1.002798     3A     -0.814851  
+       4A     -0.752665  
+
+    Alpha Virtual:                                                        
+
+       5A     -0.265823     6A     -0.265313     7A     -0.003286  
+       8A      0.034624     9A      0.137479    10A      0.173814  
+      11A      0.185321    12A      0.187042    13A      0.375564  
+      14A      0.482405    15A      0.503426    16A      0.507365  
+      17A      0.557078    18A      0.557085    19A      0.785180  
+      20A      0.991295    21A      1.123636    22A      1.223805  
+      23A      1.501175    24A      1.501934    25A      1.802185  
+      26A      1.871410    27A      1.871594    28A      2.079554  
+      29A      3.423361  
+
+    Beta Occupied:                                                        
+
+       1A     -8.099302     2A     -0.942276     3A     -0.760723  
+
+    Beta Virtual:                                                         
+
+       4A     -0.271858     5A     -0.226622     6A     -0.226065  
+       7A      0.029986     8A      0.035701     9A      0.156155  
+      10A      0.193111    11A      0.205308    12A      0.279192  
+      13A      0.385142    14A      0.523594    15A      0.557780  
+      16A      0.559520    17A      0.576483    18A      0.576488  
+      19A      0.789064    20A      1.037817    21A      1.125981  
+      22A      1.230019    23A      1.528295    24A      1.529007  
+      25A      1.803917    26A      1.872334    27A      1.872511  
+      28A      2.104592    29A      3.425017  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:   -25.94513055913726
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2315415437412724
+    Two-Electron Energy =                  10.3668727970573187
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9451305591372616
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    2  A 1.9998982
+  HONO-1 :    3  A 1.9970578
+  HONO-0 :    4  A 1.0000000
+  LUNO+0 :    5  A 0.0029422
+  LUNO+1 :    6  A 0.0001018
+  LUNO+2 :    7  A 0.0000003
+  LUNO+3 :    8  A 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4727
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8096     Total:     0.8096
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0579     Total:     2.0579
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:15 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => TRUE            !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => CD              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => FALSE           !
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       CD-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     3     2    25     26     0
+	Generating Cholesky vectors ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     128
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	CD-HF Energy (a.u.)                :   -25.94513055913726
+	REF Energy (a.u.)                  :   -25.94513055913726
+	Alpha-Alpha Contribution (a.u.)    :    -0.00171224486833
+	Alpha-Beta Contribution (a.u.)     :    -0.05664222977262
+	Beta-Beta Contribution (a.u.)      :    -0.00005535894127
+	Scaled_SS Correlation Energy (a.u.):    -0.00058920126987
+	Scaled_OS Correlation Energy (a.u.):    -0.06797067572715
+	CD-SCS-MP2 Total Energy (a.u.)     :   -26.01369043613428
+	CD-SOS-MP2 Total Energy (a.u.)     :   -26.01876545784167
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -25.94824154184216
+	CD-MP2 Correlation Energy (a.u.)   :    -0.05840983358223
+	CD-MP2 Total Energy (a.u.)         :   -26.00354039271949
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:15 2017
+Module time:
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.22 seconds =       0.04 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+	mp2 uhf cd: 1 occ*................................................PASSED
+	mp2 uhf cd: 1 occ*................................................PASSED
+	mp2 uhf cd: 1 occ*................................................PASSED
+	mp2 uhf cd: 1 occ*................................................PASSED
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         5       5       0       0       0       0
+     B2         8       8       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86016303730107   -2.48602e+01   0.00000e+00 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+   @DF-ROHF iter   1:   -22.08295861173111    2.77720e+00   6.85731e-02 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+   @DF-ROHF iter   2:   -24.98503196084307   -2.90207e+00   2.67038e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552986   -6.47477e-01   1.61411e-02 DIIS
+   @DF-ROHF iter   4:   -25.91394777516692   -2.81439e-01   6.75117e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468757   -1.93284e-02   3.98310e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855419   -1.01463e-02   5.56920e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546139   -1.67447e-04   1.66049e-04 DIIS
+   @DF-ROHF iter   8:   -25.94360441761178   -1.44322e-05   5.86158e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409362   -2.01648e-06   1.19006e-05 DIIS
+   @DF-ROHF iter  10:   -25.94360651906169   -8.49681e-08   2.32280e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186129   -2.79960e-09   5.30175e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202982   -1.68527e-10   3.45886e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1    -8.111996     2A1    -0.966086     3A1    -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A1    -0.518546  
+
+    Virtual:                                                              
+
+       1B2    -0.244953     1B1    -0.244418     5A1     0.011731  
+       2B2     0.035151     6A1     0.147391     2B1     0.183575  
+       3B2     0.195426     7A1     0.217995     8A1     0.378717  
+       9A1     0.501323     3B1     0.529573     4B2     0.532459  
+       1A2     0.566426    10A1     0.566432     5B2     0.787160  
+      11A1     1.014804     4B1     1.124944    12A1     1.226910  
+       5B1     1.516216     6B2     1.516947    13A1     1.803198  
+       2A2     1.872001     7B2     1.872171    14A1     2.093682  
+       8B2     3.424372  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202982
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918724757
+    Two-Electron Energy =                  10.3709436822959695
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220298140
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   4
+      Number of AO shells:              15
+      Number of SO shells:              12
+      Number of primitives:             37
+      Number of atomic orbitals:        30
+      Number of basis functions:        29
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  14    2    5    8 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 25380 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:15 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CACHELEVEL                  => 2                
+  CCL_ENERGY                  => FALSE            
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CEPA_OS_SCALE               => 1.27             
+  CEPA_SOS_SCALE              => 1.3              
+  CEPA_SS_SCALE               => 1.13             
+  CEPA_TYPE                   => CEPA0            
+  CI_TYPE                     => CONV             
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 14               
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EA_POLES                    => FALSE            
+  EKT_EA                      => FALSE            
+  EKT_IP                      => FALSE            
+  EP_EA_POLES                 => FALSE            
+  EP_IP_POLES                 => FALSE            
+  EP_MAXITER                  => 30               
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  INTEGRAL_PACKAGE            => ERD             !
+  IP_POLES                    => FALSE            
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOGRAD_DAMPING              => 1                
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_READ                     => FALSE            
+  MO_STEP_MAX                 => 0.5              
+  MO_WRITE                    => FALSE            
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => CONV            !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OPT_METHOD                  => ORB_RESP         
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 30               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  RELATIVISTIC                => NO               
+  RELAXED                     => TRUE             
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  SYMMETRIZE                  => TRUE             
+  TPDM_ABCD_TYPE              => DIRECT           
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => OMP2            !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       MP2   
+              Program Written by Ugur Bozkaya,
+              Latest Revision June 25, 2014.
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	RMS orbital gradient is changed to :     1.00e-06
+	MAX orbital gradient is changed to :     1.00e-04
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	  A1     1     3     2    10     11     0
+	  A2     0     0     0     2      2     0
+	  B1     0     0     0     5      5     0
+	  B2     0     0     0     8      8     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (ROHF-MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	SCF Energy (a.u.)                  :   -25.94360652202982
+	REF Energy (a.u.)                  :   -25.94360652202982
+	Alpha-Alpha Contribution (a.u.)    :    -0.00180147408716
+	Alpha-Beta Contribution (a.u.)     :    -0.05686598048829
+	Beta-Beta Contribution (a.u.)      :    -0.00005050596852
+	Scaled_SS Correlation Energy (a.u.):    -0.00061732668523
+	Scaled_OS Correlation Energy (a.u.):    -0.06823917658595
+	SCS-MP2 Total Energy (a.u.)        :   -26.01246302530100
+	SOS-MP2 Total Energy (a.u.)        :   -25.94360652202982
+	SCSN-MP2 Total Energy (a.u.)       :   -25.94686600692782
+	SCS-MP2-VDW Total Energy (a.u.)    :   -26.01732096708267
+	SOS-PI-MP2 Total Energy (a.u.)     :   -26.02321889471343
+	MP2 Singles Energy (a.u.)          :    -0.00068836049937
+	MP2 Doubles Energy (a.u.)          :    -0.05871796054397
+	MP2 Correlation Energy (a.u.)      :    -0.05940632104335
+	MP2 Total Energy (a.u.)            :   -26.00301284307317
+	============================================================================== 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:15 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.50 seconds =       0.04 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+	mp2 rohf conv: 2 occ*.............................................PASSED
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         5       5       0       0       0       0
+     B2         8       8       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86016303730107   -2.48602e+01   0.00000e+00 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+   @DF-ROHF iter   1:   -22.08295861173111    2.77720e+00   6.85731e-02 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+   @DF-ROHF iter   2:   -24.98503196084307   -2.90207e+00   2.67038e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552986   -6.47477e-01   1.61411e-02 DIIS
+   @DF-ROHF iter   4:   -25.91394777516692   -2.81439e-01   6.75117e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468757   -1.93284e-02   3.98310e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855419   -1.01463e-02   5.56920e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546139   -1.67447e-04   1.66049e-04 DIIS
+   @DF-ROHF iter   8:   -25.94360441761178   -1.44322e-05   5.86158e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409362   -2.01648e-06   1.19006e-05 DIIS
+   @DF-ROHF iter  10:   -25.94360651906169   -8.49681e-08   2.32280e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186129   -2.79960e-09   5.30175e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202982   -1.68527e-10   3.45886e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1    -8.111996     2A1    -0.966086     3A1    -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A1    -0.518546  
+
+    Virtual:                                                              
+
+       1B2    -0.244953     1B1    -0.244418     5A1     0.011731  
+       2B2     0.035151     6A1     0.147391     2B1     0.183575  
+       3B2     0.195426     7A1     0.217995     8A1     0.378717  
+       9A1     0.501323     3B1     0.529573     4B2     0.532459  
+       1A2     0.566426    10A1     0.566432     5B2     0.787160  
+      11A1     1.014804     4B1     1.124944    12A1     1.226910  
+       5B1     1.516216     6B2     1.516947    13A1     1.803198  
+       2A2     1.872001     7B2     1.872171    14A1     2.093682  
+       8B2     3.424372  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202982
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918724757
+    Two-Electron Energy =                  10.3709436822959695
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220298140
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of atoms:                   4
+      Number of AO shells:              15
+      Number of SO shells:              12
+      Number of primitives:             37
+      Number of atomic orbitals:        30
+      Number of basis functions:        29
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  14    2    5    8 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 25380 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+         ---------------------------------------------------------
+                          Configuration Interaction
+                            (a 'D E T C I' module)
+
+                 C. David Sherrill, Daniel G. A. Smith, and
+                              Matt L. Leininger
+         ---------------------------------------------------------
+
+Warning: iopen=0,opentype!=closed. Making iopen=1
+
+   ==> Parameters <==
+
+    EX LEVEL       =        5      H0 BLOCKSIZE  =        1
+    VAL EX LEVEL   =        0      H0 GUESS SIZE =        1
+    H0COUPLINGSIZE =        0      H0 COUPLING   =       NO
+    MAXITER        =       24      NUM PRINT     =       20
+    NUM ROOTS      =        1      ICORE         =        1
+    PRINT LVL      =        1      FCI           =      YES
+    R CONV         = 1.00e-04      MIXED         =      YES
+    E CONV         = 1.00e-08      MIXED4        =      YES
+    R4S            =       NO      REPL OTF      =       NO
+    DIAG METHOD    =      SEM      FOLLOW ROOT   =        0
+    PRECONDITIONER = DAVIDSON      UPDATE        = DAVIDSON
+    S              =   0.5000      Ms0           =       NO
+    GUESS VECTOR   =     UNIT      OPENTYPE      = HIGHSPIN
+    COLLAPSE SIZE  =        1      HD AVG        = ORB_ENER
+MPN options:
+    MPN            =      YES      MPN SCHMIDT   =       NO
+    ZAPTN          =       NO      MPN WIGNER    =      YES
+    PERT Z         =   1.0000
+    MAX NUM VECS   =        2      REF SYM       =     AUTO
+    IOPEN        =      YES
+
+    EX ALLOW       =  1  1  1  1  1 
+    STATE AVERAGE  =  0(1.00) 
+
+   ==> CI Orbital and Space information <==
+
+   ------------------------------------------------------
+               Space    Total    A1    A2    B1    B2
+   ------------------------------------------------------
+                 Nso       29    14     2     5     8
+                 Nmo       29    14     2     5     8
+               Ndocc        3     3     0     0     0
+               Nsocc        1     1     0     0     0
+   ------------------------------------------------------
+                       CI Spaces
+   ------------------------------------------------------
+        Dropped DOCC        1     1     0     0     0
+              Active       28    13     2     5     8
+        Dropped UOCC        0     0     0     0     0
+   ------------------------------------------------------
+
+   ==> Setting up CI strings <==
+
+    There are 3276 alpha and 378 beta strings
+    The CI space requires 315138 (3.15E+05) determinants and 30 blocks
+
+   ==> Transforming CI integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+   ==> Starting MPn CI Computation <==
+
+ orb_energy[0] = -8.111996
+   CalcInfo_->escf =       -25.943606522029818
+   CalcInfo_->e0   =       -20.206958679789793
+   CalcInfo_->enuc =         4.919538187546689
+   CalcInfo_->e1   =       -10.656186029786713
+
+   n         Corr. Energy                  E(MPn)               n         Corr. Energy                  E(MPn)
+
+   0          0.000000000000000       -15.287420492243104
+   1        -10.656186029786713       -25.943606522029818
+   1        -10.656193823195789       -25.943614315438893
+   2         -0.060939211738909       -26.004545733768726       2        -0.060939211738909       -26.004545733768726
+                                                                3        -0.014867964419581       -26.019413698188309
+
+    MP2 energy saved
+
+    EMPn = -26.0045457337687
+
+
+   ==> Energetics <==
+
+    SCF energy =          -25.943606522029814
+    Total MP energy =     -26.004545733768726
+
+		 "A good bug is a dead bug" 
+
+			 - Starship Troopers
+
+		 "I didn't write FORTRAN.  That's the problem."
+
+			 - Edward Valeev
+	mp2 rohf conv: 2 detci............................................PASSED
+	mp2 rohf conv: 2 detci............................................PASSED
+	mp2 rohf conv: 2 detci............................................PASSED
+	mp2 rohf conv: 2 detci............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86056013092314   -2.48606e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08295861173116    2.77760e+00   4.01981e-02 
+   @DF-ROHF iter   2:   -24.98503196084310   -2.90207e+00   1.56540e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552986   -6.47477e-01   9.46200e-03 DIIS
+   @DF-ROHF iter   4:   -25.91394777516690   -2.81439e-01   3.95758e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468751   -1.93284e-02   2.33492e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855418   -1.01463e-02   3.26470e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546138   -1.67447e-04   9.73390e-05 DIIS
+   @DF-ROHF iter   8:   -25.94360441761174   -1.44322e-05   3.43610e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409362   -2.01648e-06   6.97623e-06 DIIS
+   @DF-ROHF iter  10:   -25.94360651906169   -8.49681e-08   1.36164e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186132   -2.79963e-09   3.10792e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202981   -1.68491e-10   2.02761e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111996     2A     -0.966086     3A     -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518546  
+
+    Virtual:                                                              
+
+       5A     -0.244953     6A     -0.244418     7A      0.011731  
+       8A      0.035151     9A      0.147391    10A      0.183575  
+      11A      0.195426    12A      0.217995    13A      0.378717  
+      14A      0.501323    15A      0.529573    16A      0.532459  
+      17A      0.566426    18A      0.566432    19A      0.787160  
+      20A      1.014804    21A      1.124944    22A      1.226910  
+      23A      1.516216    24A      1.516947    25A      1.803198  
+      26A      1.872001    27A      1.872171    28A      2.093682  
+      29A      3.424372  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202981
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918724828
+    Two-Electron Energy =                  10.3709436822959802
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220298175
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:16 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     3     2    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	DF-HF Energy (a.u.)                :   -25.94360652202981
+	REF Energy (a.u.)                  :   -25.94360652202981
+	Alpha-Alpha Contribution (a.u.)    :    -0.00180289219716
+	Alpha-Beta Contribution (a.u.)     :    -0.05683083617484
+	Beta-Beta Contribution (a.u.)      :    -0.00005062530881
+	Scaled_SS Correlation Energy (a.u.):    -0.00061783916866
+	Scaled_OS Correlation Energy (a.u.):    -0.06819700340981
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01242136460828
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01748660905711
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94686871284032
+	DF-MP2 Correlation Energy (a.u.)   :    -0.05937274839058
+	DF-MP2 Total Energy (a.u.)         :   -26.00297927042039
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:16 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.13 seconds =       0.05 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	mp2 rohf df: 2 occ................................................PASSED
+	mp2 rohf df: 2 occ................................................PASSED
+	mp2 rohf df: 2 occ................................................PASSED
+	mp2 rohf df: 2 occ................................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:16 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         5       5       0       0       0       0
+     B2         8       8       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86016303730107   -2.48602e+01   0.00000e+00 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+   @DF-ROHF iter   1:   -22.08295861173111    2.77720e+00   6.85731e-02 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+   @DF-ROHF iter   2:   -24.98503196084307   -2.90207e+00   2.67038e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552986   -6.47477e-01   1.61411e-02 DIIS
+   @DF-ROHF iter   4:   -25.91394777516692   -2.81439e-01   6.75117e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468757   -1.93284e-02   3.98310e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855419   -1.01463e-02   5.56920e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546139   -1.67447e-04   1.66049e-04 DIIS
+   @DF-ROHF iter   8:   -25.94360441761178   -1.44322e-05   5.86158e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409362   -2.01648e-06   1.19006e-05 DIIS
+   @DF-ROHF iter  10:   -25.94360651906169   -8.49681e-08   2.32280e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186129   -2.79960e-09   5.30175e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202982   -1.68527e-10   3.45886e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1    -8.111996     2A1    -0.966086     3A1    -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A1    -0.518546  
+
+    Virtual:                                                              
+
+       1B2    -0.244953     1B1    -0.244418     5A1     0.011731  
+       2B2     0.035151     6A1     0.147391     2B1     0.183575  
+       3B2     0.195426     7A1     0.217995     8A1     0.378717  
+       9A1     0.501323     3B1     0.529573     4B2     0.532459  
+       1A2     0.566426    10A1     0.566432     5B2     0.787160  
+      11A1     1.014804     4B1     1.124944    12A1     1.226910  
+       5B1     1.516216     6B2     1.516947    13A1     1.803198  
+       2A2     1.872001     7B2     1.872171    14A1     2.093682  
+       8B2     3.424372  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202982
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918724757
+    Two-Electron Energy =                  10.3709436822959695
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220298140
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	          ROHF-MBPT(2) Wavefunction,   1 Threads         
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+	 --------------------------------------------------------
+	                 NBF =    29, NAUX =    98
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   ALPHA       1       4       3      25      25       0
+	    BETA       1       3       2      26      26       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -25.9436065220298175 [Eh]
+	 Singles Energy            =      -0.0006883947097674 [Eh]
+	 Same-Spin Energy          =      -0.0018535175059696 [Eh]
+	 Opposite-Spin Energy      =      -0.0568308361748428 [Eh]
+	 Correlation Energy        =      -0.0593727483905798 [Eh]
+	 Total Energy              =     -26.0029792704203970 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0006178391686565 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.0681970034098114 [Eh]
+	 SCS Correlation Energy    =      -0.0695032372882353 [Eh]
+	 SCS Total Energy          =     -26.0131097593180520 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
+Module time:
+	user time   =       0.30 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.43 seconds =       0.06 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	mp2 rohf df: 2 dfmp2*.............................................PASSED
+	mp2 rohf df: 2 dfmp2*.............................................PASSED
+	mp2 rohf df: 2 dfmp2*.............................................PASSED
+	mp2 rohf df: 2 dfmp2*.............................................PASSED
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86056013092314   -2.48606e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08295861173133    2.77760e+00   4.01981e-02 
+   @DF-ROHF iter   2:   -24.98503196084300   -2.90207e+00   1.56540e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552981   -6.47477e-01   9.46200e-03 DIIS
+   @DF-ROHF iter   4:   -25.91394777516684   -2.81439e-01   3.95758e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468749   -1.93284e-02   2.33492e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855413   -1.01463e-02   3.26470e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546130   -1.67447e-04   9.73390e-05 DIIS
+   @DF-ROHF iter   8:   -25.94360441761170   -1.44322e-05   3.43610e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409357   -2.01648e-06   6.97623e-06 DIIS
+   @DF-ROHF iter  10:   -25.94360651906161   -8.49680e-08   1.36164e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186121   -2.79960e-09   3.10792e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202975   -1.68534e-10   2.02761e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111996     2A     -0.966086     3A     -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518546  
+
+    Virtual:                                                              
+
+       5A     -0.244953     6A     -0.244418     7A      0.011731  
+       8A      0.035151     9A      0.147391    10A      0.183575  
+      11A      0.195426    12A      0.217995    13A      0.378717  
+      14A      0.501323    15A      0.529573    16A      0.532459  
+      17A      0.566426    18A      0.566432    19A      0.787160  
+      20A      1.014804    21A      1.124944    22A      1.226910  
+      23A      1.516216    24A      1.516947    25A      1.803198  
+      26A      1.872001    27A      1.872171    28A      2.093682  
+      29A      3.424372  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202975
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918723478
+    Two-Electron Energy =                  10.3709436822959127
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220297429
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => TRUE            !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => TRUE            !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => CD              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => FALSE           !
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       CD-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     3     2    25     26     0
+	Generating Cholesky vectors ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     128
+
+	Computing CD-MP2 energy using SCF MOs (CD-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	CD-HF Energy (a.u.)                :   -25.94360652202975
+	REF Energy (a.u.)                  :   -25.94360652202975
+	Alpha-Alpha Contribution (a.u.)    :    -0.00180151862162
+	Alpha-Beta Contribution (a.u.)     :    -0.05685307186618
+	Beta-Beta Contribution (a.u.)      :    -0.00005052576393
+	Scaled_SS Correlation Energy (a.u.):    -0.00061734812852
+	Scaled_OS Correlation Energy (a.u.):    -0.06822368623942
+	CD-SCS-MP2 Total Energy (a.u.)     :   -26.01244755639769
+	CD-SOS-MP2 Total Energy (a.u.)     :   -26.01751551545578
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -25.94686612014833
+	CD-MP2 Correlation Energy (a.u.)   :    -0.05939351096151
+	CD-MP2 Total Energy (a.u.)         :   -26.00300003299125
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
+Module time:
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.69 seconds =       0.06 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	mp2 rohf cd: 1 occ*...............................................PASSED
+	mp2 rohf cd: 1 occ*...............................................PASSED
+	mp2 rohf cd: 1 occ*...............................................PASSED
+	mp2 rohf cd: 1 occ*...............................................PASSED
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 5-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 4.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 13.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327965558160    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.560919663508     1.007825032070
+           H          0.000000000000    -0.371490000000     2.571779196492     1.007825032070
+           H         -0.000000000000     0.371490000000     2.571779196492     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99330  C =      0.97728 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29778.41683  C =  29298.20287 [MHz]
+  Nuclear repulsion =    4.923389180917277
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.2835516458E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.72527223103674   -2.47253e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.07193694666980    2.65334e+00   4.04711e-02 
+   @DF-ROHF iter   2:   -24.98500403580972   -2.91307e+00   1.56501e-02 DIIS
+   @DF-ROHF iter   3:   -25.63123626045067   -6.46232e-01   9.47886e-03 DIIS
+   @DF-ROHF iter   4:   -25.91412045841389   -2.82884e-01   3.96077e-03 DIIS
+   @DF-ROHF iter   5:   -25.93343205231380   -1.93116e-02   2.33769e-03 DIIS
+   @DF-ROHF iter   6:   -25.94355469672364   -1.01226e-02   3.32057e-04 DIIS
+   @DF-ROHF iter   7:   -25.94372697152907   -1.72275e-04   1.01531e-04 DIIS
+   @DF-ROHF iter   8:   -25.94374267578398   -1.57043e-05   3.57279e-05 DIIS
+   @DF-ROHF iter   9:   -25.94374485776446   -2.18198e-06   6.98257e-06 DIIS
+   @DF-ROHF iter  10:   -25.94374494313550   -8.53710e-08   1.36223e-06 DIIS
+   @DF-ROHF iter  11:   -25.94374494593051   -2.79501e-09   3.14641e-07 DIIS
+   @DF-ROHF iter  12:   -25.94374494610253   -1.72019e-10   1.97738e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111966     2A     -0.967134     3A     -0.765923  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518681  
+
+    Virtual:                                                              
+
+       5A     -0.245026     6A     -0.244494     7A      0.012634  
+       8A      0.035254     9A      0.146548    10A      0.183505  
+      11A      0.195330    12A      0.217780    13A      0.378933  
+      14A      0.502535    15A      0.529524    16A      0.532355  
+      17A      0.566324    18A      0.566330    19A      0.787235  
+      20A      1.017287    21A      1.125086    22A      1.226575  
+      23A      1.518015    24A      1.518758    25A      1.803359  
+      26A      1.872172    27A      1.872305    28A      2.098734  
+      29A      3.424523  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94374494610253
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9233891809172770
+    One-Electron Energy =                 -41.2400871095857298
+    Two-Electron Energy =                  10.3729529825659235
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9437449461025302
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6714
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4734
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8021     Total:     0.8021
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0386     Total:     2.0386
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92338918091728
+	DF-HF Energy (a.u.)                :   -25.94374494610253
+	REF Energy (a.u.)                  :   -25.94374494610253
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191084085380
+	Alpha-Beta Contribution (a.u.)     :    -0.05770007900376
+	Beta-Beta Contribution (a.u.)      :    -0.00009254648676
+	Scaled_SS Correlation Energy (a.u.):    -0.00066779578019
+	Scaled_OS Correlation Energy (a.u.):    -0.06924009480451
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01365283668723
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01875504880742
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94727090782191
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06038898474882
+	DF-MP2 Total Energy (a.u.)         :   -26.00413393085135
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.99 seconds =       0.07 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327595412631    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.562267465305     1.007825032070
+           H          0.000000000000    -0.371490000000     2.570431394695     1.007825032070
+           H         -0.000000000000     0.371490000000     2.570431394695     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99403  C =      0.97799 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29800.18823  C =  29319.27750 [MHz]
+  Nuclear repulsion =    4.921458924303884
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.2930353463E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.80774026248940   -2.48077e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.07746339566440    2.73028e+00   4.03343e-02 
+   @DF-ROHF iter   2:   -24.98501927768230   -2.90756e+00   1.56520e-02 DIIS
+   @DF-ROHF iter   3:   -25.63186834577339   -6.46849e-01   9.47045e-03 DIIS
+   @DF-ROHF iter   4:   -25.91403447272970   -2.82166e-01   3.95922e-03 DIIS
+   @DF-ROHF iter   5:   -25.93335496119525   -1.93205e-02   2.33636e-03 DIIS
+   @DF-ROHF iter   6:   -25.94348981013595   -1.01348e-02   3.29286e-04 DIIS
+   @DF-ROHF iter   7:   -25.94365968918288   -1.69879e-04   9.94347e-05 DIIS
+   @DF-ROHF iter   8:   -25.94367474923053   -1.50600e-05   3.50575e-05 DIIS
+   @DF-ROHF iter   9:   -25.94367684920024   -2.09997e-06   6.98133e-06 DIIS
+   @DF-ROHF iter  10:   -25.94367693441936   -8.52191e-08   1.36250e-06 DIIS
+   @DF-ROHF iter  11:   -25.94367693721896   -2.79960e-09   3.12788e-07 DIIS
+   @DF-ROHF iter  12:   -25.94367693738926   -1.70296e-10   2.00183e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111981     2A     -0.966609     3A     -0.766024  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518614  
+
+    Virtual:                                                              
+
+       5A     -0.244989     6A     -0.244456     7A      0.012183  
+       8A      0.035203     9A      0.146969    10A      0.183540  
+      11A      0.195378    12A      0.217887    13A      0.378825  
+      14A      0.501928    15A      0.529549    16A      0.532407  
+      17A      0.566375    18A      0.566381    19A      0.787198  
+      20A      1.016044    21A      1.125015    22A      1.226742  
+      23A      1.517115    24A      1.517851    25A      1.803279  
+      26A      1.872087    27A      1.872238    28A      2.096203  
+      29A      3.424448  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94367693738926
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9214589243038844
+    One-Electron Energy =                 -41.2370813966066336
+    Two-Electron Energy =                  10.3719455349134932
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436769373892560
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6672
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:    -0.0000      Z:    -4.4692
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:    -0.0000      Z:    -0.8020     Total:     0.8020
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:    -0.0000      Z:    -2.0384     Total:     2.0384
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92145892430388
+	DF-HF Energy (a.u.)                :   -25.94367693738926
+	REF Energy (a.u.)                  :   -25.94367693738926
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191221754392
+	Alpha-Beta Contribution (a.u.)     :    -0.05772150442650
+	Beta-Beta Contribution (a.u.)      :    -0.00009275675669
+	Scaled_SS Correlation Energy (a.u.):    -0.00066832476687
+	Scaled_OS Correlation Energy (a.u.):    -0.06926580531180
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01361106746792
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01871489314371
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94720569215833
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06041626396074
+	DF-MP2 Total Energy (a.u.)         :   -26.00409320134999
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:18 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.28 seconds =       0.07 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.326855121574    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.564963068900     1.007825032070
+           H          0.000000000000    -0.371490000000     2.567735791100     1.007825032070
+           H         -0.000000000000     0.371490000000     2.567735791100     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99548  C =      0.97939 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29843.75264  C =  29361.44618 [MHz]
+  Nuclear repulsion =    4.917626938209342
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3120691402E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.72095345292324   -2.47210e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08842275131547    2.63253e+00   4.00624e-02 
+   @DF-ROHF iter   2:   -24.98504211391412   -2.89662e+00   1.56560e-02 DIIS
+   @DF-ROHF iter   3:   -25.63315938700098   -6.48117e-01   9.45352e-03 DIIS
+   @DF-ROHF iter   4:   -25.91386047981500   -2.80701e-01   3.95584e-03 DIIS
+   @DF-ROHF iter   5:   -25.93319586976661   -1.93354e-02   2.33338e-03 DIIS
+   @DF-ROHF iter   6:   -25.94335290358595   -1.01570e-02   3.23608e-04 DIIS
+   @DF-ROHF iter   7:   -25.94351788073168   -1.64977e-04   9.52457e-05 DIIS
+   @DF-ROHF iter   8:   -25.94353170158648   -1.38209e-05   3.36381e-05 DIIS
+   @DF-ROHF iter   9:   -25.94353363328175   -1.93170e-06   6.96715e-06 DIIS
+   @DF-ROHF iter  10:   -25.94353371789655   -8.46148e-08   1.35955e-06 DIIS
+   @DF-ROHF iter  11:   -25.94353372069115   -2.79459e-09   3.08642e-07 DIIS
+   @DF-ROHF iter  12:   -25.94353372085772   -1.66573e-10   2.05488e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112011     2A     -0.965564     3A     -0.766225  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518478  
+
+    Virtual:                                                              
+
+       5A     -0.244917     6A     -0.244379     7A      0.011279  
+       8A      0.035100     9A      0.147812    10A      0.183610  
+      11A      0.195474    12A      0.218103    13A      0.378609  
+      14A      0.500718    15A      0.529598    16A      0.532512  
+      17A      0.566477    18A      0.566483    19A      0.787121  
+      20A      1.013566    21A      1.124873    22A      1.227079  
+      23A      1.515320    24A      1.516044    25A      1.803117  
+      26A      1.871914    27A      1.872104    28A      2.091174  
+      29A      3.424296  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94353372085772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9176269382093425
+    One-Electron Energy =                 -41.2311080771726211
+    Two-Electron Energy =                  10.3699474181055606
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9435337208577153
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6589
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4608
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8018     Total:     0.8018
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0381     Total:     2.0381
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:18 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91762693820934
+	DF-HF Energy (a.u.)                :   -25.94353372085772
+	REF Energy (a.u.)                  :   -25.94353372085772
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191498220741
+	Alpha-Beta Contribution (a.u.)     :    -0.05776453678586
+	Beta-Beta Contribution (a.u.)      :    -0.00009318520546
+	Scaled_SS Correlation Energy (a.u.):    -0.00066938913762
+	Scaled_OS Correlation Energy (a.u.):    -0.06931744414303
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01352055413837
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01862761867933
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94706809550437
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06047110058843
+	DF-MP2 Total Energy (a.u.)         :   -26.00400482144615
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:18 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.57 seconds =       0.08 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.326484976045    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.566310870697     1.007825032070
+           H          0.000000000000    -0.371490000000     2.566387989303     1.007825032070
+           H         -0.000000000000     0.371490000000     2.566387989303     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99621  C =      0.98010 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29865.54557  C =  29382.54017 [MHz]
+  Nuclear repulsion =    4.915725144051741
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3216192212E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.85111718752186   -2.48511e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.09385597020173    2.75726e+00   3.99273e-02 
+   @DF-ROHF iter   2:   -24.98504976534392   -2.89119e+00   1.56580e-02 DIIS
+   @DF-ROHF iter   3:   -25.63381915290899   -6.48769e-01   9.44499e-03 DIIS
+   @DF-ROHF iter   4:   -25.91377270514877   -2.79954e-01   3.95398e-03 DIIS
+   @DF-ROHF iter   5:   -25.93311398467521   -1.93413e-02   2.33173e-03 DIIS
+   @DF-ROHF iter   6:   -25.94328092664826   -1.01669e-02   3.20697e-04 DIIS
+   @DF-ROHF iter   7:   -25.94344339522031   -1.62469e-04   9.31563e-05 DIIS
+   @DF-ROHF iter   8:   -25.94345662165157   -1.32264e-05   3.28889e-05 DIIS
+   @DF-ROHF iter   9:   -25.94345846745095   -1.84580e-06   6.95395e-06 DIIS
+   @DF-ROHF iter  10:   -25.94345855160736   -8.41564e-08   1.35610e-06 DIIS
+   @DF-ROHF iter  11:   -25.94345855439149   -2.78413e-09   3.06325e-07 DIIS
+   @DF-ROHF iter  12:   -25.94345855455596   -1.64466e-10   2.08384e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112026     2A     -0.965042     3A     -0.766326  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518410  
+
+    Virtual:                                                              
+
+       5A     -0.244880     6A     -0.244341     7A      0.010827  
+       8A      0.035048     9A      0.148234    10A      0.183645  
+      11A      0.195521    12A      0.218212    13A      0.378501  
+      14A      0.500115    15A      0.529623    16A      0.532565  
+      17A      0.566528    18A      0.566534    19A      0.787083  
+      20A      1.012331    21A      1.124803    22A      1.227249  
+      23A      1.514424    24A      1.515142    25A      1.803035  
+      26A      1.871828    27A      1.872037    28A      2.088677  
+      29A      3.424221  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94345855455596
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9157251440517413
+    One-Electron Energy =                 -41.2281404343924933
+    Two-Electron Energy =                  10.3689567357847920
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9434585545559599
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6548
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4566
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8018     Total:     0.8018
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0379     Total:     2.0379
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:18 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91572514405174
+	DF-HF Energy (a.u.)                :   -25.94345855455596
+	REF Energy (a.u.)                  :   -25.94345855455596
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191637019930
+	Alpha-Beta Contribution (a.u.)     :    -0.05778614368592
+	Beta-Beta Contribution (a.u.)      :    -0.00009340340365
+	Scaled_SS Correlation Energy (a.u.):    -0.00066992453432
+	Scaled_OS Correlation Energy (a.u.):    -0.06934337242311
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01347185151338
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01858054134766
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94699575609715
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06049865832209
+	DF-MP2 Total Energy (a.u.)         :   -26.00395721287805
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:18 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.86 seconds =       0.08 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.567919174624     1.007825032070
+           H          0.000000000000    -0.371490000000     2.571235546658     1.007825032070
+           H         -0.000000000000     0.371490000000     2.571235546658     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99265  C =      0.97665 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29758.95999  C =  29279.36830 [MHz]
+  Nuclear repulsion =    4.910396223821721
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3289584152E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.85867254216270   -2.48587e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.09599784864501    2.76267e+00   3.98545e-02 
+   @DF-ROHF iter   2:   -24.98468473723896   -2.88869e+00   1.56539e-02 DIIS
+   @DF-ROHF iter   3:   -25.63340157089633   -6.48717e-01   9.43343e-03 DIIS
+   @DF-ROHF iter   4:   -25.91367070288567   -2.80269e-01   3.95795e-03 DIIS
+   @DF-ROHF iter   5:   -25.93303641067724   -1.93657e-02   2.33732e-03 DIIS
+   @DF-ROHF iter   6:   -25.94325427160060   -1.02179e-02   3.26576e-04 DIIS
+   @DF-ROHF iter   7:   -25.94342371929045   -1.69448e-04   9.27244e-05 DIIS
+   @DF-ROHF iter   8:   -25.94343672367795   -1.30044e-05   3.38994e-05 DIIS
+   @DF-ROHF iter   9:   -25.94343868117166   -1.95749e-06   7.06433e-06 DIIS
+   @DF-ROHF iter  10:   -25.94343876837805   -8.72064e-08   1.42508e-06 DIIS
+   @DF-ROHF iter  11:   -25.94343877145949   -3.08144e-09   3.11536e-07 DIIS
+   @DF-ROHF iter  12:   -25.94343877162978   -1.70289e-10   2.06837e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112123     2A     -0.964832     3A     -0.765952  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518518  
+
+    Virtual:                                                              
+
+       5A     -0.244899     6A     -0.244366     7A      0.010457  
+       8A      0.035262     9A      0.148188    10A      0.183629  
+      11A      0.195450    12A      0.217952    13A      0.378873  
+      14A      0.499711    15A      0.529591    16A      0.532451  
+      17A      0.566502    18A      0.566508    19A      0.787250  
+      20A      1.012141    21A      1.125072    22A      1.226329  
+      23A      1.513917    24A      1.514635    25A      1.803305  
+      26A      1.872147    27A      1.872282    28A      2.087366  
+      29A      3.424501  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94343877162978
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9103962238217207
+    One-Electron Energy =                 -41.2183148621542870
+    Two-Electron Energy =                  10.3644798667027835
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9434387716297827
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4678
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8047     Total:     0.8047
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0453     Total:     2.0453
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91039622382172
+	DF-HF Energy (a.u.)                :   -25.94343877162978
+	REF Energy (a.u.)                  :   -25.94343877162978
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191483513780
+	Alpha-Beta Contribution (a.u.)     :    -0.05778835562778
+	Beta-Beta Contribution (a.u.)      :    -0.00009267653073
+	Scaled_SS Correlation Energy (a.u.):    -0.00066917055618
+	Scaled_OS Correlation Energy (a.u.):    -0.06934602675333
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01345396893930
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01856363394590
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94697199216641
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06049929208924
+	DF-MP2 Total Energy (a.u.)         :   -26.00393806371903
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.14 seconds =       0.09 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.565767220863     1.007825032070
+           H          0.000000000000    -0.371490000000     2.570159569778     1.007825032070
+           H         -0.000000000000     0.371490000000     2.570159569778     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99370  C =      0.97767 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29790.44240  C =  29309.84363 [MHz]
+  Nuclear repulsion =    4.914960364497975
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3157292673E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.85961663917053   -2.48596e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08950229618621    2.77011e+00   4.00258e-02 
+   @DF-ROHF iter   2:   -24.98485969081510   -2.89536e+00   1.56539e-02 DIIS
+   @DF-ROHF iter   3:   -25.63295323833583   -6.48094e-01   9.44774e-03 DIIS
+   @DF-ROHF iter   4:   -25.91381073493788   -2.80857e-01   3.95779e-03 DIIS
+   @DF-ROHF iter   5:   -25.93315801669161   -1.93473e-02   2.33615e-03 DIIS
+   @DF-ROHF iter   6:   -25.94334026568801   -1.01822e-02   3.26506e-04 DIIS
+   @DF-ROHF iter   7:   -25.94350868828377   -1.68423e-04   9.50441e-05 DIIS
+   @DF-ROHF iter   8:   -25.94352240052042   -1.37122e-05   3.41440e-05 DIIS
+   @DF-ROHF iter   9:   -25.94352438899269   -1.98847e-06   7.02255e-06 DIIS
+   @DF-ROHF iter  10:   -25.94352447513527   -8.61426e-08   1.39341e-06 DIIS
+   @DF-ROHF iter  11:   -25.94352447807413   -2.93887e-09   3.11238e-07 DIIS
+   @DF-ROHF iter  12:   -25.94352447824358   -1.69447e-10   2.04775e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112059     2A     -0.965458     3A     -0.766038  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518532  
+
+    Virtual:                                                              
+
+       5A     -0.244926     6A     -0.244392     7A      0.011094  
+       8A      0.035207     9A      0.147790    10A      0.183602  
+      11A      0.195438    12A      0.217973    13A      0.378795  
+      14A      0.500516    15A      0.529582    16A      0.532455  
+      17A      0.566464    18A      0.566470    19A      0.787205  
+      20A      1.013471    21A      1.125008    22A      1.226618  
+      23A      1.515066    24A      1.515790    25A      1.803251  
+      26A      1.872074    27A      1.872226    28A      2.090515  
+      29A      3.424437  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94352447824358
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9149603644979747
+    One-Electron Energy =                 -41.2261926831264276
+    Two-Electron Energy =                  10.3677078403848739
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9435244782435817
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4664
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8033     Total:     0.8033
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0418     Total:     2.0418
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91496036449797
+	DF-HF Energy (a.u.)                :   -25.94352447824358
+	REF Energy (a.u.)                  :   -25.94352447824358
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191421503650
+	Alpha-Beta Contribution (a.u.)     :    -0.05776563241875
+	Beta-Beta Contribution (a.u.)      :    -0.00009282259981
+	Scaled_SS Correlation Energy (a.u.):    -0.00066901254543
+	Scaled_OS Correlation Energy (a.u.):    -0.06931875890250
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01351224969151
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01861980038795
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94705686448347
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06047140241332
+	DF-MP2 Total Energy (a.u.)         :   -26.00399588065689
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.43 seconds =       0.09 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.561463313342     1.007825032070
+           H          0.000000000000    -0.371490000000     2.568007616017     1.007825032070
+           H         -0.000000000000     0.371490000000     2.568007616017     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99581  C =      0.97971 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29853.53338  C =  29370.91330 [MHz]
+  Nuclear repulsion =    4.924129761654396
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.2893942137E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86150298261015   -2.48615e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.07636648198981    2.78514e+00   4.03712e-02 
+   @DF-ROHF iter   2:   -24.98520149398052   -2.90884e+00   1.56540e-02 DIIS
+   @DF-ROHF iter   3:   -25.63206934763768   -6.46868e-01   9.47620e-03 DIIS
+   @DF-ROHF iter   4:   -25.91408173484058   -2.82012e-01   3.95732e-03 DIIS
+   @DF-ROHF iter   5:   -25.93339093846994   -1.93092e-02   2.33364e-03 DIIS
+   @DF-ROHF iter   6:   -25.94350105028497   -1.01101e-02   3.26469e-04 DIIS
+   @DF-ROHF iter   7:   -25.94366757079231   -1.66521e-04   9.96081e-05 DIIS
+   @DF-ROHF iter   8:   -25.94368273399892   -1.51632e-05   3.45509e-05 DIIS
+   @DF-ROHF iter   9:   -25.94368477552293   -2.04152e-06   6.92592e-06 DIIS
+   @DF-ROHF iter  10:   -25.94368485922184   -8.36989e-08   1.32980e-06 DIIS
+   @DF-ROHF iter  11:   -25.94368486188560   -2.66376e-09   3.10204e-07 DIIS
+   @DF-ROHF iter  12:   -25.94368486205306   -1.67461e-10   2.00791e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111933     2A     -0.966715     3A     -0.766210  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518559  
+
+    Virtual:                                                              
+
+       5A     -0.244980     6A     -0.244444     7A      0.012368  
+       8A      0.035096     9A      0.146991    10A      0.183548  
+      11A      0.195414    12A      0.218018    13A      0.378639  
+      14A      0.502132    15A      0.529565    16A      0.532464  
+      17A      0.566388    18A      0.566394    19A      0.787114  
+      20A      1.016140    21A      1.124880    22A      1.227204  
+      23A      1.517370    24A      1.518106    25A      1.803144  
+      26A      1.871927    27A      1.872116    28A      2.096867  
+      29A      3.424308  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94368486205306
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9241297616543962
+    One-Electron Energy =                 -41.2420020334504187
+    Two-Electron Energy =                  10.3741874097429623
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436848620530576
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4636
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8005     Total:     0.8005
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0348     Total:     2.0348
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92412976165440
+	DF-HF Energy (a.u.)                :   -25.94368486205306
+	REF Energy (a.u.)                  :   -25.94368486205306
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191298400674
+	Alpha-Beta Contribution (a.u.)     :    -0.05772042959670
+	Beta-Beta Contribution (a.u.)      :    -0.00009311771721
+	Scaled_SS Correlation Energy (a.u.):    -0.00066870057465
+	Scaled_OS Correlation Energy (a.u.):    -0.06926451551605
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01361807814376
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01872142052878
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94721560108721
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06041599228949
+	DF-MP2 Total Energy (a.u.)         :   -26.00410085434255
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.72 seconds =       0.10 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 8 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.559311359581     1.007825032070
+           H          0.000000000000    -0.371490000000     2.566931639137     1.007825032070
+           H         -0.000000000000     0.371490000000     2.566931639137     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99686  C =      0.98073 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29885.14208  C =  29401.50775 [MHz]
+  Nuclear repulsion =    4.928735155981876
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.2762884296E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86244515903453   -2.48624e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.06972559197687    2.79272e+00   4.05452e-02 
+   @DF-ROHF iter   2:   -24.98536823622445   -2.91564e+00   1.56541e-02 DIIS
+   @DF-ROHF iter   3:   -25.63163325197711   -6.46265e-01   9.49034e-03 DIIS
+   @DF-ROHF iter   4:   -25.91421252762772   -2.82579e-01   3.95702e-03 DIIS
+   @DF-ROHF iter   5:   -25.93350212281667   -1.92896e-02   2.33230e-03 DIIS
+   @DF-ROHF iter   6:   -25.94357576068817   -1.00736e-02   3.26502e-04 DIIS
+   @DF-ROHF iter   7:   -25.94374140385044   -1.65643e-04   1.01851e-04 DIIS
+   @DF-ROHF iter   8:   -25.94375730834616   -1.59045e-05   3.47144e-05 DIIS
+   @DF-ROHF iter   9:   -25.94375937196048   -2.06361e-06   6.87213e-06 DIIS
+   @DF-ROHF iter  10:   -25.94375945431051   -8.23500e-08   1.29791e-06 DIIS
+   @DF-ROHF iter  11:   -25.94375945684201   -2.53150e-09   3.09477e-07 DIIS
+   @DF-ROHF iter  12:   -25.94375945700825   -1.66242e-10   1.98865e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111869     2A     -0.967346     3A     -0.766296  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518573  
+
+    Virtual:                                                              
+
+       5A     -0.245007     6A     -0.244469     7A      0.013005  
+       8A      0.035040     9A      0.146589    10A      0.183520  
+      11A      0.195401    12A      0.218041    13A      0.378562  
+      14A      0.502943    15A      0.529557    16A      0.532469  
+      17A      0.566351    18A      0.566356    19A      0.787069  
+      20A      1.017479    21A      1.124816    22A      1.227501  
+      23A      1.518525    24A      1.519268    25A      1.803091  
+      26A      1.871854    27A      1.872061    28A      2.100070  
+      29A      3.424243  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94375945700825
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9287351559818759
+    One-Electron Energy =                 -41.2499336531658969
+    Two-Electron Energy =                  10.3774390401757728
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9437594570082481
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4623
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.7992     Total:     0.7992
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0313     Total:     2.0313
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:20 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92873515598188
+	DF-HF Energy (a.u.)                :   -25.94375945700825
+	REF Energy (a.u.)                  :   -25.94375945700825
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191237308323
+	Alpha-Beta Contribution (a.u.)     :    -0.05769795027749
+	Beta-Beta Contribution (a.u.)      :    -0.00009326677908
+	Scaled_SS Correlation Energy (a.u.):    -0.00066854662077
+	Scaled_OS Correlation Energy (a.u.):    -0.06923754033299
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01366554396201
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01876679236899
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94728938316591
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06038847160104
+	DF-MP2 Total Energy (a.u.)         :   -26.00414792860929
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:20 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.01 seconds =       0.10 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 9 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B          0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H          0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.375217293249     2.569083592897     1.007825032070
+           H         -0.000000000000     0.375217293249     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     59.40400  B =      0.99475  C =      0.97837 [cm^-1]
+  Rotational constants: A = 1780887.01324  B =  29821.96684  C =  29330.80580 [MHz]
+  Nuclear repulsion =    4.912146744161231
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3022515878E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86093337693679   -2.48609e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08992628493661    2.77101e+00   4.01986e-02 
+   @DF-ROHF iter   2:   -24.98703069053403   -2.89710e+00   1.56220e-02 DIIS
+   @DF-ROHF iter   3:   -25.63353569147059   -6.46505e-01   9.46291e-03 DIIS
+   @DF-ROHF iter   4:   -25.91415658233209   -2.80621e-01   3.94354e-03 DIIS
+   @DF-ROHF iter   5:   -25.93335131044892   -1.91947e-02   2.32805e-03 DIIS
+   @DF-ROHF iter   6:   -25.94345145836471   -1.01001e-02   3.23925e-04 DIIS
+   @DF-ROHF iter   7:   -25.94361551403424   -1.64056e-04   9.91267e-05 DIIS
+   @DF-ROHF iter   8:   -25.94363061843633   -1.51044e-05   3.36597e-05 DIIS
+   @DF-ROHF iter   9:   -25.94363255819838   -1.93976e-06   7.05536e-06 DIIS
+   @DF-ROHF iter  10:   -25.94363264455117   -8.63528e-08   1.31110e-06 DIIS
+   @DF-ROHF iter  11:   -25.94363264714393   -2.59276e-09   3.13841e-07 DIIS
+   @DF-ROHF iter  12:   -25.94363264731587   -1.71941e-10   2.14142e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111918     2A     -0.966031     3A     -0.763964  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518421  
+
+    Virtual:                                                              
+
+       5A     -0.244911     6A     -0.244365     7A      0.011791  
+       8A      0.033728     9A      0.147468    10A      0.183620  
+      11A      0.195398    12A      0.218189    13A      0.380152  
+      14A      0.501422    15A      0.529634    16A      0.532284  
+      17A      0.566484    18A      0.566490    19A      0.782161  
+      20A      1.014846    21A      1.124114    22A      1.226407  
+      23A      1.516272    24A      1.516993    25A      1.795804  
+      26A      1.866892    27A      1.867086    28A      2.093727  
+      29A      3.380135  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94363264731587
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9121467441612312
+    One-Electron Energy =                 -41.2241382804810712
+    Two-Electron Energy =                  10.3683588890039768
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436326473158587
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4636
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8005     Total:     0.8005
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0346     Total:     2.0346
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:20 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91214674416123
+	DF-HF Energy (a.u.)                :   -25.94363264731587
+	REF Energy (a.u.)                  :   -25.94363264731587
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191491760193
+	Alpha-Beta Contribution (a.u.)     :    -0.05781783675770
+	Beta-Beta Contribution (a.u.)      :    -0.00009389556545
+	Scaled_SS Correlation Energy (a.u.):    -0.00066960438913
+	Scaled_OS Correlation Energy (a.u.):    -0.06938140410923
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01368365581422
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01879583510087
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94716815849045
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06052238558810
+	DF-MP2 Total Energy (a.u.)         :   -26.00415503290396
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:20 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.30 seconds =       0.10 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 10 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.373353646625     2.569083592897     1.007825032070
+           H         -0.000000000000     0.373353646625     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     59.99852  B =      0.99475  C =      0.97853 [cm^-1]
+  Rotational constants: A = 1798710.47679  B =  29821.96684  C =  29335.59335 [MHz]
+  Nuclear repulsion =    4.915825183599840
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3023964136E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86075735104361   -2.48608e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08646019522721    2.77430e+00   4.01983e-02 
+   @DF-ROHF iter   2:   -24.98603624593420   -2.89958e+00   1.56381e-02 DIIS
+   @DF-ROHF iter   3:   -25.63302768904855   -6.46991e-01   9.46247e-03 DIIS
+   @DF-ROHF iter   4:   -25.91406130824959   -2.81034e-01   3.95061e-03 DIIS
+   @DF-ROHF iter   5:   -25.93332322988924   -1.92619e-02   2.33154e-03 DIIS
+   @DF-ROHF iter   6:   -25.94344691464667   -1.01237e-02   3.25228e-04 DIIS
+   @DF-ROHF iter   7:   -25.94361269799140   -1.65783e-04   9.82380e-05 DIIS
+   @DF-ROHF iter   8:   -25.94362746526887   -1.47673e-05   3.40238e-05 DIIS
+   @DF-ROHF iter   9:   -25.94362944476053   -1.97949e-06   7.01497e-06 DIIS
+   @DF-ROHF iter  10:   -25.94362953040769   -8.56472e-08   1.33890e-06 DIIS
+   @DF-ROHF iter  11:   -25.94362953311309   -2.70541e-09   3.12480e-07 DIIS
+   @DF-ROHF iter  12:   -25.94362953328351   -1.70413e-10   2.08234e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111957     2A     -0.966059     3A     -0.765041  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518484  
+
+    Virtual:                                                              
+
+       5A     -0.244932     6A     -0.244392     7A      0.011761  
+       8A      0.034441     9A      0.147429    10A      0.183597  
+      11A      0.195412    12A      0.218092    13A      0.379435  
+      14A      0.501372    15A      0.529604    16A      0.532372  
+      17A      0.566455    18A      0.566461    19A      0.784648  
+      20A      1.014824    21A      1.124525    22A      1.226654  
+      23A      1.516244    24A      1.516970    25A      1.799509  
+      26A      1.869446    27A      1.869628    28A      2.093704  
+      29A      3.402037  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94362953328351
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9158251835998401
+    One-Electron Energy =                 -41.2291034732145931
+    Two-Electron Energy =                  10.3696487563312481
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436295332835023
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4643
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8012     Total:     0.8012
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0364     Total:     2.0364
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:20 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91582518359984
+	DF-HF Energy (a.u.)                :   -25.94362953328351
+	REF Energy (a.u.)                  :   -25.94362953328351
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191425737080
+	Alpha-Beta Contribution (a.u.)     :    -0.05778044335017
+	Beta-Beta Contribution (a.u.)      :    -0.00009343074073
+	Scaled_SS Correlation Energy (a.u.):    -0.00066922937051
+	Scaled_OS Correlation Energy (a.u.):    -0.06933653202020
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01363529467422
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01874410963872
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94716306435979
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06048303408209
+	DF-MP2 Total Energy (a.u.)         :   -26.00411256736560
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:20 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.59 seconds =       0.11 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 11 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B          0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H          0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.369626353375     2.569083592897     1.007825032070
+           H         -0.000000000000     0.369626353375     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     61.21467  B =      0.99475  C =      0.97885 [cm^-1]
+  Rotational constants: A = 1835169.58947  B =  29821.96684  C =  29345.10157 [MHz]
+  Nuclear repulsion =    4.923286289652303
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3026858744E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86034118526010   -2.48603e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.07942099973247    2.78092e+00   4.01978e-02 
+   @DF-ROHF iter   2:   -24.98401747144844   -2.90460e+00   1.56698e-02 DIIS
+   @DF-ROHF iter   3:   -25.63198058891194   -6.47963e-01   9.46152e-03 DIIS
+   @DF-ROHF iter   4:   -25.91381564214155   -2.81835e-01   3.96444e-03 DIIS
+   @DF-ROHF iter   5:   -25.93320986342177   -1.93942e-02   2.33819e-03 DIIS
+   @DF-ROHF iter   6:   -25.94337786992910   -1.01680e-02   3.27645e-04 DIIS
+   @DF-ROHF iter   7:   -25.94354690811907   -1.69038e-04   9.64296e-05 DIIS
+   @DF-ROHF iter   8:   -25.94356100745832   -1.40993e-05   3.46692e-05 DIIS
+   @DF-ROHF iter   9:   -25.94356305788014   -2.05042e-06   6.93830e-06 DIIS
+   @DF-ROHF iter  10:   -25.94356314217565   -8.42955e-08   1.37998e-06 DIIS
+   @DF-ROHF iter  11:   -25.94356314505261   -2.87696e-09   3.08835e-07 DIIS
+   @DF-ROHF iter  12:   -25.94356314521896   -1.66352e-10   1.97682e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112035     2A     -0.966113     3A     -0.767213  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518607  
+
+    Virtual:                                                              
+
+       5A     -0.244974     6A     -0.244444     7A      0.011701  
+       8A      0.035859     9A      0.147352    10A      0.183553  
+      11A      0.195440    12A      0.217898    13A      0.378000  
+      14A      0.501274    15A      0.529543    16A      0.532545  
+      17A      0.566397    18A      0.566403    19A      0.789695  
+      20A      1.014783    21A      1.125372    22A      1.227173  
+      23A      1.516189    24A      1.516924    25A      1.806868  
+      26A      1.874555    27A      1.874714    28A      2.093661  
+      29A      3.447146  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94356314521896
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9232862896523031
+    One-Electron Energy =                 -41.2390930970045133
+    Two-Electron Energy =                  10.3722436621332523
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9435631452189597
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -4.4657
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.8026     Total:     0.8026
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:    -2.0401     Total:     2.0401
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:21 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92328628965230
+	DF-HF Energy (a.u.)                :   -25.94356314521896
+	REF Energy (a.u.)                  :   -25.94356314521896
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191293947809
+	Alpha-Beta Contribution (a.u.)     :    -0.05770547564563
+	Beta-Beta Contribution (a.u.)      :    -0.00009251230274
+	Scaled_SS Correlation Energy (a.u.):    -0.00066848392694
+	Scaled_OS Correlation Energy (a.u.):    -0.06924657077476
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01347819992066
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01858026355828
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94709274035322
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06040418870307
+	DF-MP2 Total Energy (a.u.)         :   -26.00396733392203
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:21 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.88 seconds =       0.11 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 12 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.367762706751     2.569083592897     1.007825032070
+           H         -0.000000000000     0.367762706751     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     61.83665  B =      0.99475  C =      0.97900 [cm^-1]
+  Rotational constants: A = 1853816.25096  B =  29821.96684  C =  29349.82219 [MHz]
+  Nuclear repulsion =    4.927070034397756
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3028304851E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86009997065467   -2.48601e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.07584681368804    2.78425e+00   4.01975e-02 
+   @DF-ROHF iter   2:   -24.98299240273998   -2.90715e+00   1.56855e-02 DIIS
+   @DF-ROHF iter   3:   -25.63144192187880   -6.48450e-01   9.46102e-03 DIIS
+   @DF-ROHF iter   4:   -25.91366456587982   -2.82223e-01   3.97118e-03 DIIS
+   @DF-ROHF iter   5:   -25.93312376766990   -1.94592e-02   2.34135e-03 DIIS
+   @DF-ROHF iter   6:   -25.94331243795651   -1.01887e-02   3.28746e-04 DIIS
+   @DF-ROHF iter   7:   -25.94348298653269   -1.70549e-04   9.55094e-05 DIIS
+   @DF-ROHF iter   8:   -25.94349675566584   -1.37691e-05   3.49466e-05 DIIS
+   @DF-ROHF iter   9:   -25.94349883669130   -2.08103e-06   6.90049e-06 DIIS
+   @DF-ROHF iter  10:   -25.94349892030513   -8.36138e-08   1.39446e-06 DIIS
+   @DF-ROHF iter  11:   -25.94349892324410   -2.93897e-09   3.06648e-07 DIIS
+   @DF-ROHF iter  12:   -25.94349892340806   -1.63958e-10   1.92965e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.112073     2A     -0.966141     3A     -0.768307  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518669  
+
+    Virtual:                                                              
+
+       5A     -0.244995     6A     -0.244469     7A      0.011671  
+       8A      0.036565     9A      0.147313    10A      0.183531  
+      11A      0.195455    12A      0.217800    13A      0.377283  
+      14A      0.501225    15A      0.529513    16A      0.532630  
+      17A      0.566369    18A      0.566374    19A      0.792256  
+      20A      1.014764    21A      1.125807    22A      1.227444  
+      23A      1.516161    24A      1.516901    25A      1.810521  
+      26A      1.877109    27A      1.877257    28A      2.093640  
+      29A      3.470365  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94349892340806
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9270700343977563
+    One-Electron Energy =                 -41.2441176483338126
+    Two-Electron Energy =                  10.3735486905279970
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9434989234080575
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:    -4.4664
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:    -0.8033     Total:     0.8033
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:    -0.0000      Z:    -2.0419     Total:     2.0419
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:21 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.92707003439776
+	DF-HF Energy (a.u.)                :   -25.94349892340806
+	REF Energy (a.u.)                  :   -25.94349892340806
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191228184123
+	Alpha-Beta Contribution (a.u.)     :    -0.05766789709219
+	Beta-Beta Contribution (a.u.)      :    -0.00009205865013
+	Scaled_SS Correlation Energy (a.u.):    -0.00066811349712
+	Scaled_OS Correlation Energy (a.u.):    -0.06920147651063
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01336851341580
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01846718962791
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94702656267284
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06036469045194
+	DF-MP2 Total Energy (a.u.)         :   -26.00386361386000
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:21 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.18 seconds =       0.12 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 13 of 13   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+    SCF Algorithm Type (re)set to DF.
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    256 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           B         -0.000000000000     0.000000000000    -0.327225267103    11.009305406000
+           H         -0.000000000000     0.000000000000    -1.563615267103     1.007825032070
+           H          0.000000000000    -0.371490000000     2.569083592897     1.007825032070
+           H         -0.000000000000     0.371490000000     2.569083592897     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     60.60202  B =      0.99475  C =      0.97869 [cm^-1]
+  Rotational constants: A = 1816802.85649  B =  29821.96684  C =  29340.35861 [MHz]
+  Nuclear repulsion =    4.919538187546689
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 7
+  Nalpha       = 4
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-07
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz.gbs
+    Number of shells: 15
+    Number of basis function: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         29      29       0       0       0       0
+   -------------------------------------------------------
+    Total      29      29       4       3       3       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               183
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 51
+    Number of basis function: 139
+    Number of Cartesian functions: 156
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.3025411798E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter   0:   -24.86056013092314   -2.48606e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -22.08295861173116    2.77760e+00   4.01981e-02 
+   @DF-ROHF iter   2:   -24.98503196084310   -2.90207e+00   1.56540e-02 DIIS
+   @DF-ROHF iter   3:   -25.63250925552986   -6.47477e-01   9.46200e-03 DIIS
+   @DF-ROHF iter   4:   -25.91394777516690   -2.81439e-01   3.95758e-03 DIIS
+   @DF-ROHF iter   5:   -25.93327621468751   -1.93284e-02   2.33492e-03 DIIS
+   @DF-ROHF iter   6:   -25.94342253855418   -1.01463e-02   3.26470e-04 DIIS
+   @DF-ROHF iter   7:   -25.94358998546138   -1.67447e-04   9.73390e-05 DIIS
+   @DF-ROHF iter   8:   -25.94360441761174   -1.44322e-05   3.43610e-05 DIIS
+   @DF-ROHF iter   9:   -25.94360643409362   -2.01648e-06   6.97623e-06 DIIS
+   @DF-ROHF iter  10:   -25.94360651906169   -8.49681e-08   1.36164e-06 DIIS
+   @DF-ROHF iter  11:   -25.94360652186132   -2.79963e-09   3.10792e-07 DIIS
+   @DF-ROHF iter  12:   -25.94360652202981   -1.68491e-10   2.02761e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -8.111996     2A     -0.966086     3A     -0.766124  
+
+    Singly Occupied:                                                      
+
+       4A     -0.518546  
+
+    Virtual:                                                              
+
+       5A     -0.244953     6A     -0.244418     7A      0.011731  
+       8A      0.035151     9A      0.147391    10A      0.183575  
+      11A      0.195426    12A      0.217995    13A      0.378717  
+      14A      0.501323    15A      0.529573    16A      0.532459  
+      17A      0.566426    18A      0.566432    19A      0.787160  
+      20A      1.014804    21A      1.124944    22A      1.226910  
+      23A      1.516216    24A      1.516947    25A      1.803198  
+      26A      1.872001    27A      1.872171    28A      2.093682  
+      29A      3.424372  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     1 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:   -25.94360652202981
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.9195381875466886
+    One-Electron Energy =                 -41.2340883918724828
+    Two-Electron Energy =                  10.3709436822959802
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -25.9436065220298175
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     3.6631
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -4.4650
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:     0.0000      Z:    -0.8019     Total:     0.8019
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:     0.0000      Z:    -2.0383     Total:     2.0383
+
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:21 2017
+
+
+
+  Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                      => [  ]             
+  BASIS_RELATIVISTIC          => (empty)          
+  BENCH                       => 0                
+  CC_DIIS_MAX_VECS            => 6                
+  CC_DIIS_MIN_VECS            => 2                
+  CC_LAMBDA                   => FALSE            
+  CC_MAXITER                  => 50               
+  CC_TYPE                     => CONV             
+  CHOLESKY                    => FALSE           !
+  CHOLESKY_TOLERANCE          => 0.0001           
+  CI_TYPE                     => CONV             
+  COMPUT_S2                   => FALSE            
+  CUBEPROP_BASIS_FUNCTIONS    => [  ]             
+  CUBEPROP_FILEPATH           => .                
+  CUBEPROP_ORBITALS           => [  ]             
+  CUBEPROP_TASKS              => [  ]             
+  CUBIC_BASIS_TOLERANCE       => 1e-12            
+  CUBIC_BLOCK_MAX_POINTS      => 1000             
+  CUBIC_GRID_OVERAGE          => [  ]             
+  CUBIC_GRID_SPACING          => [  ]             
+  CUTOFF                      => 8                
+  DEBUG                       => 0                
+  DERTYPE                     => NONE             
+  DF_BASIS_CC                 => (empty)          
+  DIE_IF_NOT_CONVERGED        => TRUE             
+  DKH_ORDER                   => 2                
+  DOCC                        => [  ]             
+  DO_DIIS                     => TRUE             
+  DO_LEVEL_SHIFT              => TRUE             
+  DO_SCS                      => FALSE           !
+  DO_SOS                      => FALSE           !
+  E3_SCALE                    => 0.25             
+  EKT_IP                      => FALSE            
+  EXTERNAL_POTENTIAL_SYMMETRY => FALSE            
+  E_CONVERGENCE               => 1e-08           !
+  FREEZE_CORE                 => FALSE           !
+  FROZEN_DOCC                 => [  ]             
+  FROZEN_UOCC                 => [  ]             
+  HESS_TYPE                   => HF               
+  INTEGRAL_CUTOFF             => 9                
+  INTEGRAL_PACKAGE            => ERD             !
+  LEVEL_SHIFT                 => 0.02             
+  LINEQ_SOLVER                => CDGESV           
+  LITERAL_CFOUR               => (empty)          
+  MAT_NUM_COLUMN_PRINT        => 5                
+  MAX_MOGRAD_CONVERGENCE      => 0.001            
+  MOLDEN_WRITE                => FALSE            
+  MO_DIIS_NUM_VECS            => 6                
+  MO_MAXITER                  => 50               
+  MO_STEP_MAX                 => 0.5              
+  MP2_AMP_TYPE                => DIRECT           
+  MP2_OS_SCALE                => 1.2              
+  MP2_SOS_SCALE               => 1.3              
+  MP2_SOS_SCALE2              => 1.2              
+  MP2_SS_SCALE                => 0.333333         
+  MP2_TYPE                    => DF              !
+  MP_TYPE                     => CONV             
+  NAT_ORBS                    => FALSE            
+  NUM_FROZEN_DOCC             => 0                
+  NUM_FROZEN_UOCC             => 0                
+  OCC_ORBS_PRINT              => FALSE            
+  OEPROP                      => FALSE            
+  OO_SCALE                    => 0.01             
+  OPT_METHOD                  => QNR              
+  ORB_OPT                     => FALSE           !
+  ORB_RESP_SOLVER             => PCG              
+  ORTH_TYPE                   => MGS              
+  PCG_BETA_TYPE               => FLETCHER_REEVES  
+  PCG_CONVERGENCE             => 1e-06            
+  PCG_MAXITER                 => 50               
+  PCM                         => FALSE            
+  PCM_SCF_TYPE                => TOTAL            
+  PPL_TYPE                    => AUTO             
+  PRINT                       => 1                
+  PRINT_NOONS                 => 3                
+  PROPERTIES                  => [  ]             
+  PROPERTIES_ORIGIN           => [  ]             
+  PUREAM                      => TRUE             
+  QCHF                        => FALSE            
+  QC_MODULE                   => OCC             !
+  RAS1                        => [  ]             
+  RAS2                        => [  ]             
+  RAS3                        => [  ]             
+  RAS4                        => [  ]             
+  READ_SCF_3INDEX             => TRUE             
+  REGULARIZATION              => FALSE            
+  REG_PARAM                   => 0.4              
+  RELATIVISTIC                => NO               
+  RESTRICTED_DOCC             => [  ]             
+  RESTRICTED_UOCC             => [  ]             
+  RMS_MOGRAD_CONVERGENCE      => 1e-06            
+  R_CONVERGENCE               => 1e-05            
+  SCS_TYPE                    => SCS              
+  SOCC                        => [  ]             
+  SOS_TYPE                    => SOS              
+  TRIPLES_IABC_TYPE           => DISK             
+  UNITS                       => ANGSTROMS        
+  WFN                         => SCF              
+  WFN_TYPE                    => DF-OMP2         !
+  WRITER_FILE_LABEL           => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-MP2   
+              Program Written by Ugur Bozkaya
+              Latest Revision April 17, 2016
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     4     3    25     26     0
+	Number of basis functions in the DF-CC basis:  98
+
+	Available memory                      :    244.14 MB 
+	Minimum required memory for amplitudes:      0.23 MB 
+
+	Computing DF-MP2 energy using SCF MOs (DF-ROHF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     4.91953818754669
+	DF-HF Energy (a.u.)                :   -25.94360652202981
+	REF Energy (a.u.)                  :   -25.94360652202981
+	Alpha-Alpha Contribution (a.u.)    :    -0.00191359799208
+	Alpha-Beta Contribution (a.u.)     :    -0.05774299036043
+	Beta-Beta Contribution (a.u.)      :    -0.00009296965972
+	Scaled_SS Correlation Energy (a.u.):    -0.00066885588394
+	Scaled_OS Correlation Energy (a.u.):    -0.06929158843251
+	DF-SCS-MP2 Total Energy (a.u.)     :   -26.01356696634626
+	DF-SOS-MP2 Total Energy (a.u.)     :   -26.01867240949837
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -25.94713808109699
+	DF-MP2 Correlation Energy (a.u.)   :    -0.06044363585502
+	DF-MP2 Total Energy (a.u.)         :   -26.00405015788484
+	======================================================================= 
+
+*** tstop() called on psinet at Fri Feb  3 19:05:21 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.47 seconds =       0.12 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 5-point formula.
+	Energy without displacement:  -26.0040501579
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-2)        Energy(-1)        Energy(+1)        Energy(+2)            Force
+	    0    -26.0041339309    -26.0040932013    -26.0040048214    -26.0039572129      0.0088386876
+	    1    -26.0039380637    -26.0039958807    -26.0041008543    -26.0041479286     -0.0104987433
+	    2    -26.0041550329    -26.0041125674    -26.0039673339    -26.0038636139      0.0145074751
+
+	Gradient written.
+
+-------------------------------------------------------------
+  Irrep: 1 Size: 4 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000     0.01361285056131
+    2     0.00000000000000     0.00000000000000    -0.01314327828922
+    3     0.00000000000000     0.01029839168987    -0.00023478613605
+    4     0.00000000000000    -0.01029839168987    -0.00023478613605
+
+
+
+	mp2 grad rohf df nfc: findif......................................PASSED
+	mp2 grad rohf df nfc: findif......................................PASSED
+	mp2 grad rohf df nfc: findif......................................PASSED
+	mp2 grad rohf df nfc: findif......................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/erd/scf5/input.dat
+++ b/tests/erd/scf5/input.dat
@@ -47,59 +47,59 @@ set {
 print_stdout('    -Singlet RHF:') #TEST
 set scf reference rhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct RHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
 
 print_stdout('    -Singlet UHF:') #TEST
 set scf reference uhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct UHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
 
 print_stdout('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct CUHF energy') #TEST
 
-#set scf scf_type out_of_core
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
-#
-#set scf scf_type df
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF CUHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
+
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -112,66 +112,66 @@ set {
 print_stdout('    -Triplet UHF:') #TEST
 set scf reference uhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_uhf_can, E, 6, 'Triplet Direct UHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
-#
-#clean()
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
+
+clean()
 
 print_stdout('    -Triplet ROHF:') #TEST
 set scf reference rohf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
-#clean()
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
+clean()
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct ROHF energy') #TEST
 clean()
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
-#clean()
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
+clean()
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
-#
-#clean()
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
+
+clean()
 
 print_stdout('    -Triplet CUHF:') #TEST
 set scf reference cuhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
-#clean()
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
+clean()
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct CUHF energy') #TEST
 clean()
 
-#set scf scf_type out_of_core
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
-#clean()
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
+clean()
 
-#set scf scf_type df
-#E = energy('scf')
-#compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST

--- a/tests/erd/scf5/output.ref
+++ b/tests/erd/scf5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                              Psi4 1.0 Driver
+                               Psi4 1.1a2.dev229 
 
-                              Git: Rev dirty
+                         Git: Rev {erd2} 2e8c416 dirty
 
 
     J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
@@ -21,21 +21,21 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Sunday, 23 October 2016 06:53PM
+    Psi4 started on: Friday, 03 February 2017 07:05PM
 
-    Process ID:  33524
-    PSIDATADIR: /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4
+    Process ID:  24827
+    PSIDATADIR: /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
-#! Test of all different algorithms and reference types for SCF, on singlet and triplet O2, using the cc-pVTZ basis set.
+#! Test of all different algorithms and reference types for SCF, on singlet and triplet O2, using the cc-pVTZ basis set and using ERD integrals.
 
 memory 250 mb
 
-set INTEGRAL_PACKAGE ERD
+set integral_package ERD
 
 print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
 
@@ -80,59 +80,59 @@ set {
 print_stdout('    -Singlet RHF:') #TEST
 set scf reference rhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct RHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
 
 print_stdout('    -Singlet UHF:') #TEST
 set scf reference uhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct UHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
 
 print_stdout('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct CUHF energy') #TEST
 
-#set scf scf_type out_of_core
-#E = energy('scf')
-#compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
-#
-#set scf scf_type df
-#E = energy('scf')
-#compare_values(Eref_sing_df, E, 6, 'Singlet DF CUHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
+
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DF CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -145,84 +145,84 @@ set {
 print_stdout('    -Triplet UHF:') #TEST
 set scf reference uhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_uhf_can, E, 6, 'Triplet Direct UHF energy') #TEST
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
-#
-#clean()
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
+
+clean()
 
 print_stdout('    -Triplet ROHF:') #TEST
 set scf reference rohf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
-#clean()
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
+clean()
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct ROHF energy') #TEST
 clean()
 
-#set scf scf_type out_of_core 
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
-#clean()
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
+clean()
 
-#set scf scf_type df 
-#E = energy('scf')
-#compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
-#
-#clean()
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
+
+clean()
 
 print_stdout('    -Triplet CUHF:') #TEST
 set scf reference cuhf
 
-#set scf scf_type pk
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
-#clean()
+set scf scf_type pk
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
+clean()
 
 set scf scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct CUHF energy') #TEST
 clean()
 
-#set scf scf_type out_of_core
-#E = energy('scf')
-#compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
-#clean()
+set scf scf_type out_of_core
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
+clean()
 
-#set scf scf_type df
-#E = energy('scf')
-#compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
+set scf scf_type df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
 --------------------------------------------------------------------------
 
   Memory set to 250.000 MiB by Python script.
 	Triplet nuclear repulsion energy..................................PASSED
 	Singlet nuclear repulsion energy..................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:29 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:12 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -248,7 +248,247 @@ clean()
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -149.90298608706902   -1.49903e+02   9.01232e-02 
+   @RHF iter   1:  -149.57116658984017    3.31819e-01   9.24753e-03 
+   @RHF iter   2:  -149.58605846429731   -1.48919e-02   2.54023e-03 DIIS
+   @RHF iter   3:  -149.58715403809782   -1.09557e-03   5.55181e-04 DIIS
+   @RHF iter   4:  -149.58723434874676   -8.03106e-05   9.72979e-05 DIIS
+   @RHF iter   5:  -149.58723678917676   -2.44043e-06   1.52366e-05 DIIS
+   @RHF iter   6:  -149.58723684877026   -5.95935e-08   1.33189e-06 DIIS
+   @RHF iter   7:  -149.58723684935657   -5.86311e-10   1.37579e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813264     3Ag    -0.769319  
+       1B2u   -0.708485     1B2g   -0.419982  
+
+    Virtual:                                                              
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066014     7B2g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -149.58723684935657
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065684394666732
+    Two-Electron Energy =                  86.4308394539646514
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368493566000
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:12 2017
+Module time:
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	Singlet PK RHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:12 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 1
@@ -270,7 +510,7 @@ clean()
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -289,35 +529,35 @@ clean()
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: DF_BASIS_SAD
     Name: SAD-FIT
-    atoms 1-2 entry O          line   240 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/sad-fit.gbs 
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: DF_BASIS_SAD
     Name: SAD-FIT
-    atoms 1-2 entry O          line   240 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/sad-fit.gbs 
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -356,7 +596,7 @@ clean()
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -379,9 +619,14 @@ clean()
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -254.04243926726025   -2.54042e+02   8.98997e-02 
-   @DF-RHF iter   1:  -257.19257811713425   -3.15014e+00   1.06326e-14 
-   @DF-RHF iter   2:  -257.19257811713425    0.00000e+00   1.06326e-14 DIIS
+   @DF-RHF iter   0:  -149.90294846093602   -1.49903e+02   9.01226e-02 
+   @DF-RHF iter   1:  -149.57108660218384    3.31862e-01   9.24505e-03 
+   @DF-RHF iter   2:  -149.58597222762910   -1.48856e-02   2.54123e-03 DIIS
+   @DF-RHF iter   3:  -149.58706773148629   -1.09550e-03   5.55230e-04 DIIS
+   @DF-RHF iter   4:  -149.58714804814579   -8.03167e-05   9.72388e-05 DIIS
+   @DF-RHF iter   5:  -149.58715048478712   -2.43664e-06   1.52295e-05 DIIS
+   @DF-RHF iter   6:  -149.58715054434347   -5.95564e-08   1.33502e-06 DIIS
+   @DF-RHF iter   7:  -149.58715054493223   -5.88756e-10   1.38094e-07 DIIS
 
   DF guess converged.
 
@@ -395,19 +640,10 @@ clean()
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-
-   @RHF iter   3:  -129.99407460698805    1.27199e+02   3.58550e-01 DIIS
-   @RHF iter   4:  -138.91122982834935   -8.91716e+00   1.91751e-01 DIIS
-   @RHF iter   5:  -149.13467923115144   -1.02234e+01   5.30906e-02 DIIS
-   @RHF iter   6:  -149.57251389792145   -4.37835e-01   8.25153e-03 DIIS
-   @RHF iter   7:  -149.58708122447902   -1.45673e-02   7.45658e-04 DIIS
-   @RHF iter   8:  -149.58722634154825   -1.45117e-04   1.87887e-04 DIIS
-   @RHF iter   9:  -149.58723665061439   -1.03091e-05   2.49027e-05 DIIS
-   @RHF iter  10:  -149.58723684457522   -1.93961e-07   4.45839e-06 DIIS
-   @RHF iter  11:  -149.58723684929714   -4.72193e-09   4.02710e-07 DIIS
+   @RHF iter   8:  -149.58723673480551   -8.61899e-05   3.38769e-05 DIIS
+   @RHF iter   9:  -149.58723684741395   -1.12608e-07   3.66116e-06 DIIS
+   @RHF iter  10:  -149.58723684920653   -1.79259e-09   1.00261e-06 DIIS
+   @RHF iter  11:  -149.58723684935757   -1.51033e-10   1.38763e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -423,22 +659,22 @@ clean()
     Virtual:                                                              
 
        1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
        3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
        7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
        6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
        6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
        7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
+       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Final Occupation by Irrep:
@@ -447,18 +683,18 @@ clean()
 
   Energy converged.
 
-  @RHF Final Energy:  -149.58723684929714
+  @RHF Final Energy:  -149.58723684935757
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.8065625228703652
-    Two-Electron Energy =                  86.4308335374277590
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065842970211747
+    Two-Electron Energy =                  86.4308553115181581
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368492971418
+    Total Energy =                       -149.5872368493575664
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -479,26 +715,503 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:32 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:13 2017
 Module time:
-	user time   =       2.42 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.88 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.42 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.24 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 	Singlet Direct RHF energy.........................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:32 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:13 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -149.90298608706902   -1.49903e+02   9.01232e-02 
+   @RHF iter   1:  -149.57116658984015    3.31819e-01   9.24753e-03 
+   @RHF iter   2:  -149.58605846429737   -1.48919e-02   2.54023e-03 DIIS
+   @RHF iter   3:  -149.58715403809776   -1.09557e-03   5.55181e-04 DIIS
+   @RHF iter   4:  -149.58723434874685   -8.03106e-05   9.72979e-05 DIIS
+   @RHF iter   5:  -149.58723678917676   -2.44043e-06   1.52366e-05 DIIS
+   @RHF iter   6:  -149.58723684877032   -5.95936e-08   1.33189e-06 DIIS
+   @RHF iter   7:  -149.58723684935643   -5.86112e-10   1.37579e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813264     3Ag    -0.769319  
+       1B2u   -0.708485     1B2g   -0.419982  
+
+    Virtual:                                                              
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066014     7B2g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -149.58723684935643
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065684394666164
+    Two-Electron Energy =                  86.4308394539647509
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368493564295
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.56 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	Singlet Disk RHF energy...........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: DF_BASIS_SAD
+    Name: SAD-FIT
+    atoms 1-2 entry O          line   240 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/sad-fit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:  -149.90294846093602   -1.49903e+02   9.01226e-02 
+   @DF-RHF iter   1:  -149.57108660218384    3.31862e-01   9.24505e-03 
+   @DF-RHF iter   2:  -149.58597222762910   -1.48856e-02   2.54123e-03 DIIS
+   @DF-RHF iter   3:  -149.58706773148629   -1.09550e-03   5.55230e-04 DIIS
+   @DF-RHF iter   4:  -149.58714804814579   -8.03167e-05   9.72388e-05 DIIS
+   @DF-RHF iter   5:  -149.58715048478712   -2.43664e-06   1.52295e-05 DIIS
+   @DF-RHF iter   6:  -149.58715054434347   -5.95564e-08   1.33502e-06 DIIS
+   @DF-RHF iter   7:  -149.58715054493223   -5.88756e-10   1.38094e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
+       1B2u   -0.708490     1B2g   -0.420019  
+
+    Virtual:                                                              
+
+       1B3g    0.078675     3B1u    0.460375     2B2u    0.693541  
+       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
+       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
+       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
+       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
+       4B2g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
+       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
+       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415148     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
+       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -149.58715054493223
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8060021896076819
+    Two-Electron Energy =                  86.4303595085300174
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5871505449322285
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.81 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	Singlet DF RHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -524,7 +1237,269 @@ Total time:
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @UHF iter   1:  -142.88785540847164   -1.42888e+02   2.53565e-01 
+   @UHF iter   2:  -149.16634323167744   -6.27849e+00   4.38532e-02 DIIS
+   @UHF iter   3:  -149.53966641760130   -3.73323e-01   1.65676e-02 DIIS
+   @UHF iter   4:  -149.58424185672061   -4.45754e-02   2.54200e-03 DIIS
+   @UHF iter   5:  -149.58716684238331   -2.92499e-03   3.96051e-04 DIIS
+   @UHF iter   6:  -149.58723588184318   -6.90395e-05   5.26650e-05 DIIS
+   @UHF iter   7:  -149.58723681903359   -9.37190e-07   8.98806e-06 DIIS
+   @UHF iter   8:  -149.58723684893988   -2.99063e-08   1.20274e-06 DIIS
+   @UHF iter   9:  -149.58723684935887   -4.18993e-10   1.05493e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   8.881784197E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                8.881784197E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
+       1B2u   -0.708485     1B2g   -0.419982  
+
+    Alpha Virtual:                                                        
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
+       1B2u   -0.708485     1B2g   -0.419982  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @UHF Final Energy:  -149.58723684935887
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065772995399243
+    Two-Electron Energy =                  86.4308483140356145
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368493588738
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 2.0000000
+  HONO-1 :    2B1u 2.0000000
+  HONO-0 :    3 Ag 2.0000000
+  LUNO+0 :    4 Ag 0.0000000
+  LUNO+1 :    5 Ag 0.0000000
+  LUNO+2 :    2B2u 0.0000000
+  LUNO+3 :    2B2g 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:14 2017
+Module time:
+	user time   =       0.30 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	Singlet PK UHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:14 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 1
@@ -546,7 +1521,7 @@ Total time:
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -565,7 +1540,7 @@ Total time:
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -604,7 +1579,7 @@ Total time:
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -629,12 +1604,18 @@ Total time:
 
     Occupation by irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     2,    0,    1,    1,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-   @DF-UHF iter   1:  -236.71400742417029   -2.36714e+02   4.48701e-01 
-   @DF-UHF iter   2:  -257.19257811713425   -2.04786e+01   1.06326e-14 DIIS
-   @DF-UHF iter   3:  -257.19257811713413    1.13687e-13   1.04450e-14 DIIS
+   @DF-UHF iter   1:  -142.88808078095039   -1.42888e+02   2.53590e-01 
+   @DF-UHF iter   2:  -149.16586201577712   -6.27778e+00   4.38655e-02 DIIS
+   @DF-UHF iter   3:  -149.53949831480699   -3.73636e-01   1.65816e-02 DIIS
+   @DF-UHF iter   4:  -149.58414125175636   -4.46429e-02   2.54636e-03 DIIS
+   @DF-UHF iter   5:  -149.58708032830083   -2.93908e-03   3.96499e-04 DIIS
+   @DF-UHF iter   6:  -149.58714957814226   -6.92498e-05   5.26596e-05 DIIS
+   @DF-UHF iter   7:  -149.58715051460388   -9.36462e-07   8.98710e-06 DIIS
+   @DF-UHF iter   8:  -149.58715054451415   -2.99103e-08   1.20470e-06 DIIS
+   @DF-UHF iter   9:  -149.58715054493462   -4.20471e-10   1.05277e-07 DIIS
 
   DF guess converged.
 
@@ -648,26 +1629,16 @@ Total time:
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-
-   @UHF iter   4:  -129.99407460698819    1.27199e+02   3.58550e-01 DIIS
-   @UHF iter   5:  -138.91122982834932   -8.91716e+00   1.91751e-01 DIIS
-   @UHF iter   6:  -149.13467923115141   -1.02234e+01   5.30906e-02 DIIS
-   @UHF iter   7:  -149.57251389792145   -4.37835e-01   8.25153e-03 DIIS
-   @UHF iter   8:  -149.58708122447916   -1.45673e-02   7.45658e-04 DIIS
-   @UHF iter   9:  -149.58722634154822   -1.45117e-04   1.87887e-04 DIIS
-   @UHF iter  10:  -149.58723665061422   -1.03091e-05   2.49027e-05 DIIS
-   @UHF iter  11:  -149.58723684457513   -1.93961e-07   4.45839e-06 DIIS
-   @UHF iter  12:  -149.58723684929720   -4.72207e-09   4.02710e-07 DIIS
+   @UHF iter  10:  -149.58723673484781   -8.61899e-05   3.38733e-05 DIIS
+   @UHF iter  11:  -149.58723684741665   -1.12569e-07   3.66112e-06 DIIS
+   @UHF iter  12:  -149.58723684920682   -1.79017e-09   1.00224e-06 DIIS
+   @UHF iter  13:  -149.58723684935768   -1.50862e-10   1.38404e-07 DIIS
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   7.993605777E-15
+   @Spin Contamination Metric:   2.664535259E-15
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                7.993605777E-15
+   @S^2 Observed:                2.664535259E-15
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
@@ -683,22 +1654,22 @@ Total time:
     Alpha Virtual:                                                        
 
        1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
        3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
        7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
        6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
        6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Beta Occupied:                                                        
@@ -710,22 +1681,22 @@ Total time:
     Beta Virtual:                                                         
 
        1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
        3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
        7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
        6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
        6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
+       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Final Occupation by Irrep:
@@ -735,28 +1706,28 @@ Total time:
 
   Energy converged.
 
-  @UHF Final Energy:  -149.58723684929720
+  @UHF Final Energy:  -149.58723684935768
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.8065625228704789
-    Two-Electron Energy =                  86.4308335374278016
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065842838380490
+    Two-Electron Energy =                  86.4308552983349330
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368492971987
+    Total Energy =                       -149.5872368493576801
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
   UHF NO Occupations:
-  HONO-2 :    1B2g 2.0000000
-  HONO-1 :    2B1u 2.0000000
+  HONO-2 :    2B1u 2.0000000
+  HONO-1 :    2 Ag 2.0000000
   HONO-0 :    3 Ag 2.0000000
   LUNO+0 :    4 Ag 0.0000000
-  LUNO+1 :    2B2g 0.0000000
-  LUNO+2 :    5 Ag 0.0000000
-  LUNO+3 :    2B3u 0.0000000
+  LUNO+1 :    2B2u 0.0000000
+  LUNO+2 :    3B1u 0.0000000
+  LUNO+3 :    2B2g 0.0000000
 
 
 
@@ -777,26 +1748,547 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:35 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:15 2017
 Module time:
-	user time   =       2.52 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.95 seconds =       0.08 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       2.98 seconds =       0.05 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 	Singlet Direct UHF energy.........................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:35 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:15 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @UHF iter   1:  -142.88785540847053   -1.42888e+02   2.53565e-01 
+   @UHF iter   2:  -149.16634323167744   -6.27849e+00   4.38532e-02 DIIS
+   @UHF iter   3:  -149.53966641760135   -3.73323e-01   1.65676e-02 DIIS
+   @UHF iter   4:  -149.58424185672072   -4.45754e-02   2.54200e-03 DIIS
+   @UHF iter   5:  -149.58716684238320   -2.92499e-03   3.96051e-04 DIIS
+   @UHF iter   6:  -149.58723588184313   -6.90395e-05   5.26650e-05 DIIS
+   @UHF iter   7:  -149.58723681903354   -9.37190e-07   8.98806e-06 DIIS
+   @UHF iter   8:  -149.58723684893994   -2.99064e-08   1.20274e-06 DIIS
+   @UHF iter   9:  -149.58723684935885   -4.18908e-10   1.05493e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.065814104E-14
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                1.065814104E-14
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708485     1B3g   -0.419982  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112246    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708485     1B3g   -0.419982  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112246    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @UHF Final Energy:  -149.58723684935885
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065772995396401
+    Two-Electron Energy =                  86.4308483140353587
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368493588453
+
+
+  UHF NO Occupations:
+  HONO-2 :    2B1u 2.0000000
+  HONO-1 :    2 Ag 2.0000000
+  HONO-0 :    3 Ag 2.0000000
+  LUNO+0 :    4 Ag 0.0000000
+  LUNO+1 :    3B1u 0.0000000
+  LUNO+2 :    2B3g 0.0000000
+  LUNO+3 :    5 Ag 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:16 2017
+Module time:
+	user time   =       0.27 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.26 seconds =       0.05 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	Singlet Disk UHF energy...........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:16 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @DF-UHF iter   1:  -142.88808078095039   -1.42888e+02   2.53590e-01 
+   @DF-UHF iter   2:  -149.16586201577712   -6.27778e+00   4.38655e-02 DIIS
+   @DF-UHF iter   3:  -149.53949831480699   -3.73636e-01   1.65816e-02 DIIS
+   @DF-UHF iter   4:  -149.58414125175636   -4.46429e-02   2.54636e-03 DIIS
+   @DF-UHF iter   5:  -149.58708032830083   -2.93908e-03   3.96499e-04 DIIS
+   @DF-UHF iter   6:  -149.58714957814226   -6.92498e-05   5.26596e-05 DIIS
+   @DF-UHF iter   7:  -149.58715051460388   -9.36462e-07   8.98710e-06 DIIS
+   @DF-UHF iter   8:  -149.58715054451415   -2.99103e-08   1.20470e-06 DIIS
+   @DF-UHF iter   9:  -149.58715054493462   -4.20471e-10   1.05277e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   8.881784197E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                8.881784197E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
+       1B2u   -0.708490     1B2g   -0.420019  
+
+    Alpha Virtual:                                                        
+
+       1B3g    0.078675     3B1u    0.460375     2B2u    0.693540  
+       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
+       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
+       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
+       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
+       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
+       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
+       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
+       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415148     3B1g    6.555705  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
+       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
+       1B2u   -0.708490     1B2g   -0.420019  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.078675     3B1u    0.460375     2B2u    0.693540  
+       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
+       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
+       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
+       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
+       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
+       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
+       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
+       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415148     3B1g    6.555705  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
+       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:  -149.58715054493462
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8060110757763823
+    Two-Electron Energy =                  86.4303683946963304
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5871505449346159
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 2.0000000
+  HONO-1 :    2B1u 2.0000000
+  HONO-0 :    3 Ag 2.0000000
+  LUNO+0 :    3B1u 0.0000000
+  LUNO+1 :    2B2g 0.0000000
+  LUNO+2 :    4 Ag 0.0000000
+  LUNO+3 :    4B1u 0.0000000
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:16 2017
+Module time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.45 seconds =       0.06 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	Singlet DF UHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:16 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -822,7 +2314,257 @@ Total time:
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @CUHF iter   1:  -129.99407460698814   -1.29994e+02   3.58550e-01 
+   @CUHF iter   2:  -138.91122982835162   -8.91716e+00   1.91751e-01 DIIS
+   @CUHF iter   3:  -149.13467923115152   -1.02234e+01   5.30906e-02 DIIS
+   @CUHF iter   4:  -149.57251389792134   -4.37835e-01   8.25153e-03 DIIS
+   @CUHF iter   5:  -149.58708122447896   -1.45673e-02   7.45658e-04 DIIS
+   @CUHF iter   6:  -149.58722634154825   -1.45117e-04   1.87887e-04 DIIS
+   @CUHF iter   7:  -149.58723665061430   -1.03091e-05   2.49027e-05 DIIS
+   @CUHF iter   8:  -149.58723684457507   -1.93961e-07   4.45839e-06 DIIS
+   @CUHF iter   9:  -149.58723684929711   -4.72204e-09   4.02710e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696039     4Ag     0.713441     2B3g    0.825485  
+       2B2g    0.852363     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483688     3B2g    2.531436  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928210     8Ag     4.120756     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948846  
+       5B3u    5.102980     8B1u    5.124403     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125749  
+       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
+      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185164  
+      13B1u   15.901524  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696039     4Ag     0.713441     2B3g    0.825485  
+       2B2g    0.852363     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483688     3B2g    2.531436  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928210     8Ag     4.120756     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948846  
+       5B3u    5.102980     8B1u    5.124403     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125749  
+       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
+      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185164  
+      13B1u   15.901524  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @CUHF Final Energy:  -149.58723684929711
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065625228703084
+    Two-Electron Energy =                  86.4308335374277590
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368492971134
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:16 2017
+Module time:
+	user time   =       0.30 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.75 seconds =       0.06 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	Singlet PK CUHF energy............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:16 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 1
@@ -844,7 +2586,7 @@ Total time:
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -863,7 +2605,7 @@ Total time:
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -902,7 +2644,7 @@ Total time:
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -925,8 +2667,20 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-CUHF iter   1:  -257.19257811713425   -2.57193e+02   1.06326e-14 
-   @DF-CUHF iter   2:  -257.19257811713425    0.00000e+00   1.06326e-14 DIIS
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @DF-CUHF iter   1:  -129.98984071513098   -1.29990e+02   3.58757e-01 
+   @DF-CUHF iter   2:  -138.91391955951192   -8.92408e+00   1.91748e-01 DIIS
+   @DF-CUHF iter   3:  -149.13425927783291   -1.02203e+01   5.31048e-02 DIIS
+   @DF-CUHF iter   4:  -149.57240790092712   -4.38149e-01   8.25436e-03 DIIS
+   @DF-CUHF iter   5:  -149.58699441490953   -1.45865e-02   7.46842e-04 DIIS
+   @DF-CUHF iter   6:  -149.58713996382465   -1.45549e-04   1.88515e-04 DIIS
+   @DF-CUHF iter   7:  -149.58715034477615   -1.03810e-05   2.49652e-05 DIIS
+   @DF-CUHF iter   8:  -149.58715054014502   -1.95369e-07   4.45841e-06 DIIS
+   @DF-CUHF iter   9:  -149.58715054487251   -4.72750e-09   4.03688e-07 DIIS
 
   DF guess converged.
 
@@ -940,20 +2694,244 @@ Total time:
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
+   @CUHF iter  10:  -149.58723673471869   -8.61898e-05   3.38828e-05 DIIS
+   @CUHF iter  11:  -149.58723684740352   -1.12685e-07   3.67075e-06 DIIS
+   @CUHF iter  12:  -149.58723684920523   -1.80171e-09   1.00687e-06 DIIS
+   @CUHF iter  13:  -149.58723684935751   -1.52284e-10   1.38762e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
+       1B2u   -0.708484     1B2g   -0.419982  
+
+    Alpha Virtual:                                                        
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+      13B1u   15.901524  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
+       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
+       1B2u   -0.708484     1B2g   -0.419982  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
+       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
+       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
+       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
+       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
+       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
+       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
+       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
+       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
+       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
+       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+      13B1u   15.901524  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @CUHF Final Energy:  -149.58723684935751
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065842940815742
+    Two-Electron Energy =                  86.4308553085786571
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5872368493574811
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
+Module time:
+	user time   =       0.88 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.63 seconds =       0.08 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	Singlet Direct CUHF energy........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
     Occupation by irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-   @CUHF iter   3:  -129.99407460698805    1.27199e+02   3.58550e-01 DIIS
-   @CUHF iter   4:  -138.91122982834932   -8.91716e+00   1.91751e-01 DIIS
-   @CUHF iter   5:  -149.13467923115149   -1.02234e+01   5.30906e-02 DIIS
-   @CUHF iter   6:  -149.57251389792140   -4.37835e-01   8.25153e-03 DIIS
-   @CUHF iter   7:  -149.58708122447911   -1.45673e-02   7.45658e-04 DIIS
-   @CUHF iter   8:  -149.58722634154827   -1.45117e-04   1.87887e-04 DIIS
-   @CUHF iter   9:  -149.58723665061416   -1.03091e-05   2.49027e-05 DIIS
-   @CUHF iter  10:  -149.58723684457505   -1.93961e-07   4.45839e-06 DIIS
-   @CUHF iter  11:  -149.58723684929720   -4.72215e-09   4.02710e-07 DIIS
+   @CUHF iter   1:  -129.99407460698831   -1.29994e+02   3.58550e-01 
+   @CUHF iter   2:  -138.91122982834838   -8.91716e+00   1.91751e-01 DIIS
+   @CUHF iter   3:  -149.13467923115141   -1.02234e+01   5.30906e-02 DIIS
+   @CUHF iter   4:  -149.57251389792151   -4.37835e-01   8.25153e-03 DIIS
+   @CUHF iter   5:  -149.58708122447908   -1.45673e-02   7.45658e-04 DIIS
+   @CUHF iter   6:  -149.58722634154816   -1.45117e-04   1.87887e-04 DIIS
+   @CUHF iter   7:  -149.58723665061416   -1.03091e-05   2.49027e-05 DIIS
+   @CUHF iter   8:  -149.58723684457502   -1.93961e-07   4.45839e-06 DIIS
+   @CUHF iter   9:  -149.58723684929717   -4.72215e-09   4.02710e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -1025,20 +3003,20 @@ Total time:
 
   Energy converged.
 
-  @CUHF Final Energy:  -149.58723684929720
+  @CUHF Final Energy:  -149.58723684929717
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.8065625228704221
-    Two-Electron Energy =                  86.4308335374277874
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8065625228703084
+    Two-Electron Energy =                  86.4308335374276737
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368492971702
+    Total Energy =                       -149.5872368492971987
 
-
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
 
@@ -1057,26 +3035,289 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:37 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
 Module time:
-	user time   =       2.54 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.27 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.50 seconds =       0.12 minutes
+	user time   =       4.90 seconds =       0.08 minutes
 	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
-	Singlet Direct CUHF energy........................................PASSED
+	total time  =          5 seconds =       0.08 minutes
+	Singlet Disk CUHF energy..........................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:37 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       8       8       8       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+   @DF-CUHF iter   1:  -129.98984071513098   -1.29990e+02   3.58757e-01 
+   @DF-CUHF iter   2:  -138.91391955951192   -8.92408e+00   1.91748e-01 DIIS
+   @DF-CUHF iter   3:  -149.13425927783291   -1.02203e+01   5.31048e-02 DIIS
+   @DF-CUHF iter   4:  -149.57240790092712   -4.38149e-01   8.25436e-03 DIIS
+   @DF-CUHF iter   5:  -149.58699441490953   -1.45865e-02   7.46842e-04 DIIS
+   @DF-CUHF iter   6:  -149.58713996382465   -1.45549e-04   1.88515e-04 DIIS
+   @DF-CUHF iter   7:  -149.58715034477615   -1.03810e-05   2.49652e-05 DIIS
+   @DF-CUHF iter   8:  -149.58715054014502   -1.95369e-07   4.45841e-06 DIIS
+   @DF-CUHF iter   9:  -149.58715054487251   -4.72750e-09   4.03688e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718108     1B1u  -20.716567     2Ag    -1.762467  
+       2B1u   -1.064398     1B3u   -0.813254     3Ag    -0.769333  
+       1B2u   -0.708489     1B2g   -0.420019  
+
+    Alpha Virtual:                                                        
+
+       1B3g    0.078676     3B1u    0.460375     2B2u    0.693541  
+       2B3u    0.696264     4Ag     0.713626     2B2g    0.825653  
+       2B3g    0.852604     5Ag     0.879290     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443732     6Ag     1.444604  
+       3B2u    1.639352     3B3u    1.641209     1Au     1.953830  
+       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
+       7B1u    2.536801     3B2g    2.549182     4B2u    3.927539  
+       4B3u    3.928887     8Ag     4.122938     4B3g    4.258945  
+       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
+       5B2u    5.109415     8B1u    5.125494     5B3u    5.151848  
+       6B2u    5.270830     6B3u    5.271178    10Ag     5.561367  
+       5B3g    5.664225     5B2g    5.664231     9B1u    6.128570  
+       2Au     6.413838    10B1u    6.415148     3B1g    6.555705  
+      11Ag     6.556028     3Au     6.789297    11B1u    6.790264  
+       6B3g    6.829342     6B2g    6.860859     7B2u    7.050774  
+       7B3u    7.089665    12B1u    7.580302    12Ag     7.689596  
+       7B3g    8.072682     7B2g    8.119436    13Ag     8.191893  
+      13B1u   15.905483  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718108     1B1u  -20.716567     2Ag    -1.762467  
+       2B1u   -1.064398     1B3u   -0.813254     3Ag    -0.769333  
+       1B2u   -0.708489     1B2g   -0.420019  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.078676     3B1u    0.460375     2B2u    0.693541  
+       2B3u    0.696264     4Ag     0.713626     2B2g    0.825653  
+       2B3g    0.852604     5Ag     0.879290     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443732     6Ag     1.444604  
+       3B2u    1.639352     3B3u    1.641209     1Au     1.953830  
+       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
+       7B1u    2.536801     3B2g    2.549182     4B2u    3.927539  
+       4B3u    3.928887     8Ag     4.122938     4B3g    4.258945  
+       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
+       5B2u    5.109415     8B1u    5.125494     5B3u    5.151848  
+       6B2u    5.270830     6B3u    5.271178    10Ag     5.561367  
+       5B3g    5.664225     5B2g    5.664231     9B1u    6.128570  
+       2Au     6.413838    10B1u    6.415148     3B1g    6.555705  
+      11Ag     6.556028     3Au     6.789297    11B1u    6.790264  
+       6B3g    6.829342     6B2g    6.860859     7B2u    7.050774  
+       7B3u    7.089665    12B1u    7.580302    12Ag     7.689596  
+       7B3g    8.072682     7B2g    8.119436    13Ag     8.191893  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-CUHF Final Energy:  -149.58715054487251
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.8059964281350176
+    Two-Electron Energy =                  86.4303537471170955
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.5871505448724861
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:17 2017
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.07 seconds =       0.08 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	Singlet DF CUHF energy............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:17 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1102,7 +3343,269 @@ Total time:
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @UHF iter   1:  -131.02769690362538   -1.31028e+02   3.53068e-01 
+   @UHF iter   2:  -140.13786814792115   -9.11017e+00   1.84782e-01 DIIS
+   @UHF iter   3:  -149.26306174143716   -9.12519e+00   5.05749e-02 DIIS
+   @UHF iter   4:  -149.65701792468545   -3.93956e-01   8.05490e-03 DIIS
+   @UHF iter   5:  -149.67101505766664   -1.39971e-02   9.14034e-04 DIIS
+   @UHF iter   6:  -149.67132932058530   -3.14263e-04   2.45665e-04 DIIS
+   @UHF iter   7:  -149.67135402427445   -2.47037e-05   5.39940e-05 DIIS
+   @UHF iter   8:  -149.67135512820721   -1.10393e-06   1.11821e-05 DIIS
+   @UHF iter   9:  -149.67135517195146   -4.37443e-08   1.32318e-06 DIIS
+   @UHF iter  10:  -149.67135517240564   -4.54179e-10   1.01049e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.326638693E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033266387E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730397     1B1u  -20.729247     2Ag    -1.812944  
+       2B1u   -1.163040     1B3u   -0.882848     1B2u   -0.882848  
+       3Ag    -0.797842     1B2g   -0.503772     1B3g   -0.503772  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444074     2B3u    0.670169     2B2u    0.670169  
+       4Ag     0.710743     2B2g    0.796950     2B3g    0.796951  
+       4B1u    0.864060     5Ag     0.873833     5B1u    1.396037  
+       6Ag     1.421898     1B1g    1.421898     3B2u    1.611980  
+       3B3u    1.611980     6B1u    1.908137     1Au     1.908137  
+       7Ag     2.465892     3B2g    2.517815     3B3g    2.517815  
+       7B1u    2.527679     4B3u    3.877498     4B2u    3.877498  
+       8Ag     4.116531     4B2g    4.219543     4B3g    4.219543  
+       9Ag     4.936094     2B1g    4.936094     8B1u    5.112053  
+       5B3u    5.114145     5B2u    5.114145     6B2u    5.240079  
+       6B3u    5.240079    10Ag     5.545104     5B3g    5.629471  
+       5B2g    5.629471     9B1u    6.112243    10B1u    6.380362  
+       2Au     6.380362    11Ag     6.491862     3B1g    6.491862  
+      11B1u    6.734804     3Au     6.734804     6B2g    6.811153  
+       6B3g    6.811153     7B3u    7.039321     7B2u    7.039321  
+      12B1u    7.563721    12Ag     7.661398     7B2g    8.077183  
+       7B3g    8.077183    13Ag     8.180540    13B1u   15.889141  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677273     1B1u  -20.675406     2Ag    -1.697987  
+       2B1u   -0.956412     3Ag    -0.726305     1B2u   -0.632037  
+       1B3u   -0.632036  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.158291     1B2g    0.158291     3B1u    0.479671  
+       4Ag     0.719067     2B2u    0.727589     2B3u    0.727589  
+       5Ag     0.894526     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930237     5B1u    1.437286     6Ag     1.472619  
+       1B1g    1.472619     3B2u    1.678790     3B3u    1.678790  
+       6B1u    2.006486     1Au     2.006486     7Ag     2.509575  
+       7B1u    2.554593     3B3g    2.569016     3B2g    2.569016  
+       4B2u    3.993529     4B3u    3.993529     8Ag     4.141603  
+       4B3g    4.325773     4B2g    4.325773     2B1g    4.972187  
+       9Ag     4.972187     5B2u    5.148956     5B3u    5.148956  
+       8B1u    5.150970     6B3u    5.300884     6B2u    5.300884  
+      10Ag     5.581928     5B2g    5.699443     5B3g    5.699443  
+       9B1u    6.154195    10B1u    6.445601     2Au     6.445601  
+      11Ag     6.620146     3B1g    6.620146    11B1u    6.844544  
+       3Au     6.844544     6B3g    6.879046     6B2g    6.879046  
+       7B2u    7.100563     7B3u    7.100563    12B1u    7.601591  
+      12Ag     7.730311     7B3g    8.113474     7B2g    8.113474  
+      13Ag     8.204477    13B1u   15.932678  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @UHF Final Energy:  -149.67135517240564
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9155258831183346
+    Two-Electron Energy =                  86.4556785745672585
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6713551724056401
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9937501
+  HONO-1 :    1B3g 1.0000000
+  HONO-0 :    1B2g 1.0000000
+  LUNO+0 :    2B3u 0.0062499
+  LUNO+1 :    2B2u 0.0062498
+  LUNO+2 :    3B1u 0.0031243
+  LUNO+3 :    4 Ag 0.0009741
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:18 2017
+Module time:
+	user time   =       0.30 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.37 seconds =       0.09 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+	Triplet PK UHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:18 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 3
@@ -1124,7 +3627,7 @@ Total time:
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -1143,7 +3646,7 @@ Total time:
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1182,7 +3685,7 @@ Total time:
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -1205,8 +3708,21 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-UHF iter   1:  -256.72790828999189   -2.56728e+02   1.05270e-14 
-   @DF-UHF iter   2:  -256.72790828999189    0.00000e+00   1.05270e-14 DIIS
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-UHF iter   1:  -131.02345181239127   -1.31023e+02   3.53263e-01 
+   @DF-UHF iter   2:  -140.13876903556019   -9.11532e+00   1.84802e-01 DIIS
+   @DF-UHF iter   3:  -149.26280525049322   -9.12404e+00   5.05764e-02 DIIS
+   @DF-UHF iter   4:  -149.65691280314300   -3.94108e-01   8.05234e-03 DIIS
+   @DF-UHF iter   5:  -149.67091585716790   -1.40031e-02   9.14627e-04 DIIS
+   @DF-UHF iter   6:  -149.67123029534915   -3.14438e-04   2.46163e-04 DIIS
+   @DF-UHF iter   7:  -149.67125508387659   -2.47885e-05   5.42145e-05 DIIS
+   @DF-UHF iter   8:  -149.67125619837958   -1.11450e-06   1.12239e-05 DIIS
+   @DF-UHF iter   9:  -149.67125624246196   -4.40824e-08   1.32496e-06 DIIS
+   @DF-UHF iter  10:  -149.67125624291583   -4.53866e-10   1.00526e-07 DIIS
 
   DF guess converged.
 
@@ -1220,27 +3736,15 @@ Total time:
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
-
-   @UHF iter   3:  -131.02769690362538    1.25700e+02   3.53068e-01 DIIS
-   @UHF iter   4:  -140.13786814791996   -9.11017e+00   1.84782e-01 DIIS
-   @UHF iter   5:  -149.26306174143710   -9.12519e+00   5.05749e-02 DIIS
-   @UHF iter   6:  -149.65701792468559   -3.93956e-01   8.05490e-03 DIIS
-   @UHF iter   7:  -149.67101505766664   -1.39971e-02   9.14034e-04 DIIS
-   @UHF iter   8:  -149.67132932058541   -3.14263e-04   2.45665e-04 DIIS
-   @UHF iter   9:  -149.67135402427445   -2.47037e-05   5.39940e-05 DIIS
-   @UHF iter  10:  -149.67135512820713   -1.10393e-06   1.11821e-05 DIIS
-   @UHF iter  11:  -149.67135517195155   -4.37444e-08   1.32318e-06 DIIS
-   @UHF iter  12:  -149.67135517240558   -4.54037e-10   1.01049e-07 DIIS
+   @UHF iter  11:  -149.67135505906231   -9.88161e-05   3.40144e-05 DIIS
+   @UHF iter  12:  -149.67135517049184   -1.11430e-07   3.61220e-06 DIIS
+   @UHF iter  13:  -149.67135517225614   -1.76431e-09   9.53470e-07 DIIS
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.326638693E-02
+   @Spin Contamination Metric:   3.326719947E-02
    @S^2 Expected:                2.000000000E+00
-   @S^2 Observed:                2.033266387E+00
+   @S^2 Observed:                2.033267199E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
@@ -1249,56 +3753,56 @@ Total time:
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.730397     1B1u  -20.729247     2Ag    -1.812944  
-       2B1u   -1.163040     1B2u   -0.882848     1B3u   -0.882848  
-       3Ag    -0.797842     1B3g   -0.503772     1B2g   -0.503772  
+       1Ag   -20.730401     1B1u  -20.729250     2Ag    -1.812946  
+       2B1u   -1.163042     1B3u   -0.882849     1B2u   -0.882849  
+       3Ag    -0.797844     1B2g   -0.503774     1B3g   -0.503774  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.444074     2B2u    0.670169     2B3u    0.670169  
-       4Ag     0.710743     2B3g    0.796950     2B2g    0.796951  
-       4B1u    0.864060     5Ag     0.873833     5B1u    1.396037  
-       6Ag     1.421898     1B1g    1.421898     3B3u    1.611980  
-       3B2u    1.611980     6B1u    1.908137     1Au     1.908137  
-       7Ag     2.465892     3B3g    2.517815     3B2g    2.517815  
-       7B1u    2.527679     4B2u    3.877498     4B3u    3.877498  
-       8Ag     4.116531     4B3g    4.219543     4B2g    4.219543  
-       9Ag     4.936094     2B1g    4.936094     8B1u    5.112053  
-       5B2u    5.114145     5B3u    5.114145     6B3u    5.240079  
-       6B2u    5.240079    10Ag     5.545104     5B2g    5.629471  
-       5B3g    5.629471     9B1u    6.112243    10B1u    6.380362  
-       2Au     6.380362    11Ag     6.491862     3B1g    6.491862  
-      11B1u    6.734804     3Au     6.734804     6B3g    6.811153  
-       6B2g    6.811153     7B2u    7.039321     7B3u    7.039321  
-      12B1u    7.563721    12Ag     7.661398     7B3g    8.077183  
-       7B2g    8.077183    13Ag     8.180540    13B1u   15.889141  
+       3B1u    0.444073     2B3u    0.670168     2B2u    0.670168  
+       4Ag     0.710742     2B2g    0.796950     2B3g    0.796950  
+       4B1u    0.864058     5Ag     0.873832     5B1u    1.396036  
+       1B1g    1.421897     6Ag     1.421897     3B2u    1.611980  
+       3B3u    1.611980     1Au     1.908136     6B1u    1.908136  
+       7Ag     2.465890     3B2g    2.517814     3B3g    2.517814  
+       7B1u    2.527678     4B3u    3.877496     4B2u    3.877496  
+       8Ag     4.116530     4B2g    4.219542     4B3g    4.219542  
+       9Ag     4.936093     2B1g    4.936093     8B1u    5.112051  
+       5B3u    5.114143     5B2u    5.114143     6B3u    5.240078  
+       6B2u    5.240078    10Ag     5.545103     5B2g    5.629470  
+       5B3g    5.629470     9B1u    6.112241     2Au     6.380361  
+      10B1u    6.380361     3B1g    6.491860    11Ag     6.491860  
+       3Au     6.734802    11B1u    6.734802     6B2g    6.811151  
+       6B3g    6.811151     7B3u    7.039319     7B2u    7.039319  
+      12B1u    7.563719    12Ag     7.661396     7B2g    8.077181  
+       7B3g    8.077181    13Ag     8.180538    13B1u   15.889139  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.677273     1B1u  -20.675406     2Ag    -1.697987  
-       2B1u   -0.956412     3Ag    -0.726305     1B3u   -0.632037  
-       1B2u   -0.632036  
+       1Ag   -20.677276     1B1u  -20.675409     2Ag    -1.697988  
+       2B1u   -0.956413     3Ag    -0.726306     1B2u   -0.632037  
+       1B3u   -0.632037  
 
     Beta Virtual:                                                         
 
-       1B2g    0.158291     1B3g    0.158291     3B1u    0.479671  
-       4Ag     0.719067     2B3u    0.727589     2B2u    0.727589  
-       5Ag     0.894526     2B2g    0.895011     2B3g    0.895011  
-       4B1u    0.930237     5B1u    1.437286     6Ag     1.472619  
-       1B1g    1.472619     3B3u    1.678790     3B2u    1.678790  
-       6B1u    2.006486     1Au     2.006486     7Ag     2.509575  
-       7B1u    2.554593     3B2g    2.569016     3B3g    2.569016  
-       4B3u    3.993529     4B2u    3.993529     8Ag     4.141603  
-       4B2g    4.325773     4B3g    4.325773     2B1g    4.972187  
-       9Ag     4.972187     5B3u    5.148956     5B2u    5.148956  
-       8B1u    5.150970     6B2u    5.300884     6B3u    5.300884  
-      10Ag     5.581928     5B3g    5.699443     5B2g    5.699443  
-       9B1u    6.154195    10B1u    6.445601     2Au     6.445601  
-      11Ag     6.620146     3B1g    6.620146    11B1u    6.844544  
-       3Au     6.844544     6B2g    6.879046     6B3g    6.879046  
-       7B3u    7.100563     7B2u    7.100563    12B1u    7.601591  
-      12Ag     7.730311     7B2g    8.113474     7B3g    8.113474  
-      13Ag     8.204477    13B1u   15.932678  
+       1B3g    0.158290     1B2g    0.158290     3B1u    0.479670  
+       4Ag     0.719066     2B2u    0.727589     2B3u    0.727589  
+       5Ag     0.894525     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930236     5B1u    1.437285     6Ag     1.472618  
+       1B1g    1.472618     3B2u    1.678789     3B3u    1.678789  
+       6B1u    2.006485     1Au     2.006485     7Ag     2.509574  
+       7B1u    2.554592     3B3g    2.569015     3B2g    2.569015  
+       4B2u    3.993527     4B3u    3.993527     8Ag     4.141602  
+       4B3g    4.325772     4B2g    4.325772     9Ag     4.972187  
+       2B1g    4.972187     5B2u    5.148955     5B3u    5.148955  
+       8B1u    5.150968     6B3u    5.300883     6B2u    5.300883  
+      10Ag     5.581927     5B2g    5.699442     5B3g    5.699442  
+       9B1u    6.154193    10B1u    6.445600     2Au     6.445600  
+       3B1g    6.620144    11Ag     6.620144    11B1u    6.844543  
+       3Au     6.844543     6B3g    6.879044     6B2g    6.879044  
+       7B2u    7.100562     7B3u    7.100562    12B1u    7.601590  
+      12Ag     7.730309     7B3g    8.113473     7B2g    8.113473  
+      13Ag     8.204476    13B1u   15.932677  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
@@ -1307,26 +3811,26 @@ Total time:
 
   Energy converged.
 
-  @UHF Final Energy:  -149.67135517240558
+  @UHF Final Energy:  -149.67135517225614
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.9155258831183346
-    Two-Electron Energy =                  86.4556785745672727
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9154388970317768
+    Two-Electron Energy =                  86.4555915886302131
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6713551724055833
+    Total Energy =                       -149.6713551722561419
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
   UHF NO Occupations:
-  HONO-2 :    1B2u 1.9937501
-  HONO-1 :    1B3g 1.0000000
-  HONO-0 :    1B2g 1.0000000
-  LUNO+0 :    2B2u 0.0062499
-  LUNO+1 :    2B3u 0.0062498
+  HONO-2 :    1B3u 1.9937500
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062500
+  LUNO+1 :    2B2u 0.0062500
   LUNO+2 :    3B1u 0.0031243
   LUNO+3 :    4 Ag 0.0009741
 
@@ -1349,26 +3853,547 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:40 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
 Module time:
-	user time   =       2.79 seconds =       0.05 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.71 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.29 seconds =       0.17 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =       6.08 seconds =       0.10 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
 	Triplet Direct UHF energy.........................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:40 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @UHF iter   1:  -131.02769690362544   -1.31028e+02   3.53068e-01 
+   @UHF iter   2:  -140.13786814792002   -9.11017e+00   1.84782e-01 DIIS
+   @UHF iter   3:  -149.26306174143707   -9.12519e+00   5.05749e-02 DIIS
+   @UHF iter   4:  -149.65701792468548   -3.93956e-01   8.05490e-03 DIIS
+   @UHF iter   5:  -149.67101505766658   -1.39971e-02   9.14034e-04 DIIS
+   @UHF iter   6:  -149.67132932058530   -3.14263e-04   2.45665e-04 DIIS
+   @UHF iter   7:  -149.67135402427451   -2.47037e-05   5.39940e-05 DIIS
+   @UHF iter   8:  -149.67135512820721   -1.10393e-06   1.11821e-05 DIIS
+   @UHF iter   9:  -149.67135517195149   -4.37443e-08   1.32318e-06 DIIS
+   @UHF iter  10:  -149.67135517240570   -4.54207e-10   1.01049e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.326638693E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033266387E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730397     1B1u  -20.729247     2Ag    -1.812944  
+       2B1u   -1.163040     1B3u   -0.882848     1B2u   -0.882848  
+       3Ag    -0.797842     1B2g   -0.503772     1B3g   -0.503772  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444074     2B3u    0.670169     2B2u    0.670169  
+       4Ag     0.710743     2B2g    0.796950     2B3g    0.796951  
+       4B1u    0.864060     5Ag     0.873833     5B1u    1.396037  
+       6Ag     1.421898     1B1g    1.421898     3B2u    1.611980  
+       3B3u    1.611980     6B1u    1.908137     1Au     1.908137  
+       7Ag     2.465892     3B2g    2.517815     3B3g    2.517815  
+       7B1u    2.527679     4B3u    3.877498     4B2u    3.877498  
+       8Ag     4.116531     4B2g    4.219543     4B3g    4.219543  
+       9Ag     4.936094     2B1g    4.936094     8B1u    5.112053  
+       5B3u    5.114145     5B2u    5.114145     6B2u    5.240079  
+       6B3u    5.240079    10Ag     5.545104     5B3g    5.629471  
+       5B2g    5.629471     9B1u    6.112243    10B1u    6.380362  
+       2Au     6.380362    11Ag     6.491862     3B1g    6.491862  
+      11B1u    6.734804     3Au     6.734804     6B2g    6.811153  
+       6B3g    6.811153     7B3u    7.039321     7B2u    7.039321  
+      12B1u    7.563721    12Ag     7.661398     7B2g    8.077183  
+       7B3g    8.077183    13Ag     8.180540    13B1u   15.889141  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677273     1B1u  -20.675406     2Ag    -1.697987  
+       2B1u   -0.956412     3Ag    -0.726305     1B2u   -0.632037  
+       1B3u   -0.632036  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.158291     1B2g    0.158291     3B1u    0.479671  
+       4Ag     0.719067     2B2u    0.727589     2B3u    0.727589  
+       5Ag     0.894526     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930237     5B1u    1.437286     6Ag     1.472619  
+       1B1g    1.472619     3B2u    1.678790     3B3u    1.678790  
+       6B1u    2.006486     1Au     2.006486     7Ag     2.509575  
+       7B1u    2.554593     3B3g    2.569016     3B2g    2.569016  
+       4B2u    3.993529     4B3u    3.993529     8Ag     4.141603  
+       4B3g    4.325773     4B2g    4.325773     2B1g    4.972187  
+       9Ag     4.972187     5B2u    5.148956     5B3u    5.148956  
+       8B1u    5.150970     6B3u    5.300884     6B2u    5.300884  
+      10Ag     5.581928     5B2g    5.699443     5B3g    5.699443  
+       9B1u    6.154195    10B1u    6.445601     2Au     6.445601  
+      11Ag     6.620146     3B1g    6.620146    11B1u    6.844544  
+       3Au     6.844544     6B3g    6.879046     6B2g    6.879046  
+       7B2u    7.100563     7B3u    7.100563    12B1u    7.601591  
+      12Ag     7.730311     7B3g    8.113474     7B2g    8.113474  
+      13Ag     8.204477    13B1u   15.932678  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @UHF Final Energy:  -149.67135517240570
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9155258831183346
+    Two-Electron Energy =                  86.4556785745672158
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6713551724056970
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9937501
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062499
+  LUNO+1 :    2B2u 0.0062498
+  LUNO+2 :    3B1u 0.0031243
+  LUNO+3 :    4 Ag 0.0009741
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.35 seconds =       0.11 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+	Triplet Disk UHF energy...........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              UHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-UHF iter   1:  -131.02345181239127   -1.31023e+02   3.53263e-01 
+   @DF-UHF iter   2:  -140.13876903556019   -9.11532e+00   1.84802e-01 DIIS
+   @DF-UHF iter   3:  -149.26280525049322   -9.12404e+00   5.05764e-02 DIIS
+   @DF-UHF iter   4:  -149.65691280314300   -3.94108e-01   8.05234e-03 DIIS
+   @DF-UHF iter   5:  -149.67091585716790   -1.40031e-02   9.14627e-04 DIIS
+   @DF-UHF iter   6:  -149.67123029534915   -3.14438e-04   2.46163e-04 DIIS
+   @DF-UHF iter   7:  -149.67125508387659   -2.47885e-05   5.42145e-05 DIIS
+   @DF-UHF iter   8:  -149.67125619837958   -1.11450e-06   1.12239e-05 DIIS
+   @DF-UHF iter   9:  -149.67125624246196   -4.40824e-08   1.32496e-06 DIIS
+   @DF-UHF iter  10:  -149.67125624291583   -4.53866e-10   1.00526e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.326737155E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033267372E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730437     1B1u  -20.729287     2Ag    -1.812990  
+       2B1u   -1.163057     1B3u   -0.882849     1B2u   -0.882849  
+       3Ag    -0.797858     1B2g   -0.503795     1B3g   -0.503795  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444228     2B3u    0.670343     2B2u    0.670343  
+       4Ag     0.710914     2B2g    0.797267     2B3g    0.797267  
+       4B1u    0.864170     5Ag     0.873881     5B1u    1.396519  
+       6Ag     1.422487     1B1g    1.422487     3B2u    1.612326  
+       3B3u    1.612326     6B1u    1.908884     1Au     1.908884  
+       7Ag     2.466355     3B2g    2.518504     3B3g    2.518504  
+       7B1u    2.528257     4B3u    3.878194     4B2u    3.878194  
+       8Ag     4.118821     4B2g    4.220494     4B3g    4.220494  
+       9Ag     4.942660     2B1g    4.942660     8B1u    5.113269  
+       5B3u    5.121535     5B2u    5.121535     6B2u    5.246660  
+       6B3u    5.246660    10Ag     5.551199     5B3g    5.636725  
+       5B2g    5.636725     9B1u    6.115912    10B1u    6.389411  
+       2Au     6.389411    11Ag     6.502927     3B1g    6.502927  
+      11B1u    6.745764     3Au     6.745764     6B2g    6.821002  
+       6B3g    6.821002     7B3u    7.049034     7B2u    7.049034  
+      12B1u    7.571289    12Ag     7.663672     7B2g    8.086585  
+       7B3g    8.086585    13Ag     8.189274    13B1u   15.894715  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677311     1B1u  -20.675444     2Ag    -1.698033  
+       2B1u   -0.956428     3Ag    -0.726315     1B2u   -0.632028  
+       1B3u   -0.632028  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.158265     1B2g    0.158265     3B1u    0.479795  
+       4Ag     0.719225     2B2u    0.727817     2B3u    0.727817  
+       5Ag     0.894592     2B3g    0.895069     2B2g    0.895069  
+       4B1u    0.930255     5B1u    1.437507     6Ag     1.473088  
+       1B1g    1.473088     3B2u    1.679055     3B3u    1.679055  
+       6B1u    2.006824     1Au     2.006824     7Ag     2.509888  
+       7B1u    2.554916     3B3g    2.569302     3B2g    2.569302  
+       4B2u    3.994092     4B3u    3.994092     8Ag     4.143653  
+       4B3g    4.326400     4B2g    4.326400     2B1g    4.977139  
+       9Ag     4.977139     8B1u    5.151901     5B2u    5.154968  
+       5B3u    5.154968     6B3u    5.304600     6B2u    5.304600  
+      10Ag     5.586628     5B2g    5.702873     5B3g    5.702873  
+       9B1u    6.156238    10B1u    6.450017     2Au     6.450017  
+      11Ag     6.625337     3B1g    6.625337    11B1u    6.848995  
+       3Au     6.848995     6B3g    6.883538     6B2g    6.883538  
+       7B2u    7.105931     7B3u    7.105931    12B1u    7.605403  
+      12Ag     7.731633     7B3g    8.118002     7B2g    8.118002  
+      13Ag     8.209199    13B1u   15.935059  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-UHF Final Energy:  -149.67125624291583
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9149875268761321
+    Two-Electron Energy =                  86.4552391478148650
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6712562429158311
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9937497
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062503
+  LUNO+1 :    2B2u 0.0062503
+  LUNO+2 :    3B1u 0.0031240
+  LUNO+3 :    4 Ag 0.0009740
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.54 seconds =       0.11 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+	Triplet DF UHF energy.............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1394,7 +4419,229 @@ Total time:
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @ROHF iter   1:  -131.02769690362541   -1.31028e+02   2.71717e-01 
+   @ROHF iter   2:  -139.63756203688200   -8.60987e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99587881868305   -9.35832e+00   5.06973e-02 DIIS
+   @ROHF iter   4:  -149.63934883047094   -6.43470e-01   6.07016e-03 DIIS
+   @ROHF iter   5:  -149.65159034033221   -1.22415e-02   4.80913e-04 DIIS
+   @ROHF iter   6:  -149.65170031143234   -1.09971e-04   1.10255e-04 DIIS
+   @ROHF iter   7:  -149.65170750630924   -7.19488e-06   1.71076e-05 DIIS
+   @ROHF iter   8:  -149.65170765416400   -1.47855e-07   2.92758e-06 DIIS
+   @ROHF iter   9:  -149.65170765757176   -3.40776e-09   3.52982e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.707859     1B1u  -20.706327     2Ag    -1.755521  
+       2B1u   -1.059143     3Ag    -0.763678     1B3u   -0.754308  
+       1B2u   -0.754308  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157800     1B2g   -0.157800  
+
+    Virtual:                                                              
+
+       3B1u    0.461626     2B3u    0.696594     2B2u    0.696594  
+       4Ag     0.715168     2B2g    0.832187     2B3g    0.832187  
+       5Ag     0.883370     4B1u    0.894737     5B1u    1.415770  
+       1B1g    1.447074     6Ag     1.447074     3B3u    1.643324  
+       3B2u    1.643324     6B1u    1.957069     1Au     1.957069  
+       7Ag     2.486943     7B1u    2.540415     3B2g    2.542980  
+       3B3g    2.542980     4B3u    3.933560     4B2u    3.933560  
+       8Ag     4.127713     4B2g    4.270800     4B3g    4.270800  
+       2B1g    4.953638     9Ag     4.953638     8B1u    5.130106  
+       5B3u    5.130734     5B2u    5.130734     6B2u    5.269979  
+       6B3u    5.269979    10Ag     5.562295     5B3g    5.663988  
+       5B2g    5.663988     9B1u    6.132429    10B1u    6.413114  
+       2Au     6.413114    11Ag     6.554650     3B1g    6.554650  
+      11B1u    6.787811     3Au     6.787811     6B2g    6.844055  
+       6B3g    6.844055     7B3u    7.068873     7B2u    7.068873  
+      12B1u    7.581212    12Ag     7.694005     7B2g    8.094631  
+       7B3g    8.094631    13Ag     8.191302    13B1u   15.908946  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @ROHF Final Energy:  -149.65170765757176
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9132198610868727
+    Two-Electron Energy =                  86.4730200673696743
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6517076575717624
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:19 2017
+Module time:
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.82 seconds =       0.11 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+	Triplet PK ROHF energy............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:19 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 3
@@ -1416,7 +4663,7 @@ Total time:
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -1435,7 +4682,7 @@ Total time:
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1474,7 +4721,7 @@ Total time:
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -1497,8 +4744,20 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-ROHF iter   1:  -256.72790828999189   -2.56728e+02   2.50667e-15 
-   @DF-ROHF iter   2:  -256.72790828999177    1.13687e-13   4.23036e-15 DIIS
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-ROHF iter   1:  -131.02345181239130   -1.31023e+02   2.71866e-01 
+   @DF-ROHF iter   2:  -139.63848017548818   -8.61503e+00   1.37405e-01 DIIS
+   @DF-ROHF iter   3:  -148.99602731281800   -9.35755e+00   5.06816e-02 DIIS
+   @DF-ROHF iter   4:  -149.63927941443828   -6.43252e-01   6.05660e-03 DIIS
+   @DF-ROHF iter   5:  -149.65149023343014   -1.22108e-02   4.82235e-04 DIIS
+   @DF-ROHF iter   6:  -149.65160058036162   -1.10347e-04   1.10507e-04 DIIS
+   @DF-ROHF iter   7:  -149.65160781013682   -7.22978e-06   1.71514e-05 DIIS
+   @DF-ROHF iter   8:  -149.65160795866174   -1.48525e-07   2.92995e-06 DIIS
+   @DF-ROHF iter   9:  -149.65160796207707   -3.41532e-09   3.53720e-07 DIIS
 
   DF guess converged.
 
@@ -1512,20 +4771,9 @@ Total time:
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
-
-   @ROHF iter   3:  -131.02769690362544    1.25700e+02   2.71717e-01 DIIS
-   @ROHF iter   4:  -139.63756203688047   -8.60987e+00   1.37369e-01 DIIS
-   @ROHF iter   5:  -148.99587881868280   -9.35832e+00   5.06973e-02 DIIS
-   @ROHF iter   6:  -149.63934883047082   -6.43470e-01   6.07016e-03 DIIS
-   @ROHF iter   7:  -149.65159034033218   -1.22415e-02   4.80913e-04 DIIS
-   @ROHF iter   8:  -149.65170031143242   -1.09971e-04   1.10255e-04 DIIS
-   @ROHF iter   9:  -149.65170750630929   -7.19488e-06   1.71076e-05 DIIS
-   @ROHF iter  10:  -149.65170765416391   -1.47855e-07   2.92758e-06 DIIS
-   @ROHF iter  11:  -149.65170765757190   -3.40799e-09   3.52982e-07 DIIS
+   @ROHF iter  10:  -149.65170754318157   -9.95811e-05   2.46298e-05 DIIS
+   @ROHF iter  11:  -149.65170765561584   -1.12434e-07   2.81738e-06 DIIS
+   @ROHF iter  12:  -149.65170765742837   -1.81254e-09   8.14306e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -1534,33 +4782,33 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1Ag   -20.707859     1B1u  -20.706327     2Ag    -1.755521  
-       2B1u   -1.059143     3Ag    -0.763678     1B2u   -0.754308  
-       1B3u   -0.754308  
+       1Ag   -20.707865     1B1u  -20.706333     2Ag    -1.755524  
+       2B1u   -1.059146     3Ag    -0.763680     1B3u   -0.754310  
+       1B2u   -0.754310  
 
     Singly Occupied:                                                      
 
-       1B2g   -0.157800     1B3g   -0.157800  
+       1B2g   -0.157803     1B3g   -0.157803  
 
     Virtual:                                                              
 
-       3B1u    0.461626     2B2u    0.696594     2B3u    0.696594  
-       4Ag     0.715168     2B3g    0.832187     2B2g    0.832187  
-       5Ag     0.883370     4B1u    0.894737     5B1u    1.415770  
-       1B1g    1.447074     6Ag     1.447074     3B2u    1.643324  
-       3B3u    1.643324     6B1u    1.957069     1Au     1.957069  
-       7Ag     2.486943     7B1u    2.540415     3B3g    2.542980  
-       3B2g    2.542980     4B2u    3.933560     4B3u    3.933560  
-       8Ag     4.127713     4B3g    4.270800     4B2g    4.270800  
-       2B1g    4.953638     9Ag     4.953638     8B1u    5.130106  
-       5B2u    5.130734     5B3u    5.130734     6B3u    5.269979  
-       6B2u    5.269979    10Ag     5.562295     5B2g    5.663988  
-       5B3g    5.663988     9B1u    6.132429    10B1u    6.413114  
-       2Au     6.413114    11Ag     6.554650     3B1g    6.554650  
-      11B1u    6.787811     3Au     6.787811     6B3g    6.844055  
-       6B2g    6.844055     7B2u    7.068873     7B3u    7.068873  
-      12B1u    7.581212    12Ag     7.694005     7B3g    8.094631  
-       7B2g    8.094631    13Ag     8.191302    13B1u   15.908946  
+       3B1u    0.461625     2B3u    0.696593     2B2u    0.696593  
+       4Ag     0.715167     2B2g    0.832186     2B3g    0.832186  
+       5Ag     0.883369     4B1u    0.894734     5B1u    1.415769  
+       1B1g    1.447073     6Ag     1.447073     3B3u    1.643323  
+       3B2u    1.643323     1Au     1.957067     6B1u    1.957067  
+       7Ag     2.486941     7B1u    2.540413     3B2g    2.542979  
+       3B3g    2.542979     4B3u    3.933556     4B2u    3.933556  
+       8Ag     4.127710     4B2g    4.270797     4B3g    4.270797  
+       9Ag     4.953635     2B1g    4.953635     8B1u    5.130102  
+       5B3u    5.130732     5B2u    5.130732     6B2u    5.269977  
+       6B3u    5.269977    10Ag     5.562292     5B2g    5.663985  
+       5B3g    5.663985     9B1u    6.132426    10B1u    6.413111  
+       2Au     6.413111     3B1g    6.554647    11Ag     6.554647  
+      11B1u    6.787808     3Au     6.787808     6B2g    6.844052  
+       6B3g    6.844052     7B2u    7.068870     7B3u    7.068870  
+      12B1u    7.581208    12Ag     7.694002     7B3g    8.094628  
+       7B2g    8.094628    13Ag     8.191298    13B1u   15.908942  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
@@ -1569,18 +4817,18 @@ Total time:
 
   Energy converged.
 
-  @ROHF Final Energy:  -149.65170765757190
+  @ROHF Final Energy:  -149.65170765742837
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.9132198610869295
-    Two-Electron Energy =                  86.4730200673695606
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9131419775995369
+    Two-Electron Energy =                  86.4729421840257402
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076575719045
+    Total Energy =                       -149.6517076574283465
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -1601,26 +4849,467 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:43 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:20 2017
 Module time:
-	user time   =       2.54 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.83 seconds =       0.21 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =       7.52 seconds =       0.13 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 	Triplet Direct ROHF energy........................................PASSED
 
-*** tstart() called on ariadne
-*** at Sun Oct 23 18:53:43 2016
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:20 2017
 
    => Loading Basis Set <=
 
     Role: BASIS
     Keyword: BASIS
     Name: CC-PVTZ
-    atoms 1-2 entry O          line   247 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @ROHF iter   1:  -131.02769690362547   -1.31028e+02   2.71717e-01 
+   @ROHF iter   2:  -139.63756203687947   -8.60987e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99587881868283   -9.35832e+00   5.06973e-02 DIIS
+   @ROHF iter   4:  -149.63934883047074   -6.43470e-01   6.07016e-03 DIIS
+   @ROHF iter   5:  -149.65159034033215   -1.22415e-02   4.80913e-04 DIIS
+   @ROHF iter   6:  -149.65170031143222   -1.09971e-04   1.10255e-04 DIIS
+   @ROHF iter   7:  -149.65170750630924   -7.19488e-06   1.71076e-05 DIIS
+   @ROHF iter   8:  -149.65170765416386   -1.47855e-07   2.92758e-06 DIIS
+   @ROHF iter   9:  -149.65170765757179   -3.40793e-09   3.52982e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.707859     1B1u  -20.706327     2Ag    -1.755521  
+       2B1u   -1.059143     3Ag    -0.763678     1B3u   -0.754308  
+       1B2u   -0.754308  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157800     1B2g   -0.157800  
+
+    Virtual:                                                              
+
+       3B1u    0.461626     2B3u    0.696594     2B2u    0.696594  
+       4Ag     0.715168     2B2g    0.832187     2B3g    0.832187  
+       5Ag     0.883370     4B1u    0.894737     5B1u    1.415770  
+       1B1g    1.447074     6Ag     1.447074     3B3u    1.643324  
+       3B2u    1.643324     6B1u    1.957069     1Au     1.957069  
+       7Ag     2.486943     7B1u    2.540415     3B2g    2.542980  
+       3B3g    2.542980     4B3u    3.933560     4B2u    3.933560  
+       8Ag     4.127713     4B2g    4.270800     4B3g    4.270800  
+       2B1g    4.953638     9Ag     4.953638     8B1u    5.130106  
+       5B3u    5.130734     5B2u    5.130734     6B2u    5.269979  
+       6B3u    5.269979    10Ag     5.562295     5B3g    5.663988  
+       5B2g    5.663988     9B1u    6.132429    10B1u    6.413114  
+       2Au     6.413114    11Ag     6.554650     3B1g    6.554650  
+      11B1u    6.787811     3Au     6.787811     6B2g    6.844055  
+       6B3g    6.844055     7B3u    7.068873     7B2u    7.068873  
+      12B1u    7.581212    12Ag     7.694005     7B2g    8.094631  
+       7B3g    8.094631    13Ag     8.191302    13B1u   15.908946  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @ROHF Final Energy:  -149.65170765757179
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9132198610865316
+    Two-Electron Energy =                  86.4730200673692906
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6517076575718193
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:20 2017
+Module time:
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.78 seconds =       0.13 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+	Triplet Disk ROHF energy..........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:20 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             ROHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-ROHF iter   1:  -131.02345181239130   -1.31023e+02   2.71866e-01 
+   @DF-ROHF iter   2:  -139.63848017548818   -8.61503e+00   1.37405e-01 DIIS
+   @DF-ROHF iter   3:  -148.99602731281800   -9.35755e+00   5.06816e-02 DIIS
+   @DF-ROHF iter   4:  -149.63927941443828   -6.43252e-01   6.05660e-03 DIIS
+   @DF-ROHF iter   5:  -149.65149023343014   -1.22108e-02   4.82235e-04 DIIS
+   @DF-ROHF iter   6:  -149.65160058036162   -1.10347e-04   1.10507e-04 DIIS
+   @DF-ROHF iter   7:  -149.65160781013682   -7.22978e-06   1.71514e-05 DIIS
+   @DF-ROHF iter   8:  -149.65160795866174   -1.48525e-07   2.92995e-06 DIIS
+   @DF-ROHF iter   9:  -149.65160796207707   -3.41532e-09   3.53720e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.707896     1B1u  -20.706365     2Ag    -1.755566  
+       2B1u   -1.059159     3Ag    -0.763689     1B3u   -0.754303  
+       1B2u   -0.754303  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157824     1B2g   -0.157824  
+
+    Virtual:                                                              
+
+       3B1u    0.461780     2B3u    0.696793     2B2u    0.696793  
+       4Ag     0.715339     2B2g    0.832386     2B3g    0.832386  
+       5Ag     0.883425     4B1u    0.894801     5B1u    1.416132  
+       1B1g    1.447608     6Ag     1.447608     3B3u    1.643635  
+       3B2u    1.643635     6B1u    1.957623     1Au     1.957623  
+       7Ag     2.487334     7B1u    2.540858     3B2g    2.543482  
+       3B3g    2.543482     4B3u    3.934193     4B2u    3.934193  
+       8Ag     4.129891     4B2g    4.271595     4B3g    4.271595  
+       2B1g    4.959384     9Ag     4.959384     8B1u    5.131186  
+       5B3u    5.137429     5B2u    5.137429     6B2u    5.275113  
+       6B3u    5.275113    10Ag     5.567698     5B3g    5.669314  
+       5B2g    5.669314     9B1u    6.135277    10B1u    6.419792  
+       2Au     6.419792    11Ag     6.562727     3B1g    6.562727  
+      11B1u    6.795495     3Au     6.795495     6B2g    6.851179  
+       6B3g    6.851179     7B3u    7.076375     7B2u    7.076375  
+      12B1u    7.586881    12Ag     7.695812     7B2g    8.101576  
+       7B3g    8.101576    13Ag     8.198018    13B1u   15.912912  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-ROHF Final Energy:  -149.65160796207707
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9126966169219486
+    Two-Electron Energy =                  86.4725965186994614
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6516079620770370
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:21 2017
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       7.95 seconds =       0.13 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+	Triplet DF ROHF energy............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:21 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1646,7 +5335,256 @@ Total time:
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
   Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145454
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @CUHF iter   1:  -131.02769690362541   -1.31028e+02   3.52940e-01 
+   @CUHF iter   2:  -140.10353918415146   -9.07584e+00   1.84876e-01 DIIS
+   @CUHF iter   3:  -149.25243616104677   -9.14890e+00   5.00764e-02 DIIS
+   @CUHF iter   4:  -149.63817985442989   -3.85744e-01   8.24004e-03 DIIS
+   @CUHF iter   5:  -149.65162024791437   -1.34404e-02   5.96010e-04 DIIS
+   @CUHF iter   6:  -149.65170615921500   -8.59113e-05   1.68325e-04 DIIS
+   @CUHF iter   7:  -149.65170608248960    7.67254e-08   1.75800e-05 DIIS
+   @CUHF iter   8:  -149.65170750687167   -1.42438e-06   1.96161e-06 DIIS
+   @CUHF iter   9:  -149.65170767801644   -1.71145e-07   3.18125e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805358  
+       2B1u   -1.148926     1B2u   -0.865420     1B3u   -0.865420  
+       3Ag    -0.800964     1B3g   -0.482421     1B2g   -0.482420  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708739     2B3g    0.800671     2B2g    0.800671  
+       4B1u    0.864363     5Ag     0.868581     5B1u    1.397473  
+       6Ag     1.417440     1B1g    1.417440     3B3u    1.606467  
+       3B2u    1.606467     6B1u    1.908620     1Au     1.908620  
+       7Ag     2.465527     3B3g    2.517400     3B2g    2.517400  
+       7B1u    2.526368     4B2u    3.885569     4B3u    3.885569  
+       8Ag     4.114424     4B3g    4.226227     4B2g    4.226227  
+       9Ag     4.935165     2B1g    4.935165     8B1u    5.113334  
+       5B3u    5.113951     5B2u    5.113951     6B2u    5.242036  
+       6B3u    5.242036    10Ag     5.545666     5B3g    5.632396  
+       5B2g    5.632396     9B1u    6.112627    10B1u    6.383378  
+       2Au     6.383378    11Ag     6.502619     3B1g    6.502619  
+      11B1u    6.743007     3Au     6.743007     6B3g    6.815077  
+       6B2g    6.815077     7B3u    7.042409     7B2u    7.042409  
+      12B1u    7.564791    12Ag     7.667198     7B2g    8.077952  
+       7B3g    8.077952    13Ag     8.179857    13B1u   15.891842  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687355     1B1u  -20.685384     2Ag    -1.707004  
+       2B1u   -0.969314     3Ag    -0.725037     1B2u   -0.643196  
+       1B3u   -0.643196  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.142303     1B2g    0.142303     3B1u    0.476687  
+       2B2u    0.720163     2B3u    0.720164     4Ag     0.721317  
+       2B3g    0.886306     2B2g    0.886306     5Ag     0.898292  
+       4B1u    0.926155     5B1u    1.434129     1B1g    1.476431  
+       6Ag     1.476431     3B2u    1.680294     3B3u    1.680294  
+       1Au     2.005182     6B1u    2.005182     7Ag     2.508285  
+       7B1u    2.554508     3B3g    2.569162     3B2g    2.569162  
+       4B3u    3.981990     4B2u    3.981990     8Ag     4.141020  
+       4B2g    4.316497     4B3g    4.316497     2B1g    4.972124  
+       9Ag     4.972124     8B1u    5.146924     5B3u    5.147607  
+       5B2u    5.147607     6B2u    5.297922     6B3u    5.297922  
+      10Ag     5.578973     5B2g    5.695578     5B3g    5.695578  
+       9B1u    6.152246     2Au     6.441970    10B1u    6.441970  
+       3B1g    6.606944    11Ag     6.606944     3Au     6.833830  
+      11B1u    6.833830     6B2g    6.873085     6B3g    6.873085  
+       7B3u    7.095403     7B2u    7.095403    12B1u    7.597746  
+      12Ag     7.720940     7B2g    8.111447     7B3g    8.111447  
+      13Ag     8.202771    13B1u   15.926079  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @CUHF Final Energy:  -149.65170767801644
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9132748873977334
+    Two-Electron Energy =                  86.4730750732358757
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6517076780164075
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:21 2017
+Module time:
+	user time   =       0.29 seconds =       0.00 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.24 seconds =       0.14 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+	Triplet PK CUHF energy............................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:21 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
 
   Charge       = 0
   Multiplicity = 3
@@ -1668,7 +5606,7 @@ Total time:
   ==> Primary Basis <==
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
     Total number of shells = 20
     Number of primitives   = 52
     Number of AO           = 70
@@ -1687,7 +5625,7 @@ Total time:
     Role: JKFIT
     Keyword: DF_BASIS_SCF
     Name: CC-PVTZ-JKFIT
-    atoms 1-2 entry O          line   228 file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1726,7 +5664,7 @@ Total time:
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
-    Name                   = file /Users/loriab/linux/psihub/hrw-labfork/objdir2/stage/Users/loriab/linux/psihub/install-hrw-labfork/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
     Total number of shells = 50
     Number of primitives   = 50
     Number of AO           = 192
@@ -1749,8 +5687,20 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-CUHF iter   1:  -256.72790828999189   -2.56728e+02   1.05270e-14 
-   @DF-CUHF iter   2:  -256.72790828999189    0.00000e+00   1.05270e-14 DIIS
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-CUHF iter   1:  -131.02345181239130   -1.31023e+02   3.53137e-01 
+   @DF-CUHF iter   2:  -140.10421230724521   -9.08076e+00   1.84897e-01 DIIS
+   @DF-CUHF iter   3:  -149.25215682201215   -9.14794e+00   5.00787e-02 DIIS
+   @DF-CUHF iter   4:  -149.63807305829198   -3.85916e-01   8.23713e-03 DIIS
+   @DF-CUHF iter   5:  -149.65151993459682   -1.34469e-02   5.97253e-04 DIIS
+   @DF-CUHF iter   6:  -149.65160644610145   -8.65115e-05   1.68622e-04 DIIS
+   @DF-CUHF iter   7:  -149.65160638240945    6.36920e-08   1.76713e-05 DIIS
+   @DF-CUHF iter   8:  -149.65160780779979   -1.42539e-06   1.98195e-06 DIIS
+   @DF-CUHF iter   9:  -149.65160798262863   -1.74829e-07   3.19572e-07 DIIS
 
   DF guess converged.
 
@@ -1764,20 +5714,9 @@ Total time:
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
-
-   @CUHF iter   3:  -131.02769690362538    1.25700e+02   3.52940e-01 DIIS
-   @CUHF iter   4:  -140.10353918415015   -9.07584e+00   1.84876e-01 DIIS
-   @CUHF iter   5:  -149.25243616104672   -9.14890e+00   5.00764e-02 DIIS
-   @CUHF iter   6:  -149.63817985443004   -3.85744e-01   8.24004e-03 DIIS
-   @CUHF iter   7:  -149.65162024791445   -1.34404e-02   5.96010e-04 DIIS
-   @CUHF iter   8:  -149.65170615921514   -8.59113e-05   1.68325e-04 DIIS
-   @CUHF iter   9:  -149.65170608248960    7.67255e-08   1.75800e-05 DIIS
-   @CUHF iter  10:  -149.65170750687176   -1.42438e-06   1.96161e-06 DIIS
-   @CUHF iter  11:  -149.65170767801652   -1.71145e-07   3.18125e-07 DIIS
+   @CUHF iter  10:  -149.65170754694790   -9.95643e-05   3.40716e-05 DIIS
+   @CUHF iter  11:  -149.65170747262343    7.43245e-08   3.62414e-06 DIIS
+   @CUHF iter  12:  -149.65170769435528   -2.21732e-07   9.72666e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -1790,56 +5729,56 @@ Total time:
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805358  
-       2B1u   -1.148926     1B3u   -0.865420     1B2u   -0.865420  
-       3Ag    -0.800964     1B2g   -0.482421     1B3g   -0.482420  
+       1Ag   -20.728403     1B1u  -20.727322     2Ag    -1.805360  
+       2B1u   -1.148928     1B2u   -0.865421     1B3u   -0.865421  
+       3Ag    -0.800966     1B3g   -0.482423     1B2g   -0.482423  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.445206     2B3u    0.672317     2B2u    0.672317  
-       4Ag     0.708739     2B2g    0.800671     2B3g    0.800671  
-       4B1u    0.864363     5Ag     0.868581     5B1u    1.397473  
-       6Ag     1.417440     1B1g    1.417440     3B2u    1.606467  
-       3B3u    1.606467     6B1u    1.908620     1Au     1.908620  
-       7Ag     2.465527     3B2g    2.517400     3B3g    2.517400  
-       7B1u    2.526368     4B3u    3.885569     4B2u    3.885569  
-       8Ag     4.114424     4B2g    4.226227     4B3g    4.226227  
-       9Ag     4.935165     2B1g    4.935165     8B1u    5.113334  
-       5B2u    5.113951     5B3u    5.113951     6B3u    5.242036  
-       6B2u    5.242036    10Ag     5.545666     5B2g    5.632396  
-       5B3g    5.632396     9B1u    6.112627    10B1u    6.383378  
-       2Au     6.383378    11Ag     6.502619     3B1g    6.502619  
-      11B1u    6.743007     3Au     6.743007     6B2g    6.815077  
-       6B3g    6.815077     7B2u    7.042409     7B3u    7.042409  
-      12B1u    7.564791    12Ag     7.667198     7B3g    8.077952  
-       7B2g    8.077952    13Ag     8.179857    13B1u   15.891842  
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708738     2B3g    0.800670     2B2g    0.800670  
+       4B1u    0.864361     5Ag     0.868580     5B1u    1.397472  
+       6Ag     1.417439     1B1g    1.417439     3B3u    1.606466  
+       3B2u    1.606466     6B1u    1.908619     1Au     1.908619  
+       7Ag     2.465526     3B3g    2.517399     3B2g    2.517399  
+       7B1u    2.526367     4B2u    3.885567     4B3u    3.885567  
+       8Ag     4.114422     4B3g    4.226225     4B2g    4.226225  
+       9Ag     4.935163     2B1g    4.935163     8B1u    5.113332  
+       5B2u    5.113949     5B3u    5.113949     6B3u    5.242035  
+       6B2u    5.242035    10Ag     5.545664     5B2g    5.632395  
+       5B3g    5.632395     9B1u    6.112625    10B1u    6.383377  
+       2Au     6.383377    11Ag     6.502617     3B1g    6.502617  
+      11B1u    6.743005     3Au     6.743005     6B3g    6.815074  
+       6B2g    6.815074     7B2u    7.042406     7B3u    7.042406  
+      12B1u    7.564788    12Ag     7.667196     7B2g    8.077950  
+       7B3g    8.077950    13Ag     8.179855    13B1u   15.891839  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.687355     1B1u  -20.685384     2Ag    -1.707004  
-       2B1u   -0.969314     3Ag    -0.725037     1B3u   -0.643196  
-       1B2u   -0.643196  
+       1Ag   -20.687360     1B1u  -20.685388     2Ag    -1.707006  
+       2B1u   -0.969316     3Ag    -0.725038     1B2u   -0.643197  
+       1B3u   -0.643197  
 
     Beta Virtual:                                                         
 
-       1B2g    0.142303     1B3g    0.142303     3B1u    0.476687  
-       2B3u    0.720163     2B2u    0.720164     4Ag     0.721317  
-       2B2g    0.886306     2B3g    0.886306     5Ag     0.898292  
-       4B1u    0.926155     5B1u    1.434129     1B1g    1.476431  
-       6Ag     1.476431     3B3u    1.680294     3B2u    1.680294  
-       1Au     2.005182     6B1u    2.005182     7Ag     2.508285  
-       7B1u    2.554508     3B2g    2.569162     3B3g    2.569162  
-       4B2u    3.981990     4B3u    3.981990     8Ag     4.141020  
-       4B3g    4.316497     4B2g    4.316497     2B1g    4.972124  
-       9Ag     4.972124     8B1u    5.146924     5B2u    5.147607  
-       5B3u    5.147607     6B3u    5.297922     6B2u    5.297922  
-      10Ag     5.578973     5B3g    5.695578     5B2g    5.695578  
-       9B1u    6.152246     2Au     6.441970    10B1u    6.441970  
-       3B1g    6.606944    11Ag     6.606944     3Au     6.833830  
-      11B1u    6.833830     6B3g    6.873085     6B2g    6.873085  
-       7B2u    7.095403     7B3u    7.095403    12B1u    7.597746  
-      12Ag     7.720940     7B3g    8.111447     7B2g    8.111447  
-      13Ag     8.202771    13B1u   15.926079  
+       1B3g    0.142301     1B2g    0.142301     3B1u    0.476686  
+       2B2u    0.720163     2B3u    0.720163     4Ag     0.721316  
+       2B3g    0.886305     2B2g    0.886305     5Ag     0.898291  
+       4B1u    0.926153     5B1u    1.434128     6Ag     1.476430  
+       1B1g    1.476430     3B2u    1.680292     3B3u    1.680292  
+       1Au     2.005181     6B1u    2.005181     7Ag     2.508283  
+       7B1u    2.554507     3B3g    2.569161     3B2g    2.569161  
+       4B2u    3.981988     4B3u    3.981988     8Ag     4.141018  
+       4B2g    4.316494     4B3g    4.316494     2B1g    4.972123  
+       9Ag     4.972123     8B1u    5.146921     5B3u    5.147605  
+       5B2u    5.147605     6B3u    5.297921     6B2u    5.297921  
+      10Ag     5.578970     5B2g    5.695577     5B3g    5.695577  
+       9B1u    6.152244     2Au     6.441969    10B1u    6.441969  
+       3B1g    6.606942    11Ag     6.606942     3Au     6.833828  
+      11B1u    6.833828     6B2g    6.873082     6B3g    6.873082  
+       7B3u    7.095400     7B2u    7.095400    12B1u    7.597744  
+      12Ag     7.720938     7B2g    8.111445     7B3g    8.111445  
+      13Ag     8.202768    13B1u   15.926076  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
@@ -1848,20 +5787,20 @@ Total time:
 
   Energy converged.
 
-  @CUHF Final Energy:  -149.65170767801652
+  @CUHF Final Energy:  -149.65170769435528
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454538
-    One-Electron Energy =                -266.9132748873977903
-    Two-Electron Energy =                  86.4730750732357905
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9131678875075977
+    Two-Electron Energy =                  86.4729680570068808
     DFT Exchange-Correlation Energy =       0.0000000000000000
     Empirical Dispersion Energy =           0.0000000000000000
     PCM Polarization Energy =               0.0000000000000000
     EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076780165212
+    Total Energy =                       -149.6517076943552809
 
-
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
 
@@ -1880,15 +5819,510 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ariadne at Sun Oct 23 18:53:45 2016
+*** tstop() called on psinet at Fri Feb  3 19:05:22 2017
 Module time:
-	user time   =       2.56 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.69 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.39 seconds =       0.26 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =       8.93 seconds =       0.15 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
 	Triplet Direct CUHF energy........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:22 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               178
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @CUHF iter   1:  -131.02769690362553   -1.31028e+02   3.52940e-01 
+   @CUHF iter   2:  -140.10353918415032   -9.07584e+00   1.84876e-01 DIIS
+   @CUHF iter   3:  -149.25243616104672   -9.14890e+00   5.00764e-02 DIIS
+   @CUHF iter   4:  -149.63817985442998   -3.85744e-01   8.24004e-03 DIIS
+   @CUHF iter   5:  -149.65162024791445   -1.34404e-02   5.96010e-04 DIIS
+   @CUHF iter   6:  -149.65170615921502   -8.59113e-05   1.68325e-04 DIIS
+   @CUHF iter   7:  -149.65170608248954    7.67255e-08   1.75800e-05 DIIS
+   @CUHF iter   8:  -149.65170750687173   -1.42438e-06   1.96161e-06 DIIS
+   @CUHF iter   9:  -149.65170767801638   -1.71145e-07   3.18125e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805358  
+       2B1u   -1.148926     1B2u   -0.865420     1B3u   -0.865420  
+       3Ag    -0.800964     1B3g   -0.482421     1B2g   -0.482420  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708739     2B3g    0.800671     2B2g    0.800671  
+       4B1u    0.864363     5Ag     0.868581     5B1u    1.397473  
+       6Ag     1.417440     1B1g    1.417440     3B3u    1.606467  
+       3B2u    1.606467     6B1u    1.908620     1Au     1.908620  
+       7Ag     2.465527     3B3g    2.517400     3B2g    2.517400  
+       7B1u    2.526368     4B2u    3.885569     4B3u    3.885569  
+       8Ag     4.114424     4B3g    4.226227     4B2g    4.226227  
+       9Ag     4.935165     2B1g    4.935165     8B1u    5.113334  
+       5B3u    5.113951     5B2u    5.113951     6B2u    5.242036  
+       6B3u    5.242036    10Ag     5.545666     5B3g    5.632396  
+       5B2g    5.632396     9B1u    6.112627    10B1u    6.383378  
+       2Au     6.383378    11Ag     6.502619     3B1g    6.502619  
+      11B1u    6.743007     3Au     6.743007     6B3g    6.815077  
+       6B2g    6.815077     7B3u    7.042409     7B2u    7.042409  
+      12B1u    7.564791    12Ag     7.667198     7B2g    8.077952  
+       7B3g    8.077952    13Ag     8.179857    13B1u   15.891842  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687355     1B1u  -20.685384     2Ag    -1.707004  
+       2B1u   -0.969314     3Ag    -0.725037     1B2u   -0.643196  
+       1B3u   -0.643196  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.142303     1B2g    0.142303     3B1u    0.476687  
+       2B2u    0.720163     2B3u    0.720164     4Ag     0.721317  
+       2B3g    0.886306     2B2g    0.886306     5Ag     0.898292  
+       4B1u    0.926155     5B1u    1.434129     1B1g    1.476431  
+       6Ag     1.476431     3B2u    1.680294     3B3u    1.680294  
+       1Au     2.005182     6B1u    2.005182     7Ag     2.508285  
+       7B1u    2.554508     3B3g    2.569162     3B2g    2.569162  
+       4B3u    3.981990     4B2u    3.981990     8Ag     4.141020  
+       4B2g    4.316497     4B3g    4.316497     2B1g    4.972124  
+       9Ag     4.972124     8B1u    5.146924     5B3u    5.147607  
+       5B2u    5.147607     6B2u    5.297922     6B3u    5.297922  
+      10Ag     5.578973     5B2g    5.695578     5B3g    5.695578  
+       9B1u    6.152246     2Au     6.441970    10B1u    6.441970  
+       3B1g    6.606944    11Ag     6.606944     3Au     6.833830  
+      11B1u    6.833830     6B2g    6.873085     6B3g    6.873085  
+       7B3u    7.095403     7B2u    7.095403    12B1u    7.597746  
+      12Ag     7.720940     7B2g    8.111447     7B3g    8.111447  
+      13Ag     8.202771    13B1u   15.926079  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @CUHF Final Energy:  -149.65170767801638
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9132748873976198
+    Two-Electron Energy =                  86.4730750732357905
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6517076780164075
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:22 2017
+Module time:
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.19 seconds =       0.15 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         10 seconds =       0.17 minutes
+	Triplet Disk CUHF energy..........................................PASSED
+
+*** tstart() called on psinet
+*** at Fri Feb  3 19:05:22 2017
+
+   => Loading Basis Set <=
+
+    Role: BASIS
+    Keyword: BASIS
+    Name: CC-PVTZ
+    atoms 1-2 entry O          line   247 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                             CUHF Reference
+                        1 Threads,    250 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
+           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
+  Nuclear repulsion =   30.788492136145440
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz.gbs
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    Name: CC-PVTZ-JKFIT
+    atoms 1-2 entry O          line   228 file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       0       0       0       0
+     B1g        3       3       0       0       0       0
+     B2g        7       7       0       0       0       0
+     B3g        7       7       0       0       0       0
+     Au         3       3       0       0       0       0
+     B1u       13      13       0       0       0       0
+     B2u        7       7       0       0       0       0
+     B3u        7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               178
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = file /theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/objdir30/stage/theoryfs2/ds/cdsgroup/psi4-compile/hrw-temp/install-psi4/share/psi4/basis/cc-pvtz-jkfit.gbs
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+   @DF-CUHF iter   1:  -131.02345181239130   -1.31023e+02   3.53137e-01 
+   @DF-CUHF iter   2:  -140.10421230724521   -9.08076e+00   1.84897e-01 DIIS
+   @DF-CUHF iter   3:  -149.25215682201215   -9.14794e+00   5.00787e-02 DIIS
+   @DF-CUHF iter   4:  -149.63807305829198   -3.85916e-01   8.23713e-03 DIIS
+   @DF-CUHF iter   5:  -149.65151993459682   -1.34469e-02   5.97253e-04 DIIS
+   @DF-CUHF iter   6:  -149.65160644610145   -8.65115e-05   1.68622e-04 DIIS
+   @DF-CUHF iter   7:  -149.65160638240945    6.36920e-08   1.76713e-05 DIIS
+   @DF-CUHF iter   8:  -149.65160780779979   -1.42539e-06   1.98195e-06 DIIS
+   @DF-CUHF iter   9:  -149.65160798262863   -1.74829e-07   3.19572e-07 DIIS
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728437     1B1u  -20.727356     2Ag    -1.805402  
+       2B1u   -1.148942     1B2u   -0.865418     1B3u   -0.865418  
+       3Ag    -0.800976     1B3g   -0.482443     1B2g   -0.482443  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445379     2B2u    0.672516     2B3u    0.672516  
+       4Ag     0.708931     2B3g    0.801015     2B2g    0.801015  
+       4B1u    0.864475     5Ag     0.868644     5B1u    1.398009  
+       6Ag     1.418034     1B1g    1.418034     3B3u    1.606817  
+       3B2u    1.606817     6B1u    1.909365     1Au     1.909365  
+       7Ag     2.465995     3B3g    2.518097     3B2g    2.518097  
+       7B1u    2.526939     4B2u    3.886281     4B3u    3.886281  
+       8Ag     4.116749     4B3g    4.227176     4B2g    4.227176  
+       9Ag     4.941673     2B1g    4.941673     8B1u    5.114579  
+       5B3u    5.121284     5B2u    5.121284     6B2u    5.248401  
+       6B3u    5.248401    10Ag     5.551654     5B3g    5.639394  
+       5B2g    5.639394     9B1u    6.116138    10B1u    6.392135  
+       2Au     6.392135    11Ag     6.513061     3B1g    6.513061  
+      11B1u    6.753437     3Au     6.753437     6B3g    6.824515  
+       6B2g    6.824515     7B3u    7.051666     7B2u    7.051666  
+      12B1u    7.572154    12Ag     7.669410     7B2g    8.087162  
+       7B3g    8.087162    13Ag     8.188327    13B1u   15.897366  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687392     1B1u  -20.685421     2Ag    -1.707051  
+       2B1u   -0.969330     3Ag    -0.725047     1B2u   -0.643189  
+       1B3u   -0.643189  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.142275     1B2g    0.142275     3B1u    0.476815  
+       2B2u    0.720362     2B3u    0.720362     4Ag     0.721466  
+       2B3g    0.886357     2B2g    0.886357     5Ag     0.898337  
+       4B1u    0.926176     5B1u    1.434313     1B1g    1.476900  
+       6Ag     1.476900     3B2u    1.680564     3B3u    1.680564  
+       1Au     2.005533     6B1u    2.005533     7Ag     2.508597  
+       7B1u    2.554825     3B3g    2.569468     3B2g    2.569468  
+       4B3u    3.982546     4B2u    3.982546     8Ag     4.143053  
+       4B2g    4.317139     4B3g    4.317139     2B1g    4.977108  
+       9Ag     4.977108     8B1u    5.147840     5B3u    5.153664  
+       5B2u    5.153664     6B2u    5.301825     6B3u    5.301825  
+      10Ag     5.583795     5B3g    5.699234     5B2g    5.699234  
+       9B1u    6.154433     2Au     6.446604    10B1u    6.446604  
+       3B1g    6.612663    11Ag     6.612663     3Au     6.838745  
+      11B1u    6.838745     6B2g    6.877897     6B3g    6.877897  
+       7B3u    7.101148     7B2u    7.101148    12B1u    7.601719  
+      12Ag     7.722339     7B2g    8.116129     7B3g    8.116129  
+      13Ag     8.207733    13B1u   15.928487  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+
+  Energy converged.
+
+  @DF-CUHF Final Energy:  -149.65160798262863
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884921361454396
+    One-Electron Energy =                -266.9127520403153540
+    Two-Electron Energy =                  86.4726519215412708
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -149.6516079826286614
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Fri Feb  3 19:05:22 2017
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.37 seconds =       0.16 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         10 seconds =       0.17 minutes
+	Triplet DF CUHF energy............................................PASSED
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This is a continuation of @bennybp's #587 that I'd like to wrap up, but the gdma Travis isssue needs fixing. We can work out merge order later.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] everything #587 does
  - [x] changes the ERD warning, updates the docs, adds test case
* **User-Facing for Release Notes**
  - [x] ERD integrals now work for far more types of systems. Previously it was only direct, conventional HF. Now works for most all energies (except LRC DFT). Does not work for gradients, but those are disabled.

## Questions
- [x]  Waiting for a clean Travis test (gdma culprit), then ready to go

## Status
- [x]  Ready to go


