### PR TITLE
adds t1/d1 diagnostics computed in fnocc to psi4 global variables

### DIFF
--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -523,9 +523,6 @@ PsiReturnType CoupledCluster::CCSDIterations() {
   // add T1 diagnostic to globals
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
-  // add T1 diagnostic to wavefunction variables
-  set_variable("CC T1 DIAGNOSTIC",t1diag);
-
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -545,9 +542,6 @@ PsiReturnType CoupledCluster::CCSDIterations() {
 
   // add D1 diagnostic to globals
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
-
-  // add D1 diagnostic to wavefunction variables
-  set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -523,6 +523,9 @@ PsiReturnType CoupledCluster::CCSDIterations() {
   // add T1 diagnostic to globals
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
+  // add T1 diagnostic to wavefunction variables
+  reference_wavefunction_->set_variable("CC T1 DIAGNOSTIC",t1diag);
+
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -542,6 +545,9 @@ PsiReturnType CoupledCluster::CCSDIterations() {
 
   // add D1 diagnostic to globals
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
+
+  // add D1 diagnostic to wavefunction variables
+  reference_wavefunction_->set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -524,7 +524,7 @@ PsiReturnType CoupledCluster::CCSDIterations() {
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
   // add T1 diagnostic to wavefunction variables
-  reference_wavefunction_->set_variable("CC T1 DIAGNOSTIC",t1diag);
+  set_variable("CC T1 DIAGNOSTIC",t1diag);
 
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
@@ -547,7 +547,7 @@ PsiReturnType CoupledCluster::CCSDIterations() {
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
 
   // add D1 diagnostic to wavefunction variables
-  reference_wavefunction_->set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
+  set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -519,6 +519,10 @@ PsiReturnType CoupledCluster::CCSDIterations() {
 
   double t1diag = C_DNRM2(o*v,t1,1) / sqrt(2.0 * o);
   outfile->Printf("        T1 diagnostic:                   %20.12lf\n",t1diag);
+
+  // add T1 diagnostic to globals
+  Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
+
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -535,6 +539,9 @@ PsiReturnType CoupledCluster::CCSDIterations() {
   T->diagonalize(eigvec,eigval,descending);
   outfile->Printf("        D1 diagnostic:                   %20.12lf\n",sqrt(eigval->pointer()[0]));
   outfile->Printf("\n");
+
+  // add D1 diagnostic to globals
+  Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -405,6 +405,9 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
   // add T1 diagnostic to globals
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
+  // add T1 diagnostic to wavefunction variables
+  reference_wavefunction_->set_variable("CC T1 DIAGNOSTIC",t1diag);
+
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -424,6 +427,9 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
 
   // add D1 diagnostic to globals
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
+
+  // add D1 diagnostic to wavefunction variables
+  reference_wavefunction_->set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -406,7 +406,7 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
   // add T1 diagnostic to wavefunction variables
-  reference_wavefunction_->set_variable("CC T1 DIAGNOSTIC",t1diag);
+  set_variable("CC T1 DIAGNOSTIC",t1diag);
 
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
@@ -429,7 +429,7 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
 
   // add D1 diagnostic to wavefunction variables
-  reference_wavefunction_->set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
+  set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -405,9 +405,6 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
   // add T1 diagnostic to globals
   Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
 
-  // add T1 diagnostic to wavefunction variables
-  set_variable("CC T1 DIAGNOSTIC",t1diag);
-
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -427,9 +424,6 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
 
   // add D1 diagnostic to globals
   Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
-
-  // add D1 diagnostic to wavefunction variables
-  set_variable("CC D1 DIAGNOSTIC",sqrt(eigval->pointer()[0]));
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -401,6 +401,10 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
 
   double t1diag = C_DNRM2(o*v,t1,1) / sqrt(2.0 * o);
   outfile->Printf("        T1 diagnostic:                  %20.12lf\n",t1diag);
+
+  // add T1 diagnostic to globals
+  Process::environment.globals["CC T1 DIAGNOSTIC"] = t1diag;
+
   std::shared_ptr<Matrix>T (new Matrix(o,o));
   std::shared_ptr<Matrix>eigvec (new Matrix(o,o));
   std::shared_ptr<Vector>eigval (new Vector(o));
@@ -417,6 +421,9 @@ PsiReturnType DFCoupledCluster::CCSDIterations() {
   T->diagonalize(eigvec,eigval,descending);
   outfile->Printf("        D1 diagnostic:                  %20.12lf\n",sqrt(eigval->pointer()[0]));
   outfile->Printf("\n");
+
+  // add D1 diagnostic to globals
+  Process::environment.globals["CC D1 DIAGNOSTIC"] = sqrt(eigval->pointer()[0]);
 
   // delta mp2 correction for fno computations:
   if (options_.get_bool("NAT_ORBS")){


### PR DESCRIPTION
## Description
T1 and D1 diagnostics computed by ccsd/df-ccsd routed through fnocc are added to psi4 global variables

## Status
- [x] Ready to go
