### PR TITLE
Fix gh-719, inability to project between custom basis sets

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -71,8 +71,8 @@ def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, pur
             atom_basis_list.append(lmbs)
             #lmbs.print_detail_out()
         return atom_basis_list
-
-    if isinstance(resolved_target, basestring):
+    if ((sys.version_info < (3,0) and isinstance(resolved_target, basestring)) or
+        (sys.version_info >= (3,0) and isinstance(resolved_target, str))):
         basisdict['name'] = basisdict['name'].split('/')[-1].replace('.gbs', '')
     if callable(resolved_target):
         basisdict['name'] = resolved_target.__name__.replace('basisspec_psi4_yo__', '').upper()

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -38,23 +38,27 @@ from psi4 import core
 
 ## Python basis helps
 
+
 @staticmethod
 def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, puream=-1, return_atomlist=False, quiet=False):
-    horde = qcdb.libmintsbasisset.basishorde
-
     if key == 'ORBITAL':
         key = 'BASIS'
 
-    # Figure out what exactly was meant by 'target'.
-    if target is not None:
+    def _resolve_target(key, target):
+        """Figure out exactly what basis set was intended by (key, target)
+        """
+        horde = qcdb.libmintsbasisset.basishorde
+        if not target:
+            if not key:
+                key = 'BASIS'
+            target = core.get_global_option(key)
+    
         if target in horde:
-            resolved_target = horde[target]
-        else:
-            resolved_target = target
-    else:
-        if key is None:
-            key = 'BASIS'
-        resolved_target = core.get_global_option(key)
+            return horde[target]
+        return target
+
+    # Figure out what exactly was meant by 'target'.
+    resolved_target = _resolve_target(key, target)
 
     # resolved_target needs to be either a string or function for pyconstuct.
     # if a string, they search for a gbs file with that name.

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -84,6 +84,8 @@ def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, pur
     if not quiet:
         core.print_out(basisdict['message'])
 
+    if basisdict['key'] is None:
+        basisdict['key'] = 'BASIS'
     psibasis = core.BasisSet.construct_from_pydict(mol, basisdict, puream)
     ecpbasis = None
     if 'ecp_shell_map' in basisdict:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-sa-sp ao-casscf-sp casscf-sp ca
                   pywrap-db3 pywrap-freq-e-sowreap pywrap-freq-g-sowreap 
                   pywrap-molecule pywrap-opt-sowreap rasci-c2-active rasci-h2o 
                   rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 
-                  sapt7 sapt8 scf-bz2 scf-ecp scf-guess-read1 scf-guess-read2 scf-bs scf1 scf-occ
+                  sapt7 sapt8 scf-bz2 scf-ecp scf-guess-read1 scf-upcast-custom-basis scf-guess-read2 scf-bs scf1 scf-occ
                   scf2 scf3 scf4 scf5 scf6 scf7 scf-property soscf-large soscf-ref
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare
                   stability2 tu1-h2o-energy tu2-ch2-energy tu3-h2o-opt scf-response1 

