### PR TITLE
Use upstream libint1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n p4env python=$PYTHON_VER numpy cmake dftd3 libint=1.1.6 libxc gdma libefp -c psi4 -c psi4/label/dev -c psi4/label/test
+- conda create -q -n p4env python=$PYTHON_VER numpy cmake dftd3 libint=1.2.0 libxc gdma libefp -c psi4 -c psi4/label/dev -c psi4/label/test
 - source activate p4env
 - conda list
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #    - PYTHON_INCLUDE_DIR "Path to the python include files (e.g., /path/to/include/python2.7)"
 #    - SPHINX_ROOT "Root directory for Sphinx: 'bin/sphinx-build' (or similar) should be in this dir."
 #
-#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gdma, libint, PCMSolver, pybind11, simint
+#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gdma, Libint, PCMSolver, pybind11, simint
 #    - CMAKE_PREFIX_PATH "Set to list of root directories to look for externally built add-ons and dependencies
 #      (e.g., /path/to/install-libint;/path/to/install-gdma where exists /path/to/install-libint/lib/libderiv.a)"
 #    - ${AddOn}_DIR "Set to directory containing ${AddOn}Config.cmake file to facilitate detection of external build"
@@ -73,7 +73,7 @@ option(ENABLE_ambit "Enables the ambit tensor library" OFF)
 option(ENABLE_CheMPS2 "Enables CheMPS2 for DMRG (requires HDF5)" OFF)
 option(ENABLE_dkh "Enables DKH integrals (requires Fortran)" OFF)
 option(ENABLE_libefp "Enables LIBEFP for fragments" OFF)
-option(ENABLE_erd "Enables use of ERD instead of libint (requires Fortran)" OFF)
+option(ENABLE_erd "Enables use of ERD instead of Libint (requires Fortran)" OFF)
 option(ENABLE_simint "Enables use of SIMINT two-electron integral library" OFF)
 option(ENABLE_gdma "Enables Stone's GDMA multipole code (requires Fortran)" OFF)
 option(ENABLE_PCMSolver "Enables PCMSolver library (requires Fortran)" OFF)
@@ -210,7 +210,7 @@ ExternalProject_Add(psi4-core
               -Dlibefp_DIR=${libefp_DIR}
               -Derd_DIR=${erd_DIR}
               -Dgdma_DIR=${gdma_DIR}
-              -Dlibint_DIR=${libint_DIR}
+              -DLibint_DIR=${Libint_DIR}
               -DPCMSolver_DIR=${PCMSolver_DIR}
               -Dpybind11_DIR=${pybind11_DIR}
               -Dsimint_DIR=${simint_DIR}

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -179,7 +179,7 @@ What are the tools and dependencies strictly required for building Psi4
 -----------------------------------------------------------------------
 
 The core |PSIfour| build requires the software below. Note that Python,
-CMake, NumPy, and libint (and even C++ compilers on Linux) can be
+CMake, NumPy, and Libint (and even C++ compilers on Linux) can be
 satisfied through conda. The links below give examples of how to configure
 that software for |PSIfour| and any notes and warnings pertaining to it.
 
@@ -199,7 +199,7 @@ that software for |PSIfour| and any notes and warnings pertaining to it.
 The following are also required for |PSIfour|, but if not detected, the
 build system will automatically download and build.
 
-* :ref:`libint <cmake:libint>` |w---w| :ref:`[what is this?] <sec:libint>` `[min version] <https://github.com/psi4/psi4/blob/master/external/upstream/libint/CMakeLists.txt#L1>`_
+* :ref:`Libint <cmake:libint>` |w---w| :ref:`[what is this?] <sec:libint>` `[min version] <https://github.com/psi4/psi4/blob/master/external/upstream/libint/CMakeLists.txt#L1>`_
 
 * pybind11 |w---w| `[what is this?] <https://pybind11.readthedocs.io/en/master/>`_ `[min version] <https://github.com/psi4/psi4/blob/master/external/upstream/pybind11/CMakeLists.txt#L1>`_
 
@@ -269,7 +269,7 @@ Additionally, there are runtime-only capabilities:
 How to configure code to use high angular momentum basis sets
 -------------------------------------------------------------
 
-The :ref:`libint <addon:libint>` integral code handles arbitrary order
+The :ref:`Libint <addon:libint>` integral code handles arbitrary order
 angular momentum, but compiling that is prohibitive. The default of ``5``
 is generally good. ``6`` has met all of a research group's needs for
 years. ``4`` is handy for quickly testing other parts of the build.
@@ -294,7 +294,7 @@ years. ``4`` is handy for quickly testing other parts of the build.
                        # cc-pVQZ for energies, cc-pVTZ for gradients, cc-pVDZ
                        # for frequencies. [default: 5]
 
-Note that since |PSIfour| 1.1, it is possible to build libint
+Note that since |PSIfour| 1.1, it is possible to build Libint
 independently (or install just the libint conda package), then have
 any/all |PSIfour| builds detect that installation at compile-time.
 
@@ -428,7 +428,7 @@ are detected pre-built rather than built.
 How to fix error "``RuntimeError: value for ERI``"
 --------------------------------------------------
 
-You will need to rebuild libint. Reissue ``cmake`` or edit
+You will need to rebuild Libint. Reissue ``cmake`` or edit
 ``CMakeCache.txt`` with larger ``MAX_AM_ERI`` and rebuilt.
 
 * :ref:`faq:setupmaxameri`

--- a/doc/sphinxman/source/erd.rst
+++ b/doc/sphinxman/source/erd.rst
@@ -54,7 +54,7 @@ Interface to ERD by N. Flocke and V. Lotrich
 These are the AcesIII electron repulsion integrals that have
 been partially interfaced into libmints. Enabling erd and adding
 ``set integral_package erd`` (do this in ``~/.psi4rc`` for universal
-effect) runs libderiv from libint for derivative integrals and erd for
+effect) runs libderiv from Libint for derivative integrals and erd for
 non-derivative integrals.
 
 .. warning:: The interface between erd and libderiv is not fully

