### PR TITLE
PCM-CCSD in the PTE approximation

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -33,11 +33,11 @@ Bibliography
 |
 
 .. [Gonthier:2016:134106]
-   J. F. Gonthier and C.D. Sherrill, 
+   J. F. Gonthier and C.D. Sherrill,
    *J. Chem. Phys.* **145**, 134106 (2016).
 
 .. [Parrish:2015:051103]
-   R. M. Parrish, J. F. Gonthier, C. Corminboeuf, and C.D. Sherrill, 
+   R. M. Parrish, J. F. Gonthier, C. Corminboeuf, and C.D. Sherrill,
    *J. Chem. Phys.* **143**, 051103 (2015).
 
 .. [Parrish:2014:17386]
@@ -99,17 +99,17 @@ Bibliography
 .. [Cohen:GreenBook:2008]
    E. R. Cohen, T. Cvitas, J. G. Frey, B. Holmstr\ |o_dots|\ om,
    K. Kuchitsu, R. Marquardt, I. Mills, F. Pavese, M. Quack,
-   J. Stohner, H. L. Strauss, M. Takami, and A. J. Thor, 
+   J. Stohner, H. L. Strauss, M. Takami, and A. J. Thor,
    Quantities, Units, and Symbols in Physical chemistry, IUPAC Green
    Book, 3rd. Ed., IUPAC & RSC Publishing (Cambridge, 2008).
 
 .. [PubChem]
-   E. Bolton, Y. Wang, P. A. Thiessen, S. H. Bryant.  PubChem: 
+   E. Bolton, Y. Wang, P. A. Thiessen, S. H. Bryant.  PubChem:
    Integrated Platform of Small Molecules and Biological Activities,
    Chapter 12 in *Annual Reports in Computational Chemistry*, Volume
    4 (American Chemical Society: Washington, DC, 2008).
    See `pubchem.ncbi.nlm.nih.gov <http://pubchem.ncbi.nlm.nih.gov/>`_.
-   
+
 .. [Sherrill:1999:CI]
    C. D. Sherrill and H. F. Schaefer,
    *Advances in Quantum Chemistry*, Vol. 34, edited by P.-O. L\ |o_dots|\ wdin
@@ -125,7 +125,7 @@ Bibliography
 
 .. [Peng:1996:49]
    Peng, Ayala, Schlegel, and Frisch,
-   *J. Comput. Chem.* **17**, 49 (1996). 
+   *J. Comput. Chem.* **17**, 49 (1996).
 
 .. [Bakken:2002:9160]
    Bakken and Helgaker,
@@ -163,12 +163,12 @@ Bibliography
    J. Schirmer,
    *Phys. Rev. A* **26**, 2395 (1982).
 
-.. [Trofimov:2006] 
-   A. B. Trofimov, I. L, Krivdina, J. Weller, and J. Schirmer, 
+.. [Trofimov:2006]
+   A. B. Trofimov, I. L, Krivdina, J. Weller, and J. Schirmer,
    *Chem. Phys.* **329**, 1 (2006).
 
 .. [Haettig:2002]
-   C. H\ |a_dots|\ aettig and K. Hald, 
+   C. H\ |a_dots|\ aettig and K. Hald,
    *Phys. Chem. Chem. Phys.* **4**, 2111 (2002).
 
 .. [Saitow:2012]
@@ -184,12 +184,12 @@ Bibliography
    *Phys. Chem. Chem. Phys.* **11**, 4728 (2009).
 
 .. [Evangelista:2006:154113]
-   F. A. Evangelista, W. D. Allen, and H. F. Schaefer, III, 
+   F. A. Evangelista, W. D. Allen, and H. F. Schaefer, III,
    *J. Chem. Phys.* **125**, 154113 (2006).
 
 .. [Evangelista:2008:124104]
-   F. A. Evangelista, A. C. Simmonett, W. D. Allen, H. F. Schaefer, III, and J. Gauss, 
-   *J. Chem. Phys.* **128**, 124104 (2008).    
+   F. A. Evangelista, A. C. Simmonett, W. D. Allen, H. F. Schaefer, III, and J. Gauss,
+   *J. Chem. Phys.* **128**, 124104 (2008).
 
 .. [Cheng:084114]
    L. Cheng and J. Gauss,
@@ -212,7 +212,7 @@ Bibliography
    *J. Chem. Phys.* **76**, 1910-1918 (1982).
 
 .. [Sosa:1989:148]
-   C. Sosa, J. Geersten, G. W. Trucks, R. J. Barlett, and J. A. Franz, 
+   C. Sosa, J. Geersten, G. W. Trucks, R. J. Barlett, and J. A. Franz,
    *Chem. Phys. Lett.* **159**, 148--154 (1989).
 
 .. [Roos:1980]
