### PR TITLE
Fixed issue where dovirt is undefined if dovirtual is passed in as a …

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1857,8 +1857,8 @@ def molden(wfn, filename=None, density_a=None, density_b=None, dovirtual=None):
 
         if density_b:
             NO_Rb = core.Matrix("NO Beta Rotation Matrix", nmopi, nmopi)
-            NO_occa = core.Vector(nmopi)
-            density_b.diagonalize(NO_Ra, NO_occa, core.DiagonalizeOrder.Descending)
+            NO_occb = core.Vector(nmopi)
+            density_b.diagonalize(NO_Rb, NO_occb, core.DiagonalizeOrder.Descending)
             NO_Cb = core.Matrix("Cb Natural Orbitals", nsopi, nmopi)
             NO_Cb.gemm(False, False, 1.0, wfn.Cb(), NO_Rb, 0)
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1842,6 +1842,9 @@ def molden(wfn, filename=None, density_a=None, density_b=None, dovirtual=None):
     if dovirtual is None:
         dovirt = bool(core.get_option("SCF", "MOLDEN_WITH_VIRTUAL"))
 
+    else:
+        dovirt = dovirtual
+
     if density_a:
         nmopi = wfn.nmopi()
         nsopi = wfn.nsopi()


### PR DESCRIPTION
…keyword argument.

## Description
When `dovirtual` is passed in as a keyword argument, `dovirt` is never assigned. Assigning `dovirt = dovirtual` allows the methods that use `dovirt` as an argument later to function correctly.

## Status
- [x] Ready to go
