### PR TITLE
DFMP2 gradients with external potential

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-sa-sp ao-casscf-sp casscf-sp ca
                   dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-dldf 
                   dft-freq dft-grad dft-pbe0-2 dft-psivar dft-b3lyp dft1 
-                  dft1-alt dft2 dft3 docs-bases docs-dft extern1
+                  dft1-alt dft2 dft3 docs-bases docs-dft extern1 extern2
                   fci-dipole fci-h2o fci-h2o-2 fci-h2o-fzcv fci-tdm fci-tdm-2 
                   fd-freq-energy fd-freq-energy-large fd-freq-gradient 
                   fd-freq-gradient-large fd-gradient freq-isotope fnocc1 fnocc2 

--- a/tests/extern2/CMakeLists.txt
+++ b/tests/extern2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(extern2 "psi;mp2")

--- a/tests/extern2/input.dat
+++ b/tests/extern2/input.dat
@@ -1,0 +1,35 @@
+#! External potential calculation involving a TIP3P water and a QM water for DFMP2.
+#! Finite different test of the gradient is performed to validate forces.
+memory 500 mb
+
+molecule water {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+# Define a TIP3P water as the external potential
+Chrgfield = QMMM()
+Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+
+set {
+    scf_type df
+    d_convergence 8
+    basis 6-31G*
+}
+
+fd_grad = gradient('mp2', molecule=water, dertype=0)
+fd_ener = psi4.get_variable('CURRENT ENERGY')
+an_grad = gradient('mp2', molecule=water)
+an_ener = psi4.get_variable('CURRENT ENERGY')
+
+compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
+compare_values(-76.2080976129895618, fd_ener, 6, 'Finite difference energy')  #TEST
+compare_values(-76.2080976129895618, an_ener, 6, 'Analytic energy')  #TEST

--- a/tests/extern2/output.ref
+++ b/tests/extern2/output.ref
@@ -1,0 +1,5130 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1a2.dev250 
+
+                         Git: Rev {mp2qmmm} e6887c2 dirty
+
+
+    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
+    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
+    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
+    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
+    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
+    (doi: 10.1002/wcms.93)
+
+
+                         Additional Contributions by
+    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
+    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
+    B. P. Pritchard
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Friday, 17 February 2017 09:38AM
+
+    Process ID:  63321
+    PSIDATADIR: /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! External potential calculation involving a TIP3P water and a QM water for DFMP2.
+#! Finite different test of the gradient is performed to validate forces.
+memory 500 mb
+
+molecule water {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+# Define a TIP3P water as the external potential
+Chrgfield = QMMM()
+Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+
+set {
+    scf_type df
+    d_convergence 8
+    basis 6-31G*
+}
+
+fd_grad = gradient('mp2', molecule=water, dertype=0)
+fd_ener = psi4.get_variable('CURRENT ENERGY')
+an_grad = gradient('mp2', molecule=water)
+an_ener = psi4.get_variable('CURRENT ENERGY')
+
+compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
+compare_values(-76.2080976129895618, fd_ener, 6, 'Finite difference energy')  #TEST
+compare_values(-76.2080976129895618, an_ener, 6, 'Analytic energy')  #TEST
+--------------------------------------------------------------------------
+
+  Memory set to 500.000 MiB by Python script.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 9.
+	Number of displacements (including reference) is 19.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:19 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.779464576656     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49101  B =      0.45557  C =      0.44491 [cm^-1]
+  Rotational constants: A = 344491.84174  B =  13657.68756  C =  13338.09317 [MHz]
+  Nuclear repulsion =    9.146852154519253
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.146852154519253
+  Additional nuclear repulsion =    0.278873722228465
+  Total nuclear repulsion      =    9.425725876747718
+
+  Minimum eigenvalue in the overlap matrix is 2.2468778762E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.97687894906412   -7.59769e+01   8.80172e-02 
+   @DF-RHF iter   1:   -75.98568693328436   -8.80798e-03   1.44320e-02 
+   @DF-RHF iter   2:   -76.01201370202635   -2.63268e-02   7.30871e-03 DIIS
+   @DF-RHF iter   3:   -76.01883150054074   -6.81780e-03   1.23488e-03 DIIS
+   @DF-RHF iter   4:   -76.01932769108467   -4.96191e-04   3.64543e-04 DIIS
+   @DF-RHF iter   5:   -76.01939705245505   -6.93614e-05   9.06098e-05 DIIS
+   @DF-RHF iter   6:   -76.01940255249500   -5.50004e-06   1.33382e-05 DIIS
+   @DF-RHF iter   7:   -76.01940266659400   -1.14099e-07   2.66711e-06 DIIS
+   @DF-RHF iter   8:   -76.01940267090352   -4.30951e-09   5.06180e-07 DIIS
+   @DF-RHF iter   9:   -76.01940267104612   -1.42606e-10   7.58094e-08 DIIS
+   @DF-RHF iter  10:   -76.01940267104854   -2.41585e-12   1.35087e-08 DIIS
+   @DF-RHF iter  11:   -76.01940267104862   -8.52651e-14   2.00860e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586657     2A     -1.364177     3A     -0.730307  
+       4A     -0.598176     5A     -0.524222  
+
+    Virtual:                                                              
+
+       6A      0.191863     7A      0.285551     8A      0.998523  
+       9A      1.098600    10A      1.135842    11A      1.142901  
+      12A      1.354158    13A      1.409219    14A      1.994992  
+      15A      2.007882    16A      2.040894    17A      2.591064  
+      18A      2.913078    19A      3.941731  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01940267104862
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4257258767477179
+    One-Electron Energy =                -123.2831798374998158
+    Two-Electron Energy =                  37.8380512897034578
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194026710486384
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.3035      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4643      Y:    -0.0000      Z:   -22.6703
+
+  Dipole Moment: (a.u.)
+     X:     0.1608      Y:    -0.0000      Z:     0.9022     Total:     0.9165
+
+  Dipole Moment: (Debye)
+     X:     0.4088      Y:    -0.0000      Z:     2.2933     Total:     2.3294
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194026710486241 [Eh]
+	 Singles Energy            =      -0.0000000000000001 [Eh]
+	 Same-Spin Energy          =      -0.0484793126010058 [Eh]
+	 Opposite-Spin Energy      =      -0.1402140566494938 [Eh]
+	 Correlation Energy        =      -0.1886933692504997 [Eh]
+	 Total Energy              =     -76.2080960402991252 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161597708670019 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682568679793925 [Eh]
+	 SCS Correlation Energy    =      -0.1844166388463946 [Eh]
+	 SCS Total Energy          =     -76.2038193098950245 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:20 2017
+Module time:
+	user time   =       0.61 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.61 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:20 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778141423344     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.50695  B =      0.45598  C =      0.44527 [cm^-1]
+  Rotational constants: A = 344969.70276  B =  13669.86550  C =  13348.99103 [MHz]
+  Nuclear repulsion =    9.148263043209003
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.148263043209003
+  Additional nuclear repulsion =    0.278963154351173
+  Total nuclear repulsion      =    9.427226197560175
+
+  Minimum eigenvalue in the overlap matrix is 2.2463310653E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.08411722205901   -7.60841e+01   8.87172e-02 
+   @DF-RHF iter   1:   -75.96509380952827    1.19023e-01   1.75242e-02 
+   @DF-RHF iter   2:   -76.00818487738843   -4.30911e-02   9.01227e-03 DIIS
+   @DF-RHF iter   3:   -76.01850996108504   -1.03251e-02   1.67910e-03 DIIS
+   @DF-RHF iter   4:   -76.01934615923990   -8.36198e-04   4.21465e-04 DIIS
+   @DF-RHF iter   5:   -76.01941693919849   -7.07800e-05   7.43424e-05 DIIS
+   @DF-RHF iter   6:   -76.01941963786795   -2.69867e-06   1.31377e-05 DIIS
+   @DF-RHF iter   7:   -76.01941972180738   -8.39394e-08   2.64390e-06 DIIS
+   @DF-RHF iter   8:   -76.01941972525793   -3.45055e-09   3.31873e-07 DIIS
+   @DF-RHF iter   9:   -76.01941972530541   -4.74785e-11   6.55055e-08 DIIS
+   @DF-RHF iter  10:   -76.01941972530746   -2.04636e-12   1.85605e-08 DIIS
+   @DF-RHF iter  11:   -76.01941972530778   -3.26850e-13   2.09107e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586620     2A     -1.364241     3A     -0.730441  
+       4A     -0.598177     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191898     7A      0.285595     8A      0.998690  
+       9A      1.098585    10A      1.135898    11A      1.142920  
+      12A      1.354219    13A      1.409147    14A      1.995003  
+      15A      2.007823    16A      2.040884    17A      2.591274  
+      18A      2.913358    19A      3.941847  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01941972530778
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4272261975601754
+    One-Electron Energy =                -123.2858880871893774
+    Two-Electron Energy =                  37.8392421643214121
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194197253077846
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2835      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4423      Y:    -0.0000      Z:   -22.6701
+
+  Dipole Moment: (a.u.)
+     X:     0.1589      Y:    -0.0000      Z:     0.9024     Total:     0.9163
+
+  Dipole Moment: (Debye)
+     X:     0.4038      Y:    -0.0000      Z:     2.2938     Total:     2.3290
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194197253077846 [Eh]
+	 Singles Energy            =      -0.0000000000000005 [Eh]
+	 Same-Spin Energy          =      -0.0484766084244261 [Eh]
+	 Opposite-Spin Energy      =      -0.1402028320214677 [Eh]
+	 Correlation Energy        =      -0.1886794404458943 [Eh]
+	 Total Energy              =     -76.2080991657536799 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161588694748087 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682433984257612 [Eh]
+	 SCS Correlation Energy    =      -0.1844022679005704 [Eh]
+	 SCS Total Energy          =     -76.2038219932083507 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:20 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.20 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:20 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000    -0.000661576656     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49897  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.50936  B =  13663.77435  C =  13343.53950 [MHz]
+  Nuclear repulsion =    9.147561457614870
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.147561457614870
+  Additional nuclear repulsion =    0.278918423874489
+  Total nuclear repulsion      =    9.426479881489358
+
+  Minimum eigenvalue in the overlap matrix is 2.2466013991E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.00678318719488   -7.60068e+01   8.83097e-02 
+   @DF-RHF iter   1:   -75.98120092070599    2.55823e-02   1.51956e-02 
+   @DF-RHF iter   2:   -76.01115495471670   -2.99540e-02   7.79650e-03 DIIS
+   @DF-RHF iter   3:   -76.01882062647334   -7.66567e-03   1.28944e-03 DIIS
+   @DF-RHF iter   4:   -76.01935300885127   -5.32382e-04   3.56409e-04 DIIS
+   @DF-RHF iter   5:   -76.01940784779848   -5.48389e-05   7.28589e-05 DIIS
+   @DF-RHF iter   6:   -76.01941062644728   -2.77865e-06   9.05247e-06 DIIS
+   @DF-RHF iter   7:   -76.01941066664260   -4.01953e-08   1.43260e-06 DIIS
+   @DF-RHF iter   8:   -76.01941066750845   -8.65853e-10   2.45820e-07 DIIS
+   @DF-RHF iter   9:   -76.01941066753055   -2.20979e-11   2.63598e-08 DIIS
+   @DF-RHF iter  10:   -76.01941066753064   -8.52651e-14   6.29168e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998605  
+       9A      1.098592    10A      1.135871    11A      1.142911  
+      12A      1.354189    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591167  
+      18A      2.913221    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01941066753064
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4264798814893584
+    One-Electron Energy =                -123.2845397365123148
+    Two-Electron Energy =                  37.8386491874923152
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194106675306500
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:    -0.0100      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:     0.0107      Z:   -22.6702
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:     0.0007      Z:     0.9023     Total:     0.9164
+
+  Dipole Moment: (Debye)
+     X:     0.4063      Y:     0.0018      Z:     2.2935     Total:     2.3292
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194106675306358 [Eh]
+	 Singles Energy            =      -0.0000000000000013 [Eh]
+	 Same-Spin Energy          =      -0.0484779535227070 [Eh]
+	 Opposite-Spin Energy      =      -0.1402084322049182 [Eh]
+	 Correlation Energy        =      -0.1886863857276265 [Eh]
+	 Total Energy              =     -76.2080970532582569 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161593178409023 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682501186459018 [Eh]
+	 SCS Correlation Energy    =      -0.1844094364868054 [Eh]
+	 SCS Total Energy          =     -76.2038201040174386 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:21 2017
+Module time:
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.78 seconds =       0.03 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:21 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000661576656     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49897  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.50961  B =  13663.77435  C =  13343.53950 [MHz]
+  Nuclear repulsion =    9.147561448675397
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.147561448675397
+  Additional nuclear repulsion =    0.278918423874489
+  Total nuclear repulsion      =    9.426479872549885
+
+  Minimum eigenvalue in the overlap matrix is 2.2466014061E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94330650975928   -7.59433e+01   8.76554e-02 
+   @DF-RHF iter   1:   -75.98945804341471   -4.61515e-02   1.37204e-02 
+   @DF-RHF iter   2:   -76.01295203688646   -2.34940e-02   6.78164e-03 DIIS
+   @DF-RHF iter   3:   -76.01889739380000   -5.94536e-03   1.19666e-03 DIIS
+   @DF-RHF iter   4:   -76.01933402689772   -4.36633e-04   3.56236e-04 DIIS
+   @DF-RHF iter   5:   -76.01940457722739   -7.05503e-05   9.42122e-05 DIIS
+   @DF-RHF iter   6:   -76.01941059072161   -6.01349e-06   1.15409e-05 DIIS
+   @DF-RHF iter   7:   -76.01941066665829   -7.59367e-08   1.95268e-06 DIIS
+   @DF-RHF iter   8:   -76.01941066870280   -2.04452e-09   4.10593e-07 DIIS
+   @DF-RHF iter   9:   -76.01941066877990   -7.70939e-11   7.48799e-08 DIIS
+   @DF-RHF iter  10:   -76.01941066878221   -2.31637e-12   1.91110e-08 DIIS
+   @DF-RHF iter  11:   -76.01941066878234   -1.27898e-13   3.49965e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998605  
+       9A      1.098592    10A      1.135871    11A      1.142911  
+      12A      1.354189    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591167  
+      18A      2.913221    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01941066878234
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4264798725498853
+    One-Electron Energy =                -123.2845398074557295
+    Two-Electron Energy =                  37.8386492661235039
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194106687823421
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0100      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:    -0.0107      Z:   -22.6702
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:    -0.0007      Z:     0.9023     Total:     0.9164
+
+  Dipole Moment: (Debye)
+     X:     0.4063      Y:    -0.0018      Z:     2.2935     Total:     2.3292
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194106687823421 [Eh]
+	 Singles Energy            =      -0.0000000000000007 [Eh]
+	 Same-Spin Energy          =      -0.0484779533549428 [Eh]
+	 Opposite-Spin Energy      =      -0.1402084316758840 [Eh]
+	 Correlation Energy        =      -0.1886863850308274 [Eh]
+	 Total Energy              =     -76.2080970538131766 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161593177849809 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682501180110608 [Eh]
+	 SCS Correlation Energy    =      -0.1844094357960424 [Eh]
+	 SCS Total Energy          =     -76.2038201045783836 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:21 2017
+Module time:
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.36 seconds =       0.04 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:21 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132021423344    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49397  B =      0.45607  C =      0.44538 [cm^-1]
+  Rotational constants: A = 344580.53870  B =  13672.63529  C =  13352.21595 [MHz]
+  Nuclear repulsion =    9.143950701435717
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.143950701435717
+  Additional nuclear repulsion =    0.279020850162104
+  Total nuclear repulsion      =    9.422971551597822
+
+  Minimum eigenvalue in the overlap matrix is 2.2480125076E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.89051784776855   -7.58905e+01   8.70900e-02 
+   @DF-RHF iter   1:   -75.99630949095354   -1.05792e-01   1.25487e-02 
+   @DF-RHF iter   2:   -76.01452943198228   -1.82199e-02   6.05967e-03 DIIS
+   @DF-RHF iter   3:   -76.01918150776645   -4.65208e-03   9.48893e-04 DIIS
+   @DF-RHF iter   4:   -76.01937342343476   -1.91916e-04   2.07901e-04 DIIS
+   @DF-RHF iter   5:   -76.01939223387620   -1.88104e-05   5.14340e-05 DIIS
+   @DF-RHF iter   6:   -76.01939364493286   -1.41106e-06   7.60690e-06 DIIS
+   @DF-RHF iter   7:   -76.01939367403114   -2.90983e-08   1.49542e-06 DIIS
+   @DF-RHF iter   8:   -76.01939367524528   -1.21415e-09   2.87946e-07 DIIS
+   @DF-RHF iter   9:   -76.01939367529020   -4.49205e-11   5.36020e-08 DIIS
+   @DF-RHF iter  10:   -76.01939367529174   -1.53477e-12   9.79385e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586753     2A     -1.364066     3A     -0.730051  
+       4A     -0.598237     5A     -0.524226  
+
+    Virtual:                                                              
+
+       6A      0.191782     7A      0.285452     8A      0.998152  
+       9A      1.098534    10A      1.135736    11A      1.142834  
+      12A      1.353999    13A      1.409375    14A      1.994909  
+      15A      2.007990    16A      2.040877    17A      2.590613  
+      18A      2.912461    19A      3.941461  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01939367529174
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4229715515978221
+    One-Electron Energy =                -123.2780649764068528
+    Two-Electron Energy =                  37.8356997495172820
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0193936752917523
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5625
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4532      Y:    -0.0000      Z:   -22.6595
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:    -0.0000      Z:     0.9030     Total:     0.9170
+
+  Dipole Moment: (Debye)
+     X:     0.4061      Y:    -0.0000      Z:     2.2952     Total:     2.3308
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0193936752917381 [Eh]
+	 Singles Energy            =      -0.0000000000000120 [Eh]
+	 Same-Spin Energy          =      -0.0484847552285264 [Eh]
+	 Opposite-Spin Energy      =      -0.1402363067651580 [Eh]
+	 Correlation Energy        =      -0.1887210619936964 [Eh]
+	 Total Energy              =     -76.2081147372854275 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161615850761755 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682835681181896 [Eh]
+	 SCS Correlation Energy    =      -0.1844451531943770 [Eh]
+	 SCS Total Energy          =     -76.2038388284861128 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:22 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.95 seconds =       0.05 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:22 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.133344576656    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.50399  B =      0.45548  C =      0.44480 [cm^-1]
+  Rotational constants: A = 344880.84907  B =  13654.92381  C =  13334.87500 [MHz]
+  Nuclear repulsion =    9.151168766395070
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.151168766395070
+  Additional nuclear repulsion =    0.278816086187886
+  Total nuclear repulsion      =    9.429984852582956
+
+  Minimum eigenvalue in the overlap matrix is 2.2451969903E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.00921678444739   -7.60092e+01   8.83604e-02 
+   @DF-RHF iter   1:   -75.98038907391150    2.88277e-02   1.52923e-02 
+   @DF-RHF iter   2:   -76.01111547828953   -3.07264e-02   7.81012e-03 DIIS
+   @DF-RHF iter   3:   -76.01882017272331   -7.70469e-03   1.31700e-03 DIIS
+   @DF-RHF iter   4:   -76.01936791455364   -5.47742e-04   3.63274e-04 DIIS
+   @DF-RHF iter   5:   -76.01942496483981   -5.70503e-05   7.48197e-05 DIIS
+   @DF-RHF iter   6:   -76.01942795238831   -2.98755e-06   1.08062e-05 DIIS
+   @DF-RHF iter   7:   -76.01942801719753   -6.48092e-08   2.28355e-06 DIIS
+   @DF-RHF iter   8:   -76.01942802027956   -3.08204e-09   4.90557e-07 DIIS
+   @DF-RHF iter   9:   -76.01942802042259   -1.43032e-10   1.07758e-07 DIIS
+   @DF-RHF iter  10:   -76.01942802042937   -6.77858e-12   3.07838e-08 DIIS
+   @DF-RHF iter  11:   -76.01942802042988   -5.11591e-13   3.20854e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586524     2A     -1.364353     3A     -0.730697  
+       4A     -0.598116     5A     -0.524219  
+
+    Virtual:                                                              
+
+       6A      0.191980     7A      0.285694     8A      0.999063  
+       9A      1.098649    10A      1.136002    11A      1.142988  
+      12A      1.354379    13A      1.408992    14A      1.995086  
+      15A      2.007715    16A      2.040902    17A      2.591726  
+      18A      2.913974    19A      3.942117  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01942802042988
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4299848525829564
+    One-Electron Energy =                -123.2910098800118845
+    Two-Electron Energy =                  37.8415970069990379
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194280204298849
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5825
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4534      Y:    -0.0000      Z:   -22.6808
+
+  Dipole Moment: (a.u.)
+     X:     0.1599      Y:    -0.0000      Z:     0.9017     Total:     0.9158
+
+  Dipole Moment: (Debye)
+     X:     0.4065      Y:    -0.0000      Z:     2.2918     Total:     2.3276
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194280204298849 [Eh]
+	 Singles Energy            =      -0.0000000000000004 [Eh]
+	 Same-Spin Energy          =      -0.0484711686291954 [Eh]
+	 Opposite-Spin Energy      =      -0.1401805873509016 [Eh]
+	 Correlation Energy        =      -0.1886517559800974 [Eh]
+	 Total Energy              =     -76.2080797764099884 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161570562097318 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682167048210819 [Eh]
+	 SCS Correlation Energy    =      -0.1843737610308141 [Eh]
+	 SCS Total Energy          =     -76.2038017814606974 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:23 2017
+Module time:
+	user time   =       0.60 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.56 seconds =       0.06 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:23 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.669317594332     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.51107  B =      0.45573  C =      0.44503 [cm^-1]
+  Rotational constants: A = 345093.30199  B =  13662.46676  C =  13341.74834 [MHz]
+  Nuclear repulsion =    9.148948399506164
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.148948399506164
+  Additional nuclear repulsion =    0.278913425878046
+  Total nuclear repulsion      =    9.427861825384209
+
+  Minimum eigenvalue in the overlap matrix is 2.2460654294E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95954789648906   -7.59595e+01   8.78124e-02 
+   @DF-RHF iter   1:   -75.98697106661905   -2.74232e-02   1.41220e-02 
+   @DF-RHF iter   2:   -76.01246242262869   -2.54914e-02   7.00537e-03 DIIS
+   @DF-RHF iter   3:   -76.01882757782870   -6.36516e-03   1.27114e-03 DIIS
+   @DF-RHF iter   4:   -76.01933471165358   -5.07134e-04   3.81434e-04 DIIS
+   @DF-RHF iter   5:   -76.01941446515477   -7.97535e-05   9.74079e-05 DIIS
+   @DF-RHF iter   6:   -76.01942074419014   -6.27904e-06   1.29533e-05 DIIS
+   @DF-RHF iter   7:   -76.01942083861297   -9.44228e-08   2.37890e-06 DIIS
+   @DF-RHF iter   8:   -76.01942084167636   -3.06339e-09   4.66824e-07 DIIS
+   @DF-RHF iter   9:   -76.01942084177155   -9.51843e-11   8.35901e-08 DIIS
+   @DF-RHF iter  10:   -76.01942084177422   -2.67164e-12   2.17312e-08 DIIS
+   @DF-RHF iter  11:   -76.01942084177446   -2.41585e-13   3.99463e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586595     2A     -1.364264     3A     -0.730500  
+       4A     -0.598164     5A     -0.524217  
+
+    Virtual:                                                              
+
+       6A      0.191918     7A      0.285618     8A      0.998779  
+       9A      1.098594    10A      1.135932    11A      1.142935  
+      12A      1.354257    13A      1.409115    14A      1.995020  
+      15A      2.007802    16A      2.040891    17A      2.591384  
+      18A      2.913504    19A      3.941913  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01942084177446
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4278618253842090
+    One-Electron Energy =                -123.2870860580356265
+    Two-Electron Energy =                  37.8398033908769662
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194208417744477
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2985      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4563      Y:     0.0001      Z:   -22.6700
+
+  Dipole Moment: (a.u.)
+     X:     0.1579      Y:     0.0001      Z:     0.9025     Total:     0.9162
+
+  Dipole Moment: (Debye)
+     X:     0.4012      Y:     0.0002      Z:     2.2939     Total:     2.3287
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194208417744619 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484752874928170 [Eh]
+	 Opposite-Spin Energy      =      -0.1401974836918598 [Eh]
+	 Correlation Energy        =      -0.1886727711846778 [Eh]
+	 Total Energy              =     -76.2080936129591464 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161584291642723 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682369804302317 [Eh]
+	 SCS Correlation Energy    =      -0.1843954095945050 [Eh]
+	 SCS Total Energy          =     -76.2038162513689628 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:23 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.14 seconds =       0.07 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 8 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:23 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.664046405668     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.48684  B =      0.45582  C =      0.44515 [cm^-1]
+  Rotational constants: A = 344366.79742  B =  13665.08355  C =  13345.33238 [MHz]
+  Nuclear repulsion =    9.146138076314957
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.146138076314957
+  Additional nuclear repulsion =    0.278923432828582
+  Total nuclear repulsion      =    9.425061509143539
+
+  Minimum eigenvalue in the overlap matrix is 2.2471546104E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95819102956146   -7.59582e+01   8.77569e-02 
+   @DF-RHF iter   1:   -75.98705586172288   -2.88648e-02   1.41016e-02 
+   @DF-RHF iter   2:   -76.01245930729858   -2.54034e-02   6.99641e-03 DIIS
+   @DF-RHF iter   3:   -76.01880929033270   -6.34998e-03   1.26907e-03 DIIS
+   @DF-RHF iter   4:   -76.01931493786394   -5.05648e-04   3.81302e-04 DIIS
+   @DF-RHF iter   5:   -76.01939478693730   -7.98491e-05   9.74978e-05 DIIS
+   @DF-RHF iter   6:   -76.01940108479668   -6.29786e-06   1.29084e-05 DIIS
+   @DF-RHF iter   7:   -76.01940117850802   -9.37113e-08   2.37088e-06 DIIS
+   @DF-RHF iter   8:   -76.01940118155132   -3.04330e-09   4.66620e-07 DIIS
+   @DF-RHF iter   9:   -76.01940118164663   -9.53122e-11   8.35412e-08 DIIS
+   @DF-RHF iter  10:   -76.01940118164939   -2.75691e-12   2.16823e-08 DIIS
+   @DF-RHF iter  11:   -76.01940118164967   -2.84217e-13   3.98928e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586683     2A     -1.364152     3A     -0.730246  
+       4A     -0.598189     5A     -0.524228  
+
+    Virtual:                                                              
+
+       6A      0.191843     7A      0.285527     8A      0.998433  
+       9A      1.098590    10A      1.135806    11A      1.142885  
+      12A      1.354119    13A      1.409251    14A      1.994975  
+      15A      2.007904    16A      2.040888    17A      2.590950  
+      18A      2.912928    19A      3.941663  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01940118164967
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4250615091435392
+    One-Electron Energy =                -123.2819307408638139
+    Two-Electron Energy =                  37.8374680500706262
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194011816496555
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2885      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4503      Y:    -0.0001      Z:   -22.6703
+
+  Dipole Moment: (a.u.)
+     X:     0.1618      Y:    -0.0001      Z:     0.9022     Total:     0.9166
+
+  Dipole Moment: (Debye)
+     X:     0.4113      Y:    -0.0002      Z:     2.2931     Total:     2.3297
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194011816496698 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484806842811768 [Eh]
+	 Opposite-Spin Energy      =      -0.1402196117231952 [Eh]
+	 Correlation Energy        =      -0.1887002960043729 [Eh]
+	 Total Energy              =     -76.2081014776540400 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161602280937256 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682635340678342 [Eh]
+	 SCS Correlation Energy    =      -0.1844237621615608 [Eh]
+	 SCS Total Energy          =     -76.2038249438112274 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:24 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.72 seconds =       0.08 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 9 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:24 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.761463405668     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.53086  B =      0.45577  C =      0.44514 [cm^-1]
+  Rotational constants: A = 345686.42696  B =  13663.77651  C =  13344.96957 [MHz]
+  Nuclear repulsion =    9.157748787276153
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.157748787276153
+  Additional nuclear repulsion =    0.278929203380242
+  Total nuclear repulsion      =    9.436677990656396
+
+  Minimum eigenvalue in the overlap matrix is 2.2426354522E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94244316831667   -7.59424e+01   8.78502e-02 
+   @DF-RHF iter   1:   -75.99029349493028   -4.78503e-02   1.36207e-02 
+   @DF-RHF iter   2:   -76.01315291782421   -2.28594e-02   6.73701e-03 DIIS
+   @DF-RHF iter   3:   -76.01899157195324   -5.83865e-03   1.15838e-03 DIIS
+   @DF-RHF iter   4:   -76.01939591408582   -4.04342e-04   3.41462e-04 DIIS
+   @DF-RHF iter   5:   -76.01946092720267   -6.50131e-05   9.21775e-05 DIIS
+   @DF-RHF iter   6:   -76.01946684305970   -5.91586e-06   1.10945e-05 DIIS
+   @DF-RHF iter   7:   -76.01946691612338   -7.30637e-08   1.63933e-06 DIIS
+   @DF-RHF iter   8:   -76.01946691751721   -1.39383e-09   3.37952e-07 DIIS
+   @DF-RHF iter   9:   -76.01946691757063   -5.34186e-11   6.31033e-08 DIIS
+   @DF-RHF iter  10:   -76.01946691757242   -1.79057e-12   1.69665e-08 DIIS
+   @DF-RHF iter  11:   -76.01946691757249   -7.10543e-14   2.88229e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586504     2A     -1.364834     3A     -0.730784  
+       4A     -0.598578     5A     -0.524345  
+
+    Virtual:                                                              
+
+       6A      0.192100     7A      0.285849     8A      0.998599  
+       9A      1.098856    10A      1.136835    11A      1.143381  
+      12A      1.354443    13A      1.409599    14A      1.994446  
+      15A      2.007664    16A      2.040585    17A      2.592361  
+      18A      2.914967    19A      3.942152  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01946691757249
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4366779906563956
+    One-Electron Energy =                -123.3022018313788237
+    Two-Electron Energy =                  37.8460569231499591
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194669175724727
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:    -0.0050      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4534      Y:     0.0036      Z:   -22.6699
+
+  Dipole Moment: (a.u.)
+     X:     0.1599      Y:    -0.0014      Z:     0.9026     Total:     0.9166
+
+  Dipole Moment: (Debye)
+     X:     0.4064      Y:    -0.0036      Z:     2.2941     Total:     2.3299
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194669175724869 [Eh]
+	 Singles Energy            =      -0.0000000000000003 [Eh]
+	 Same-Spin Energy          =      -0.0484615042210986 [Eh]
+	 Opposite-Spin Energy      =      -0.1401433648799414 [Eh]
+	 Correlation Energy        =      -0.1886048691010403 [Eh]
+	 Total Energy              =     -76.2080717866735284 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161538347403662 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1681720378559297 [Eh]
+	 SCS Correlation Energy    =      -0.1843258725962962 [Eh]
+	 SCS Total Energy          =     -76.2037927901687766 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:24 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.31 seconds =       0.09 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 10 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:24 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.766734594332     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.46718  B =      0.45577  C =      0.44504 [cm^-1]
+  Rotational constants: A = 343777.38385  B =  13663.77651  C =  13342.10936 [MHz]
+  Nuclear repulsion =    9.137401948296720
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.137401948296720
+  Additional nuclear repulsion =    0.278907655890854
+  Total nuclear repulsion      =    9.416309604187575
+
+  Minimum eigenvalue in the overlap matrix is 2.2505613478E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95661630235259   -7.59566e+01   8.75804e-02 
+   @DF-RHF iter   1:   -75.98692545670184   -3.03092e-02   1.41068e-02 
+   @DF-RHF iter   2:   -76.01237632746881   -2.54509e-02   7.00734e-03 DIIS
+   @DF-RHF iter   3:   -76.01874859371790   -6.37227e-03   1.27190e-03 DIIS
+   @DF-RHF iter   4:   -76.01925860724286   -5.10014e-04   3.83168e-04 DIIS
+   @DF-RHF iter   5:   -76.01933941104602   -8.08038e-05   9.80085e-05 DIIS
+   @DF-RHF iter   6:   -76.01934578880712   -6.37776e-06   1.30610e-05 DIIS
+   @DF-RHF iter   7:   -76.01934588505353   -9.62464e-08   2.41025e-06 DIIS
+   @DF-RHF iter   8:   -76.01934588820284   -3.14931e-09   4.72742e-07 DIIS
+   @DF-RHF iter   9:   -76.01934588830021   -9.73728e-11   8.46388e-08 DIIS
+   @DF-RHF iter  10:   -76.01934588830296   -2.75691e-12   2.18494e-08 DIIS
+   @DF-RHF iter  11:   -76.01934588830323   -2.70006e-13   4.01083e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586772     2A     -1.363588     3A     -0.729964  
+       4A     -0.597775     5A     -0.524101  
+
+    Virtual:                                                              
+
+       6A      0.191658     7A      0.285297     8A      0.998602  
+       9A      1.098299    10A      1.134809    11A      1.142584  
+      12A      1.353943    13A      1.408768    14A      1.995547  
+      15A      2.008041    16A      2.041193    17A      2.589966  
+      18A      2.911483    19A      3.941426  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01934588830323
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4163096041875747
+    One-Electron Energy =                -123.2669112521553245
+    Two-Electron Energy =                  37.8312557596645149
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0193458883032349
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0050      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:    -0.0036      Z:   -22.6704
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:     0.0014      Z:     0.9021     Total:     0.9161
+
+  Dipole Moment: (Debye)
+     X:     0.4062      Y:     0.0036      Z:     2.2929     Total:     2.3286
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0193458883032349 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484943847793520 [Eh]
+	 Opposite-Spin Energy      =      -0.1402735791524003 [Eh]
+	 Correlation Energy        =      -0.1887679639317533 [Eh]
+	 Total Energy              =     -76.2081138522349875 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161647949264507 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1683282949828803 [Eh]
+	 SCS Correlation Energy    =      -0.1844930899093320 [Eh]
+	 SCS Total Energy          =     -76.2038389782125734 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:25 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.89 seconds =       0.10 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 11 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:25 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.703655405668     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.50659  B =      0.45589  C =      0.44519 [cm^-1]
+  Rotational constants: A = 344958.81832  B =  13667.12375  C =  13346.39189 [MHz]
+  Nuclear repulsion =    9.154748995344473
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.154748995344473
+  Additional nuclear repulsion =    0.278948720081833
+  Total nuclear repulsion      =    9.433697715426305
+
+  Minimum eigenvalue in the overlap matrix is 2.2438005040E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.96017563313364   -7.59602e+01   8.79082e-02 
+   @DF-RHF iter   1:   -75.98711778598121   -2.69422e-02   1.41096e-02 
+   @DF-RHF iter   2:   -76.01252614701875   -2.54084e-02   6.99224e-03 DIIS
+   @DF-RHF iter   3:   -76.01886542664109   -6.33928e-03   1.26746e-03 DIIS
+   @DF-RHF iter   4:   -76.01936794563258   -5.02519e-04   3.79342e-04 DIIS
+   @DF-RHF iter   5:   -76.01944671221388   -7.87666e-05   9.69314e-05 DIIS
+   @DF-RHF iter   6:   -76.01945292189991   -6.20969e-06   1.28116e-05 DIIS
+   @DF-RHF iter   7:   -76.01945301406890   -9.21690e-08   2.34076e-06 DIIS
+   @DF-RHF iter   8:   -76.01945301703296   -2.96406e-09   4.62167e-07 DIIS
+   @DF-RHF iter   9:   -76.01945301712672   -9.37632e-11   8.28663e-08 DIIS
+   @DF-RHF iter  10:   -76.01945301712941   -2.68585e-12   2.15921e-08 DIIS
+   @DF-RHF iter  11:   -76.01945301712961   -1.98952e-13   3.97611e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586432     2A     -1.364517     3A     -0.731039  
+       4A     -0.598079     5A     -0.524239  
+
+    Virtual:                                                              
+
+       6A      0.192064     7A      0.285800     8A      0.999495  
+       9A      1.098678    10A      1.136104    11A      1.143049  
+      12A      1.354549    13A      1.408785    14A      1.995152  
+      15A      2.007555    16A      2.040889    17A      2.592253  
+      18A      2.914705    19A      3.942419  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01945301712961
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4336977154263053
+    One-Electron Energy =                -123.2976912792497473
+    Two-Electron Energy =                  37.8445405466938354
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194530171296066
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5675
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4535      Y:     0.0004      Z:   -22.6665
+
+  Dipole Moment: (a.u.)
+     X:     0.1600      Y:     0.0004      Z:     0.9011     Total:     0.9152
+
+  Dipole Moment: (Debye)
+     X:     0.4066      Y:     0.0010      Z:     2.2903     Total:     2.3261
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194530171296066 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484644834717365 [Eh]
+	 Opposite-Spin Energy      =      -0.1401529626559039 [Eh]
+	 Correlation Energy        =      -0.1886174461276413 [Eh]
+	 Total Energy              =     -76.2080704632572434 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161548278239122 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1681835551870846 [Eh]
+	 SCS Correlation Energy    =      -0.1843383830109977 [Eh]
+	 SCS Total Energy          =     -76.2037914001406023 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:26 2017
+Module time:
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.47 seconds =       0.11 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 12 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:26 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.708926594332     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49136  B =      0.45566  C =      0.44500 [cm^-1]
+  Rotational constants: A = 344502.24779  B =  13660.42643  C =  13340.68887 [MHz]
+  Nuclear repulsion =    9.140371364959286
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.140371364959286
+  Additional nuclear repulsion =    0.278888222619063
+  Total nuclear repulsion      =    9.419259587578349
+
+  Minimum eigenvalue in the overlap matrix is 2.2494087027E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.93904645278405   -7.59390e+01   8.75240e-02 
+   @DF-RHF iter   1:   -75.99015060799502   -5.11042e-02   1.36138e-02 
+   @DF-RHF iter   2:   -76.01302061780022   -2.28700e-02   6.74717e-03 DIIS
+   @DF-RHF iter   3:   -76.01888164466351   -5.86103e-03   1.16175e-03 DIIS
+   @DF-RHF iter   4:   -76.01929111006406   -4.09465e-04   3.44649e-04 DIIS
+   @DF-RHF iter   5:   -76.01935770341589   -6.65934e-05   9.31337e-05 DIIS
+   @DF-RHF iter   6:   -76.01936376517125   -6.06176e-06   1.12214e-05 DIIS
+   @DF-RHF iter   7:   -76.01936383996033   -7.47891e-08   1.67730e-06 DIIS
+   @DF-RHF iter   8:   -76.01936384141734   -1.45701e-09   3.45034e-07 DIIS
+   @DF-RHF iter   9:   -76.01936384147210   -5.47544e-11   6.33328e-08 DIIS
+   @DF-RHF iter  10:   -76.01936384147382   -1.71951e-12   1.64926e-08 DIIS
+   @DF-RHF iter  11:   -76.01936384147399   -1.70530e-13   2.67838e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586845     2A     -1.363902     3A     -0.729710  
+       4A     -0.598272     5A     -0.524206  
+
+    Virtual:                                                              
+
+       6A      0.191696     7A      0.285345     8A      0.997718  
+       9A      1.098503    10A      1.135630    11A      1.142779  
+      12A      1.353832    13A      1.409585    14A      1.994846  
+      15A      2.008149    16A      2.040891    17A      2.590080  
+      18A      2.911733    19A      3.941159  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01936384147399
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4192595875783489
+    One-Electron Energy =                -123.2713767836180807
+    Two-Electron Energy =                  37.8327533545657246
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0193638414740036
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5775
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4532      Y:    -0.0004      Z:   -22.6739
+
+  Dipole Moment: (a.u.)
+     X:     0.1597      Y:    -0.0004      Z:     0.9036     Total:     0.9176
+
+  Dipole Moment: (Debye)
+     X:     0.4059      Y:    -0.0011      Z:     2.2967     Total:     2.3323
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0193638414739894 [Eh]
+	 Singles Energy            =      -0.0000000000000002 [Eh]
+	 Same-Spin Energy          =      -0.0484914692043416 [Eh]
+	 Opposite-Spin Energy      =      -0.1402640998140232 [Eh]
+	 Correlation Energy        =      -0.1887555690183651 [Eh]
+	 Total Energy              =     -76.2081194104923583 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161638230681139 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1683169197768279 [Eh]
+	 SCS Correlation Energy    =      -0.1844807428449420 [Eh]
+	 SCS Total Energy          =     -76.2038445843189294 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:26 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.06 seconds =       0.12 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 13 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:26 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.669317594332    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.51107  B =      0.45573  C =      0.44503 [cm^-1]
+  Rotational constants: A = 345093.30141  B =  13662.46677  C =  13341.74834 [MHz]
+  Nuclear repulsion =    9.148948402090360
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.148948402090360
+  Additional nuclear repulsion =    0.278913425866462
+  Total nuclear repulsion      =    9.427861827956821
+
+  Minimum eigenvalue in the overlap matrix is 2.2460654274E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95910344623125   -7.59591e+01   8.78084e-02 
+   @DF-RHF iter   1:   -75.98702438344871   -2.79209e-02   1.41127e-02 
+   @DF-RHF iter   2:   -76.01247199099809   -2.54476e-02   7.00079e-03 DIIS
+   @DF-RHF iter   3:   -76.01882873087298   -6.35674e-03   1.26965e-03 DIIS
+   @DF-RHF iter   4:   -76.01933476171624   -5.06031e-04   3.81141e-04 DIIS
+   @DF-RHF iter   5:   -76.01941445775435   -7.96960e-05   9.74214e-05 DIIS
+   @DF-RHF iter   6:   -76.01942074402007   -6.28627e-06   1.29367e-05 DIIS
+   @DF-RHF iter   7:   -76.01942083825065   -9.42306e-08   2.37457e-06 DIIS
+   @DF-RHF iter   8:   -76.01942084130324   -3.05259e-09   4.66716e-07 DIIS
+   @DF-RHF iter   9:   -76.01942084139837   -9.51275e-11   8.34751e-08 DIIS
+   @DF-RHF iter  10:   -76.01942084140111   -2.74269e-12   2.16482e-08 DIIS
+   @DF-RHF iter  11:   -76.01942084140138   -2.70006e-13   3.97914e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586595     2A     -1.364264     3A     -0.730500  
+       4A     -0.598164     5A     -0.524217  
+
+    Virtual:                                                              
+
+       6A      0.191918     7A      0.285618     8A      0.998779  
+       9A      1.098594    10A      1.135932    11A      1.142935  
+      12A      1.354257    13A      1.409115    14A      1.995020  
+      15A      2.007802    16A      2.040891    17A      2.591384  
+      18A      2.913504    19A      3.941913  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01942084140138
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4278618279568214
+    One-Electron Energy =                -123.2870860616706494
+    Two-Electron Energy =                  37.8398033923124473
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194208414013843
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2985      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4563      Y:    -0.0001      Z:   -22.6700
+
+  Dipole Moment: (a.u.)
+     X:     0.1579      Y:    -0.0001      Z:     0.9025     Total:     0.9162
+
+  Dipole Moment: (Debye)
+     X:     0.4012      Y:    -0.0002      Z:     2.2939     Total:     2.3287
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194208414013843 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484752874885345 [Eh]
+	 Opposite-Spin Energy      =      -0.1401974836842314 [Eh]
+	 Correlation Energy        =      -0.1886727711727669 [Eh]
+	 Total Energy              =     -76.2080936125741459 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161584291628448 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682369804210777 [Eh]
+	 SCS Correlation Energy    =      -0.1843954095839235 [Eh]
+	 SCS Total Energy          =     -76.2038162509853123 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:27 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       7.65 seconds =       0.13 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 14 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:27 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.664046405668    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.48684  B =      0.45582  C =      0.44515 [cm^-1]
+  Rotational constants: A = 344366.79800  B =  13665.08355  C =  13345.33238 [MHz]
+  Nuclear repulsion =    9.146138073673514
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.146138073673514
+  Additional nuclear repulsion =    0.278923432840151
+  Total nuclear repulsion      =    9.425061506513666
+
+  Minimum eigenvalue in the overlap matrix is 2.2471546124E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95863640728388   -7.59586e+01   8.77609e-02 
+   @DF-RHF iter   1:   -75.98700262107802   -2.83662e-02   1.41108e-02 
+   @DF-RHF iter   2:   -76.01244974221254   -2.54471e-02   7.00099e-03 DIIS
+   @DF-RHF iter   3:   -76.01880813575225   -6.35839e-03   1.27056e-03 DIIS
+   @DF-RHF iter   4:   -76.01931488760954   -5.06752e-04   3.81595e-04 DIIS
+   @DF-RHF iter   5:   -76.01939479449108   -7.99069e-05   9.74838e-05 DIIS
+   @DF-RHF iter   6:   -76.01940108499642   -6.29051e-06   1.29244e-05 DIIS
+   @DF-RHF iter   7:   -76.01940117888921   -9.38928e-08   2.37503e-06 DIIS
+   @DF-RHF iter   8:   -76.01940118194291   -3.05370e-09   4.66705e-07 DIIS
+   @DF-RHF iter   9:   -76.01940118203824   -9.53264e-11   8.36522e-08 DIIS
+   @DF-RHF iter  10:   -76.01940118204101   -2.77112e-12   2.17647e-08 DIIS
+   @DF-RHF iter  11:   -76.01940118204115   -1.42109e-13   4.00460e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586683     2A     -1.364152     3A     -0.730246  
+       4A     -0.598189     5A     -0.524228  
+
+    Virtual:                                                              
+
+       6A      0.191843     7A      0.285527     8A      0.998433  
+       9A      1.098590    10A      1.135806    11A      1.142885  
+      12A      1.354119    13A      1.409251    14A      1.994975  
+      15A      2.007904    16A      2.040888    17A      2.590950  
+      18A      2.912928    19A      3.941663  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01940118204115
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4250615065136660
+    One-Electron Energy =                -123.2819307371543402
+    Two-Electron Energy =                  37.8374680485995114
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194011820411504
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2885      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4503      Y:     0.0001      Z:   -22.6703
+
+  Dipole Moment: (a.u.)
+     X:     0.1618      Y:     0.0001      Z:     0.9022     Total:     0.9166
+
+  Dipole Moment: (Debye)
+     X:     0.4113      Y:     0.0002      Z:     2.2931     Total:     2.3297
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194011820411504 [Eh]
+	 Singles Energy            =      -0.0000000000000010 [Eh]
+	 Same-Spin Energy          =      -0.0484806842855585 [Eh]
+	 Opposite-Spin Energy      =      -0.1402196117309946 [Eh]
+	 Correlation Energy        =      -0.1887002960165541 [Eh]
+	 Total Energy              =     -76.2081014780576993 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161602280951862 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682635340771935 [Eh]
+	 SCS Correlation Energy    =      -0.1844237621723807 [Eh]
+	 SCS Total Energy          =     -76.2038249442135367 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:28 2017
+Module time:
+	user time   =       0.59 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.24 seconds =       0.14 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 15 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:28 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.766734594332     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.46718  B =      0.45577  C =      0.44504 [cm^-1]
+  Rotational constants: A = 343777.38377  B =  13663.77651  C =  13342.10936 [MHz]
+  Nuclear repulsion =    9.137401930556162
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.137401930556162
+  Additional nuclear repulsion =    0.278907655879405
+  Total nuclear repulsion      =    9.416309586435567
+
+  Minimum eigenvalue in the overlap matrix is 2.2505613616E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.93822991185827   -7.59382e+01   8.74454e-02 
+   @DF-RHF iter   1:   -75.99020305132014   -5.19731e-02   1.36039e-02 
+   @DF-RHF iter   2:   -76.01301747796714   -2.28144e-02   6.74087e-03 DIIS
+   @DF-RHF iter   3:   -76.01886680816642   -5.84933e-03   1.15987e-03 DIIS
+   @DF-RHF iter   4:   -76.01927385735348   -4.07049e-04   3.43236e-04 DIIS
+   @DF-RHF iter   5:   -76.01933980749638   -6.59501e-05   9.27497e-05 DIIS
+   @DF-RHF iter   6:   -76.01934581523233   -6.00774e-06   1.11549e-05 DIIS
+   @DF-RHF iter   7:   -76.01934588923231   -7.40000e-08   1.65769e-06 DIIS
+   @DF-RHF iter   8:   -76.01934589066165   -1.42934e-09   3.42987e-07 DIIS
+   @DF-RHF iter   9:   -76.01934589071683   -5.51807e-11   6.43707e-08 DIIS
+   @DF-RHF iter  10:   -76.01934589071871   -1.87583e-12   1.72765e-08 DIIS
+   @DF-RHF iter  11:   -76.01934589071887   -1.56319e-13   2.94833e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586772     2A     -1.363588     3A     -0.729964  
+       4A     -0.597775     5A     -0.524101  
+
+    Virtual:                                                              
+
+       6A      0.191658     7A      0.285297     8A      0.998602  
+       9A      1.098299    10A      1.134809    11A      1.142584  
+      12A      1.353943    13A      1.408768    14A      1.995547  
+      15A      2.008041    16A      2.041193    17A      2.589966  
+      18A      2.911483    19A      3.941426  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01934589071887
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4163095864355668
+    One-Electron Energy =                -123.2669112057023710
+    Two-Electron Energy =                  37.8312557285479443
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0193458907188528
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:    -0.0050      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:     0.0036      Z:   -22.6704
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:    -0.0014      Z:     0.9021     Total:     0.9161
+
+  Dipole Moment: (Debye)
+     X:     0.4062      Y:    -0.0036      Z:     2.2929     Total:     2.3286
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0193458907188671 [Eh]
+	 Singles Energy            =      -0.0000000000000003 [Eh]
+	 Same-Spin Energy          =      -0.0484943848027517 [Eh]
+	 Opposite-Spin Energy      =      -0.1402735791932329 [Eh]
+	 Correlation Energy        =      -0.1887679639959849 [Eh]
+	 Total Energy              =     -76.2081138547148527 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161647949342506 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1683282950318794 [Eh]
+	 SCS Correlation Energy    =      -0.1844930899661303 [Eh]
+	 SCS Total Energy          =     -76.2038389806849921 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:28 2017
+Module time:
+	user time   =       0.59 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.84 seconds =       0.15 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 16 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:28 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.761463405668     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.53086  B =      0.45577  C =      0.44514 [cm^-1]
+  Rotational constants: A = 345686.42704  B =  13663.77651  C =  13344.96957 [MHz]
+  Nuclear repulsion =    9.157748805149035
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.157748805149035
+  Additional nuclear repulsion =    0.278929203391667
+  Total nuclear repulsion      =    9.436678008540703
+
+  Minimum eigenvalue in the overlap matrix is 2.2426354384E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.96079968618585   -7.59608e+01   8.79846e-02 
+   @DF-RHF iter   1:   -75.98702926558629   -2.62296e-02   1.41218e-02 
+   @DF-RHF iter   2:   -76.01251697846122   -2.54877e-02   7.00149e-03 DIIS
+   @DF-RHF iter   3:   -76.01887432045405   -6.35734e-03   1.27003e-03 DIIS
+   @DF-RHF iter   4:   -76.01938083027719   -5.06510e-04   3.81229e-04 DIIS
+   @DF-RHF iter   5:   -76.01946053334052   -7.97031e-05   9.74282e-05 DIIS
+   @DF-RHF iter   6:   -76.01946681742501   -6.28408e-06   1.29572e-05 DIIS
+   @DF-RHF iter   7:   -76.01946691193078   -9.45058e-08   2.38162e-06 DIIS
+   @DF-RHF iter   8:   -76.01946691499967   -3.06889e-09   4.66989e-07 DIIS
+   @DF-RHF iter   9:   -76.01946691509465   -9.49854e-11   8.30482e-08 DIIS
+   @DF-RHF iter  10:   -76.01946691509744   -2.78533e-12   2.14155e-08 DIIS
+   @DF-RHF iter  11:   -76.01946691509765   -2.13163e-13   3.91975e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586504     2A     -1.364834     3A     -0.730784  
+       4A     -0.598578     5A     -0.524345  
+
+    Virtual:                                                              
+
+       6A      0.192100     7A      0.285849     8A      0.998599  
+       9A      1.098856    10A      1.136835    11A      1.143381  
+      12A      1.354443    13A      1.409599    14A      1.994446  
+      15A      2.007664    16A      2.040585    17A      2.592361  
+      18A      2.914967    19A      3.942152  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01946691509765
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4366780085407029
+    One-Electron Energy =                -123.3022018773901465
+    Two-Electron Energy =                  37.8460569537517983
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194669150976381
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0050      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4534      Y:    -0.0036      Z:   -22.6699
+
+  Dipole Moment: (a.u.)
+     X:     0.1599      Y:     0.0014      Z:     0.9026     Total:     0.9166
+
+  Dipole Moment: (Debye)
+     X:     0.4064      Y:     0.0036      Z:     2.2941     Total:     2.3299
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194669150976523 [Eh]
+	 Singles Energy            =      -0.0000000000000009 [Eh]
+	 Same-Spin Energy          =      -0.0484615041984480 [Eh]
+	 Opposite-Spin Energy      =      -0.1401433648405082 [Eh]
+	 Correlation Energy        =      -0.1886048690389571 [Eh]
+	 Total Energy              =     -76.2080717841366067 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161538347328160 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1681720378086098 [Eh]
+	 SCS Correlation Energy    =      -0.1843258725414267 [Eh]
+	 SCS Total Energy          =     -76.2037927876390739 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:29 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       9.43 seconds =       0.16 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 17 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:29 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.703654405668     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.50659  B =      0.45589  C =      0.44519 [cm^-1]
+  Rotational constants: A = 344958.81799  B =  13667.12375  C =  13346.39189 [MHz]
+  Nuclear repulsion =    9.154748995359864
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.154748995359864
+  Additional nuclear repulsion =    0.278948720103028
+  Total nuclear repulsion      =    9.433697715462891
+
+  Minimum eigenvalue in the overlap matrix is 2.2438004988E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94141287209833   -7.59414e+01   8.77657e-02 
+   @DF-RHF iter   1:   -75.99027134633353   -4.88585e-02   1.36184e-02 
+   @DF-RHF iter   2:   -76.01313171195085   -2.28604e-02   6.73883e-03 DIIS
+   @DF-RHF iter   3:   -76.01897517619690   -5.84346e-03   1.15924e-03 DIIS
+   @DF-RHF iter   4:   -76.01938151396983   -4.06338e-04   3.42341e-04 DIIS
+   @DF-RHF iter   5:   -76.01944697732451   -6.54634e-05   9.24882e-05 DIIS
+   @DF-RHF iter   6:   -76.01945293962831   -5.96230e-06   1.11722e-05 DIIS
+   @DF-RHF iter   7:   -76.01945301371576   -7.40875e-08   1.66157e-06 DIIS
+   @DF-RHF iter   8:   -76.01945301514367   -1.42791e-09   3.41293e-07 DIIS
+   @DF-RHF iter   9:   -76.01945301519730   -5.36318e-11   6.27655e-08 DIIS
+   @DF-RHF iter  10:   -76.01945301519896   -1.66267e-12   1.63574e-08 DIIS
+   @DF-RHF iter  11:   -76.01945301519905   -8.52651e-14   2.63895e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586432     2A     -1.364517     3A     -0.731039  
+       4A     -0.598079     5A     -0.524239  
+
+    Virtual:                                                              
+
+       6A      0.192064     7A      0.285800     8A      0.999495  
+       9A      1.098678    10A      1.136104    11A      1.143049  
+      12A      1.354549    13A      1.408785    14A      1.995152  
+      15A      2.007555    16A      2.040889    17A      2.592253  
+      18A      2.914705    19A      3.942419  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01945301519905
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4336977154628912
+    One-Electron Energy =                -123.2976912568265391
+    Two-Electron Energy =                  37.8445405261645789
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194530151990620
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5675
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4535      Y:    -0.0004      Z:   -22.6665
+
+  Dipole Moment: (a.u.)
+     X:     0.1600      Y:    -0.0004      Z:     0.9011     Total:     0.9152
+
+  Dipole Moment: (Debye)
+     X:     0.4066      Y:    -0.0010      Z:     2.2903     Total:     2.3261
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194530151990477 [Eh]
+	 Singles Energy            =      -0.0000000000000002 [Eh]
+	 Same-Spin Energy          =      -0.0484644834632015 [Eh]
+	 Opposite-Spin Energy      =      -0.1401529626851763 [Eh]
+	 Correlation Energy        =      -0.1886174461483780 [Eh]
+	 Total Energy              =     -76.2080704613474325 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161548278210672 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1681835552222115 [Eh]
+	 SCS Correlation Energy    =      -0.1843383830432789 [Eh]
+	 SCS Total Energy          =     -76.2037913982423305 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:29 2017
+Module time:
+	user time   =       0.59 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.03 seconds =       0.17 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 18 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:29 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.708925594332     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49136  B =      0.45566  C =      0.44500 [cm^-1]
+  Rotational constants: A = 344502.24812  B =  13660.42643  C =  13340.68888 [MHz]
+  Nuclear repulsion =    9.140371364868820
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.140371364868820
+  Additional nuclear repulsion =    0.278888222597908
+  Total nuclear repulsion      =    9.419259587466728
+
+  Minimum eigenvalue in the overlap matrix is 2.2494087079E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.93907198401702   -7.59391e+01   8.75258e-02 
+   @DF-RHF iter   1:   -75.99019591240115   -5.11239e-02   1.36087e-02 
+   @DF-RHF iter   2:   -76.01303220453620   -2.28363e-02   6.74286e-03 DIIS
+   @DF-RHF iter   3:   -76.01888448185515   -5.85228e-03   1.16012e-03 DIIS
+   @DF-RHF iter   4:   -76.01929168205753   -4.07200e-04   3.43508e-04 DIIS
+   @DF-RHF iter   5:   -76.01935775004718   -6.60680e-05   9.28182e-05 DIIS
+   @DF-RHF iter   6:   -76.01936376800748   -6.01796e-06   1.11521e-05 DIIS
+   @DF-RHF iter   7:   -76.01936384194013   -7.39327e-08   1.65501e-06 DIIS
+   @DF-RHF iter   8:   -76.01936384336199   -1.42185e-09   3.41582e-07 DIIS
+   @DF-RHF iter   9:   -76.01936384341657   -5.45839e-11   6.37233e-08 DIIS
+   @DF-RHF iter  10:   -76.01936384341830   -1.73372e-12   1.70552e-08 DIIS
+   @DF-RHF iter  11:   -76.01936384341843   -1.27898e-13   2.89074e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586845     2A     -1.363902     3A     -0.729710  
+       4A     -0.598272     5A     -0.524206  
+
+    Virtual:                                                              
+
+       6A      0.191696     7A      0.285345     8A      0.997718  
+       9A      1.098503    10A      1.135630    11A      1.142779  
+      12A      1.353832    13A      1.409585    14A      1.994846  
+      15A      2.008149    16A      2.040891    17A      2.590080  
+      18A      2.911733    19A      3.941159  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01936384341843
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4192595874667280
+    One-Electron Energy =                -123.2713767869954751
+    Two-Electron Energy =                  37.8327533561103166
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0193638434184322
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5775
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4532      Y:     0.0004      Z:   -22.6739
+
+  Dipole Moment: (a.u.)
+     X:     0.1597      Y:     0.0004      Z:     0.9036     Total:     0.9176
+
+  Dipole Moment: (Debye)
+     X:     0.4059      Y:     0.0011      Z:     2.2967     Total:     2.3323
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0193638434184322 [Eh]
+	 Singles Energy            =      -0.0000000000000003 [Eh]
+	 Same-Spin Energy          =      -0.0484914692044394 [Eh]
+	 Opposite-Spin Energy      =      -0.1402640997681795 [Eh]
+	 Correlation Energy        =      -0.1887555689726192 [Eh]
+	 Total Energy              =     -76.2081194123910564 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161638230681465 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1683169197218154 [Eh]
+	 SCS Correlation Energy    =      -0.1844807427899621 [Eh]
+	 SCS Total Energy          =     -76.2038445862083904 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:30 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      10.62 seconds =       0.18 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   Loading displacement 19 of 19   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:30 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49898  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.75741  B =  13663.77640  C =  13343.54211 [MHz]
+  Nuclear repulsion =    9.147559595308433
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.147559595308433
+  Additional nuclear repulsion =    0.278918443446434
+  Total nuclear repulsion      =    9.426478038754867
+
+  Minimum eigenvalue in the overlap matrix is 2.2466036533E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94024437987363   -7.59402e+01   8.76458e-02 
+   @DF-RHF iter   1:   -75.99023668249011   -4.99923e-02   1.36135e-02 
+   @DF-RHF iter   2:   -76.01308485847773   -2.28482e-02   6.74079e-03 DIIS
+   @DF-RHF iter   3:   -76.01893263724752   -5.84778e-03   1.15968e-03 DIIS
+   @DF-RHF iter   4:   -76.01933939941948   -4.06762e-04   3.42921e-04 DIIS
+   @DF-RHF iter   5:   -76.01940516314251   -6.57637e-05   9.26520e-05 DIIS
+   @DF-RHF iter   6:   -76.01941115305890   -5.98992e-06   1.11618e-05 DIIS
+   @DF-RHF iter   7:   -76.01941122706279   -7.40039e-08   1.65808e-06 DIIS
+   @DF-RHF iter   8:   -76.01941122848724   -1.42445e-09   3.41336e-07 DIIS
+   @DF-RHF iter   9:   -76.01941122854117   -5.39302e-11   6.32057e-08 DIIS
+   @DF-RHF iter  10:   -76.01941122854302   -1.84741e-12   1.66943e-08 DIIS
+   @DF-RHF iter  11:   -76.01941122854318   -1.56319e-13   2.76412e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998607  
+       9A      1.098592    10A      1.135870    11A      1.142910  
+      12A      1.354188    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591169  
+      18A      2.913219    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01941122854318
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4264780387548672
+    One-Electron Energy =                -123.2845377058328893
+    Two-Electron Energy =                  37.8386484385348538
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194112285431629
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:    -0.0000      Z:   -22.6702
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:    -0.0000      Z:     0.9023     Total:     0.9164
+
+  Dipole Moment: (Debye)
+     X:     0.4063      Y:    -0.0000      Z:     2.2935     Total:     2.3292
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194112285431771 [Eh]
+	 Singles Energy            =      -0.0000000000000003 [Eh]
+	 Same-Spin Energy          =      -0.0484779565293744 [Eh]
+	 Opposite-Spin Energy      =      -0.1402084280293517 [Eh]
+	 Correlation Energy        =      -0.1886863845587264 [Eh]
+	 Total Energy              =     -76.2080976131018986 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161593188431248 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682501136352220 [Eh]
+	 SCS Correlation Energy    =      -0.1844094324783472 [Eh]
+	 SCS Total Energy          =     -76.2038206610215241 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:31 2017
+Module time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      11.21 seconds =       0.19 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -76.2080976131
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -76.2080960403   -76.2080991658    -0.0003125455
+	    1    -76.2080970533   -76.2080970538    -0.0000000555
+	    2    -76.2081147373   -76.2080797764     0.0034960875
+	    3    -76.2080936130   -76.2081014777    -0.0007864695
+	    4    -76.2080717867   -76.2081138522    -0.0042065561
+	    5    -76.2080704633   -76.2081194105    -0.0048947235
+	    6    -76.2080936126   -76.2081014781    -0.0007865484
+	    7    -76.2081138547   -76.2080717841     0.0042070578
+	    8    -76.2080704613   -76.2081194124    -0.0048951044
+
+	Gradient written.
+
+-------------------------------------------------------------
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1    -0.00124998312953    -0.00000022193259     0.01398212763212
+    2    -0.00078954056773    -0.00422298229311    -0.00491383687789
+    3    -0.00078961974167     0.00422348593081    -0.00491421921598
+
+
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on QuickSilver.local
+*** at Fri Feb 17 09:38:31 2017
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49898  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.75741  B =  13663.77640  C =  13343.54211 [MHz]
+  Nuclear repulsion =    9.147559595308433
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         19      19       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [a.u.] < 
+
+              Z          x          y          z
+       -0.83400    1.64923    0.00000   -2.35602
+        0.41700    0.54476    0.00000   -3.79996
+        0.41700    0.54476    0.00000   -0.91209
+
+  Old nuclear repulsion        =    9.147559595308433
+  Additional nuclear repulsion =    0.278918443446434
+  Total nuclear repulsion      =    9.426478038754867
+
+  Minimum eigenvalue in the overlap matrix is 2.2466036533E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94024437987360   -7.59402e+01   8.76458e-02 
+   @DF-RHF iter   1:   -75.99023668249013   -4.99923e-02   1.36135e-02 
+   @DF-RHF iter   2:   -76.01308485847774   -2.28482e-02   6.74079e-03 DIIS
+   @DF-RHF iter   3:   -76.01893263724749   -5.84778e-03   1.15968e-03 DIIS
+   @DF-RHF iter   4:   -76.01933939941938   -4.06762e-04   3.42921e-04 DIIS
+   @DF-RHF iter   5:   -76.01940516314254   -6.57637e-05   9.26520e-05 DIIS
+   @DF-RHF iter   6:   -76.01941115305881   -5.98992e-06   1.11618e-05 DIIS
+   @DF-RHF iter   7:   -76.01941122706278   -7.40040e-08   1.65808e-06 DIIS
+   @DF-RHF iter   8:   -76.01941122848723   -1.42445e-09   3.41336e-07 DIIS
+   @DF-RHF iter   9:   -76.01941122854124   -5.40155e-11   6.32057e-08 DIIS
+   @DF-RHF iter  10:   -76.01941122854302   -1.77636e-12   1.66943e-08 DIIS
+   @DF-RHF iter  11:   -76.01941122854316   -1.42109e-13   2.76412e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998607  
+       9A      1.098592    10A      1.135870    11A      1.142910  
+      12A      1.354188    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591169  
+      18A      2.913219    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.01941122854316
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4264780387548672
+    One-Electron Energy =                -123.2845377058329319
+    Two-Electron Energy =                  37.8386484385349036
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0194112285431629
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -14.2935      Y:     0.0000      Z:    23.5725
+
+  Electronic Dipole Moment: (a.u.)
+     X:    14.4533      Y:    -0.0000      Z:   -22.6702
+
+  Dipole Moment: (a.u.)
+     X:     0.1598      Y:    -0.0000      Z:     0.9023     Total:     0.9164
+
+  Dipole Moment: (Debye)
+     X:     0.4063      Y:    -0.0000      Z:     2.2935     Total:     2.3292
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-ri.gbs
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    19, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      14      14       0
+	 --------------------------------------------------------
+
+
+         ------------------------------------------------------------
+                                     CPHF                           
+                                  Rob Parrish                       
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -0.778803000000     0.000000000000     1.132683000000    15.994914619560
+           H         -0.666682000000     0.764099000000     1.706291000000     1.007825032070
+           H         -0.666682000000    -0.764099000000     1.706290000000     1.007825032070
+
+  Nuclear repulsion =    9.147559595308433
+  Reference energy  =  -76.019411228543163
+
+  ==> Basis Set <==
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/6-31gs.gbs
+    Number of shells: 10
+    Number of basis function: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> CGRSolver (by Rob Parrish) <==
+
+   Number of roots    =         1
+   Preconditioning    =    JACOBI
+   Convergence cutoff =     1E-06
+   Maximum iterations =       100
+
+  ==> CPHFRHamiltonian (by Rob Parrish) <== 
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+  ==> CPHF Iterations <==
+
+  => Iterations <=
+
+             Iter  Converged  Remaining    Residual
+  CGR           1          0          1   6.602E-02
+  CGR           2          0          1   1.433E-02
+  CGR           3          0          1   2.165E-03
+  CGR           4          0          1   4.305E-04
+  CGR           5          0          1   8.106E-05
+  CGR           6          0          1   1.665E-05
+  CGR           7          0          1   2.769E-06
+  CGR           8          1          0   6.889E-07
+
+    CGRSolver converged.
+
+  ## External Potential Gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1    -0.00446220029017     0.00000000431488     0.00527523187358
+    2     0.00081611590265     0.00232391234326    -0.00055999123033
+    3     0.00081611654914    -0.00232391492458    -0.00055999387368
+
+
+
+  ==> DFCorrGrad: Density-Fitted Correlated Gradients <==
+
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               357
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: file /Users/andysim/programming/psi4/obj_debug/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs
+    Number of shells: 42
+    Number of basis function: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0194112285431629 [Eh]
+	 Singles Energy            =      -0.0000000000000003 [Eh]
+	 Same-Spin Energy          =      -0.0484779565293746 [Eh]
+	 Opposite-Spin Energy      =      -0.1402084280293518 [Eh]
+	 Correlation Energy        =      -0.1886863845587267 [Eh]
+	 Total Energy              =     -76.2080976131018843 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0161593188431249 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1682501136352222 [Eh]
+	 SCS Correlation Energy    =      -0.1844094324783473 [Eh]
+	 SCS Total Energy          =     -76.2038206610215099 [Eh]
+	-----------------------------------------------------------
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.001249970169    -0.000000510745     0.013982159470
+       2       -0.000789958585    -0.004219518955    -0.004913264505
+       3       -0.000790039084     0.004220031434    -0.004913648195
+
+
+*** tstop() called on QuickSilver.local at Fri Feb 17 09:38:32 2017
+Module time:
+	user time   =       1.09 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      12.31 seconds =       0.21 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
+	Finite difference (3-pt.) vs. analytic gradient to 10^-5..........PASSED
+	Finite difference energy..........................................PASSED
+	Analytic energy...................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION


## Description
Adds missing CPHF terms, so that DF-MP2 gradients are correct when an external potential is present. Fixes #618.

## Todos

* **Developer Interest**
  - [x] Fixed DF-MP2 gradient code.
  - [x] Added test case for DF-MP2 QM/MM gradients (extern2, not currently in quicktests, but runs in 12 seconds).
* **User-Facing for Release Notes**
  - [x] Fixed bug so that QM/MM gradients are correct for DF-MP2.


## Status
- [x]  Ready to go


