### PR TITLE
Fix for building with Intel without fortran enabled

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -36,8 +36,9 @@ target_link_libraries(core PUBLIC pybind11::module)
 target_link_libraries(core PRIVATE Threads::Threads)
 
 if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-  # Enable call to for_rtl_init_() and link to the correct library
-  target_compile_definitions(core PRIVATE -DFortran_ENABLED)
+  # Enable call to for_rtl_init_() which is required if using the
+  # Intel fortran compiler
+  target_compile_definitions(core PRIVATE -DINTEL_Fortran_ENABLED)
 endif()
 
 

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -34,6 +34,13 @@ target_link_libraries(core PRIVATE ${psi4_binmodules})
 target_link_libraries(core PRIVATE ${LIBC_INTERJECT})
 target_link_libraries(core PUBLIC pybind11::module)
 target_link_libraries(core PRIVATE Threads::Threads)
+
+if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+  # Enable call to for_rtl_init_() and link to the correct library
+  target_compile_definitions(core PRIVATE -DFortran_ENABLED)
+endif()
+
+
 # LAPACK & BLAS linking attached to modules in BIN/LIBLIST to maximally defer
 
 target_include_directories(core PRIVATE $<TARGET_PROPERTY:libint::libint,INTERFACE_INCLUDE_DIRECTORIES>)  # comp def instead? only b/c boost export here not w/i mints

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1184,7 +1184,7 @@ bool psi4_python_module_initialize()
     read_options("", Process::environment.options, true);
     Process::environment.options.set_read_globals(false);
 
-#if defined Fortran_ENABLED && defined __INTEL_COMPILER
+#ifdef INTEL_Fortran_ENABLED
     for_rtl_init_(NULL, NULL);
 #endif
 
@@ -1195,7 +1195,7 @@ bool psi4_python_module_initialize()
 
 void psi4_python_module_finalize()
 {
-#if defined Fortran_ENABLED && defined __INTEL_COMPILER
+#ifdef INTEL_Fortran_ENABLED
     for_rtl_finish_();
 #endif
 

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1184,7 +1184,7 @@ bool psi4_python_module_initialize()
     read_options("", Process::environment.options, true);
     Process::environment.options.set_read_globals(false);
 
-#ifdef __INTEL_COMPILER
+#if defined Fortran_ENABLED && defined __INTEL_COMPILER
     for_rtl_init_(NULL, NULL);
 #endif
 
@@ -1195,7 +1195,7 @@ bool psi4_python_module_initialize()
 
 void psi4_python_module_finalize()
 {
-#ifdef __INTEL_COMPILER
+#if defined Fortran_ENABLED && defined __INTEL_COMPILER
     for_rtl_finish_();
 #endif
 


### PR DESCRIPTION
## Description
Fixes an issue where building with Intel but without fortran enabled would lead to undefined symbols `for_rtl_init_()` and `for_rtl_finish_()`

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [X] Psi4 now builds and runs with intel without fortran

## Status
- [X]  Ready to go


