### PR TITLE
Fixes a small bug in ccresponse

### DIFF
--- a/psi4/src/psi4/ccresponse/LHX1Y2.cc
+++ b/psi4/src/psi4/ccresponse/LHX1Y2.cc
@@ -363,7 +363,7 @@ double LHX1Y2(const char *pert_x, int irrep_x, double omega_x,
       }
       nrows = moinfo.virtpi[Gf];
       ncols = moinfo.virtpi[Ge];
-      if(nrows & ncols) {
+      if(nrows && ncols) {
 	C_DGEMV('n',nrows,ncols,1,&X[W.col_offset[Gfe][Gf]],ncols,
 		X1.matrix[Gm][M],1,1,z.matrix[Gb][B],1);
       }

--- a/psi4/src/psi4/ccresponse/LHX1Y2.cc
+++ b/psi4/src/psi4/ccresponse/LHX1Y2.cc
@@ -324,12 +324,6 @@ double LHX1Y2(const char *pert_x, int irrep_x, double omega_x,
   global_dpd_->buf4_close(&Z1);
   global_dpd_->file2_close(&z);
 
-/*** marker ***/
-/*** I suspect a bug in this term.  H2O2/STO-3G or DZ yields different results
- * with symmetry on and off here.  The discrepancy disappears for larger
- * basis sets, however. Note also that a similar bug may exist in the X1 or
- * X2 code, based on comparisons with a spin-adapted toy code.
- * -TDC 5 May 2009 */
   sprintf(lbl, "Z_%s_AE", pert_x);
   global_dpd_->file2_init(&z, PSIF_CC_TMP0, irrep_x, 1, 1, lbl);
 

--- a/psi4/src/psi4/ccresponse/X2.cc
+++ b/psi4/src/psi4/ccresponse/X2.cc
@@ -178,7 +178,7 @@ void X2_build(const char *pert, int irrep, double omega)
       }
       nrows = moinfo.virtpi[Gf];
       ncols = moinfo.virtpi[Ge];
-      if(nrows & ncols)
+      if(nrows && ncols)
 	C_DGEMV('n',nrows,ncols,1,&X[W.col_offset[Gfe][Gf]],ncols,
 		X1.matrix[Gm][M],1,1,z.matrix[Gb][B],1);
     }

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -110,6 +110,7 @@ void polar(void)
         if(alpha!=beta) {
           value = 0.5 * (tensor[i][alpha][beta] + tensor[i][beta][alpha]);
           tensor[i][alpha][beta] = value;
+          tensor[i][beta][alpha] = value;
         }
       }
 


### PR DESCRIPTION
## Description
Fixes a small bug in out of core dpd_dot24 function in X2.cc and LHX1Y2.cc files of ccresponse. The bug resulted in different polarizability values with symmetry on and off. It was traced to a small typo: 
use of '&' vs '&&'. Also, the polarizability tensor is properly symmetrized.
## Status
- [ X] Ready to go
