### PR TITLE
Add a function to save normal modes and geometry after a vibrational analysis

### DIFF
--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -50,6 +50,16 @@ the scenes, :py:func:`~psi4.frequency` is a light wrapper over
 :py:func:`~psi4.hessian` that computes the Hessian then adds a
 thermochemical analysis.
 
+Visualization of Normal Modes
+-----------------------------
+
+|PSIfour| has the ability to export a Molden file that stores information about
+the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
+This feature can be enabled by setting the option |globals__normal_modes_write| to true.
+The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
+determined by |globals__writer_file_label| (if set), or else by the name of the
+output file plus the name of the current molecule.
+
 .. autofunction:: psi4.frequency(name [, molecule, return_wfn, func, mode, dertype, irrep])
 
 .. autofunction:: psi4.hessian(name [, molecule, return_wfn, func, dertype, irrep])

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -50,17 +50,24 @@ the scenes, :py:func:`~psi4.frequency` is a light wrapper over
 :py:func:`~psi4.hessian` that computes the Hessian then adds a
 thermochemical analysis.
 
-Visualization of Normal Modes
------------------------------
-
-|PSIfour| has the ability to export a Molden file that stores information about
-the harmonic frequencies and normal modes computed using :py:func:`~psi4.frequency`.
-This feature can be enabled by setting the option |globals__normal_modes_write| to true.
-The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
-determined by |globals__writer_file_label| (if set), or else by the name of the
-output file plus the name of the current molecule.
-
 .. autofunction:: psi4.frequency(name [, molecule, return_wfn, func, mode, dertype, irrep])
 
 .. autofunction:: psi4.hessian(name [, molecule, return_wfn, func, dertype, irrep])
 
+Visualization of Normal Modes
+-----------------------------
+
+|PSIfour| has the ability to export a Molden file that stores information about
+the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
+This feature can be enabled by setting the option |globals__normal_modes_write| to true.
+The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
+determined by |globals__writer_file_label| (if set), or else by the name of the
+output file plus the name of the current molecule.
+The normal coordinates saved in the Molden file are mass-weighted and are not normalized.
+
+Molden Interface Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: autodir_options_c/globals__normal_modes_write.rst
+
+.. include:: autodir_options_c/globals__writer_file_label.rst

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -36,8 +36,8 @@
 
 .. _`sec:freq()`:
 
-Harmonic Vibrational Analysis |w---w| :py:func:`~psi4.frequency` and :py:func:`~psi4.hessian`
-=============================================================================================
+Harmonic Vibrational Analysis and Visualization of Normal Modes |w---w| :py:func:`~psi4.frequency` and :py:func:`~psi4.hessian`
+===============================================================================================================================
 
 * :ref:`Psi4 Native Hessian Methods <table:freq_gen>`
 
@@ -49,6 +49,16 @@ need to access directly to perform frequency calculations. Behind
 the scenes, :py:func:`~psi4.frequency` is a light wrapper over
 :py:func:`~psi4.hessian` that computes the Hessian then adds a
 thermochemical analysis.
+
+Visualization of Normal Modes
+-----------------------------
+
+|PSIfour| has the ability to export a Molden file that stores information about
+the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
+This feature can be enabled by setting the option |globals__normal_modes_write| to true.
+The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
+determined by |globals__writer_file_label| (if set), or else by the name of the
+output file plus the name of the current molecule.
 
 .. autofunction:: psi4.frequency(name [, molecule, return_wfn, func, mode, dertype, irrep])
 

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -54,7 +54,7 @@ Visualization of Normal Modes
 -----------------------------
 
 |PSIfour| has the ability to export a Molden file that stores information about
-the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
+the harmonic frequencies and normal modes computed using :py:func:`~psi4.frequency`.
 This feature can be enabled by setting the option |globals__normal_modes_write| to true.
 The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
 determined by |globals__writer_file_label| (if set), or else by the name of the

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -54,26 +54,13 @@ Visualization of Normal Modes
 -----------------------------
 
 |PSIfour| has the ability to export a Molden file that stores information about
-the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
+the harmonic frequencies and normal modes computed via :py:func:`~psi4.frequency`.
 This feature can be enabled by setting the option |globals__normal_modes_write| to true.
 The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
 determined by |globals__writer_file_label| (if set), or else by the name of the
 output file plus the name of the current molecule.