@@ -256,11 +256,11 @@ Bibliography
    *J. Chem. Theory Comput.* **9**, 2687-2696 (2013).
 
 .. [Curtiss:1991:7221]
-   L. A. Curtiss, K. Raghavachari, G. W. Trucks, and J. A. Pople, 
+   L. A. Curtiss, K. Raghavachari, G. W. Trucks, and J. A. Pople,
    *J. Chem. Phys.* **94**, 7221-7230 (1991).
 
 .. [Pople:1987:5968]
-   J. A. Pople, M. Head-Gordon, and K. J. Raghavachari, 
+   J. A. Pople, M. Head-Gordon, and K. J. Raghavachari,
    *Chem. Phys.* **87**, 5968 (1987).
 
 .. [Crawford:1997:instability]
@@ -347,12 +347,12 @@ Bibliography
 
 .. [FW:1950]
    L. L. Foldy and S. A. Wouthuysen,
-   *Phys. Rev.* **78**, 29-36 (1950) 
+   *Phys. Rev.* **78**, 29-36 (1950)
 
 .. [Kutzelnigg:1984]
    W. Kutzelnigg,
    *Int. J. Quantum Chem.* **25**, 107-129 (1984)
- 
+
 .. [Smith:2016:2197]
    D. Smith, L. Burns, K. Patkowski, and D. Sherrill,
    *J. Phys. Chem. Lett.* **7**, 2197-2203 (2016).
@@ -378,3 +378,10 @@ Bibliography
    J. M. L. Martin,
    *Mol. Phys.* **112**, 785 (2014).
 
+.. [Cammi:2009:164104]
+   R. Cammi,
+   *J. Chem. Phys.* **131**, 164104 (2009).
+
+.. [Tomasi:2005:2999]
+   J. Tomasi, B. Mennucci, and R. Cammi
+   *Chem. Rev.* **105**, 2999 (2005).

--- a/doc/sphinxman/source/cc.rst
+++ b/doc/sphinxman/source/cc.rst
@@ -73,10 +73,10 @@ generate singly-excited, doubly-excited, *etc.*, determinants:
 
 with
 
-.. math:: 
+.. math::
 
    {\hat T}_1 | \Phi_0 \rangle &= \sum_{i}^{\rm occ} \sum_a^{\rm vir} t_i^a | \Phi_i^a \rangle \\