--- a/tests/mints3/input.dat
+++ b/tests/mints3/input.dat
@@ -17,7 +17,7 @@ set {
   basis sto-3g
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 
@@ -44,7 +44,7 @@ set {
   basis 6-311G**
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 
@@ -71,7 +71,7 @@ set {
   basis cc-pVTZ
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 
@@ -102,7 +102,7 @@ set {
   basis sto-3g
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 
@@ -129,7 +129,7 @@ set {
   basis 6-311G**
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 
@@ -156,7 +156,7 @@ set {
   basis cc-pVTZ
 }
 
-wfn = Wavefunction(h2o, BasisSet.build(h2o)[0])
+wfn = Wavefunction(h2o, BasisSet.build(h2o))
 mints = MintsHelper(wfn.basisset())
 factory = mints.factory()                                            #TEST
 

--- a/tests/mints9/purepythonanalog.in
+++ b/tests/mints9/purepythonanalog.in
@@ -13,7 +13,7 @@ H_l -0.5  0.7 0.0
 """)
 
 print('[1]    <<<  uniform cc-pVDZ  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', 'cc-pvdz')
+wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', 'cc-pvdz')[0]
 compare_integers(38, wert.nbf(), 'nbf()')
 compare_integers(40, wert.nao(), 'nao()')
 compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -21,7 +21,7 @@ mymol.print_out()
 
 
 print('[2]        <<<  RIFIT (default)  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', '', 'RIFIT', 'cc-pvdz')
+wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', '', 'RIFIT', 'cc-pvdz')[0]
 qcdb.compare_integers(140, wert.nbf(), 'nbf()')
 qcdb.compare_integers(162, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -33,7 +33,7 @@ basis dz_PLUS {
     assign cc-pvdz
     assign c aug-cc-pvdz
 }
-wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plus)[0]
 qcdb.compare_integers(47, wert.nbf(), 'nbf()')
 qcdb.compare_integers(50, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -41,7 +41,7 @@ mymol.print_out()
 
 
 print('[4]        <<<  RIFIT (default)  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', '', 'RIFIT', basisspec_psi4_yo__dz_plus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', '', 'RIFIT', basisspec_psi4_yo__dz_plus)[0]
 qcdb.compare_integers(156, wert.nbf(), 'nbf()')
 qcdb.compare_integers(182, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -54,7 +54,7 @@ basis dz_PLUSplus {
     assign c aug-cc-pvdz
     assign h_r aug-cc-pvdz
 }
-wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plusplus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plusplus)[0]
 qcdb.compare_integers(51, wert.nbf(), 'nbf()')
 qcdb.compare_integers(54, wert.nao(), 'nao()')
 qcdb.compare_strings('cs', mymol.schoenflies_symbol(), 'symm')
@@ -66,7 +66,7 @@ basis dz_PLUSplusRI {
     #assign aug-cc-pvdz-ri
     assign h cc-pvdz-ri
 }
-wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', basisspec_psi4_yo__dz_plusplusri, 'RIFIT', basisspec_psi4_yo__dz_plusplus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_MP2', basisspec_psi4_yo__dz_plusplusri, 'RIFIT', basisspec_psi4_yo__dz_plusplus)[0]
 qcdb.compare_integers(156, wert.nbf(), 'nbf()')
 qcdb.compare_integers(182, wert.nao(), 'nao()')
 qcdb.compare_strings('cs', mymol.schoenflies_symbol(), 'symm')
@@ -79,7 +79,7 @@ basis dz_PLUSplusplus {
     assign c aug-cc-pvdz
     assign h aug-cc-pvdz
 }
-wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plusplusplus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', basisspec_psi4_yo__dz_plusplusplus)[0]
 qcdb.compare_integers(55, wert.nbf(), 'nbf()')
 qcdb.compare_integers(58, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -87,7 +87,7 @@ mymol.print_out()
 
 
 print('[8]        <<<  JKFIT (default)  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_SCF', '', 'JKFIT', basisspec_psi4_yo__dz_plusplusplus)
+wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_SCF', '', 'JKFIT', basisspec_psi4_yo__dz_plusplusplus)[0]
 qcdb.compare_integers(220, wert.nbf(), 'nbf()')
 qcdb.compare_integers(252, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -95,7 +95,7 @@ mymol.print_out()
 
 
 print('[9]    <<<  aug-cc-pVDZ  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', 'aug-cc-pvdz')
+wert = qcdb.BasisSet.pyconstruct(mymol, 'BASIS', 'aug-cc-pvdz')[0]
 qcdb.compare_integers(64, wert.nbf(), 'nbf()')
 qcdb.compare_integers(68, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -103,7 +103,7 @@ mymol.print_out()
 
 
 print('[10]       <<<  JKFIT (default)  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_SCF', '', 'JKFIT', 'aug-cc-PVDZ')
+wert = qcdb.BasisSet.pyconstruct(mymol, 'DF_BASIS_SCF', '', 'JKFIT', 'aug-cc-PVDZ')[0]
 qcdb.compare_integers(236, wert.nbf(), 'nbf()')
 qcdb.compare_integers(272, wert.nao(), 'nao()')
 qcdb.compare_strings('c2v', mymol.schoenflies_symbol(), 'symm')
@@ -119,7 +119,7 @@ H_c -0.5  0.0 0.7
 """)
 
 print('[11]   <<<  cc-pVDZ w/ aug-cc-pVDZ on C, H  >>>')
-wert = qcdb.BasisSet.pyconstruct(mymol2, 'BASIS', basisspec_psi4_yo__dz_plusplusplus)
+wert = qcdb.BasisSet.pyconstruct(mymol2, 'BASIS', basisspec_psi4_yo__dz_plusplusplus)[0]
 qcdb.compare_integers(64, wert.nbf(), 'nbf()')
 qcdb.compare_integers(67, wert.nao(), 'nao()')
 qcdb.compare_strings('cs', mymol2.schoenflies_symbol(), 'symm')
@@ -136,13 +136,13 @@ H1         0.000000000000  0.000000000000   1.246511684916
 """)
 
 print('[13]')
-wert = qcdb.BasisSet.pyconstruct(mymol3, 'BASIS', 'cc-pvdz')
+wert = qcdb.BasisSet.pyconstruct(mymol3, 'BASIS', 'cc-pvdz')[0]
 qcdb.compare_integers(23, wert.nbf(), 'nbf()')
 qcdb.compare_integers(24, wert.nao(), 'nao()')
 mymol3.print_out()
 
 print('[14]')
-wert = qcdb.BasisSet.pyconstruct(mymol3, 'BASIS_X2C', '', 'DECON', 'cc-pvdz')
+wert = qcdb.BasisSet.pyconstruct(mymol3, 'BASIS_X2C', '', 'DECON', 'cc-pvdz')[0]
 #wert.print_by_level(level=3)
 qcdb.compare_integers(48, wert.nbf(), 'nbf()')
 qcdb.compare_integers(49, wert.nao(), 'nao()')

--- a/tests/scf-upcast-custom-basis/CMakeLists.txt
+++ b/tests/scf-upcast-custom-basis/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(scf-upcast-custom-basis "psi;quicktests;scf")

--- a/tests/scf-upcast-custom-basis/input.dat
+++ b/tests/scf-upcast-custom-basis/input.dat
@@ -1,0 +1,30 @@
+molecule {
+  O 
+  H 1 0.96
+  H 1 0.96 2 104.5
+}
+
+basis low {
+    assign sto-3g
+}
+basis high {
+    assign cc-pvdz
+}
+set scf d_convergence 6
+
+
+core.IO.set_default_namespace("low")
+set basis low
+energy('hf')
+
+compare_values(-74.9634059, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+
+
+core.IO.set_default_namespace('high')
+core.IO.change_file_namespace(180, 'low', 'high')
+set guess read
+set basis high
+energy('hf')
+
+
+compare_values(-76.02663273485877, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST


### PR DESCRIPTION
## Description
Fixes #719 by changing the `name` that's passed to the C++ BasisSet constructor. It used to be like `file /path/to/basis/set.gbs`, but that it very tricky to read the basis set name from a dumped wavefunction and reinstantiate the basis set. For built-in basis sets, it's not too bad -- we can just [parse the string](https://github.com/psi4/psi4/blob/9d1564e67837bbf7f348c1600aa2c353457671ec/psi4/driver/procrouting/proc.py#L1295). For custom basis sets that assign different basis sets to different atoms, that string ends up as a `'+'`-delimited list of gbs files, which isn't information preserving.

@andysim: if you're going to rewrite this stuff anyways, it might not be worth merging this.

## Status
- [ ] Ready to go