-
-.. autofunction:: psi4.frequency(name [, molecule, return_wfn, func, mode, dertype, irrep])
-
-.. autofunction:: psi4.hessian(name [, molecule, return_wfn, func, dertype, irrep])
-
-Visualization of Normal Modes
------------------------------
-
-|PSIfour| has the ability to export a Molden file that stores information about
-the harmonic frequancies and normal modes computed via :py:func:`~psi4.frequency`.
-This feature can be enabled by setting the option |globals__normal_modes_write| to true.
-The filename of the Molden file ends in ”.molden_normal_modes, and the prefix is
-determined by |globals__writer_file_label| (if set), or else by the name of the
-output file plus the name of the current molecule.
-The normal coordinates saved in the Molden file are mass-weighted and are not normalized.
+The normal coordinates saved in the Molden file are normalized and are not
+mass weighted.
 
 Molden Interface Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -50,6 +50,10 @@ the scenes, :py:func:`~psi4.frequency` is a light wrapper over
 :py:func:`~psi4.hessian` that computes the Hessian then adds a
 thermochemical analysis.
 
+.. autofunction:: psi4.frequency(name [, molecule, return_wfn, func, mode, dertype, irrep])
+
+.. autofunction:: psi4.hessian(name [, molecule, return_wfn, func, dertype, irrep])
+
 Visualization of Normal Modes
 -----------------------------
 

--- a/psi4/src/psi4/findif/fd_freq_0.cc
+++ b/psi4/src/psi4/findif/fd_freq_0.cc
@@ -274,6 +274,11 @@ SharedMatrix fd_freq_0(std::shared_ptr <Molecule> mol, Options &options,
     // This print function also saves frequencies in wavefunction.
     print_vibrations(mol, modes);
 
+    // Optionally, save normal modes to file.
+    if (options.get_bool("NORMAL_MODES_WRITE")) {
+        save_normal_modes(mol, modes);
+    }
+
     for (int i = 0; i < modes.size(); ++i)
         delete modes[i];
     modes.clear();

--- a/psi4/src/psi4/findif/fd_freq_1.cc
+++ b/psi4/src/psi4/findif/fd_freq_1.cc
@@ -370,6 +370,11 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
     // This print function also saves frequencies in wavefunction.
     print_vibrations(mol, modes);
 
+    // Optionally, save normal modes to file.
+    if (options.get_bool("NORMAL_MODES_WRITE")) {
+        save_normal_modes(mol, modes);
+    }
+
     for (int i = 0; i < modes.size(); ++i)
         delete modes[i];
     modes.clear();

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -172,7 +172,7 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
         printer->Printf("%-3s %.6f %.6f %.6f\n",mol->symbol(a).c_str(),x,y,z);
     }
     printer->Printf("\n[FR-NORM-COORD]\n");
-    for(int i = 0; i < modes.size(); ++i) { // print descending order
+    for(int i = 0; i < modes.size(); ++i) {
         printer->Printf("vibration %d\n",i + 1);
         int Natom = mol->natom();
         double norm2 = 0.0;
@@ -191,42 +191,7 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
         }
     }
     printer->Printf("\n[INT]\n");