-   {\hat T}_2 | \Phi_0 \rangle &= \sum_{i<j}^{\rm occ} \sum_{a<b}^{\rm vir} t_{ij}^{ab} | \Phi_{ij}^{ab} \rangle, 
+   {\hat T}_2 | \Phi_0 \rangle &= \sum_{i<j}^{\rm occ} \sum_{a<b}^{\rm vir} t_{ij}^{ab} | \Phi_{ij}^{ab} \rangle,
 
 *etc.*  The popular coupled cluster singles and doubles (CCSD) model
 [Purvis:1982]_ truncates the expansion at :math:`{\hat{T}} = {\hat{T}_1}
@@ -107,6 +107,10 @@ also be computed by the CC2 and CC3 models, or by EOM-CCSD.  Table
 describes how to carry out coupled cluster calculations within |PSIfour|.
 For higher-order coupled-cluster methods like CCSDT and CCSDTQ, |PSIfour|
 can interface to K\ |a_acute|\ llay's MRCC code (see :ref:`MRCC <sec:mrcc>`).
+
+Solvent effects on energies can be taken into account using the polarizable
+continuum model (PCM) in the PTE approximation [Cammi:2009:164104]_, see
+:ref:`PCM <sec:pcmsolver>`
 
 .. _`table:ccsummary`:
 
@@ -160,7 +164,7 @@ Basic Keywords
 
 A complete list of keywords related to coupled-cluster computations is
 provided in the appendices, with the majority of the relevant
-keywords appearing in Appendix :ref:`apdx:ccenergy`.  For a standard ground-state 
+keywords appearing in Appendix :ref:`apdx:ccenergy`.  For a standard ground-state
 CCSD or CCSD(T) computation, the following keywords are common:
 
 .. include:: autodir_options_c/ccenergy__reference.rst
@@ -177,10 +181,10 @@ Larger Calculations
 ^^^^^^^^^^^^^^^^^^^
 
 Here are a few recommendations for carrying out large-basis-set coupled
-cluster calculations with |PSIfour|: 
+cluster calculations with |PSIfour|:
 
-* In most cases it is reasonable to set the ``memory`` keyword to 90% of 
-  the available physical memory, at most.  There is a small amount of overhead 
+* In most cases it is reasonable to set the ``memory`` keyword to 90% of
+  the available physical memory, at most.  There is a small amount of overhead
   associated with the
   coupled cluster modules that is not accounted for by the internal CC memory
   handling routines.  Thus, the user should *not* specify the entire
@@ -192,8 +196,8 @@ cluster calculations with |PSIfour|:
   lead to heap fragmentation and memory faults, even when sufficient
   physical memory exists.
 
-* Set the |globals__print| keyword to ``2``.  This 
-  will help narrow where memory bottlenecks or other errors exist in the 
+* Set the |globals__print| keyword to ``2``.  This
+  will help narrow where memory bottlenecks or other errors exist in the
   event of a crash.
 
 .. _`sec:eomcc`:
@@ -201,7 +205,7 @@ cluster calculations with |PSIfour|:
 Excited State Coupled Cluster Calculations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A complete list of keywords related to 
+A complete list of keywords related to
 coupled cluster linear response is provided in Appendix :ref:`apdx:cceom`.
 The most important keywords associated with EOM-CC calculations are:
 
@@ -215,7 +219,7 @@ Linear Response (CCLR) Calculations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Linear response computations are invoked like ``property('ccsd')``
-or ``property('cc2')``, along with a list of requested properties.  
+or ``property('cc2')``, along with a list of requested properties.
 A complete list of keywords related to
 coupled cluster linear response is provided in Appendix :ref:`apdx:ccresponse`.
 

--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -53,7 +53,7 @@ Interface to PCMSolver by R. Di Remigio
 by R. Di Remigio and L. Frediani.
 The PCMSolver library requires no additional licence, downloads, or
 configuration. The library allows for calculations in solution with the
-polarizable continuum model (PCM), a continuum solvation model.
+polarizable continuum model (PCM), a continuum solvation model [Tomasi:2005:2999]_.
 
 Installation
 ~~~~~~~~~~~~
@@ -100,13 +100,15 @@ is achieved by setting |globals__pcm| ``true`` in your input file.
 The latter forces the separate handling of nuclear and electronic electrostatic potentials and
 polarization charges. It is mainly useful for debugging.
 
-.. note:: At present PCM can only be used for energy calculations with SCF wavefunctions.
-   Moreover, the PCMSolver library **cannot** exploit molecular point group symmetry.
+.. note:: At present PCM can only be used for energy calculations with SCF
+          wavefunctions and CC wavefunctions in the PTE approximation [Cammi:2009:164104]_
+
+.. warning:: The PCMSolver library **cannot** exploit molecular point group symmetry.
 
 The PCM model and molecular cavity are specified in a ``pcm`` section that has
 to be explicitly typed in by the user. This additional section follows a syntax
 that is slightly different from that of |Psifour| and is fully documented
-`here <http://pcmsolver.readthedocs.org/en/latest/users/input.html>`_
+`here <http://pcmsolver.readthedocs.io/en/latest/users/input.html>`_
 
 A typical input for a Hartree--Fock calculation with PCM would look like the following: ::
 
@@ -154,6 +156,7 @@ Keywords for PCMSolver
 
 .. include:: autodir_options_c/globals__pcm.rst
 .. include:: autodir_options_c/globals__pcm_scf_type.rst
+.. include:: autodir_options_c/globals__pcm_cc_type.rst
 
 .. _`cmake:pcmsolver`:
 

--- a/psi4/src/psi4/cctransort/CMakeLists.txt
+++ b/psi4/src/psi4/cctransort/CMakeLists.txt
@@ -1,2 +1,5 @@
 set(sources_list c_sort.cc d_sort.cc e_sort.cc fock.cc scf_check.cc a_spinad.cc cache.cc d_spinad.cc e_spinad.cc memcheck.cc sort_tei_rhf.cc b_spinad.cc cctransort.cc denom.cc f_sort.cc pitzer2qt.cc sort_tei_uhf.cc)
 psi4_add_module(bin cctransort sources_list dpd iwl trans options qt psio mints)
+if(TARGET PCMSolver::pcm)
+    target_link_libraries(cctransort PRIVATE psipcm PCMSolver::pcm)
+endif()

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -112,10 +112,14 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
   char **labels = ref->molecule()->irrep_labels();
   double enuc = ref->molecule()->nuclear_repulsion_energy();
   double escf;
-  if(ref->reference_wavefunction())
+  double epcm;
+  if(ref->reference_wavefunction()) {
       escf = ref->reference_wavefunction()->reference_energy();
-  else
+      epcm = ref->reference_wavefunction()->get_variable("PCM POLARIZATION ENERGY");
+  } else {
       escf = ref->reference_energy();
+      epcm = ref->get_variable("PCM POLARIZATION ENERGY");
+  }
 
   Dimension nmopi = ref->nmopi();
   Dimension nsopi = ref->nsopi();
@@ -656,8 +660,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
 
   outfile->Printf("\tNuclear Rep. energy          =  %20.14f\n", enuc);
   outfile->Printf("\tSCF energy                   =  %20.14f\n", escf);
