### PR TITLE
Fix misplaced regexp flags arguments 

### DIFF
--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -693,8 +693,8 @@ def process_input(raw_input, print_level=1):
     #    check_parentheses_and_brackets(temp, 1)
 
     # First, remove everything from lines containing only spaces
-    blankline = re.compile(r'^\s*$')
-    temp = re.sub(blankline, '', temp, re.MULTILINE)
+    blankline = re.compile(r'^\s*$', re.MULTILINE)
+    temp = re.sub(blankline, '', temp)
 
     # Look for things like
     # set matrix [

--- a/psi4/driver/qcdb/cfour.py
+++ b/psi4/driver/qcdb/cfour.py
@@ -49,7 +49,7 @@ def harvest_output(outtext):
     pass_coord = []
     pass_grad = []
 
-    for outpass in re.split(r'--invoking executable xjoda', outtext, re.MULTILINE):
+    for outpass in re.split(r'--invoking executable xjoda', outtext):
         psivar, c4coord, c4grad = harvest_outfile_pass(outpass)
         pass_psivar.append(psivar)
         pass_coord.append(c4coord)


### PR DESCRIPTION
This fixes multiple invalid uses of flags in `re.compile(...).sub()` and `re.split()` calls.

Found using [pydiatra](https://github.com/jwilk/pydiatra).