### PR TITLE
Add missing include.

### DIFF
--- a/psi4/src/psi4/libpsio/aio_handler.cc
+++ b/psi4/src/psi4/libpsio/aio_handler.cc
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <memory>
 #include <algorithm>
+#include <functional>
 
 using namespace std;
 


### PR DESCRIPTION
## Description
Add missing include to fix build with gcc 7 (see #631).