-    for(int i = 0; i < modes.size(); ++i) { // print descending order
-=======
-    for(int i = 0; i < modes.size(); ++i) { // print descending order
-        double frequency_cm = modes[i]->get_cm();
-        printer->Printf("%.2f\n", frequency_cm);
-    }
-    printer->Printf("\n[FR-COORD]\n");
-    int Natom = mol->natom();
-    for (int a = 0; a < Natom; a++) {
-        double x = mol->x(a);
-        double y = mol->y(a);
-        double z = mol->z(a);
-        printer->Printf("%-3s %.6f %.6f %.6f\n",mol->symbol(a).c_str(),x,y,z);
-    }
-    printer->Printf("\n[FR-NORM-COORD]\n");
-    for(int i = 0; i < modes.size(); ++i) { // print descending order
-        printer->Printf("vibration %d\n",i + 1);
-        int Natom = mol->natom();
-        double norm2 = 0.0;
-        for (int a = 0; a < Natom; a++) {
-            for (int xyz = 0; xyz < 3; ++xyz){
-                norm2 += std::pow(modes[i]->get_lx(3 * a + xyz),2.0);
-            }
-        }
-        double scaling_factor = 1.0 / std::sqrt(norm2);
-        for (int a = 0; a < Natom; a++) {
-            for (int xyz = 0; xyz < 3; ++xyz){
-                double scaled_mode = scaling_factor * modes[i]->get_lx(3 * a + xyz);
-                printer->Printf(" %.6f",scaled_mode);
-            }
-            printer->Printf("\n");
-        }
-    }
-    printer->Printf("\n[INT]\n");
-    for(int i = 0; i < modes.size(); ++i) { // print descending order
->>>>>>> Save normal modes in Molden format.
+    for(int i = 0; i < modes.size(); ++i) {
         printer->Printf("1.0\n");
     }
 }

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -158,39 +158,35 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
     std::string geometry_fname = get_writer_file_prefix(mol->name()) + ".xyz";
     mol->save_xyz_file(geometry_fname);
 
-    std::string normal_modes_fname = get_writer_file_prefix(mol->name()) + ".modes";
+    std::string normal_modes_fname = get_writer_file_prefix(mol->name()) + ".molden_normal_modes";
     std::shared_ptr <OutFile> printer(new OutFile(normal_modes_fname, TRUNCATE));
 
-    /* save normal modes to file. It uses the following format:
-      Frequency: freq1
-      Atom1 Lx1 Ly1 Lz1
-      ...
-      AtomN LxN LyN LzN
-      [empty line]
-      Frequency: freq2
-      Atom1 Lx1 Ly1 Lz1
-      ...
-      AtomN LxN LyN LzN
-      [empty line]
-      ...
-    */
+    printer->Printf("[Molden Format]\n[FREQ]\n");
     for(int i = 0; i < modes.size(); ++i) { // print descending order
-      double frequency_cm = modes[i]->get_cm();
-      if (frequency_cm < 0.0)
-        printer->Printf( "Frequency: %8.2f i\n", -frequency_cm);
-      else
-        printer->Printf( "Frequency: %8.2f\n", frequency_cm);
-
-      int Natom = mol->natom();
-      for (int a=0; a<Natom; a++) {
-        printer->Printf("%-3s", mol->symbol(a).c_str() );
-
-        for (int xyz = 0; xyz < 3; ++xyz)
-          printer->Printf(" %10.5f", modes[i]->get_lx(3 * a + xyz));
-
-        printer->Printf("\n");
-      }
-      printer->Printf("\n");
+        double frequency_cm = modes[i]->get_cm();
+        printer->Printf("%.2f\n", frequency_cm);
+    }
+    printer->Printf("\n[FR-COORD]\n");
+    int Natom = mol->natom();
+    for (int a = 0; a < Natom; a++) {
+        double x = mol->x(a);
+        double y = mol->y(a);
+        double z = mol->z(a);
+        printer->Printf("%-3s %.6f %.6f %.6f\n",mol->symbol(a).c_str(),x,y,z);
+    }
+    printer->Printf("\n[FR-NORM-COORD]\n");
+    for(int i = 0; i < modes.size(); ++i) { // print descending order
+        printer->Printf("vibration %d\n",i + 1);
+        int Natom = mol->natom();
+        for (int a=0; a<Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz)
+                printer->Printf(" %.6f", modes[i]->get_lx(3 * a + xyz));
+            printer->Printf("\n");
+        }
+    }
+    printer->Printf("\n[INT]\n");
+    for(int i = 0; i < modes.size(); ++i) { // print descending order
+        printer->Printf("1.0\n");
     }
 }
 

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -175,9 +175,18 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
     for(int i = 0; i < modes.size(); ++i) { // print descending order
         printer->Printf("vibration %d\n",i + 1);
         int Natom = mol->natom();
-        for (int a=0; a<Natom; a++) {
-            for (int xyz = 0; xyz < 3; ++xyz)
-                printer->Printf(" %.6f", modes[i]->get_lx(3 * a + xyz));
+        double norm2 = 0.0;
+        for (int a = 0; a < Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz){
+                norm2 += std::pow(modes[i]->get_lx(3 * a + xyz),2.0);
+            }
+        }
+        double scaling_factor = 1.0 / std::sqrt(norm2);
+        for (int a = 0; a < Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz){
+                double scaled_mode = scaling_factor * modes[i]->get_lx(3 * a + xyz);
+                printer->Printf(" %.6f",scaled_mode);
+            }
             printer->Printf("\n");
         }
     }

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -209,9 +209,18 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
     for(int i = 0; i < modes.size(); ++i) { // print descending order
         printer->Printf("vibration %d\n",i + 1);
         int Natom = mol->natom();
-        for (int a=0; a<Natom; a++) {
-            for (int xyz = 0; xyz < 3; ++xyz)
-                printer->Printf(" %.6f", modes[i]->get_lx(3 * a + xyz));
+        double norm2 = 0.0;
+        for (int a = 0; a < Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz){
+                norm2 += std::pow(modes[i]->get_lx(3 * a + xyz),2.0);
+            }
+        }
+        double scaling_factor = 1.0 / std::sqrt(norm2);
+        for (int a = 0; a < Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz){
+                double scaled_mode = scaling_factor * modes[i]->get_lx(3 * a + xyz);
+                printer->Printf(" %.6f",scaled_mode);
+            }
             printer->Printf("\n");
         }
     }

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -155,9 +155,6 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
 
 void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes)
 {
-    std::string geometry_fname = get_writer_file_prefix(mol->name()) + ".xyz";
-    mol->save_xyz_file(geometry_fname);
-
     std::string normal_modes_fname = get_writer_file_prefix(mol->name()) + ".molden_normal_modes";
     std::shared_ptr <OutFile> printer(new OutFile(normal_modes_fname, TRUNCATE));
 

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -192,6 +192,32 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
     }
     printer->Printf("\n[INT]\n");
     for(int i = 0; i < modes.size(); ++i) { // print descending order
+=======
+    for(int i = 0; i < modes.size(); ++i) { // print descending order
+        double frequency_cm = modes[i]->get_cm();
+        printer->Printf("%.2f\n", frequency_cm);
+    }
+    printer->Printf("\n[FR-COORD]\n");
+    int Natom = mol->natom();
+    for (int a = 0; a < Natom; a++) {
+        double x = mol->x(a);
+        double y = mol->y(a);
+        double z = mol->z(a);
+        printer->Printf("%-3s %.6f %.6f %.6f\n",mol->symbol(a).c_str(),x,y,z);
+    }
+    printer->Printf("\n[FR-NORM-COORD]\n");
+    for(int i = 0; i < modes.size(); ++i) { // print descending order
+        printer->Printf("vibration %d\n",i + 1);
+        int Natom = mol->natom();
+        for (int a=0; a<Natom; a++) {
+            for (int xyz = 0; xyz < 3; ++xyz)
+                printer->Printf(" %.6f", modes[i]->get_lx(3 * a + xyz));
+            printer->Printf("\n");
+        }
+    }
+    printer->Printf("\n[INT]\n");
+    for(int i = 0; i < modes.size(); ++i) { // print descending order
+>>>>>>> Save normal modes in Molden format.
         printer->Printf("1.0\n");
     }
 }