-  double Epcm = Process::environment.globals["PCM POLARIZATION ENERGY"];
-  double eref = scf_check(reference, openpi) + enuc + efzc + Epcm;
+  double eref = scf_check(reference, openpi) + enuc + efzc + epcm;
   outfile->Printf("\tReference energy             =  %20.14f\n", eref);
   psio->write_entry(PSIF_CC_INFO, "Reference Energy", (char *) &(eref), sizeof(double));
 

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -112,14 +112,20 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
   char **labels = ref->molecule()->irrep_labels();
   double enuc = ref->molecule()->nuclear_repulsion_energy();
   double escf;
-  double epcm;
   if(ref->reference_wavefunction()) {
       escf = ref->reference_wavefunction()->reference_energy();
-      epcm = ref->reference_wavefunction()->get_variable("PCM POLARIZATION ENERGY");
   } else {
       escf = ref->reference_energy();
-      epcm = ref->get_variable("PCM POLARIZATION ENERGY");
   }
+  double epcm = 0.0;
+#ifdef USING_PCMSolver
+  if(options.get_bool("PCM")) {
+    epcm = ref->reference_wavefunction()
+               ? ref->reference_wavefunction()->get_variable(
+                     "PCM POLARIZATION ENERGY")
+               : ref->get_variable("PCM POLARIZATION ENERGY");
+  }
+#endif
 
   Dimension nmopi = ref->nmopi();
   Dimension nsopi = ref->nsopi();

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -656,7 +656,8 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
 
   outfile->Printf("\tNuclear Rep. energy          =  %20.14f\n", enuc);
   outfile->Printf("\tSCF energy                   =  %20.14f\n", escf);
-  double eref = scf_check(reference, openpi) + enuc + efzc;
+  double Epcm = Process::environment.globals["PCM POLARIZATION ENERGY"];
+  double eref = scf_check(reference, openpi) + enuc + efzc + Epcm;
   outfile->Printf("\tReference energy             =  %20.14f\n", eref);
   psio->write_entry(PSIF_CC_INFO, "Reference Energy", (char *) &(eref), sizeof(double));
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1038,7 +1038,7 @@ double Wavefunction::get_variable(std::string label)
     std::transform(uc_label.begin(), uc_label.end(), uc_label.begin(), ::toupper);
 
     if (variables_.count(uc_label) == 0){
-        throw PSIEXCEPTION("Wavefunction::get_variable: Requested variable was not set!\n");
+        throw PSIEXCEPTION("Wavefunction::get_variable: Requested variable " + label + " was not set!\n");
     } else {
         return variables_[uc_label];
     }
@@ -1046,7 +1046,7 @@ double Wavefunction::get_variable(std::string label)
 SharedMatrix Wavefunction::get_array(std::string label)
 {
     if (arrays_.count(label) == 0){
-        throw PSIEXCEPTION("Wavefunction::get_array: Requested array was not set!\n");
+        throw PSIEXCEPTION("Wavefunction::get_array: Requested array " + label + " was not set!\n");
     } else {
         return arrays_[label];
     }

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1689,7 +1689,7 @@ void HF::iterations()
             Epcm = hf_pcm_->compute_E(D_pcm, PCM::NucAndEle);
       }
           energies_["PCM Polarization"] = Epcm;
-      Process::environment.globals["PCM POLARIZATION ENERGY"] = Epcm;
+          variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
           E_ += Epcm;
 
           // Add the PCM potential to the Fock matrix

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1679,18 +1679,18 @@ void HF::iterations()
           }
 
           // Compute the PCM charges and polarization energy
-          double Epcm = 0.0;
-      if (options_.get_str("PCM_SCF_TYPE") == "TOTAL")
-      {
-            Epcm = hf_pcm_->compute_E(D_pcm, PCM::Total);
-      }
-      else
-      {
-            Epcm = hf_pcm_->compute_E(D_pcm, PCM::NucAndEle);
-      }
-          energies_["PCM Polarization"] = Epcm;
+          double epcm = 0.0;
+          if (options_.get_str("PCM_SCF_TYPE") == "TOTAL")
+          {
+            epcm = hf_pcm_->compute_E(D_pcm, PCM::Total);
+          }
+          else
+          {
+            epcm = hf_pcm_->compute_E(D_pcm, PCM::NucAndEle);
+          }
+          energies_["PCM Polarization"] = epcm;
           variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
-          E_ += Epcm;
+          E_ += epcm;
 
           // Add the PCM potential to the Fock matrix
           SharedMatrix V_pcm;
@@ -1700,6 +1700,9 @@ void HF::iterations()
             Fa_->add(V_pcm);
             Fb_->add(V_pcm);
           }
+        } else {
+          energies_["PCM Polarization"] = 0.0;
+          variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
         }
 #endif
         std::string status = "";