--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -28,11 +28,11 @@
 
 .. include:: autodoc_abbr_options_c.rst
 
-.. index:: LIBINT, integrals
+.. index:: Libint, integrals
 
 .. _`sec:libint`:
 
-Interface to LIBINT by E. Valeev
+Interface to Libint by E. Valeev
 ================================
 
 .. codeauthor:: Edward F. Valeev and Justin T. Fermann
@@ -41,7 +41,7 @@ Interface to LIBINT by E. Valeev
 .. *Module:* :ref:`Keywords <apdx:efp>`, :ref:`PSI Variables <apdx:efp_psivar>`, :source:`LIBEFP <src/lib/libefp_solver>`
 
 .. image:: https://img.shields.io/badge/home-libint-5077AB.svg
-   :target: https://github.com/psi4/libint
+   :target: https://github.com/evaleev/libint
 
 .. raw:: html
 
@@ -50,60 +50,60 @@ Interface to LIBINT by E. Valeev
 .. image:: https://img.shields.io/badge/docs-latest-5077AB.svg
    :target: http://evaleev.github.io/libint/
 
-|PSIfour|, particularly libmints utterly relies upon the LIBINT library
+|PSIfour|, particularly libmints utterly relies upon the Libint library
 developed by E. Valeev from early roots by J. Fermann. Libint requires no
 additional licence, downloads, or configuration. Conversely, |Psifour|
-cannot build *without* libint.
+cannot build *without* Libint.
 
 Installation
 ~~~~~~~~~~~~
 
 **Binary**
 
-* .. image:: https://anaconda.org/psi4/libint/badges/version.svg
-     :target: https://anaconda.org/psi4/libint
+* .. image:: https://anaconda.org/evaleev/libint/badges/version.svg
+     :target: https://anaconda.org/evaleev/libint
 
-* libint is available as a conda package for Linux and macOS.
+* Libint is available as a conda package for Linux and macOS.
 
-* If using the |PSIfour| binary, libint has already been installed alongside.
+* If using the |PSIfour| binary, Libint has already been installed alongside.
 
 * If using |PSIfour| built from source, and anaconda or miniconda has
   already been installed (instructions at :ref:`sec:quickconda`),
-  libint can be obtained through ``conda install libint``.
+  Libint can be obtained through ``conda install libint``.
   Then, hint its location with :makevar:`CMAKE_PREFIX_PATH`,
-  and rebuild |PSIfour| to detect libint and activate dependent code.
+  and rebuild |PSIfour| to detect Libint and activate dependent code.
 
 * To remove a conda installation, ``conda remove libint``.
 
 **Source**
 
-* .. image:: https://img.shields.io/github/tag/psi4/libint.svg?maxAge=2592000
-     :target: https://github.com/psi4/libint
+* .. image:: https://img.shields.io/github/tag/evaleev/libint.svg?maxAge=2592000
+     :target: https://github.com/evaleev/libint/tree/v1
 