--- a/psi4/src/psi4/findif/findif.h
+++ b/psi4/src/psi4/findif/findif.h
@@ -69,6 +69,10 @@ class VIBRATION {
     friend bool ascending(const VIBRATION *, const VIBRATION *);
     friend void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes);
 
+    double get_km() {return km;}
+    double get_cm() {return cm;}
+    double get_lx(int i) {return lx[i];}
+
     VIBRATION(int irrep_in, double km_in, double *lx_in) { irrep = irrep_in; km = km_in; lx = lx_in; }
     ~VIBRATION() { free(lx); }
 };
@@ -92,6 +96,10 @@ void mass_weight_columns_plus_one_half(SharedMatrix B);
 // displace an atomic coordinate
 void displace_atom(SharedMatrix geom, const int atom, const int coord,
                    const int sign, const double disp_size);
+
+// save gemetry and normal modes to files
+void save_normal_modes(std::shared_ptr<Molecule> mol,
+                       std::vector<VIBRATION *> modes);
 
 
 template <class T>

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2475,10 +2475,10 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       (if set), or else by the name of the output file plus the name of
       the current molecule. -*/
       options.add_bool("HESSIAN_WRITE", false);
-       /*- Do write a file containing the normal modes?  If so, the filename will
-      end in .modes, and the prefix is determined by |globals__writer_file_label|
-      (if set), or else by the name of the output file plus the name of
-      the current molecule. -*/
+       /*- Do write a file containing the normal modes in Molden format?
+      If so, the filename will end in .molden_normal_modes, and the prefix is
+      determined by |globals__writer_file_label| (if set), or else by the name
+      of the output file plus the name of the current molecule. -*/
       options.add_bool("NORMAL_MODES_WRITE", false);
   }
   if (name == "OCC"|| options.read_globals()) {

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2475,6 +2475,11 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       (if set), or else by the name of the output file plus the name of
       the current molecule. -*/
       options.add_bool("HESSIAN_WRITE", false);
+       /*- Do write a file containing the normal modes?  If so, the filename will
+      end in .modes, and the prefix is determined by |globals__writer_file_label|
+      (if set), or else by the name of the output file plus the name of
+      the current molecule. -*/
+      options.add_bool("NORMAL_MODES_WRITE", false);
   }
   if (name == "OCC"|| options.read_globals()) {
     /*- MODULEDESCRIPTION Performs orbital-optimized MPn and CC computations and conventional MPn computations. -*/


### PR DESCRIPTION
## Description
This PR adds code to the findif codes that allows to save the current geometry and normal modes to  a Molden file.

Normal mode info is only written if explicitly requested by the user (via the boolean keyword NORMAL_MODES_WRITE). The normal modes are saved in [Molden format](http://www.cmbi.ru.nl/molden/molden_format.html).

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Exposes (read only-mode) some variables in the VIBRATIONS class.
  - [x] Adds a function to save normal modes info in Molden format.
  - [x] Adds an option to write normal modes (false by default).
* **User-Facing for Release Notes**
  - [x] Documentation

## Questions
- [x]  Where should the documentation go?
- [x]  Suggestions to improve output format?

## Status
- [x] Ready to go