### PR TITLE
Fix Plugin Testing

### DIFF
--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -203,7 +203,7 @@ endif()
 endmacro(optional_plugin plugin_name test_names)
 
 #Macro for adding a skeleton plugin
-macro(add_skeleton_plugin PLUG EXTRA_FLAGS)
+macro(add_skeleton_plugin PLUG TEMPLATE TESTLABELS)
     set(CCSD "${CMAKE_CURRENT_SOURCE_DIR}")
     set(CCBD "${CMAKE_CURRENT_BINARY_DIR}")
     set(PSIEXE ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/psi4)
@@ -212,7 +212,7 @@ add_custom_target(plugin_${PLUG}
     ALL
     DEPENDS psi4-core
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
-    COMMAND ${PSIEXE} --plugin-name ${PLUG} ${EXTRA_FLAGS}
+    COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template ${TEMPLATE}
     COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake "-DCMAKE_PREFIX_PATH=${DIR_2_PASS}" .
     COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
@@ -222,7 +222,7 @@ add_custom_target(plugin_${PLUG}
     COMMENT "Build ${PLUG} example plugin"
     VERBATIM)
 include(TestingMacros)
-add_regression_test(${PLUG} "${test_names}")
-endmacro(add_skeleton_plugin PLUG EXTRA_FLAGS)
+add_regression_test(${PLUG} "${TESTLABELS}")
+endmacro(add_skeleton_plugin)
 
 

--- a/plugins/skeleton/CMakeLists.txt
+++ b/plugins/skeleton/CMakeLists.txt
@@ -2,6 +2,4 @@
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
 
-add_skeleton_plugin("skeleton" "" "psi;plug")
-
-
+add_skeleton_plugin("skeleton" "basic" "psi;plug")

--- a/plugins/skeletonambit/CMakeLists.txt
+++ b/plugins/skeletonambit/CMakeLists.txt
@@ -2,5 +2,4 @@
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
 
-add_skeleton_plugin("skeletonambit" "--plugin-template ambit" "psi;plug")
-
+add_skeleton_plugin("skeletonambit" "ambit" "psi;plug")

--- a/plugins/skeletonaointegrals/CMakeLists.txt
+++ b/plugins/skeletonaointegrals/CMakeLists.txt
@@ -1,5 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-add_skeleton_plugin("skeletonaointegrals" "--plugin-template aointegrals" "psi;plug")
 
+add_skeleton_plugin("skeletonaointegrals" "aointegrals" "psi;plug")

--- a/plugins/skeletondfmp2/CMakeLists.txt
+++ b/plugins/skeletondfmp2/CMakeLists.txt
@@ -2,4 +2,4 @@
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
 
-add_skeleton_plugin("skeletondfmp2" "--plugin-template dfmp2" "psi;plug;minitests;quicktests")
+add_skeleton_plugin("skeletondfmp2" "dfmp2" "psi;plug;minitests;quicktests")

--- a/plugins/skeletonmointegrals/CMakeLists.txt
+++ b/plugins/skeletonmointegrals/CMakeLists.txt
@@ -1,5 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-add_skeleton_plugin("skeletonmointegrals" "--plugin-template mointegrals" "psi;plug")
 
+add_skeleton_plugin("skeletonmointegrals" "mointegrals" "psi;plug")

--- a/plugins/skeletonscf/CMakeLists.txt
+++ b/plugins/skeletonscf/CMakeLists.txt
@@ -2,5 +2,4 @@
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
 
-
-add_skeleton_plugin("skeletonscf" "--plugin-template scf")
+add_skeleton_plugin("skeletonscf" "scf" "psi;plug")

--- a/plugins/skeletonsointegrals/CMakeLists.txt
+++ b/plugins/skeletonsointegrals/CMakeLists.txt
@@ -1,5 +1,5 @@
 # check out and build fresh plugin
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
-add_skeleton_plugin("skeletonsointegrals" "--plugin-template sointegrals" "psi;plug")
 
+add_skeleton_plugin("skeletonsointegrals" "sointegrals" "psi;plug")

--- a/plugins/skeletonwavefunction/CMakeLists.txt
+++ b/plugins/skeletonwavefunction/CMakeLists.txt
@@ -2,5 +2,4 @@
 # creates a dir skeleton w/i skeleton then copies files up to satisfy requirements of both CMake and Psi4 plugins
 # symlinks input.dat back to source dir to satisfy TestingMacro
 
-add_skeleton_plugin("skeletonwavefunction" "--plugin-template wavefunction" "psi;plug")
-
+add_skeleton_plugin("skeletonwavefunction" "wavefunction" "psi;plug")


### PR DESCRIPTION
## Description
Since #582, presumably, all the skeleton plugins that we check out and build from template have actually been using the same, `basic`, template. The adding to ctest bit wasn't working either.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Now we have the compacted code of #582 _and_ the testing functionality of pre- #582 .
* **User-Facing for Release Notes**

## Status
- [x]  Ready to go