-* If using |PSIfour| built from source and you want libint built from
+* If using |PSIfour| built from source and you want Libint built from
   from source also,
   let the build system fetch and build it and activate dependent code.
 
 
 .. _`cmake:libint`:
 
-How to configure libint for building Psi4
+How to configure Libint for building Psi4
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Role and Dependencies**
 
-* Role |w---w| In |PSIfour|, libint is a library that provides essential
+* Role |w---w| In |PSIfour|, Libint is a library that provides essential
   two-body molecular integrals over Gaussian functions.
 
-* Downstream Dependencies |w---w| |PSIfour| |dr| libint
+* Downstream Dependencies |w---w| |PSIfour| |dr| Libint
 
-* Upstream Dependencies |w---w| libint |dr| None
+* Upstream Dependencies |w---w| Libint |dr| None
 
 **CMake Variables**
 
-* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For libint, set to an installation directory containing ``include/libint/libint.h``
-* :makevar:`libint_DIR` |w---w| CMake variable to specify where pre-built libint can be found. Set to installation directory containing ``share/cmake/libint/libintConfig.cmake``
-* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_libint` |w---w| CMake variable to force internal build of libint instead of detecting pre-built
+* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For Libint, set to an installation directory containing ``include/libint/libint.h``
+* :makevar:`Libint_DIR` |w---w| CMake variable to specify where pre-built Libint can be found. Set to installation directory containing ``share/cmake/Libint/LibintConfig.cmake``
+* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_Libint` |w---w| CMake variable to force internal build of Libint instead of detecting pre-built
 
 **Examples**
 
@@ -121,11 +121,11 @@ B. Link against pre-built
 
   .. code-block:: bash
 
-    >>> cmake -Dlibint_DIR=/path/to/libint/configdir
+    >>> cmake -DLibint_DIR=/path/to/libint/configdir
 
 C. Build bundled despite pre-built being detectable
 
   .. code-block:: bash
 
-    >>> cmake -DCMAKE_PREFIX_PATH=/path/to/unwanted/libint/root/and/wanted/other/dependencies/root -DCMAKE_DISABLE_FIND_PACKAGE_libint=ON
+    >>> cmake -DCMAKE_PREFIX_PATH=/path/to/unwanted/libint/root/and/wanted/other/dependencies/root -DCMAKE_DISABLE_FIND_PACKAGE_Libint=ON
 

--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -60,8 +60,8 @@ Installation
 
 **Binary**
 
-* .. image:: https://anaconda.org/evaleev/libint/badges/version.svg
-     :target: https://anaconda.org/evaleev/libint
+* .. image:: https://anaconda.org/psi4/libint/badges/version.svg
+     :target: https://anaconda.org/psi4/libint
 
 * Libint is available as a conda package for Linux and macOS.
 

--- a/doc/sphinxman/source/manage_addon.rst
+++ b/doc/sphinxman/source/manage_addon.rst
@@ -97,7 +97,7 @@ How to integrate an Add-On into build, testing, and docs
 
 * :source:`psi4/CMakeLists.txt`
 
-  * Add a block imitating libint if Add-On required or CheMPS2 if not
+  * Add a block imitating Libint if Add-On required or CheMPS2 if not
     required
 
   * If there are shared resources to the external that need

--- a/doc/sphinxman/source/simint.rst
+++ b/doc/sphinxman/source/simint.rst
@@ -54,7 +54,7 @@ These are the vectorized implementation of the Obara-Saika (OS) method of
 calculating electron repulsion integrals developed by B. Pritchard and
 interfaced into libmints. Enabling simint and adding ``set
 integral_package simint`` (do this in ``~/.psi4rc`` for universal effect)
-runs libderiv from libint for derivative integrals and simint for
+runs libderiv from Libint for derivative integrals and simint for
 non-derivative integrals. Note that present AM maximum is ``$$(gg|gg)$$``
 
 Installation

--- a/external/upstream/libint/CMakeLists.txt
+++ b/external/upstream/libint/CMakeLists.txt
@@ -1,15 +1,15 @@
-find_package(libint CONFIG QUIET COMPONENTS ${MAX_AM_ERI})
+find_package(Libint 1.2.0 CONFIG QUIET COMPONENTS ${MAX_AM_ERI})
 
