### PR TITLE
Fix PCM test failure in psi4 --test

### DIFF
--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1674,36 +1674,35 @@ void HF::iterations()
           SharedMatrix D_pcm(Da_->clone());
           if(same_a_b_orbs()) {
             D_pcm->scale(2.0); // PSI4's density doesn't include the occupation
-          }
-          else {
+          } else {
             D_pcm->add(Db_);
           }
 
           // Compute the PCM charges and polarization energy
           double epcm = 0.0;
-          if (options_.get_str("PCM_SCF_TYPE") == "TOTAL")
-          {
+          if (options_.get_str("PCM_SCF_TYPE") == "TOTAL") {
             epcm = hf_pcm_->compute_E(D_pcm, PCM::Total);
-          }
-          else
-          {
+          } else {
             epcm = hf_pcm_->compute_E(D_pcm, PCM::NucAndEle);
           }
           energies_["PCM Polarization"] = epcm;
           variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+          Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
           E_ += epcm;
 
           // Add the PCM potential to the Fock matrix
           SharedMatrix V_pcm;
           V_pcm = hf_pcm_->compute_V();
-          if(same_a_b_orbs()) Fa_->add(V_pcm);
-          else {
+          if (same_a_b_orbs()) {
+            Fa_->add(V_pcm);
+          } else {
             Fa_->add(V_pcm);
             Fb_->add(V_pcm);
           }
         } else {
           energies_["PCM Polarization"] = 0.0;
           variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+          Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
         }
 #endif
         std::string status = "";

--- a/tests/pytest/test_addons.py
+++ b/tests/pytest/test_addons.py
@@ -418,23 +418,23 @@ def test_pcmsolver():
     """)
 
     print('RHF-PCM, total algorithm')
-    energy_scf1 = psi4.energy('scf')
-    assert psi4.compare_values(NH3.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)")
-    assert psi4.compare_values(energy_scf1, totalenergy, 10, "Total energy (PCM, total algorithm)")
-    assert psi4.compare_values(psi4.get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, total algorithm)")
+    energy_scf1, wfn1 = psi4.energy('scf', return_wfn=True)
+    assert psi4.compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
+    assert psi4.compare_values(totalenergy, energy_scf1, 10, "Total energy (PCM, total algorithm)") #TEST
+    assert psi4.compare_values(polenergy, wfn1.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
     psi4.set_options({'pcm_scf_type': 'separate'})
     print('RHF-PCM, separate algorithm')
     energy_scf2 = psi4.energy('scf')
-    assert psi4.compare_values(energy_scf2, totalenergy, 10, "Total energy (PCM, separate algorithm)")
-    assert psi4.compare_values(psi4.get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")
+    assert psi4.compare_values(totalenergy, energy_scf2, 10, "Total energy (PCM, separate algorithm)")
+    assert psi4.compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
 
     # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
     psi4.set_options({'pcm_scf_type': 'total', 'reference': 'uhf'})
     print('UHF-PCM, total algorithm')
     energy_scf3 = psi4.energy('scf')
-    assert psi4.compare_values(energy_scf3, totalenergy, 10, "Total energy (PCM, separate algorithm)")
-    assert psi4.compare_values(psi4.get_variable("PCM POLARIZATION ENERGY"), polenergy, 6, "Polarization energy (PCM, separate algorithm)")
+    assert psi4.compare_values(totalenergy, energy_scf3, 10, "Total energy (PCM, separate algorithm)")
+    assert psi4.compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
 
 
 def _test_scf5():


### PR DESCRIPTION
## Description
Fixes a PCM test failure when running `psi4 --test`. The bug was pointed out by @loriab in #697 

Closes #697.

## Questions
- [x] Should I also modify `tests/pytest/test_addons.py` to mirror the contents of `pcmsolver/scf/input.dat` so that it doesn't rely on `P::e.globals`? Both methods to get `PCM POLARIZATION ENERGY` are now tested. See discussion in #697 

## Status
- [x] Ready to go