@@ -1840,8 +1843,6 @@ void HF::print_energies()
     outfile->Printf("    Two-Electron Energy =             %24.16f\n", energies_["Two-Electron"]);
     outfile->Printf("    DFT Exchange-Correlation Energy = %24.16f\n", energies_["XC"]);
     outfile->Printf("    Empirical Dispersion Energy =     %24.16f\n", energies_["-D"]);
-    if (!pcm_enabled_)
-        energies_["PCM Polarization"] = 0.0;
     outfile->Printf("    PCM Polarization Energy =         %24.16f\n", energies_["PCM Polarization"]);
     outfile->Printf("    EFP Energy =                      %24.16f\n", energies_["EFP"]);
     outfile->Printf("    Total Energy =                    %24.16f\n", energies_["Nuclear"] +

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -155,7 +155,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
   /*- Use total or separate potentials and charges in the PCM-SCF step. !expert -*/
   options.add_str("PCM_SCF_TYPE", "TOTAL", "TOTAL SEPARATE");
   /*- PCM-CCSD algorithm type. -*/
-  options.add_str("PCM_CC_TYPE", "PTE", "PTE PTED PTES PTE(S)");
+  options.add_str("PCM_CC_TYPE", "PTE", "PTE");
   /*- The density fitting basis to use in coupled cluster computations. -*/
   options.add_str("DF_BASIS_CC", "");
   /*- Assume external fields are arranged so that they have symmetry. It is up to the user to know what to do here. The code does NOT help you out in any way! !expert -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -154,6 +154,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
   options.add_bool("PCM", false);
   /*- Use total or separate potentials and charges in the PCM-SCF step. !expert -*/
   options.add_str("PCM_SCF_TYPE", "TOTAL", "TOTAL SEPARATE");
+  /*- PCM-CCSD algorithm type. -*/
+  options.add_str("PCM_CC_TYPE", "PTE", "PTE PTED PTES PTE(S)");
   /*- The density fitting basis to use in coupled cluster computations. -*/
   options.add_str("DF_BASIS_CC", "");
   /*- Assume external fields are arranged so that they have symmetry. It is up to the user to know what to do here. The code does NOT help you out in any way! !expert -*/

--- a/tests/pcmsolver/CMakeLists.txt
+++ b/tests/pcmsolver/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(dft)
 add_subdirectory(dipole)
 add_subdirectory(scf)
+add_subdirectory(ccsd-pte)

--- a/tests/pcmsolver/ccsd-pte/CMakeLists.txt
+++ b/tests/pcmsolver/ccsd-pte/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(pcmsolver-ccsd-pte "psi;quicktests;pcmsolver;addon;ccsd;pte")

--- a/tests/pcmsolver/ccsd-pte/input.dat
+++ b/tests/pcmsolver/ccsd-pte/input.dat
@@ -41,9 +41,9 @@ pcm =
 	}
 }
 