-if(${libint_FOUND})
-    get_property(_loc TARGET libint::int PROPERTY LOCATION)
-    message(STATUS "${Cyan}Found libint ${libint_MAX_AM_ERI}${ColourReset}: ${_loc} (found version ${libint_VERSION})")
+if(${Libint_FOUND})
+    get_property(_loc TARGET Libint::int PROPERTY LOCATION)
+    message(STATUS "${Cyan}Found Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (found version ${Libint_VERSION})")
     add_library(libint_external INTERFACE)  # dummy
 else()
     include(ExternalProject)
-    message(STATUS "Suitable libint could not be located, ${Magenta}Building libint${ColourReset} instead.")
+    message(STATUS "Suitable Libint could not be located, ${Magenta}Building Libint${ColourReset} instead.")
     ExternalProject_Add(libint_external
-        GIT_REPOSITORY https://github.com/psi4/libint
-        #GIT_TAG v1.7.1  # TODO tag when stable
+        GIT_REPOSITORY https://github.com/evaleev/libint
+        GIT_TAG release-1-2-0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -24,11 +24,12 @@ else()
                    -DBUILD_FPIC=${BUILD_FPIC}
                    -DENABLE_GENERIC=${ENABLE_GENERIC}
                    -DLIBC_INTERJECT=${LIBC_INTERJECT}
+                   -DMERGE_LIBDERIV_INCLUDEDIR=ON
         CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
         INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
         DESTDIR=${CMAKE_BINARY_DIR}/stage)
 
-    set(libint_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/libint CACHE PATH "path to internally built libintConfig.cmake" FORCE)
+    set(Libint_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/Libint CACHE PATH "path to internally built LibintConfig.cmake" FORCE)
 endif()
 

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -108,10 +108,10 @@ else()
     message(STATUS "Disabled gdma")
 endif()
 
