### PR TITLE
Expose P::e.options in Python.

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(sources_list
         export_plugins.cc
         export_psio.cc
         export_wavefunction.cc
+        export_options.cc
         create_new_plugin.cc
         read_options.cc
         core.cc

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -80,6 +80,7 @@ void export_oeprop(py::module&);
 void export_plugins(py::module&);
 void export_psio(py::module&);
 void export_wavefunction(py::module&);
+void export_options(py::module&);
 
 // In export_plugins.cc
 void py_psi_plugin_close_all();
@@ -1442,6 +1443,7 @@ PYBIND11_PLUGIN(core) {
     core.def("opt_clean", py_psi_opt_clean, "Cleans up the optimizer's scratch files.");
     core.def("set_environment", [](const std::string key, const std::string value){ return Process::environment.set(key, value); }, "Set enviromental vairable");
     core.def("get_environment", [](const std::string key){ return Process::environment(key); }, "Get enviromental vairable");
+    core.def("get_options",[](){ return Process::environment.options; }, "Get options");
     core.def("set_output_file", [](const std::string ofname){
                  outfile = std::shared_ptr<PsiOutStream>(new OutFile(ofname, TRUNCATE));
                  outfile_name = ofname;
@@ -1461,6 +1463,7 @@ PYBIND11_PLUGIN(core) {
     export_misc(core);
     export_fock(core);
     export_wavefunction(core);
+    export_options(core);
 
     // ??
     //py::class_<Process::Environment>(core, "Environment")

--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -1,0 +1,39 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2017 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "psi4/liboptions/liboptions.h"
+
+#include <string>
+
+using namespace psi;
+
+
+void export_options(py::module& m)
+{
+    py::class_<Options>(m, "Options", "docstring");
+}


### PR DESCRIPTION
## Description
Expose P::e.options in Python and enable pure pybind11 plugins.

## Status
- [x] Ready to go