-energy_pte = energy('ccsd')
+energy_pte, wfn = energy('ccsd', return_wfn=True)
 compare_values(Mg.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") # TEST
 compare_values(scf_totalenergy, get_variable("SCF Total energy"), 10, "SCF Total energy (PCM, total algorithm)") # TEST
-compare_values(scf_polenergy, get_variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
+compare_values(scf_polenergy, wfn.reference_wavefunction().get_variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
 compare_values(pte_totalenergy, energy_pte, 10, "CCSD Total energy (PCM PTE algorithm)") #TEST
 compare_values(pte_correnergy, get_variable("CURRENT CORRELATION ENERGY"), 10, "CCSD Correlation energy (PCM PTE algorithm)") # TEST

--- a/tests/pcmsolver/ccsd-pte/input.dat
+++ b/tests/pcmsolver/ccsd-pte/input.dat
@@ -1,0 +1,49 @@
+nucenergy = 0.0000000000000000 # TEST 
+scf_polenergy = -0.6908724085545570 # TEST
+scf_totalenergy = -199.515074015114 # TEST
+pte_correnergy = -0.002501910865185 # TEST
+pte_totalenergy = -199.517575925979429 # TEST
+
+molecule Mg
+{
+	symmetry c1
+	Mg 0.00000 0.00000 0.00000
+	2 1
+	units bohr
+	no_reorient
+	no_com
+}
+
+set
+{
+	basis cc-pVDZ
+	scf_type pk
+	pcm true
+	pcm_scf_type total
+	pcm_cc_type pte
+}
+
+pcm =
+{
+	Units = Angstrom
+	Medium
+	{
+		SolverType = IEFPCM
+		Solvent = Water
+	}
+	Cavity
+	{
+		RadiiSet = UFF
+		Type = GePol
+		Scaling = False
+		Area = 1.0
+		Mode = Implicit
+	}
+}
+
+energy_pte = energy('ccsd')
+compare_values(Mg.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") # TEST
+compare_values(scf_totalenergy, get_variable("SCF Total energy"), 10, "SCF Total energy (PCM, total algorithm)") # TEST
+compare_values(scf_polenergy, get_variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
+compare_values(pte_totalenergy, energy_pte, 10, "CCSD Total energy (PCM PTE algorithm)") #TEST
+compare_values(pte_correnergy, get_variable("CURRENT CORRELATION ENERGY"), 10, "CCSD Correlation energy (PCM PTE algorithm)") # TEST

--- a/tests/pcmsolver/ccsd-pte/output.ref
+++ b/tests/pcmsolver/ccsd-pte/output.ref
@@ -1,0 +1,534 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1rc2.dev3 
+
+                         Git: Rev {pcm+coupled_cluster} 53e752c dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    submitted.
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 19 April 2017 06:07PM
+
+    Process ID:   8324
+    PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/objdir_pcm/stage/usr/local/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+nucenergy = 0.0000000000000000 # TEST 
+scf_polenergy = -0.6908724085545570 # TEST
+scf_totalenergy = -199.515074015114 # TEST
+pte_correnergy = -0.002501910865185 # TEST
+pte_totalenergy = -199.517575925979429 # TEST
+
+molecule Mg
+{
+	symmetry c1
+	Mg 0.00000 0.00000 0.00000
+	2 1
+	units bohr
+	no_reorient
+	no_com
+}
+
+set
+{
+	basis cc-pVDZ
+	scf_type pk
+	pcm true
+	pcm_scf_type total
+	pcm_cc_type pte
+}
+
+pcm =
+{
+	Units = Angstrom
+	Medium
+	{
+		SolverType = IEFPCM
+		Solvent = Water
+	}
+	Cavity
+	{
+		RadiiSet = UFF
+		Type = GePol
+		Scaling = False
+		Area = 1.0
+		Mode = Implicit
+	}
+}
+
+energy_pte = energy('ccsd')
+compare_values(Mg.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") # TEST
+compare_values(scf_totalenergy, get_variable("SCF Total energy"), 10, "SCF Total energy (PCM, total algorithm)") # TEST
+compare_values(scf_polenergy, get_variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
+compare_values(pte_totalenergy, energy_pte, 10, "CCSD Total energy (PCM PTE algorithm)") #TEST
+compare_values(pte_correnergy, get_variable("CURRENT CORRELATION ENERGY"), 10, "CCSD Correlation energy (PCM PTE algorithm)") # TEST
+--------------------------------------------------------------------------
+
+*** tstart() called on merzbob
+*** at Wed Apr 19 18:07:41 2017
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry MG         line   340 file /home/roberto/Workspace/robertodr/psi4/objdir_pcm/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Geometry (in Bohr), charge = 2, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          MG          0.000000000000     0.000000000000     0.000000000000    23.985041699000
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 2
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 8
+    Number of basis function: 18
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  **PSI4:PCMSOLVER Interface Active**
+
+
+ * PCMSolver, an API for the Polarizable Continuum Model electrostatic problem. Version 1.1.10
+   Main authors: R. Di Remigio, L. Frediani, K. Mozgawa
+    With contributions from:
+     R. Bast            (CMake framework)
+     U. Ekstroem        (automatic differentiation library)
+     J. Juselius        (input parsing library and CMake framework)
+   Theory: - J. Tomasi, B. Mennucci and R. Cammi:
+            "Quantum Mechanical Continuum Solvation Models", Chem. Rev., 105 (2005) 2999
+   PCMSolver is distributed under the terms of the GNU Lesser General Public License.
+
+ * Git last commit hash   : d8224d3
+ * Git last commit date   : Tue Apr 4 10:59:34 2017 +0200
+ * Git last commit author : Roberto Di Remigio
+
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 1 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 1 [initial = 1; added = 0]
+Number of finite elements = 32
+Number of irreducible finite elements = 32
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      Mg    1.5105   1.00     0.000000     0.000000     0.000000  
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.776
+Solvent radius =       1.385 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 32 tesserae, 32 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         18      18       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   1
+      Number of AO shells:               8
+      Number of primitives:             50
+      Number of atomic orbitals:        19
+      Number of basis functions:        18
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 29412 doubles for integral storage.
+  We computed 666 shell quartets total.
+  Whereas there are 666 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 1.3235326893E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.69810830105103
+   @RHF iter   1:  -199.21259729633738   -1.99213e+02   4.90283e-02 
+   PCM polarization energy = -0.69088178177868
+   @RHF iter   2:  -199.51217729708429   -2.99580e-01   4.97686e-03 DIIS
+   PCM polarization energy = -0.69087224473044
+   @RHF iter   3:  -199.51507021452034   -2.89292e-03   1.79056e-04 DIIS
+   PCM polarization energy = -0.69087224885571
+   @RHF iter   4:  -199.51507399967085   -3.78515e-06   1.16130e-05 DIIS
+   PCM polarization energy = -0.69087241214323
+   @RHF iter   5:  -199.51507401507234   -1.54015e-08   5.62809e-07 DIIS
+   PCM polarization energy = -0.69087240897607
+   @RHF iter   6:  -199.51507401510963   -3.72893e-11   6.35922e-08 DIIS
+   PCM polarization energy = -0.69087240855573
+   @RHF iter   7:  -199.51507401511003   -3.97904e-13   3.28184e-10 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -49.093830     2A     -3.798339     3A     -2.320738  
+       4A     -2.320738     5A     -2.320738  
+
+    Virtual:                                                              
+
+       6A      0.032316     7A      0.087661     8A      0.087661  
+       9A      0.087661    10A      0.245820    11A      0.350631  
+      12A      0.350631    13A      0.350631    14A      0.532397  
+      15A      0.532397    16A      0.534445    17A      0.534445  
+      18A      0.534445  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -199.51507401511003
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -271.0311192515649168
+    Two-Electron Energy =                  72.2069176450105772
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =              -0.6908724085557291
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                       -199.5150740151100592
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:    -0.0000      Y:    -0.0000      Z:    -0.0000
+
+  Dipole Moment: (a.u.)
+     X:    -0.0000      Y:    -0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:    -0.0000      Y:    -0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on merzbob at Wed Apr 19 18:07:41 2017
+Module time:
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   1
+      Number of AO shells:               8
+      Number of SO shells:               8
+      Number of primitives:             50
+      Number of atomic orbitals:        19
+      Number of basis functions:        18
+
+      Number of irreps:                  1
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  18 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 2069 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on merzbob
+*** at Wed Apr 19 18:07:42 2017
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = CCSD
+	Number of irreps     = 1
+	Number of MOs        = 18
+	Number of active MOs = 18
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = RHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A	   18	    0	    5	    0	    13	    0
+	Transforming integrals...
+	IWL integrals will be deleted.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =      0.00000000000000
+
+	Size of irrep 0 of <ab|cd> integrals:      0.029 (MW) /      0.228 (MB)
+	Total:                                     0.029 (MW) /      0.228 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.011 (MW) /      0.088 (MB)
+	Total:                                     0.011 (MW) /      0.088 (MB)
+
+	Size of irrep 0 of tijab amplitudes:       0.004 (MW) /      0.034 (MB)
+	Total:                                     0.004 (MW) /      0.034 (MB)
+
+	Nuclear Rep. energy          =      0.00000000000000
+	SCF energy                   =   -199.51507401511003
+	One-electron energy          =   -271.03111926891688
+	Two-electron energy          =     72.20691766236001
+	Reference energy             =   -199.51507401511259
+
+*** tstop() called on merzbob at Wed Apr 19 18:07:42 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.09 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on merzbob
+*** at Wed Apr 19 18:07:42 2017
+
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    0.000000000000000
+    SCF energy          (wfn)     = -199.515074015110031
+    Reference energy    (file100) = -199.515074015112589
+
+    Input parameters:
+    -----------------
+    Wave function   =     CCSD
+    Reference wfn   =     RHF
+    Brueckner       =     No
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LOW
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+MP2 correlation energy -0.0025521381885613
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.002552138188561    0.000e+00    0.000000    0.000000    0.000000    0.009563
+     1        -0.002461477056708    2.678e-03    0.000773    0.001367    0.001367    0.009126
+     2        -0.002500589165904    3.648e-04    0.000831    0.001468    0.001468    0.009283
+     3        -0.002501903541118    6.644e-05    0.000852    0.001505    0.001505    0.009286
+     4        -0.002501911364001    3.080e-06    0.000853    0.001506    0.001506    0.009286
+     5        -0.002501910961052    2.281e-07    0.000853    0.001506    0.001506    0.009286
+     6        -0.002501910888175    4.226e-08    0.000853    0.001506    0.001506    0.009286
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              3   5         0.0012496354
+              4   7         0.0012489233
+              2   6         0.0011887169
+              4   6        -0.0006905640
+              2   5         0.0006892746
+              3   7        -0.0005730078
+              1   4         0.0005590771
+              2   7         0.0004901466
+              3   6        -0.0004883283
+              1   0        -0.0003951970
+
+    Largest TIjAb Amplitudes:
+      3   3   5   5        -0.0039043516
+      4   4   7   7        -0.0039003584
+      2   2   6   6        -0.0035709418
+      3   4   5   7        -0.0030802413
+      4   3   7   5        -0.0030802413
+      2   3   6   5        -0.0028899511
+      3   2   5   6        -0.0028899511
+      2   4   6   7        -0.0028877974
+      4   2   7   6        -0.0028877974
+      1   3   4   5        -0.0023898537
+
+    SCF energy       (wfn)                    = -199.515074015110031
+    Reference energy (file100)                = -199.515074015112589
+
+    Opposite-spin MP2 correlation energy      =   -0.001841076790916
+    Same-spin MP2 correlation energy          =   -0.000711061397646
+    MP2 correlation energy                    =   -0.002552138188561
+      * MP2 total energy                      = -199.517626153301137
+
+    Opposite-spin CCSD correlation energy     =   -0.001790521079725
+    Same-spin CCSD correlation energy         =   -0.000711389807145
+    CCSD correlation energy                   =   -0.002501910888175
+      * CCSD total energy                     = -199.517575926000774
+
+
+*** tstop() called on merzbob at Wed Apr 19 18:07:42 2017
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.17 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	Nuclear repulsion energy (PCM, total algorithm)...................PASSED
+	SCF Total energy (PCM, total algorithm)...........................PASSED
+	SCF Polarization energy (PCM, total algorithm)....................PASSED
+	CCSD Total energy (PCM PTE algorithm).............................PASSED
+	CCSD Correlation energy (PCM PTE algorithm).......................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/pcmsolver/dft/input.dat
+++ b/tests/pcmsolver/dft/input.dat
@@ -39,21 +39,21 @@ pcm = {
 }
 
 print('RKS-PCM B3LYP, total algorithm')
-energy_scf1 = energy('b3lyp')
-compare_values(NH3.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
-compare_values(energy_scf1, totalenergy, 9, "Total energy (PCM, total algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, total algorithm)") #TEST
+energy_scf1, wfn1 = energy('b3lyp', return_wfn=True)
+compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
+compare_values(totalenergy, energy_scf1, 9, "Total energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, wfn1.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('RKS-PCM B3LYP, separate algorithm')
-energy_scf2 = energy('b3lyp')
-compare_values(energy_scf2, totalenergy, 9, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+energy_scf2, wfn2 = energy('b3lyp', return_wfn=True)
+compare_values(totalenergy, energy_scf2, 9, "Total energy (PCM, separate algorithm)") #TEST
+compare_values(polenergy, wfn2.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UKS on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
 set reference uks
 print('UKS-PCM B3LYP, total algorithm')
-energy_scf3 = energy('b3lyp')
-compare_values(energy_scf3, totalenergy, 9, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+energy_scf3, wfn3 = energy('b3lyp', return_wfn=True)
+compare_values(totalenergy, energy_scf3, 9, "Total energy (PCM, separate algorithm)") #TEST
+compare_values(polenergy, wfn3.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST

--- a/tests/pcmsolver/scf/input.dat
+++ b/tests/pcmsolver/scf/input.dat
@@ -45,10 +45,10 @@ pcm = {
 }
 
 print('RHF-PCM, total algorithm')
-energy_scf1 = energy('scf')
-compare_values(NH3.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
-compare_values(energy_scf1, totalenergy, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, total algorithm)") #TEST
+energy_scf1, wfn1 = energy('scf', return_wfn=True)
+compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
+compare_values(totalenergy, energy_scf1, 10, "Total energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, wfn1.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 pid = str(os.getpid())
 scratch_dir = os.path.join(core.IOManager.shared_object().get_default_path(), 'psi.' + pid + '.pcmsolver')
@@ -57,14 +57,14 @@ filter(lambda x : shutil.copy(x, psi4.extras.get_input_directory()), pcm_save)
 
 set pcm_scf_type separate
 print('RHF-PCM, separate algorithm')
-energy_scf2 = energy('scf')
-compare_values(energy_scf2, totalenergy, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+energy_scf2, wfn2 = energy('scf', return_wfn=True)
+compare_values(totalenergy, energy_scf2, 10, "Total energy (PCM, separate algorithm)") #TEST
+compare_values(polenergy, wfn2.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
 set reference uhf
 print('UHF-PCM, total algorithm')
-energy_scf3 = energy('scf')
-compare_values(energy_scf3, totalenergy, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+energy_scf3, wfn3 = energy('scf', return_wfn=True)
+compare_values(totalenergy, energy_scf3, 10, "Total energy (PCM, separate algorithm)") #TEST
+compare_values(polenergy, wfn3.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST


### PR DESCRIPTION
## Description
This PR enables CCSD calculations with the PCM in the [PTE (Perturbation-To-Energy) approximation](http://dx.doi.org/10.1063/1.3245400). The CCSD amplitude equations are solved using the solvated Fock matrix and MOs, _i.e._ running SCF with PCM and then using the solvated SCF determinant as the reference.
It boils down to adding the PCM polarization energy in the reference energy used in the CC modules.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [x] CCSD with the PCM in the PTE approximation.

## Questions
- [x] Accessing the PCM polarization energy of the reference with `Process::environment.globals["PCM POLARIZATION ENERGY"]` is probably not the cleanest solution. Are there alternatives?
- [x] This PR lacks documentation. Where should I add some notes about this?

## Status
- [x] Ready to go