-find_package(libint CONFIG REQUIRED COMPONENTS ${MAX_AM_ERI})
-get_property(_loc TARGET libint::int PROPERTY LOCATION)
+find_package(Libint 1.2.0 CONFIG REQUIRED COMPONENTS ${MAX_AM_ERI})
+get_property(_loc TARGET Libint::int PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
-message(STATUS "${Cyan}Using libint ${libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${libint_VERSION})")
+message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
 if(${ENABLE_PCMSolver})
     find_package(PCMSolver 1.1.10 CONFIG REQUIRED)

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 # LAPACK & BLAS linking attached to modules in BIN/LIBLIST to maximally defer
 
-target_include_directories(core PRIVATE $<TARGET_PROPERTY:libint::libint,INTERFACE_INCLUDE_DIRECTORIES>)  # comp def instead? only b/c boost export here not w/i mints
+target_include_directories(core PRIVATE $<TARGET_PROPERTY:Libint::libint,INTERFACE_INCLUDE_DIRECTORIES>)  # comp def instead? only b/c boost export here not w/i mints
 target_include_directories(core INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 install(TARGETS core

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -73,7 +73,7 @@ if(TARGET simint::simint)
 endif()
 psi4_add_module(lib mints sources_list iwl options psi4util trans efp_solver)
 
-target_link_libraries(mints PRIVATE libint::libint)
+target_link_libraries(mints PRIVATE Libint::libint)
 if(TARGET dkh::dkh)
     target_link_libraries(mints PRIVATE dkh::dkh)
 endif()

--- a/psi4/src/psi4/libmints/eribase.cc
+++ b/psi4/src/psi4/libmints/eribase.cc
@@ -1808,21 +1808,21 @@ TwoElectronInt::TwoElectronInt(const IntegralFactory *integral, int deriv, bool 
 
     // Make sure libint is compiled to handle our max AM
     if (max_am >= LIBINT_MAX_AM) {
-        outfile->Printf("ERROR: ERI - libint cannot handle angular momentum this high (%d).\n"
-                                "       Rebuild libint with MAX_AM_ERI at least %d.\n", max_am, max_am);
-        throw LimitExceeded<int>("ERI - libint cannot handle angular momentum this high.\n"
-                                         "Rebuild libint with MAX_AM_ERI at least (actual).\n", LIBINT_MAX_AM - 1, max_am, __FILE__, __LINE__);
+        outfile->Printf("ERROR: ERI - Libint cannot handle angular momentum this high (%d).\n"
+                                "       Rebuild Libint with MAX_AM_ERI at least %d.\n", max_am, max_am);
+        throw LimitExceeded<int>("ERI - Libint cannot handle angular momentum this high.\n"
+                                         "Rebuild Libint with MAX_AM_ERI at least (actual).\n", LIBINT_MAX_AM - 1, max_am, __FILE__, __LINE__);
     } else if (deriv_ == 1 && max_am >= LIBDERIV_MAX_AM1) {
-        outfile->Printf("ERROR: ERI - libint cannot handle angular momentum this high (%d) for first derivatives.\n"
-                                "     Rebuild libint with MAX_AM_ERI at least %d.\n", max_am, max_am + 1);
-        throw LimitExceeded<int>("ERI - libint cannot handle angular momentum this high.\n"
-                                         "Rebuild libint with MAX_AM_ERI at least (actual + 1).\n",
+        outfile->Printf("ERROR: ERI - Libint cannot handle angular momentum this high (%d) for first derivatives.\n"
+                                "     Rebuild Libint with MAX_AM_ERI at least %d.\n", max_am, max_am + 1);
+        throw LimitExceeded<int>("ERI - Libint cannot handle angular momentum this high.\n"
+                                         "Rebuild Libint with MAX_AM_ERI at least (actual + 1).\n",
                                  LIBDERIV_MAX_AM1 - 1, max_am, __FILE__, __LINE__);
     } else if (deriv_ == 2 && max_am >= LIBDERIV_MAX_AM12) {
-        outfile->Printf("ERROR: ERI - libint cannot handle angular momentum this high (%d) for second derivatives.\n"
-                                "       Reconfigure libint with MAX_AM_ERI at least %d\n", max_am, max_am + 2);
-        throw LimitExceeded<int>("ERI - libint cannot handle angular momentum this high.\n"
-                                         "Rebuild libint with MAX_AM_ERI at least (actual + 2).\n",
+        outfile->Printf("ERROR: ERI - Libint cannot handle angular momentum this high (%d) for second derivatives.\n"
+                                "       Reconfigure Libint with MAX_AM_ERI at least %d\n", max_am, max_am + 2);
+        throw LimitExceeded<int>("ERI - Libint cannot handle angular momentum this high.\n"
+                                         "Rebuild Libint with MAX_AM_ERI at least (actual + 2).\n",
                                  LIBDERIV_MAX_AM12 - 1, max_am, __FILE__, __LINE__);
     } else if (deriv_ > 2) {
         outfile->Printf("ERROR: ERI - Cannot compute higher than second derivatives.");

--- a/tests/pywrap-checkrun-rhf/input.dat
+++ b/tests/pywrap-checkrun-rhf/input.dat
@@ -18,6 +18,10 @@ set reference rhf
 print('  Checking gradient methods (ground state) ...')
 
 set basis sto-3g
+# three keywords below are so test can pass with default max_am_eri=5
+set df_basis_scf cc-pvdz-jkfit
+set df_basis_mp2 cc-pvdz-ri
+set df_basis_cc cc-pvdz-ri
 
 Earray = [
   'SCF',

--- a/tests/pywrap-checkrun-rohf/input.dat
+++ b/tests/pywrap-checkrun-rohf/input.dat
@@ -18,6 +18,10 @@ set reference rohf
 print('  Checking gradient methods (ground state) ...')
 
 set basis sto-3g
+# three keywords below are so test can pass with default max_am_eri=5
+set df_basis_scf cc-pvdz-jkfit
+set df_basis_mp2 cc-pvdz-ri
+set df_basis_cc cc-pvdz-ri
 
 Earray = [
   'SCF',

--- a/tests/pywrap-checkrun-uhf/input.dat
+++ b/tests/pywrap-checkrun-uhf/input.dat
@@ -18,6 +18,10 @@ set reference uhf
 print('  Checking gradient methods (ground state) ...')
 
 set basis sto-3g
+# three keywords below are so test can pass with default max_am_eri=5
+set df_basis_scf cc-pvdz-jkfit
+set df_basis_mp2 cc-pvdz-ri
+set df_basis_cc cc-pvdz-ri
 
 Earray = [
   'SCF',


### PR DESCRIPTION
## Description
Updates Libint 1.2.0 @ evaleev/libint <-- libint 1.1.6 @ psi4/libint, evaleev/libint#77

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] All your Psi4 build will start building Libint again b/c wrong version detected until your pre-compiled libints get updated.
* **User-Facing for Release Notes**
  - [x] Now using github.com/evaleev/libint (branch v1) rather than our own github.com/psi4/libint after pushing some CMake build details upstream. The evaleev repo didn't have CMake before v1.2.0, so that version is now required. Also, the project name changed from `libint` to `Libint` and CMake cares about this, so Psi4 repo and libint repo will have to be carefully matched for a bit.

## Status
- [x] Ready to go – Go ahead and review, but I want to look at travis/distelli before quite ready to go.
