### PR TITLE
Fixes an integer overflow in libdpd

### DIFF
--- a/psi4/src/psi4/libdpd/buf4_scmcopy.cc
+++ b/psi4/src/psi4/libdpd/buf4_scmcopy.cc
@@ -54,8 +54,8 @@ namespace psi {
 int DPD::buf4_scmcopy(dpdbuf4 *InBuf, int outfilenum, const char *label, double alpha)
 {
     int h, row, col, rowtot, coltot, all_buf_irrep;
-    int nbuckets, incore, n, size;
-    long int memoryd, rows_per_bucket, rows_left;
+    int nbuckets, incore, n;
+    long int size, memoryd, rows_per_bucket, rows_left;
     dpdbuf4 OutBuf;
 
     all_buf_irrep = InBuf->file.my_irrep;
@@ -106,7 +106,7 @@ int DPD::buf4_scmcopy(dpdbuf4 *InBuf, int outfilenum, const char *label, double 
 
             rowtot = InBuf->params->rowtot[h];
             coltot = InBuf->params->coltot[h^all_buf_irrep];
-            size = rowtot*coltot;
+            size = ((long) rowtot)*((long) coltot);
 
             if(rowtot && coltot) {
                 memcpy((void *) &(OutBuf.matrix[h][0][0]),


### PR DESCRIPTION
## Description
I tracked down a seg fault during a largish cc2 calculation to an integer overflow in the value of `size` in DPD::buf4_scmcopy(). I think it was triggered because I allocated a large amount of RAM so a huge chunk of data was to be copied in one go rather than in bits. In my case,
`size = rowtot*coltot = 47252*47252 = -2062215792`
Funnily enough, memcpy wasn't very happy being called with a negative size to copy!

It's a simple case of `int*int` being larger than an int!

Changing `size` to a `long int` and adding some casts matches other sections of the file (although perhaps replacing them all with `size_t` might be better?).

## Questions
This fix got my calculation past the point where it caused the seg fault (although it's still running: it might take a few days!).

This bug probably only got triggered by large jobs with a lot of RAM so the in-core copy was performed: there could be similar overflows to track down (similar to that [recently found in the SAPT code](http://forum.psicode.org/t/sapt2-calculation-segmentation-fault-during-exch12-computation/415/6)).

I guess a safer option would be test the values for overflow (I've not thought how it behaves 32 vs 64 bit!).

## Status
- [ ] Ready to go
