### PR TITLE
Minor changes in ccdensity and ccresponse

### DIFF
--- a/psi4/src/psi4/ccdensity/Params.h
+++ b/psi4/src/psi4/ccdensity/Params.h
@@ -59,6 +59,7 @@ struct Params {
   int prop_all;
   std::string gauge;
   bool write_nos;
+  int debug_;
 
   /* these are used by Xi and twopdm code */
   int G_irr; 

--- a/psi4/src/psi4/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/ccdensity/ccdensity.cc
@@ -271,7 +271,7 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options& options)
  
     sortone(rho_params[i]); /* puts full 1-pdm into moinfo.opdm */
     if (!params.onepdm) {
-      if(!params.aobasis) energy(rho_params[i]);
+      if(!params.aobasis && params.debug_) energy(rho_params[i]);
 
       kinetic(ref_wfn); /* puts kinetic energy integrals into MO basis */
 

--- a/psi4/src/psi4/ccdensity/deanti_RHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_RHF.cc
@@ -80,7 +80,7 @@ namespace psi { namespace ccdensity {
       double one_energy = 0.0, two_energy = 0.0, total_two_energy = 0.0;
       dpdbuf4 A, B, C, DInts, E, FInts;
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
 	outfile->Printf(   "\t-------------------------------------------\n");
 
@@ -120,7 +120,7 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 0, 0, 0, 0, 0, "2 Gijkl - Gijlk");
       global_dpd_->buf4_copy(&G1, PSIF_CC_GAMMA, "GIjKl");
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
 	two_energy = global_dpd_->buf4_dot(&A, &G1);
 	global_dpd_->buf4_close(&A);
@@ -139,7 +139,7 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 0, 10, 0, 10, 0, "2 Gijka - Gjika");
       /* The factor of 2 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GIjKa", 2);
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
 	two_energy = global_dpd_->buf4_dot(&E, &G1);
 	global_dpd_->buf4_close(&E);
@@ -164,7 +164,7 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "2 Gijab - Gijba");
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GIjAb", 2);
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
 	two_energy = 2.0 * global_dpd_->buf4_dot(&DInts, &G1);
 	global_dpd_->buf4_close(&DInts);
@@ -180,7 +180,7 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_axpy(&G2, &G1, 1);
       global_dpd_->buf4_close(&G2);
       //  dpd_buf4_scm(&G1, 2);
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
 	two_energy = 2.0 * global_dpd_->buf4_dot(&C, &G1);
 	global_dpd_->buf4_close(&C);
@@ -200,7 +200,7 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "2 Gciab - Gciba");
       /* The factor of 2 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GCiAb", 2);
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
 	global_dpd_->buf4_sort(&FInts, PSIF_CC_FINTS, qpsr, 11, 5, "F <ai|bc>");
 	global_dpd_->buf4_close(&FInts);
@@ -223,7 +223,7 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "2 Gabcd - Gabdc");
       global_dpd_->buf4_copy(&G1, PSIF_CC_GAMMA, "GAbCd");
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
 	two_energy = global_dpd_->buf4_dot(&B, &G1);
 	global_dpd_->buf4_close(&B);
@@ -233,7 +233,7 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_close(&G1);
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
 	if (params.ground) {
 	  //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",

--- a/psi4/src/psi4/ccdensity/deanti_RHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_RHF.cc
@@ -81,35 +81,34 @@ namespace psi { namespace ccdensity {
       dpdbuf4 A, B, C, DInts, E, FInts;
 
       if(!params.aobasis && params.debug_) {
-	outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
-	outfile->Printf(   "\t-------------------------------------------\n");
+	    outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
+	    outfile->Printf(   "\t-------------------------------------------\n");
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(i,j)");
-	one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(i,j)");
+	    one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(a,b)");
-	one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(a,b)");
+	    one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
-	one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
+	    one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
-	one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
+	    one_energy += 2.0*global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
 
-	outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
-
+	    outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
       }
 
       /* E_ijkl = (2 Gijkl - Gijlk) <ij|kl> */
@@ -120,12 +119,13 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 0, 0, 0, 0, 0, "2 Gijkl - Gijlk");
       global_dpd_->buf4_copy(&G1, PSIF_CC_GAMMA, "GIjKl");
+
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
-	two_energy = global_dpd_->buf4_dot(&A, &G1);
-	global_dpd_->buf4_close(&A);
-	outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-	total_two_energy += two_energy;
+	    global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
+	    two_energy = global_dpd_->buf4_dot(&A, &G1);
+	    global_dpd_->buf4_close(&A);
+	    outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
+	    total_two_energy += two_energy;
       }
       global_dpd_->buf4_close(&G1);
 
@@ -140,12 +140,12 @@ namespace psi { namespace ccdensity {
       /* The factor of 2 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GIjKa", 2);
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
-	two_energy = global_dpd_->buf4_dot(&E, &G1);
-	global_dpd_->buf4_close(&E);
-	/* The factor of 4 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
-	outfile->Printf( "\tIJKA energy                = %20.15f\n", 4*two_energy);
-	total_two_energy += 4*two_energy;
+	    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
+	    two_energy = global_dpd_->buf4_dot(&E, &G1);
+	    global_dpd_->buf4_close(&E);
+	    /* The factor of 4 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
+	    outfile->Printf( "\tIJKA energy                = %20.15f\n", 4*two_energy);
+	    total_two_energy += 4*two_energy;
       }
       global_dpd_->buf4_close(&G1);
 
@@ -165,11 +165,11 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "2 Gijab - Gijba");
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GIjAb", 2);
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
-	two_energy = 2.0 * global_dpd_->buf4_dot(&DInts, &G1);
-	global_dpd_->buf4_close(&DInts);
-	outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
-	total_two_energy += two_energy;
+	    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
+	    two_energy = 2.0 * global_dpd_->buf4_dot(&DInts, &G1);
+	    global_dpd_->buf4_close(&DInts);
+	    outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
+	    total_two_energy += two_energy;
       }
 
       global_dpd_->buf4_close(&G1);
@@ -181,11 +181,11 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_close(&G2);
       //  dpd_buf4_scm(&G1, 2);
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
-	two_energy = 2.0 * global_dpd_->buf4_dot(&C, &G1);
-	global_dpd_->buf4_close(&C);
-	outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
-	total_two_energy += two_energy;
+	    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
+	    two_energy = 2.0 * global_dpd_->buf4_dot(&C, &G1);
+	    global_dpd_->buf4_close(&C);
+	    outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
+	    total_two_energy += two_energy;
       }
 
       global_dpd_->buf4_close(&G1);
@@ -201,15 +201,15 @@ namespace psi { namespace ccdensity {
       /* The factor of 2 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
       global_dpd_->buf4_scmcopy(&G1, PSIF_CC_GAMMA, "GCiAb", 2);
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
-	global_dpd_->buf4_sort(&FInts, PSIF_CC_FINTS, qpsr, 11, 5, "F <ai|bc>");
-	global_dpd_->buf4_close(&FInts);
-	global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 11, 5, 11, 5, 0, "F <ai|bc>");
-	two_energy = global_dpd_->buf4_dot(&FInts, &G1);
-	global_dpd_->buf4_close(&FInts);
-	/* The factor of 4 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
-	outfile->Printf( "\tCIAB energy                = %20.15f\n", 4*two_energy);
-	total_two_energy += 4*two_energy;
+	    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
+	    global_dpd_->buf4_sort(&FInts, PSIF_CC_FINTS, qpsr, 11, 5, "F <ai|bc>");
+	    global_dpd_->buf4_close(&FInts);
+	    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 11, 5, 11, 5, 0, "F <ai|bc>");
+	    two_energy = global_dpd_->buf4_dot(&FInts, &G1);
+	    global_dpd_->buf4_close(&FInts);
+	    /* The factor of 4 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
+	    outfile->Printf( "\tCIAB energy                = %20.15f\n", 4*two_energy);
+	    total_two_energy += 4*two_energy;
       }
 
       global_dpd_->buf4_close(&G1);
@@ -224,26 +224,26 @@ namespace psi { namespace ccdensity {
       global_dpd_->buf4_init(&G1, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "2 Gabcd - Gabdc");
       global_dpd_->buf4_copy(&G1, PSIF_CC_GAMMA, "GAbCd");
       if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
-	two_energy = global_dpd_->buf4_dot(&B, &G1);
-	global_dpd_->buf4_close(&B);
-	outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
-	total_two_energy += two_energy;
+	    global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
+	    two_energy = global_dpd_->buf4_dot(&B, &G1);
+	    global_dpd_->buf4_close(&B);
+	    outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
+	    total_two_energy += two_energy;
       }
 
       global_dpd_->buf4_close(&G1);
 
       if(!params.aobasis && params.debug_) {
-	outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
-	if (params.ground) {
-	  //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
-	  //	  one_energy + total_two_energy);
-	  //outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
-	  //	  one_energy + total_two_energy + moinfo.eref);
-	  outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-                one_energy + total_two_energy);
-          outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-                one_energy + total_two_energy + moinfo.eref);	  
+	    outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
+	    if (params.ground) {
+	      //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
+	      //	  one_energy + total_two_energy);
+	      //outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
+	      //	  one_energy + total_two_energy + moinfo.eref);
+	      outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+                    one_energy + total_two_energy);
+              outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+                    one_energy + total_two_energy + moinfo.eref);	  
 	}
 	else {
 	  outfile->Printf( "\tTotal EOM CCSD correlation energy        = %20.15f\n",
@@ -252,7 +252,7 @@ namespace psi { namespace ccdensity {
 		  moinfo.ecc + params.cceom_energy);
 	  outfile->Printf( "\tTotal EOM CCSD energy                    = %20.15f\n",
 		  one_energy + total_two_energy + moinfo.eref);
-	}
+	    }
       }
     }
 

--- a/psi4/src/psi4/ccdensity/deanti_ROHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_ROHF.cc
@@ -131,7 +131,6 @@ void deanti_ROHF(struct RHO_Params rho_params)
     global_dpd_->file2_close(&D);
 
     outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
-
   }
 
   /* G(Ij,Kl) <-- 1/2 G(IJ,KL) + 1/2 G(ij,kl) + 1/2 G(Ij,Kl) + 1/2 G(iJ,kL) */
@@ -322,12 +321,12 @@ void deanti_ROHF(struct RHO_Params rho_params)
   if(!params.aobasis && params.debug_) {
     outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
     if (params.ground) {
-      outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
+       outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
 	      one_energy + total_two_energy);
-      outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
+       outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
 	      one_energy + total_two_energy + moinfo.eref);
-    }
-    else {
+  }
+   else {
       outfile->Printf( "\tTotal EOM CCSD correlation energy        = %20.15f\n",
           one_energy + total_two_energy);
       outfile->Printf( "\tCCSD correlation + EOM excitation energy = %20.15f\n",

--- a/psi4/src/psi4/ccdensity/deanti_ROHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_ROHF.cc
@@ -78,7 +78,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   double one_energy = 0.0, two_energy = 0.0, total_two_energy = 0.0;
   dpdbuf4 A, B, C, DInts, E, FInts;
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
     outfile->Printf(   "\t-------------------------------------------\n");
 
@@ -151,7 +151,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_close(&G2);
   global_dpd_->buf4_scm(&G1, 0.5);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
     two_energy = global_dpd_->buf4_dot(&A, &G1);
     global_dpd_->buf4_close(&A);
@@ -173,7 +173,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G1, 1.0);
   global_dpd_->buf4_close(&G2);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
     two_energy = global_dpd_->buf4_dot(&E, &G1);
     global_dpd_->buf4_close(&E);
@@ -232,7 +232,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G1, 1.0);
   global_dpd_->buf4_close(&G2);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
     two_energy = global_dpd_->buf4_dot(&DInts, &G1);
     global_dpd_->buf4_close(&DInts);
@@ -254,7 +254,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G1, 1.0);
   global_dpd_->buf4_close(&G2);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
     two_energy = global_dpd_->buf4_dot(&C, &G1);
     global_dpd_->buf4_close(&C);
@@ -276,7 +276,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G1, 1.0);
   global_dpd_->buf4_close(&G2);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
     global_dpd_->buf4_sort(&FInts, PSIF_CC_TMP0, qprs, 11, 5, "F(CI,BA)");
     global_dpd_->buf4_close(&FInts);
@@ -309,7 +309,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
   global_dpd_->buf4_close(&G2);
   global_dpd_->buf4_scm(&G1, 0.5);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
     two_energy = global_dpd_->buf4_dot(&B, &G1);
     global_dpd_->buf4_close(&B);
@@ -319,7 +319,7 @@ void deanti_ROHF(struct RHO_Params rho_params)
 
   global_dpd_->buf4_close(&G1);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
     if (params.ground) {
       outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",

--- a/psi4/src/psi4/ccdensity/deanti_UHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_UHF.cc
@@ -83,84 +83,82 @@ void deanti_UHF(struct RHO_Params rho_params)
   dpdbuf4 G, G2, A, B, C, D, E, F;
 
  double one_energy=0.0, two_energy=0.0, total_two_energy=0.0;
+
  if(params.debug_) {
+   outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
+   outfile->Printf(   "\t-------------------------------------------\n");
 
-  outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
-  outfile->Printf(   "\t-------------------------------------------\n");
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 0, "h(I,J)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 0, "h(I,J)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 2, rho_params.Dij_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 2, "h(i,j)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 2, rho_params.Dij_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 2, "h(i,j)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 1, 1, "h(A,B)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 1, 1, "h(A,B)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 3, 3, rho_params.Dab_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 3, 3, "h(a,b)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 3, 3, rho_params.Dab_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 3, 3, "h(a,b)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 3, rho_params.Dia_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 3, rho_params.Dia_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
+   global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 3, rho_params.Dai_lbl);
+   global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
+   one_energy += global_dpd_->file2_dot(&d, &h);
+   global_dpd_->file2_close(&h);
+   global_dpd_->file2_close(&d);
 
-  global_dpd_->file2_init(&d, PSIF_CC_OEI, 0, 2, 3, rho_params.Dai_lbl);
-  global_dpd_->file2_init(&h, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
-  one_energy += global_dpd_->file2_dot(&d, &h);
-  global_dpd_->file2_close(&h);
-  global_dpd_->file2_close(&d);
-
-  outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
+   outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
   }
 
   /* G(Ij,Kl) = 1/2 G(Ij,Kl) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 22, 22, 22, 0, "GIjKl");
   global_dpd_->buf4_scm(&G, 0.5);
   if(params.debug_) {
-  global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
-  two_energy = 2*global_dpd_->buf4_dot(&A, &G);
-  global_dpd_->buf4_close(&A);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIjKl energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
+    two_energy = 2*global_dpd_->buf4_dot(&A, &G);
+    global_dpd_->buf4_close(&A);
+    outfile->Printf( "\tIjKl energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   } 
   global_dpd_->buf4_close(&G);
   /* G(IJ,KL) = 1/2 G(IJ,KL) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 0, 2, 2, 0, "GIJKL");
   global_dpd_->buf4_scm(&G, 0.5);
   if(params.debug_) {
-  global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <IJ|KL>");
-  two_energy = global_dpd_->buf4_dot(&A, &G);
-  global_dpd_->buf4_close(&A);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <IJ|KL>");
+    two_energy = global_dpd_->buf4_dot(&A, &G);
+    global_dpd_->buf4_close(&A);
+    outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
@@ -168,46 +166,45 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 12, 12, 0, "Gijkl");
   global_dpd_->buf4_scm(&G, 0.5);
   if(params.debug_) {
-  global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 0, "A <ij|kl>");
-  two_energy = global_dpd_->buf4_dot(&A, &G);
-  global_dpd_->buf4_close(&A);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tijkl energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 0, "A <ij|kl>");
+    two_energy = global_dpd_->buf4_dot(&A, &G);
+    global_dpd_->buf4_close(&A);
+    outfile->Printf( "\tijkl energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
   if(params.debug_) {
   /* No change to G(IJ,KA) components */
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 24, 22, 24, 0, "GIjKa");
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
-  two_energy = 2*global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
-  global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 24, 22, 24, 0, "GIjKa");
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
+    two_energy = 2*global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_close(&G);
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 23, 27, 23, 27, 0, "GiJkA");
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 23, 27, 23, 27, 0, "E <iJ|kA>");
-  two_energy += 2*global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIjKa+iJkA energy           = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 23, 27, 23, 27, 0, "GiJkA");
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 23, 27, 23, 27, 0, "E <iJ|kA>");
+    two_energy += 2*global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tIjKa+iJkA energy           = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 20, 2, 20, 0, "GIJKA");
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 20, 0, 20, 0, "E <IJ|KA>");
-  two_energy = 2*global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 20, 2, 20, 0, "GIJKA");
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 20, 0, 20, 0, "E <IJ|KA>");
+    two_energy = 2*global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 30, 12, 30, 0, "Gijka");
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 10, 30, 10, 30, 0, "E <ij|ka>");
-  two_energy = 2*global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tijka energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 30, 12, 30, 0, "Gijka");
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 10, 30, 10, 30, 0, "E <ij|ka>");
+    two_energy = 2*global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tijka energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
 
   /* G(Ij,Ab) <-- G(Ij,Ab) - G(Ib,jA) */
@@ -219,12 +216,11 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
   if(params.debug_) {
-  global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 22, 28, 22, 28, 0, "D <Ij|Ab>");
-  two_energy = 2 * global_dpd_->buf4_dot(&D, &G);
-  global_dpd_->buf4_close(&D);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIjAb energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 22, 28, 22, 28, 0, "D <Ij|Ab>");
+    two_energy = 2 * global_dpd_->buf4_dot(&D, &G);
+    global_dpd_->buf4_close(&D);
+    outfile->Printf( "\tIjAb energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
@@ -240,12 +236,11 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
   if(params.debug_) {
-  global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <IJ|AB>");
-  two_energy = global_dpd_->buf4_dot(&D, &G);
-  global_dpd_->buf4_close(&D);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <IJ|AB>");
+    two_energy = global_dpd_->buf4_dot(&D, &G);
+    global_dpd_->buf4_close(&D);
+    outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
@@ -261,122 +256,121 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
   if(params.debug_) {
-  global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 10, 15, 10, 15, 0, "D <ij|ab>");
-  two_energy = global_dpd_->buf4_dot(&D, &G);
-  global_dpd_->buf4_close(&D);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tijab energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 10, 15, 10, 15, 0, "D <ij|ab>");
+    two_energy = global_dpd_->buf4_dot(&D, &G);
+    global_dpd_->buf4_close(&D);
+    outfile->Printf( "\tijab energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
   if(params.debug_) {
-  /* No change to G(IB,JA) components */
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 20, 20, 20, 20, 0, "GIBJA");
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA|JB>");
-  two_energy = global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    /* No change to G(IB,JA) components */
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 20, 20, 20, 20, 0, "GIBJA");
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA|JB>");
+    two_energy = global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 30, 30, 30, 30, 0, "Gibja");
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 30, 30, 30, 30, 0, "C <ia|jb>");
-  two_energy = global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tibja energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 30, 30, 30, 30, 0, "Gibja");
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 30, 30, 30, 30, 0, "C <ia|jb>");
+    two_energy = global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tibja energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 24, 24, 24, 24, 0, "GIbJa");
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 24, 24, 24, 24, 0, "C <Ia|Jb>");
-  two_energy = global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
-  global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 24, 24, 24, 24, 0, "GIbJa");
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 24, 24, 24, 24, 0, "C <Ia|Jb>");
+    two_energy = global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_close(&G);
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 27, 27, 27, 27, 0, "GiBjA");
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 27, 27, 27, 27, 0, "C <iA|jB>");
-  two_energy += global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tiBjA+IbJa energy           = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 27, 27, 27, 27, 0, "GiBjA");
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 27, 27, 27, 27, 0, "C <iA|jB>");
+    two_energy += global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tiBjA+IbJa energy           = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
 
-  /* No change to G(CI,AB) components */
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 26, 28, 26, 28, 0, "GCiAb");
-  global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 26, 28, 26, 28, 0, "F <Ai|Bc>");
-  two_energy = 2*global_dpd_->buf4_dot(&F, &G);
-  global_dpd_->buf4_close(&F);
-  global_dpd_->buf4_close(&G);
+    /* No change to G(CI,AB) components */
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 26, 28, 26, 28, 0, "GCiAb");
+    global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 26, 28, 26, 28, 0, "F <Ai|Bc>");
+    two_energy = 2*global_dpd_->buf4_dot(&F, &G);
+    global_dpd_->buf4_close(&F);
+    global_dpd_->buf4_close(&G);
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 25, 29, 25, 29, 0, "GcIaB");
-  global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 25, 29, 25, 29, 0, "F <aI|bC>");
-  two_energy += 2*global_dpd_->buf4_dot(&F, &G);
-  global_dpd_->buf4_close(&F);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tcIaB+CiAb energy           = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 25, 29, 25, 29, 0, "GcIaB");
+    global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 25, 29, 25, 29, 0, "F <aI|bC>");
+    two_energy += 2*global_dpd_->buf4_dot(&F, &G);
+    global_dpd_->buf4_close(&F);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tcIaB+CiAb energy           = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 21, 5, 21, 7, 0, "GCIAB");
-  global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 21, 5, 21, 5, 0, "F <AI|BC>");
-  two_energy = 2*global_dpd_->buf4_dot(&F, &G);
-  global_dpd_->buf4_close(&F);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 21, 5, 21, 7, 0, "GCIAB");
+    global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 21, 5, 21, 5, 0, "F <AI|BC>");
+    two_energy = 2*global_dpd_->buf4_dot(&F, &G);
+    global_dpd_->buf4_close(&F);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
 
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 31, 15, 31, 17, 0, "Gciab");
-  global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 31, 15, 31, 15, 0, "F <ai|bc>");
-  two_energy = 2*global_dpd_->buf4_dot(&F, &G);
-  global_dpd_->buf4_close(&F);
-  global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tciab energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 31, 15, 31, 17, 0, "Gciab");
+    global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 31, 15, 31, 15, 0, "F <ai|bc>");
+    two_energy = 2*global_dpd_->buf4_dot(&F, &G);
+    global_dpd_->buf4_close(&F);
+    global_dpd_->buf4_close(&G);
+    outfile->Printf( "\tciab energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
 
   /* G(Ab,Cd) = 1/2 G(Ab,Cd) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 28, 28, 28, 28, 0, "GAbCd");
   global_dpd_->buf4_scm(&G, 0.5);
   if(params.debug_) {
-  global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 28, 28, 28, 28, 0, "B <Ab|Cd>");
-  two_energy = 2*global_dpd_->buf4_dot(&B, &G);
-  global_dpd_->buf4_close(&B);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tAbCd energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 28, 28, 28, 28, 0, "B <Ab|Cd>");
+    two_energy = 2*global_dpd_->buf4_dot(&B, &G);
+    global_dpd_->buf4_close(&B);
+    outfile->Printf( "\tAbCd energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
 
   /* G(AB,CD) = 1/2 G(AB,CD) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 7, 7, 0, "GABCD");
   global_dpd_->buf4_scm(&G, 0.5);
-  global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <AB|CD>");
-  two_energy = global_dpd_->buf4_dot(&B, &G);
-  global_dpd_->buf4_close(&B);
+  if(params.debug_) {
+    global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <AB|CD>");
+    two_energy = global_dpd_->buf4_dot(&B, &G);
+    global_dpd_->buf4_close(&B);
+    outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
+  }
   global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
 
   /* G(ab,cd) = 1/2 G(ab,cd) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 15, 15, 17, 17, 0, "Gabcd");
   global_dpd_->buf4_scm(&G, 0.5);
   if(params.debug_) {
-  global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 15, 15, 15, 15, 0, "B <ab|cd>");
-  two_energy = global_dpd_->buf4_dot(&B, &G);
-  global_dpd_->buf4_close(&B);
-  //global_dpd_->buf4_close(&G);
-  outfile->Printf( "\tabcd energy                = %20.15f\n", two_energy);
-  total_two_energy += two_energy;
+    global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 15, 15, 15, 15, 0, "B <ab|cd>");
+    two_energy = global_dpd_->buf4_dot(&B, &G);
+    global_dpd_->buf4_close(&B);
+    outfile->Printf( "\tabcd energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
   }
   global_dpd_->buf4_close(&G);
   if(params.debug_) {
-  outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
-
-  outfile->Printf( "\t%-7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-	  one_energy + total_two_energy);
-  outfile->Printf( "\tTotal %-7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-	  one_energy + total_two_energy + moinfo.eref);
+    outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
+  
+    outfile->Printf( "\t%-7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+  	  one_energy + total_two_energy);
+    outfile->Printf( "\tTotal %-7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+  	  one_energy + total_two_energy + moinfo.eref);
   }
 }
 

--- a/psi4/src/psi4/ccdensity/deanti_UHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_UHF.cc
@@ -81,7 +81,9 @@ void deanti_UHF(struct RHO_Params rho_params)
 {
   dpdfile2 h, d;
   dpdbuf4 G, G2, A, B, C, D, E, F;
-  double one_energy=0.0, two_energy=0.0, total_two_energy=0.0;
+
+ double one_energy=0.0, two_energy=0.0, total_two_energy=0.0;
+ if(params.debug_) {
 
   outfile->Printf( "\n\tEnergies re-computed from Mulliken density:\n");
   outfile->Printf(   "\t-------------------------------------------\n");
@@ -135,38 +137,47 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->file2_close(&d);
 
   outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
-
+  }
 
   /* G(Ij,Kl) = 1/2 G(Ij,Kl) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 22, 22, 22, 0, "GIjKl");
   global_dpd_->buf4_scm(&G, 0.5);
+  if(params.debug_) {
   global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
   two_energy = 2*global_dpd_->buf4_dot(&A, &G);
   global_dpd_->buf4_close(&A);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tIjKl energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
-
+  } 
+  global_dpd_->buf4_close(&G);
   /* G(IJ,KL) = 1/2 G(IJ,KL) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 0, 2, 2, 0, "GIJKL");
   global_dpd_->buf4_scm(&G, 0.5);
+  if(params.debug_) {
   global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <IJ|KL>");
   two_energy = global_dpd_->buf4_dot(&A, &G);
   global_dpd_->buf4_close(&A);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
   /* G(ij,kl) = 1/2 G(ij,kl) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 12, 12, 0, "Gijkl");
   global_dpd_->buf4_scm(&G, 0.5);
+  if(params.debug_) {
   global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 0, "A <ij|kl>");
   two_energy = global_dpd_->buf4_dot(&A, &G);
   global_dpd_->buf4_close(&A);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tijkl energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
+  if(params.debug_) {
   /* No change to G(IJ,KA) components */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 24, 22, 24, 0, "GIjKa");
   global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
@@ -197,6 +208,7 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_close(&G);
   outfile->Printf( "\tijka energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
 
   /* G(Ij,Ab) <-- G(Ij,Ab) - G(Ib,jA) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 28, 22, 28, 0, "GIjAb");
@@ -206,12 +218,15 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_init(&G2, PSIF_CC_TMP0, 0, 22, 28, 22, 28, 0, "GIbjA (Ij,Ab)");
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
+  if(params.debug_) {
   global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 22, 28, 22, 28, 0, "D <Ij|Ab>");
   two_energy = 2 * global_dpd_->buf4_dot(&D, &G);
   global_dpd_->buf4_close(&D);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tIjAb energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
   /* G(IJ,AB) <-- G(IJ,AB) - G(IB,JA) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 2, 7, 0, "GIJAB");
@@ -224,12 +239,15 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_init(&G2, PSIF_CC_TMP0, 0, 0, 5, 0, 5, 0, "GIBJA (IJ,AB)");
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
+  if(params.debug_) {
   global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <IJ|AB>");
   two_energy = global_dpd_->buf4_dot(&D, &G);
   global_dpd_->buf4_close(&D);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
   /* G(ij,ab) <-- G(ij,ab) - G(ib,ja) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 15, 12, 17, 0, "Gijab");
@@ -242,13 +260,17 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_init(&G2, PSIF_CC_TMP0, 0, 10, 15, 10, 15, 0, "Gibja (ij,ab)");
   global_dpd_->buf4_axpy(&G2, &G, -1.0);
   global_dpd_->buf4_close(&G2);
+  if(params.debug_) {
   global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 10, 15, 10, 15, 0, "D <ij|ab>");
   two_energy = global_dpd_->buf4_dot(&D, &G);
   global_dpd_->buf4_close(&D);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tijab energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
+  if(params.debug_) {
   /* No change to G(IB,JA) components */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 20, 20, 20, 20, 0, "GIBJA");
   global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA|JB>");
@@ -311,16 +333,20 @@ void deanti_UHF(struct RHO_Params rho_params)
   global_dpd_->buf4_close(&G);
   outfile->Printf( "\tciab energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
 
   /* G(Ab,Cd) = 1/2 G(Ab,Cd) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 28, 28, 28, 28, 0, "GAbCd");
   global_dpd_->buf4_scm(&G, 0.5);
+  if(params.debug_) {
   global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 28, 28, 28, 28, 0, "B <Ab|Cd>");
   two_energy = 2*global_dpd_->buf4_dot(&B, &G);
   global_dpd_->buf4_close(&B);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tAbCd energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
+  }
+  global_dpd_->buf4_close(&G);
 
   /* G(AB,CD) = 1/2 G(AB,CD) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 7, 7, 0, "GABCD");
@@ -335,19 +361,23 @@ void deanti_UHF(struct RHO_Params rho_params)
   /* G(ab,cd) = 1/2 G(ab,cd) */
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 15, 15, 17, 17, 0, "Gabcd");
   global_dpd_->buf4_scm(&G, 0.5);
+  if(params.debug_) {
   global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 15, 15, 15, 15, 0, "B <ab|cd>");
   two_energy = global_dpd_->buf4_dot(&B, &G);
   global_dpd_->buf4_close(&B);
-  global_dpd_->buf4_close(&G);
+  //global_dpd_->buf4_close(&G);
   outfile->Printf( "\tabcd energy                = %20.15f\n", two_energy);
   total_two_energy += two_energy;
-
+  }
+  global_dpd_->buf4_close(&G);
+  if(params.debug_) {
   outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
 
   outfile->Printf( "\t%-7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
 	  one_energy + total_two_energy);
   outfile->Printf( "\tTotal %-7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
 	  one_energy + total_two_energy + moinfo.eref);
+  }
 }
 
 }} // namespace psi::ccdensity

--- a/psi4/src/psi4/ccdensity/fold_RHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_RHF.cc
@@ -89,38 +89,38 @@ namespace psi { namespace ccdensity {
       openpi = moinfo.openpi;
 
       if(!params.aobasis && params.debug_) {
-	outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
-	outfile->Printf(   "\t---------------------------------------------------\n");
+	    outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
+	    outfile->Printf(   "\t---------------------------------------------------\n");
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(i,j)");
-	this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
-	one_energy += this_energy;
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(i,j)");
+	    this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
+	    one_energy += this_energy;
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(a,b)");
-	this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
-	one_energy += this_energy;
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(a,b)");
+	    this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
+	    one_energy += this_energy;
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
-	this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
-	one_energy += this_energy;
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
+	    this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
+	    one_energy += this_energy;
 
-	global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
-	global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
-	this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
-	global_dpd_->file2_close(&F);
-	global_dpd_->file2_close(&D);
-	one_energy += this_energy;
+	    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
+	    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(i,a)");
+	    this_energy = 2.0 * global_dpd_->file2_dot(&D, &F);
+	    global_dpd_->file2_close(&F);
+	    global_dpd_->file2_close(&D);
+	    one_energy += this_energy;
 
-	outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
+	    outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
 
       }
 
@@ -130,53 +130,49 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 0, 0, 0, 0, "GIjKl");
       for(h=0; h < nirreps; h++) {
-	global_dpd_->buf4_mat_irrep_init(&G, h);
-	global_dpd_->buf4_mat_irrep_rd(&G, h);
+        global_dpd_->buf4_mat_irrep_init(&G, h);
+        global_dpd_->buf4_mat_irrep_rd(&G, h);
 
-	for(Gm=0; Gm < nirreps; Gm++) {
-	  Gi = Gj = h^Gm;
+	    for(Gm=0; Gm < nirreps; Gm++) {
+	      Gi = Gj = h^Gm;
 
-	  for(i=0; i < occpi[Gi]; i++) {
-	    I = occ_off[Gi] + i;
-	    for(j=0; j < occpi[Gj]; j++) {
-	      J = occ_off[Gj] + j;
-	      for(m=0; m < occpi[Gm]; m++) {
-		M = occ_off[Gm] + m;
+	      for(i=0; i < occpi[Gi]; i++) {
+	        I = occ_off[Gi] + i;
+	        for(j=0; j < occpi[Gj]; j++) {
+	          J = occ_off[Gj] + j;
+	          for(m=0; m < occpi[Gm]; m++) {
+	    	      M = occ_off[Gm] + m;
 
-		IM = G.params->rowidx[I][M];
-		JM = G.params->colidx[J][M];
-		MI = G.params->rowidx[M][I];
-		MJ = G.params->colidx[M][J];
+	    	      IM = G.params->rowidx[I][M];
+	    	      JM = G.params->colidx[J][M];
+	    	      MI = G.params->rowidx[M][I];
+	    	      MJ = G.params->colidx[M][J];
 
-		G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-		G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
-	      }
-	    }
-	  }
-	}
+	    	      G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	    	      G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
+    	      }
+    	    }
+    	  }
+        }
 
-	global_dpd_->buf4_mat_irrep_wrt(&G, h);
-	global_dpd_->buf4_mat_irrep_close(&G, h);
+	  global_dpd_->buf4_mat_irrep_wrt(&G, h);
+	  global_dpd_->buf4_mat_irrep_close(&G, h);
       }
 
-      /* Generate spin-adapted Gijkl just for the energy calculation */
-      global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijkl - Gijlk", 2);
-      global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 0, 0, "2 Gijkl - Gijlk", -1);
+      if(params.debug_ && !params.aobasis) {
+        /* Generate spin-adapted Gijkl just for the energy calculation */
+        global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijkl - Gijlk", 2);
+        global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 0, 0, "2 Gijkl - Gijlk", -1);
+        global_dpd_->buf4_close(&G);
+
+        global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 0, 0, 0, 0, "2 Gijkl - Gijlk");
+	    global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
+	    two_energy += global_dpd_->buf4_dot(&Aints, &G);
+	    global_dpd_->buf4_close(&Aints);
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
+      }
       global_dpd_->buf4_close(&G);
-
-      global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 0, 0, 0, 0, "2 Gijkl - Gijlk");
-      if(!params.aobasis) {
-	global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
-	two_energy += global_dpd_->buf4_dot(&Aints, &G);
-	global_dpd_->buf4_close(&Aints);
-      }
-      global_dpd_->buf4_close(&G);
-
-      if(!params.aobasis && params.debug_) {
-	total_two_energy += two_energy;
-	outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-
-      }
 
       global_dpd_->file2_mat_close(&D);
       global_dpd_->file2_close(&D);
@@ -190,54 +186,48 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 10, 0, 10, 0, "GIjKa");
       for(h=0; h < nirreps; h++) {
-	global_dpd_->buf4_mat_irrep_init(&G, h);
-	global_dpd_->buf4_mat_irrep_rd(&G, h);
+	    global_dpd_->buf4_mat_irrep_init(&G, h);
+	    global_dpd_->buf4_mat_irrep_rd(&G, h);
 
-	for(Gm=0; Gm < nirreps; Gm++) {
-	  Gi = Ga = h^Gm;
+	    for(Gm=0; Gm < nirreps; Gm++) {
+	      Gi = Ga = h^Gm;
 
-	  for(i=0; i < (occpi[Gi] - openpi[Gi]); i++) {
-	    I = occ_off[Gi] + i;
-	    for(a=0; a < virtpi[Ga]; a++) {
-	      A = vir_off[Ga] + a;
-	      for(m=0; m < occpi[Gm]; m++) {
-		M = occ_off[Gm] + m;
+	      for(i=0; i < (occpi[Gi] - openpi[Gi]); i++) {
+	        I = occ_off[Gi] + i;
+	        for(a=0; a < virtpi[Ga]; a++) {
+	          A = vir_off[Ga] + a;
+	          for(m=0; m < occpi[Gm]; m++) {
+	    	      M = occ_off[Gm] + m;
 
-		MI = G.params->rowidx[M][I];
-		MA = G.params->colidx[M][A];
+	    	      MI = G.params->rowidx[M][I];
+	    	      MA = G.params->colidx[M][A];
 
-		G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					      D2.matrix[Gi][i][a]);
+	    	      G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    	      			      D2.matrix[Gi][i][a]);
+	          }
+	        }
 	      }
 	    }
-	  }
-	}
 
-	global_dpd_->buf4_mat_irrep_wrt(&G, h);
-	global_dpd_->buf4_mat_irrep_close(&G, h);
+	  global_dpd_->buf4_mat_irrep_wrt(&G, h);
+	  global_dpd_->buf4_mat_irrep_close(&G, h);
       }
 
-     if(params.debug_){
-      /* Generate spin-adapted Gijka just for the energy calculation */
-      global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijka - Gjika", 2);
-      global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, qprs, 0, 10, "2 Gijka - Gjika", -1);
+      if(params.debug_ && !params.aobasis){
+        /* Generate spin-adapted Gijka just for the energy calculation */
+        global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijka - Gjika", 2);
+        global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, qprs, 0, 10, "2 Gijka - Gjika", -1);
+        global_dpd_->buf4_close(&G);
+
+        global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 10, 0, 10, 0, "2 Gijka - Gjika");
+	    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
+	    /* The factor of 4 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
+	    two_energy = 4 * global_dpd_->buf4_dot(&E, &G);
+	    global_dpd_->buf4_close(&E);
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
+      }
       global_dpd_->buf4_close(&G);
-
-      global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 10, 0, 10, 0, "2 Gijka - Gjika");
-      if(!params.aobasis) {
-	global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
-	/* The factor of 4 here is necessary because Gijka is multiplied by 1/2 in Gijka.cc */
-	two_energy = 4 * global_dpd_->buf4_dot(&E, &G);
-	global_dpd_->buf4_close(&E);
-      }
-      global_dpd_->buf4_close(&G);
-
-      if(!params.aobasis) {
-	total_two_energy += two_energy;
-	outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
-
-      }
-    }
 
       global_dpd_->file2_mat_close(&D1);
       global_dpd_->file2_close(&D1);
@@ -245,20 +235,19 @@ namespace psi { namespace ccdensity {
       global_dpd_->file2_close(&D2);
 
       if(!params.aobasis && params.debug_) {
-	/* Generate spin-adapted Gijab jut for energy calculation */
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "GIjAb");
-	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijab - Gijba", 2);
-	global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 0, 5, "2 Gijab - Gijba", -1);
-	global_dpd_->buf4_close(&G);
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "2 Gijab - Gijba");
-	global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
-	two_energy = 2 * global_dpd_->buf4_dot(&G, &DInts);
-	global_dpd_->buf4_close(&G);
-	global_dpd_->buf4_close(&DInts);
+	    /* Generate spin-adapted Gijab jut for energy calculation */
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "GIjAb");
+	    global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijab - Gijba", 2);
+	    global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 0, 5, "2 Gijab - Gijba", -1);
+	    global_dpd_->buf4_close(&G);
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "2 Gijab - Gijba");
+	    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
+	    two_energy = 2 * global_dpd_->buf4_dot(&G, &DInts);
+	    global_dpd_->buf4_close(&G);
+	    global_dpd_->buf4_close(&DInts);
 
-	total_two_energy += two_energy;
-	outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
-
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
       }
 
       global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
@@ -267,30 +256,30 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIBJA");
       for(h=0; h < nirreps; h++) {
-	global_dpd_->buf4_mat_irrep_init(&G, h);
-	global_dpd_->buf4_mat_irrep_rd(&G, h);
+	    global_dpd_->buf4_mat_irrep_init(&G, h);
+	    global_dpd_->buf4_mat_irrep_rd(&G, h);
 
-	for(Gm=0; Gm < nirreps; Gm++) {
-	  Ga = Gb = h^Gm;
+	    for(Gm=0; Gm < nirreps; Gm++) {
+	      Ga = Gb = h^Gm;
 
-	  for(b=0; b < (virtpi[Gb] - openpi[Gb]); b++) {
-	    B = vir_off[Gb] + b;
-	    for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
-	      A = vir_off[Ga] + a;
-	      for(m=0; m < occpi[Gm]; m++) {
-		M = occ_off[Gm] + m;
-
-		MB = G.params->rowidx[M][B];
-		MA = G.params->colidx[M][A];
-
-		G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      for(b=0; b < (virtpi[Gb] - openpi[Gb]); b++) {
+	        B = vir_off[Gb] + b;
+	        for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
+	          A = vir_off[Ga] + a;
+	          for(m=0; m < occpi[Gm]; m++) {
+    	    	M = occ_off[Gm] + m;
+    
+    	    	MB = G.params->rowidx[M][B];
+    	    	MA = G.params->colidx[M][A];
+    
+    	    	G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	          }
+	        }
 	      }
 	    }
-	  }
-	}
 
-	global_dpd_->buf4_mat_irrep_wrt(&G, h);
-	global_dpd_->buf4_mat_irrep_close(&G, h);
+	  global_dpd_->buf4_mat_irrep_wrt(&G, h);
+	  global_dpd_->buf4_mat_irrep_close(&G, h);
       }
 
       global_dpd_->buf4_close(&G);
@@ -304,30 +293,30 @@ namespace psi { namespace ccdensity {
 
       global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbJa");
       for(h=0; h < nirreps; h++) {
-	global_dpd_->buf4_mat_irrep_init(&G, h);
-	global_dpd_->buf4_mat_irrep_rd(&G, h);
+	    global_dpd_->buf4_mat_irrep_init(&G, h);
+	    global_dpd_->buf4_mat_irrep_rd(&G, h);
 
-	for(Gm=0; Gm < nirreps; Gm++) {
-	  Ga = Gb = h^Gm;
+	    for(Gm=0; Gm < nirreps; Gm++) {
+	      Ga = Gb = h^Gm;
 
-	  for(b=0; b < virtpi[Gb]; b++) {
-	    B = vir_off[Gb] + b;
-	    for(a=0; a < virtpi[Ga]; a++) {
-	      A = vir_off[Ga] + a;
-	      for(m=0; m < occpi[Gm]; m++) {
-		M = occ_off[Gm] + m;
+	      for(b=0; b < virtpi[Gb]; b++) {
+	        B = vir_off[Gb] + b;
+	        for(a=0; a < virtpi[Ga]; a++) {
+	          A = vir_off[Ga] + a;
+	          for(m=0; m < occpi[Gm]; m++) {
+    	    	M = occ_off[Gm] + m;
+    
+    	    	MB = G.params->rowidx[M][B];
+    	    	MA = G.params->colidx[M][A];
+    
+    	    	G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+    	          }
+    	        }
+    	     }
+    	  }
 
-		MB = G.params->rowidx[M][B];
-		MA = G.params->colidx[M][A];
-
-		G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	      }
-	    }
-	  }
-	}
-
-	global_dpd_->buf4_mat_irrep_wrt(&G, h);
-	global_dpd_->buf4_mat_irrep_close(&G, h);
+	    global_dpd_->buf4_mat_irrep_wrt(&G, h);
+	    global_dpd_->buf4_mat_irrep_close(&G, h);
       }
 
       global_dpd_->buf4_close(&G);
@@ -336,86 +325,77 @@ namespace psi { namespace ccdensity {
       global_dpd_->file2_close(&D);
 
       if(!params.aobasis && params.debug_) {
-	two_energy = 0.0;
-	global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia||jb>");
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIBJA");
-	two_energy += 2.0 * global_dpd_->buf4_dot(&G, &C);
-	global_dpd_->buf4_close(&G);
+	    two_energy = 0.0;
+	    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia||jb>");
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIBJA");
+	    two_energy += 2.0 * global_dpd_->buf4_dot(&G, &C);
+	    global_dpd_->buf4_close(&G);
 
-	global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbJa");
-	two_energy += 2.0 * global_dpd_->buf4_dot(&G, &C);
-	global_dpd_->buf4_close(&G);
+	    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbJa");
+	    two_energy += 2.0 * global_dpd_->buf4_dot(&G, &C);
+	    global_dpd_->buf4_close(&G);
 
-	global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 10, 10, 10, 10, 0, "D <ij|ab> (ib,ja)");
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbjA");
-	two_energy -= 2.0 * global_dpd_->buf4_dot(&G, &DInts);
-	global_dpd_->buf4_close(&G);
-	global_dpd_->buf4_close(&DInts);
+	    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 10, 10, 10, 10, 0, "D <ij|ab> (ib,ja)");
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbjA");
+	    two_energy -= 2.0 * global_dpd_->buf4_dot(&G, &DInts);
+	    global_dpd_->buf4_close(&G);
+	    global_dpd_->buf4_close(&DInts);
 
-	total_two_energy += two_energy;
-	outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
+	    
+        /* Generate spin-adapted Gciab just for energy calculation */
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "GCiAb");
+	    global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gciab - Gciba", 2);
+	    global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 11, 5, "2 Gciab - Gciba", -1);
+	    global_dpd_->buf4_close(&G);
 
-      }
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "2 Gciab - Gciba");
+	    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
+	    global_dpd_->buf4_sort(&FInts, PSIF_CC_FINTS, qpsr, 11, 5, "F <ai|bc>");
+	    global_dpd_->buf4_close(&FInts);
+	    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 11, 5, 11, 5, 0, "F <ai|bc>");
+	    /* The factor of 4 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
+	    two_energy = 4*global_dpd_->buf4_dot(&FInts, &G);
+	    global_dpd_->buf4_close(&FInts);
+	    global_dpd_->buf4_close(&G);
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
 
-      if(!params.aobasis && params.debug_) {
-	/* Generate spin-adapted Gciab just for energy calculation */
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "GCiAb");
-	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gciab - Gciba", 2);
-	global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 11, 5, "2 Gciab - Gciba", -1);
-	global_dpd_->buf4_close(&G);
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "GAbCd");
 
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "2 Gciab - Gciba");
-	global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
-	global_dpd_->buf4_sort(&FInts, PSIF_CC_FINTS, qpsr, 11, 5, "F <ai|bc>");
-	global_dpd_->buf4_close(&FInts);
-	global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 11, 5, 11, 5, 0, "F <ai|bc>");
-	/* The factor of 4 here is necessary because Gciab is multiplied by 1/2 in Gciab.cc */
-	two_energy = 4*global_dpd_->buf4_dot(&FInts, &G);
-	global_dpd_->buf4_close(&FInts);
-	global_dpd_->buf4_close(&G);
-	total_two_energy += two_energy;
-	outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
+	    global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gabcd - Gabdc", 2);
+	    global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 5, 5, "2 Gabcd - Gabdc", -1);
+	    global_dpd_->buf4_close(&G);
 
-      }
+	    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "2 Gabcd - Gabdc");
+	    global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
+	    two_energy = global_dpd_->buf4_dot(&BInts, &G);
+	    global_dpd_->buf4_close(&BInts);
+	    global_dpd_->buf4_close(&G);
+	    total_two_energy += two_energy;
+	    outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
 
-      if(!params.aobasis && params.debug_) {
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "GAbCd");
-
-	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gabcd - Gabdc", 2);
-	global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, pqsr, 5, 5, "2 Gabcd - Gabdc", -1);
-	global_dpd_->buf4_close(&G);
-
-	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "2 Gabcd - Gabdc");
-	global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
-	two_energy = global_dpd_->buf4_dot(&BInts, &G);
-	global_dpd_->buf4_close(&BInts);
-	global_dpd_->buf4_close(&G);
-	total_two_energy += two_energy;
-	outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
-      }
-
-      if(!params.aobasis && params.debug_) {
-	outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
-	if (params.ground) {
-	  //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
-	  //	  one_energy + total_two_energy);
-	  //outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
-	  //	  one_energy + total_two_energy + moinfo.eref);
-	  outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-          	one_energy + total_two_energy);
-          outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-          	one_energy + total_two_energy + moinfo.eref);
-	}
-	else {
-	  outfile->Printf( "\tTotal EOM CCSD correlation energy        = %20.15f\n",
-		  one_energy + total_two_energy);
-	  outfile->Printf( "\tCCSD correlation + EOM excitation energy = %20.15f\n",
-		  moinfo.ecc + params.cceom_energy);
-	  outfile->Printf( "\tTotal EOM CCSD energy                    = %20.15f\n",
-		  one_energy + total_two_energy + moinfo.eref);
-	}
+	    outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
+	    if (params.ground) {
+	      //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",
+	      //	  one_energy + total_two_energy);
+	      //outfile->Printf( "\tTotal CCSD energy          = %20.15f\n",
+	      //	  one_energy + total_two_energy + moinfo.eref);
+	      outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+              	one_energy + total_two_energy);
+              outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+              	one_energy + total_two_energy + moinfo.eref);
+	    }
+	    else {
+	      outfile->Printf( "\tTotal EOM CCSD correlation energy        = %20.15f\n",
+	    	  one_energy + total_two_energy);
+	      outfile->Printf( "\tCCSD correlation + EOM excitation energy = %20.15f\n",
+	    	  moinfo.ecc + params.cceom_energy);
+	      outfile->Printf( "\tTotal EOM CCSD energy                    = %20.15f\n",
+	    	  one_energy + total_two_energy + moinfo.eref);
+        }
       }
     }
-
   }} // namespace psi::ccdensity

--- a/psi4/src/psi4/ccdensity/fold_RHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_RHF.cc
@@ -88,7 +88,7 @@ namespace psi { namespace ccdensity {
       occ_sym = moinfo.occ_sym; vir_sym = moinfo.vir_sym;
       openpi = moinfo.openpi;
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
 	outfile->Printf(   "\t---------------------------------------------------\n");
 
@@ -172,7 +172,7 @@ namespace psi { namespace ccdensity {
       }
       global_dpd_->buf4_close(&G);
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	total_two_energy += two_energy;
 	outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
 
@@ -217,6 +217,7 @@ namespace psi { namespace ccdensity {
 	global_dpd_->buf4_mat_irrep_close(&G, h);
       }
 
+     if(params.debug_){
       /* Generate spin-adapted Gijka just for the energy calculation */
       global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijka - Gjika", 2);
       global_dpd_->buf4_sort_axpy(&G, PSIF_CC_GAMMA, qprs, 0, 10, "2 Gijka - Gjika", -1);
@@ -236,13 +237,14 @@ namespace psi { namespace ccdensity {
 	outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
 
       }
+    }
 
       global_dpd_->file2_mat_close(&D1);
       global_dpd_->file2_close(&D1);
       global_dpd_->file2_mat_close(&D2);
       global_dpd_->file2_close(&D2);
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	/* Generate spin-adapted Gijab jut for energy calculation */
 	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 0, 5, 0, 5, 0, "GIjAb");
 	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gijab - Gijba", 2);
@@ -333,7 +335,7 @@ namespace psi { namespace ccdensity {
       global_dpd_->file2_mat_close(&D);
       global_dpd_->file2_close(&D);
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	two_energy = 0.0;
 	global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia||jb>");
 	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIBJA");
@@ -356,7 +358,7 @@ namespace psi { namespace ccdensity {
 
       }
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	/* Generate spin-adapted Gciab just for energy calculation */
 	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 11, 5, 11, 5, 0, "GCiAb");
 	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gciab - Gciba", 2);
@@ -377,7 +379,7 @@ namespace psi { namespace ccdensity {
 
       }
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 5, 5, 5, 5, 0, "GAbCd");
 
 	global_dpd_->buf4_scmcopy(&G, PSIF_CC_GAMMA, "2 Gabcd - Gabdc", 2);
@@ -393,7 +395,7 @@ namespace psi { namespace ccdensity {
 	outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
       }
 
-      if(!params.aobasis) {
+      if(!params.aobasis && params.debug_) {
 	outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
 	if (params.ground) {
 	  //outfile->Printf( "\tCCSD correlation energy    = %20.15f\n",

--- a/psi4/src/psi4/ccdensity/fold_ROHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_ROHF.cc
@@ -181,23 +181,23 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Gj = h^Gm;
 
       for(i=0; i < occpi[Gi]; i++) {
-	I = occ_off[Gi] + i;
-	for(j=0; j < occpi[Gj]; j++) {
-	  J = occ_off[Gj] + j;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(j=0; j < occpi[Gj]; j++) {
+	      J = occ_off[Gj] + j;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
-	    MI = G.params->rowidx[M][I];
-	    MJ = G.params->colidx[M][J];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
+	        MI = G.params->rowidx[M][I];
+	        MJ = G.params->colidx[M][J];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	    G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
-	    G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
-	    G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	        G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
+	        G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
+	        G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
+	      }
+	    }
       }
     }
 
@@ -230,23 +230,23 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Gj = h^Gm;
 
       for(i=0; i < (occpi[Gi] - openpi[Gi]); i++) {
-	I = occ_off[Gi] + i;
-	for(j=0; j < (occpi[Gj] - openpi[Gj]); j++) {
-	  J = occ_off[Gj] + j;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(j=0; j < (occpi[Gj] - openpi[Gj]); j++) {
+	      J = occ_off[Gj] + j;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
-	    MI = G.params->rowidx[M][I];
-	    MJ = G.params->colidx[M][J];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
+	        MI = G.params->rowidx[M][I];
+	        MJ = G.params->colidx[M][J];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	    G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
-	    G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
-	    G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	        G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
+	        G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
+	        G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
+	      }
+	    }
       }
     }
 
@@ -278,18 +278,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Gj = h^Gm;
 
       for(i=0; i < occpi[Gi]; i++) {
-	I = occ_off[Gi] + i;
-	for(j=0; j < occpi[Gj]; j++) {
-	  J = occ_off[Gj] + j;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(j=0; j < occpi[Gj]; j++) {
+	      J = occ_off[Gj] + j;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	      }
+	    }
       }
     }
 
@@ -315,18 +315,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gk = Gl = h^Gm;
 
       for(k=0; k < (occpi[Gk] - openpi[Gk]); k++) {
-	K = occ_off[Gk] + k;
-	for(l=0; l < (occpi[Gl] - openpi[Gl]); l++) {
-	  L = occ_off[Gl] + l;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    K = occ_off[Gk] + k;
+	    for(l=0; l < (occpi[Gl] - openpi[Gl]); l++) {
+	      L = occ_off[Gl] + l;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    MK = G.params->rowidx[M][K];
-	    ML = G.params->colidx[M][L];
+	        MK = G.params->rowidx[M][K];
+	        ML = G.params->colidx[M][L];
 
-	    G.matrix[h][MK][ML] += D.matrix[Gk][k][l];
-	  }
-	}
+	        G.matrix[h][MK][ML] += D.matrix[Gk][k][l];
+	      }
+	    }
       }
     }
 
@@ -345,7 +345,6 @@ void fold_ROHF(struct RHO_Params rho_params)
   if(!params.aobasis && params.debug_) {
     total_two_energy += two_energy;
     outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-
   }
 
   global_dpd_->file2_mat_close(&D);
@@ -367,22 +366,22 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < occpi[Gi]; i++) {
-	I = occ_off[Gi] + i;
-	for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    IM = G.params->rowidx[I][M];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        IM = G.params->rowidx[I][M];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	    G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	        G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -420,22 +419,22 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < (occpi[Gi] - openpi[Gi]); i++) {
-	I = occ_off[Gi] + i;
-	for(a=0; a < virtpi[Ga]; a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(a=0; a < virtpi[Ga]; a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    IM = G.params->rowidx[I][M];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        IM = G.params->rowidx[I][M];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	    G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	        G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -471,19 +470,19 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < occpi[Gi]; i++) {
-	I = occ_off[Gi] + i;
-	for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -521,19 +520,19 @@ void fold_ROHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < (occpi[Gi] - openpi[Gi]); i++) {
-	I = occ_off[Gi] + i;
-	for(a=0; a < virtpi[Ga]; a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    I = occ_off[Gi] + i;
+	    for(a=0; a < virtpi[Ga]; a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -545,16 +544,11 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
     two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
     global_dpd_->buf4_close(&E);
+    total_two_energy += two_energy;
+    outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
   }
 
   global_dpd_->buf4_close(&G);
-
-  if(!params.aobasis && params.debug_) {
-    total_two_energy += two_energy;
-    outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
-
-  }
-
   global_dpd_->file2_mat_close(&D1);
   global_dpd_->file2_close(&D1);
   global_dpd_->file2_mat_close(&D2);
@@ -579,7 +573,6 @@ void fold_ROHF(struct RHO_Params rho_params)
     two_energy *= 2;
     total_two_energy += two_energy;
     outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
-
   }
 
   global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
@@ -595,18 +588,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < (virtpi[Gb] - openpi[Gb]); b++) {
-	B = vir_off[Gb] + b;
-	for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    B = vir_off[Gb] + b;
+	    for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -640,18 +633,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < virtpi[Gb]; b++) {
-	B = vir_off[Gb] + b;
-	for(a=0; a < virtpi[Ga]; a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    B = vir_off[Gb] + b;
+	    for(a=0; a < virtpi[Ga]; a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -684,18 +677,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < virtpi[Gb]; b++) {
-	B = vir_off[Gb] + b;
-	for(a=0; a < virtpi[Ga]; a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < occpi[Gm]; m++) {
-	    M = occ_off[Gm] + m;
+	    B = vir_off[Gb] + b;
+	    for(a=0; a < virtpi[Ga]; a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < occpi[Gm]; m++) {
+	        M = occ_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -728,18 +721,18 @@ void fold_ROHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < (virtpi[Gb] - openpi[Gb]); b++) {
-	B = vir_off[Gb] + b;
-	for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
-	  A = vir_off[Ga] + a;
-	  for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
-	    M = occ_off[Gm] + m;
+	    B = vir_off[Gb] + b;
+	    for(a=0; a < (virtpi[Ga] - openpi[Ga]); a++) {
+	      A = vir_off[Ga] + a;
+	      for(m=0; m < (occpi[Gm] - openpi[Gm]); m++) {
+	        M = occ_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
     global_dpd_->buf4_mat_irrep_wrt(&G, h);
@@ -805,9 +798,6 @@ void fold_ROHF(struct RHO_Params rho_params)
     total_two_energy += two_energy;
     outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
 
-  }
-
-  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 7, 7, 5, 5, 1, "B <ab|cd>");
     global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 7, 7, 7, 7, 0, "GABCD");
@@ -822,9 +812,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     two_energy += global_dpd_->buf4_dot(&G, &BInts);
     global_dpd_->buf4_close(&G);
     global_dpd_->buf4_close(&BInts);
-  }
 
-  if(!params.aobasis && params.debug_) {
     total_two_energy += two_energy;
     outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
     outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);

--- a/psi4/src/psi4/ccdensity/fold_ROHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_ROHF.cc
@@ -88,7 +88,7 @@ void fold_ROHF(struct RHO_Params rho_params)
   occ_sym = moinfo.occ_sym; vir_sym = moinfo.vir_sym;
   openpi = moinfo.openpi;
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
     outfile->Printf(   "\t---------------------------------------------------\n");
 
@@ -205,7 +205,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 1, "A <ij|kl>");
     two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
@@ -254,7 +254,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 1, "A <ij|kl>");
     two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
     global_dpd_->buf4_close(&Aints);
@@ -334,7 +334,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");
     two_energy += global_dpd_->buf4_dot(&Aints, &G);
     global_dpd_->buf4_close(&Aints);
@@ -342,7 +342,7 @@ void fold_ROHF(struct RHO_Params rho_params)
 
   global_dpd_->buf4_close(&G);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     total_two_energy += two_energy;
     outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
 
@@ -390,7 +390,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 2, 10, 0, "E <ij||ka> (i>j,ka)");
     two_energy += global_dpd_->buf4_dot(&E, &G);
@@ -442,7 +442,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_wrt(&G, h);
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 2, 10, 0, "E <ij||ka> (i>j,ka)");
     two_energy += global_dpd_->buf4_dot(&E, &G);
     global_dpd_->buf4_close(&E);
@@ -491,7 +491,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
     two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
     global_dpd_->buf4_close(&E);
@@ -541,7 +541,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 10, 0, 10, 0, "E <ij|ka>");
     two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
     global_dpd_->buf4_close(&E);
@@ -549,7 +549,7 @@ void fold_ROHF(struct RHO_Params rho_params)
 
   global_dpd_->buf4_close(&G);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     total_two_energy += two_energy;
     outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
 
@@ -560,7 +560,7 @@ void fold_ROHF(struct RHO_Params rho_params)
   global_dpd_->file2_mat_close(&D2);
   global_dpd_->file2_close(&D2);
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 2, 7, 2, 7, 0, "D <ij||ab> (i>j,a>b)");
     global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 2, 7, 2, 7, 0, "GIJAB");
@@ -614,7 +614,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia||jb>");
     two_energy += global_dpd_->buf4_dot(&C, &G);
@@ -659,7 +659,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia||jb>");
     two_energy += global_dpd_->buf4_dot(&C, &G);
     global_dpd_->buf4_close(&C);
@@ -703,7 +703,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
     two_energy += global_dpd_->buf4_dot(&C, &G);
     global_dpd_->buf4_close(&C);
@@ -746,7 +746,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 10, 10, 10, 10, 0, "C <ia|jb>");
     two_energy += global_dpd_->buf4_dot(&C, &G);
     global_dpd_->buf4_close(&C);
@@ -758,7 +758,7 @@ void fold_ROHF(struct RHO_Params rho_params)
   global_dpd_->file2_close(&D);
 
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 10, 10, 10, 10, 0, "D <ij|ab> (ib,ja)");
     global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 10, 10, 10, 10, 0, "GIbjA");
     two_energy -= global_dpd_->buf4_dot(&G, &DInts);
@@ -773,7 +773,7 @@ void fold_ROHF(struct RHO_Params rho_params)
 
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 10, 7, 10, 5, 1, "F <ia|bc>");
     global_dpd_->buf4_sort(&FInts, PSIF_CC_TMP0, qprs, 11, 7, "F(CI,AB)");
@@ -807,7 +807,7 @@ void fold_ROHF(struct RHO_Params rho_params)
 
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     two_energy = 0.0;
     global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 7, 7, 5, 5, 1, "B <ab|cd>");
     global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 7, 7, 7, 7, 0, "GABCD");
@@ -824,7 +824,7 @@ void fold_ROHF(struct RHO_Params rho_params)
     global_dpd_->buf4_close(&BInts);
   }
 
-  if(!params.aobasis) {
+  if(!params.aobasis && params.debug_) {
     total_two_energy += two_energy;
     outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
     outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);

--- a/psi4/src/psi4/ccdensity/fold_UHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_UHF.cc
@@ -95,81 +95,81 @@ void fold_UHF(struct RHO_Params rho_params)
 
 
   if(params.debug_) {
-  outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
-  outfile->Printf(   "\t---------------------------------------------------\n");
+    outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
+    outfile->Printf(   "\t---------------------------------------------------\n");
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(I,J)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
-  /*  outfile->Printf( "\tDIJ = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 0, "h(I,J)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
+    /*  outfile->Printf( "\tDIJ = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 2, rho_params.Dij_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 2, "h(i,j)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 2, rho_params.Dij_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 2, "h(i,j)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDij = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDij = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(A,B)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 1, 1, "h(A,B)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDAB = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDAB = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 3, 3, rho_params.Dab_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 3, 3, "h(a,b)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 3, 3, rho_params.Dab_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 3, 3, "h(a,b)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDab = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDab = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DIA_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDIA = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDIA = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 3, rho_params.Dia_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 3, rho_params.Dia_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDia = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDia = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 1, rho_params.DAI_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "h(I,A)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDAI = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDAI = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 3, rho_params.Dai_lbl);
-  global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
-  this_energy = global_dpd_->file2_dot(&D, &F);
-  global_dpd_->file2_close(&F);
-  global_dpd_->file2_close(&D);
+    global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 2, 3, rho_params.Dai_lbl);
+    global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 2, 3, "h(i,a)");
+    this_energy = global_dpd_->file2_dot(&D, &F);
+    global_dpd_->file2_close(&F);
+    global_dpd_->file2_close(&D);
 
-  /*  outfile->Printf( "\tDai = %20.15f\n", this_energy); */
-  one_energy += this_energy;
+    /*  outfile->Printf( "\tDai = %20.15f\n", this_energy); */
+    one_energy += this_energy;
 
-  outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
+    outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
   }
 
   global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
@@ -185,23 +185,23 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Gj = h^Gm;
 
       for(i=0; i < aoccpi[Gi]; i++) {
-	I = aocc_off[Gi] + i;
-	for(j=0; j < aoccpi[Gj]; j++) {
-	  J = aocc_off[Gj] + j;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    I = aocc_off[Gi] + i;
+	    for(j=0; j < aoccpi[Gj]; j++) {
+	      J = aocc_off[Gj] + j;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
-	    MI = G.params->rowidx[M][I];
-	    MJ = G.params->colidx[M][J];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
+	        MI = G.params->rowidx[M][I];
+	        MJ = G.params->colidx[M][J];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	    G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
-	    G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
-	    G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	        G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
+	        G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
+	        G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
+   	      }
+  	    } 
       }
     }
 
@@ -209,10 +209,12 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
-  two_energy = 0.0;
-  global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 1, "A <IJ|KL>");
-  two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
-  global_dpd_->buf4_close(&Aints);
+  if(params.debug_) {
+    two_energy = 0.0;
+    global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 1, "A <IJ|KL>");
+    two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
+    global_dpd_->buf4_close(&Aints);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -230,25 +232,24 @@ void fold_UHF(struct RHO_Params rho_params)
 
     for(Gm=0; Gm < nirreps; Gm++) {
       Gi = Gj = h^Gm;
-
       for(i=0; i < boccpi[Gi]; i++) {
-	I = bocc_off[Gi] + i;
-	for(j=0; j < boccpi[Gj]; j++) {
-	  J = bocc_off[Gj] + j;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    I = bocc_off[Gi] + i;
+	    for(j=0; j < boccpi[Gj]; j++) {
+	      J = bocc_off[Gj] + j;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
-	    MI = G.params->rowidx[M][I];
-	    MJ = G.params->colidx[M][J];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
+	        MI = G.params->rowidx[M][I];
+	        MJ = G.params->colidx[M][J];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	    G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
-	    G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
-	    G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	        G.matrix[h][MI][JM] -= D.matrix[Gi][i][j];
+	        G.matrix[h][MI][MJ] += D.matrix[Gi][i][j];
+	        G.matrix[h][IM][MJ] -= D.matrix[Gi][i][j];
+	      }
+	    }
       }
     }
 
@@ -257,9 +258,9 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 1, "A <ij|kl>");
-  two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
-  global_dpd_->buf4_close(&Aints);
+    global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 1, "A <ij|kl>");
+    two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
+    global_dpd_->buf4_close(&Aints);
   }
   global_dpd_->buf4_close(&G);
 
@@ -279,18 +280,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Gj = h^Gm;
 
       for(i=0; i < aoccpi[Gi]; i++) {
-	I = aocc_off[Gi] + i;
-	for(j=0; j < aoccpi[Gj]; j++) {
-	  J = aocc_off[Gj] + j;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    I = aocc_off[Gi] + i;
+	    for(j=0; j < aoccpi[Gj]; j++) {
+	      J = aocc_off[Gj] + j;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    IM = G.params->rowidx[I][M];
-	    JM = G.params->colidx[J][M];
+	        IM = G.params->rowidx[I][M];
+	        JM = G.params->colidx[J][M];
 
-	    G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
-	  }
-	}
+	        G.matrix[h][IM][JM] += D.matrix[Gi][i][j];
+	      }
+	    }
       }
     }
 
@@ -316,18 +317,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Gk = Gl = h^Gm;
 
       for(k=0; k < boccpi[Gk]; k++) {
-	K = bocc_off[Gk] + k;
-	for(l=0; l < boccpi[Gl]; l++) {
-	  L = bocc_off[Gl] + l;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    K = bocc_off[Gk] + k;
+	    for(l=0; l < boccpi[Gl]; l++) {
+	      L = bocc_off[Gl] + l;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    MK = G.params->rowidx[M][K];
-	    ML = G.params->colidx[M][L];
+	        MK = G.params->rowidx[M][K];
+	        ML = G.params->colidx[M][L];
 
-	    G.matrix[h][MK][ML] += D.matrix[Gk][k][l];
-	  }
-	}
+	        G.matrix[h][MK][ML] += D.matrix[Gk][k][l];
+	      }
+	    }
       }
     }
 
@@ -336,18 +337,15 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
-  two_energy += global_dpd_->buf4_dot(&Aints, &G);
-  global_dpd_->buf4_close(&Aints);
+    global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
+    two_energy += global_dpd_->buf4_dot(&Aints, &G);
+    global_dpd_->buf4_close(&Aints);
+
+    total_two_energy += two_energy;
+    outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
   }
 
   global_dpd_->buf4_close(&G);
-
-  if(params.debug_){
-  total_two_energy += two_energy;
-  outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-  }
-
   global_dpd_->file2_mat_close(&D);
   global_dpd_->file2_close(&D);
 
@@ -367,22 +365,22 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < aoccpi[Gi]; i++) {
-	I = aocc_off[Gi] + i;
-	for(a=0; a < avirtpi[Ga]; a++) {
-	  A = avir_off[Ga] + a;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    I = aocc_off[Gi] + i;
+	    for(a=0; a < avirtpi[Ga]; a++) {
+	      A = avir_off[Ga] + a;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    IM = G.params->rowidx[I][M];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        IM = G.params->rowidx[I][M];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+		    			  D2.matrix[Gi][i][a]);
+	        G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
 					  D2.matrix[Gi][i][a]);
-	    G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	      }
+	    }
       }
     }
 
@@ -391,10 +389,10 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  two_energy = 0.0;
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 20, 2, 20, 0, "E <IJ||KA> (I>J,KA)");
-  two_energy += global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
+    two_energy = 0.0;
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 20, 2, 20, 0, "E <IJ||KA> (I>J,KA)");
+    two_energy += global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
   }
 
   global_dpd_->buf4_close(&G);
@@ -420,22 +418,22 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < boccpi[Gi]; i++) {
-	I = bocc_off[Gi] + i;
-	for(a=0; a < bvirtpi[Ga]; a++) {
-	  A = bvir_off[Ga] + a;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    I = bocc_off[Gi] + i;
+	    for(a=0; a < bvirtpi[Ga]; a++) {
+	      A = bvir_off[Ga] + a;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    IM = G.params->rowidx[I][M];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        IM = G.params->rowidx[I][M];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	    G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+		    			  D2.matrix[Gi][i][a]);
+	        G.matrix[h][IM][MA] -= 0.5 * (D1.matrix[Gi][i][a] +
+		    			  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -443,9 +441,9 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
   if(params.debug_){
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 10, 30, 12, 30, 0, "E <ij||ka> (i>j,ka)");
-  two_energy += global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 10, 30, 12, 30, 0, "E <ij||ka> (i>j,ka)");
+    two_energy += global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
   }
   global_dpd_->buf4_close(&G);
 
@@ -470,19 +468,19 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < aoccpi[Gi]; i++) {
-	I = aocc_off[Gi] + i;
-	for(a=0; a < avirtpi[Ga]; a++) {
-	  A = avir_off[Ga] + a;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    I = aocc_off[Gi] + i;
+	    for(a=0; a < avirtpi[Ga]; a++) {
+	      A = avir_off[Ga] + a;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -491,9 +489,9 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 23, 27, 23, 27, 0, "E <iJ|kA>");
-  two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 23, 27, 23, 27, 0, "E <iJ|kA>");
+    two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
   }
 
   global_dpd_->buf4_close(&G);
@@ -520,19 +518,19 @@ void fold_UHF(struct RHO_Params rho_params)
       Gi = Ga = h^Gm;
 
       for(i=0; i < boccpi[Gi]; i++) {
-	I = bocc_off[Gi] + i;
-	for(a=0; a < bvirtpi[Ga]; a++) {
-	  A = bvir_off[Ga] + a;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    I = bocc_off[Gi] + i;
+	    for(a=0; a < bvirtpi[Ga]; a++) {
+	      A = bvir_off[Ga] + a;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    MI = G.params->rowidx[M][I];
-	    MA = G.params->colidx[M][A];
+	        MI = G.params->rowidx[M][I];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
-					  D2.matrix[Gi][i][a]);
-	  }
-	}
+	        G.matrix[h][MI][MA] += 0.5 * (D1.matrix[Gi][i][a] +
+	    				  D2.matrix[Gi][i][a]);
+	      }
+	    }
       }
     }
 
@@ -541,16 +539,16 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
-  two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
-  global_dpd_->buf4_close(&E);
+    global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
+    two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
+    global_dpd_->buf4_close(&E);
   }
 
   global_dpd_->buf4_close(&G);
 
   if(params.debug_){
-  total_two_energy += two_energy;
-  outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
+    total_two_energy += two_energy;
+    outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
   }
 
   global_dpd_->file2_mat_close(&D1);
@@ -559,29 +557,29 @@ void fold_UHF(struct RHO_Params rho_params)
   global_dpd_->file2_close(&D2);
 
   if(params.debug_){
-  two_energy = 0.0;
-  global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 2, 7, 2, 7, 0, "D <IJ||AB> (I>J,A>B)");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 2, 7, 2, 7, 0, "GIJAB");
-  two_energy += global_dpd_->buf4_dot(&G, &DInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&DInts);
+    two_energy = 0.0;
+    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 2, 7, 2, 7, 0, "D <IJ||AB> (I>J,A>B)");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 2, 7, 2, 7, 0, "GIJAB");
+    two_energy += global_dpd_->buf4_dot(&G, &DInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&DInts);
 
 
-  global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 12, 17, 12, 17, 0, "D <ij||ab> (i>j,a>b)");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 12, 17, 12, 17, 0, "Gijab");
-  two_energy += global_dpd_->buf4_dot(&G, &DInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&DInts);
+    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 12, 17, 12, 17, 0, "D <ij||ab> (i>j,a>b)");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 12, 17, 12, 17, 0, "Gijab");
+    two_energy += global_dpd_->buf4_dot(&G, &DInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&DInts);
 
-  global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 22, 28, 22, 28, 0, "D <Ij|Ab>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 28, 22, 28, 0, "GIjAb");
-  two_energy += global_dpd_->buf4_dot(&G, &DInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&DInts);
+    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 22, 28, 22, 28, 0, "D <Ij|Ab>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 22, 28, 22, 28, 0, "GIjAb");
+    two_energy += global_dpd_->buf4_dot(&G, &DInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&DInts);
 
-  two_energy *= 2;
-  total_two_energy += two_energy;
-  outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
+    two_energy *= 2;
+    total_two_energy += two_energy;
+    outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
   }
 
 
@@ -598,18 +596,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < avirtpi[Gb]; b++) {
-	B = avir_off[Gb] + b;
-	for(a=0; a < avirtpi[Ga]; a++) {
-	  A = avir_off[Ga] + a;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    B = avir_off[Gb] + b;
+	    for(a=0; a < avirtpi[Ga]; a++) {
+	      A = avir_off[Ga] + a;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -618,10 +616,10 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  two_energy = 0.0;
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA||JB>");
-  two_energy += global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
+    two_energy = 0.0;
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA||JB>");
+    two_energy += global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
   }
 
   global_dpd_->buf4_close(&G);
@@ -643,18 +641,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < bvirtpi[Gb]; b++) {
-	B = bvir_off[Gb] + b;
-	for(a=0; a < bvirtpi[Ga]; a++) {
-	  A = bvir_off[Ga] + a;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    B = bvir_off[Gb] + b;
+	    for(a=0; a < bvirtpi[Ga]; a++) {
+	      A = bvir_off[Ga] + a;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -663,9 +661,9 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 30, 30, 30, 30, 0, "C <ia||jb>");
-  two_energy += global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 30, 30, 30, 30, 0, "C <ia||jb>");
+    two_energy += global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
   }
 
   global_dpd_->buf4_close(&G);
@@ -687,18 +685,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < bvirtpi[Gb]; b++) {
-	B = bvir_off[Gb] + b;
-	for(a=0; a < bvirtpi[Ga]; a++) {
-	  A = bvir_off[Ga] + a;
-	  for(m=0; m < aoccpi[Gm]; m++) {
-	    M = aocc_off[Gm] + m;
+	    B = bvir_off[Gb] + b;
+	    for(a=0; a < bvirtpi[Ga]; a++) {
+	      A = bvir_off[Ga] + a;
+	      for(m=0; m < aoccpi[Gm]; m++) {
+	        M = aocc_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
 
@@ -707,9 +705,9 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 24, 24, 24, 24, 0, "C <Ia|Jb>");
-  two_energy += global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 24, 24, 24, 24, 0, "C <Ia|Jb>");
+    two_energy += global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
   }
 
   global_dpd_->buf4_close(&G);
@@ -731,18 +729,18 @@ void fold_UHF(struct RHO_Params rho_params)
       Ga = Gb = h^Gm;
 
       for(b=0; b < avirtpi[Gb]; b++) {
-	B = avir_off[Gb] + b;
-	for(a=0; a < avirtpi[Ga]; a++) {
-	  A = avir_off[Ga] + a;
-	  for(m=0; m < boccpi[Gm]; m++) {
-	    M = bocc_off[Gm] + m;
+	    B = avir_off[Gb] + b;
+	    for(a=0; a < avirtpi[Ga]; a++) {
+	      A = avir_off[Ga] + a;
+	      for(m=0; m < boccpi[Gm]; m++) {
+	        M = bocc_off[Gm] + m;
 
-	    MB = G.params->rowidx[M][B];
-	    MA = G.params->colidx[M][A];
+	        MB = G.params->rowidx[M][B];
+	        MA = G.params->colidx[M][A];
 
-	    G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
-	  }
-	}
+	        G.matrix[h][MB][MA] += D.matrix[Ga][a][b];
+	      }
+	    }
       }
     }
     global_dpd_->buf4_mat_irrep_wrt(&G, h);
@@ -750,9 +748,9 @@ void fold_UHF(struct RHO_Params rho_params)
   }
 
   if(params.debug_){
-  global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 27, 27, 27, 27, 0, "C <iA|jB>");
-  two_energy += global_dpd_->buf4_dot(&C, &G);
-  global_dpd_->buf4_close(&C);
+    global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 27, 27, 27, 27, 0, "C <iA|jB>");
+    two_energy += global_dpd_->buf4_dot(&C, &G);
+    global_dpd_->buf4_close(&C);
   }
 
   global_dpd_->buf4_close(&G);
@@ -762,83 +760,83 @@ void fold_UHF(struct RHO_Params rho_params)
 
 
   if(params.debug_){
-  global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 24, 27, 24, 27, 0, "D <Ij|Ab> (Ib,jA)");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 24, 27, 24, 27, 0, "GIbjA");
-  two_energy -= global_dpd_->buf4_dot(&G, &DInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&DInts);
-
-  global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 27, 24, 27, 24, 0, "D <iJ|aB> (iB,Ja)");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 27, 24, 27, 24, 0, "GiBJa");
-  two_energy -= global_dpd_->buf4_dot(&G, &DInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&DInts);
-
-  total_two_energy += two_energy;
-  outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
-
-
-  two_energy = 0.0;
-
-  global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 21, 7, 21, 5, 1, "F <AI|BC>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 21, 7, 21, 7, 0, "GCIAB");
-  two_energy += global_dpd_->buf4_dot(&G, &FInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&FInts);
-
-  global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 31, 17, 31, 15, 1, "F <ai|bc>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 31, 17, 31, 17, 0, "Gciab");
-  two_energy += global_dpd_->buf4_dot(&G, &FInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&FInts);
-
-  global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 25, 29, 25, 29, 0, "F <aI|bC>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 25, 29, 25, 29, 0, "GcIaB");
-  two_energy += global_dpd_->buf4_dot(&G, &FInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&FInts);
-
-  global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 26, 28, 26, 28, 0, "F <Ai|Bc>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 26, 28, 26, 28, 0, "GCiAb");
-  two_energy += global_dpd_->buf4_dot(&G, &FInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&FInts);
-
-  two_energy *= 2;
-  total_two_energy += two_energy;
-  outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
-
-
-  two_energy = 0.0;
-
-  global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 7, 7, 5, 5, 1, "B <AB|CD>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 7, 7, 7, 7, 0, "GABCD");
-  two_energy += global_dpd_->buf4_dot(&G, &BInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&BInts);
-
-  global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 17, 17, 15, 15, 1, "B <ab|cd>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 17, 17, 17, 17, 0, "Gabcd");
-  two_energy += global_dpd_->buf4_dot(&G, &BInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&BInts);
-
-  global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 28, 28, 28, 28, 0, "B <Ab|Cd>");
-  global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 28, 28, 28, 28, 0, "GAbCd");
-  two_energy += global_dpd_->buf4_dot(&G, &BInts);
-  global_dpd_->buf4_close(&G);
-  global_dpd_->buf4_close(&BInts);
-
-
-  total_two_energy += two_energy;
-  outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
-
-  outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
-  outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-	  one_energy + total_two_energy);
-  outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
-	  one_energy + total_two_energy + moinfo.eref);
-   }
+    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 24, 27, 24, 27, 0, "D <Ij|Ab> (Ib,jA)");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 24, 27, 24, 27, 0, "GIbjA");
+    two_energy -= global_dpd_->buf4_dot(&G, &DInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&DInts);
+  
+    global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 27, 24, 27, 24, 0, "D <iJ|aB> (iB,Ja)");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 27, 24, 27, 24, 0, "GiBJa");
+    two_energy -= global_dpd_->buf4_dot(&G, &DInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&DInts);
+  
+    total_two_energy += two_energy;
+    outfile->Printf( "\tIBJA energy                = %20.15f\n", two_energy);
+  
+  
+    two_energy = 0.0;
+  
+    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 21, 7, 21, 5, 1, "F <AI|BC>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 21, 7, 21, 7, 0, "GCIAB");
+    two_energy += global_dpd_->buf4_dot(&G, &FInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&FInts);
+  
+    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 31, 17, 31, 15, 1, "F <ai|bc>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 31, 17, 31, 17, 0, "Gciab");
+    two_energy += global_dpd_->buf4_dot(&G, &FInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&FInts);
+  
+    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 25, 29, 25, 29, 0, "F <aI|bC>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 25, 29, 25, 29, 0, "GcIaB");
+    two_energy += global_dpd_->buf4_dot(&G, &FInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&FInts);
+  
+    global_dpd_->buf4_init(&FInts, PSIF_CC_FINTS, 0, 26, 28, 26, 28, 0, "F <Ai|Bc>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 26, 28, 26, 28, 0, "GCiAb");
+    two_energy += global_dpd_->buf4_dot(&G, &FInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&FInts);
+  
+    two_energy *= 2;
+    total_two_energy += two_energy;
+    outfile->Printf( "\tCIAB energy                = %20.15f\n", two_energy);
+  
+  
+    two_energy = 0.0;
+  
+    global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 7, 7, 5, 5, 1, "B <AB|CD>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 7, 7, 7, 7, 0, "GABCD");
+    two_energy += global_dpd_->buf4_dot(&G, &BInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&BInts);
+  
+    global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 17, 17, 15, 15, 1, "B <ab|cd>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 17, 17, 17, 17, 0, "Gabcd");
+    two_energy += global_dpd_->buf4_dot(&G, &BInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&BInts);
+  
+    global_dpd_->buf4_init(&BInts, PSIF_CC_BINTS, 0, 28, 28, 28, 28, 0, "B <Ab|Cd>");
+    global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 28, 28, 28, 28, 0, "GAbCd");
+    two_energy += global_dpd_->buf4_dot(&G, &BInts);
+    global_dpd_->buf4_close(&G);
+    global_dpd_->buf4_close(&BInts);
+  
+  
+    total_two_energy += two_energy;
+    outfile->Printf( "\tABCD energy                = %20.15f\n", two_energy);
+  
+    outfile->Printf( "\tTotal two-electron energy  = %20.15f\n", total_two_energy);
+    outfile->Printf( "\t%7s correlation energy = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+  	  one_energy + total_two_energy);
+    outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
+  	  one_energy + total_two_energy + moinfo.eref);
+    }
 }
 
 }} // namespace psi::ccdensity

--- a/psi4/src/psi4/ccdensity/fold_UHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_UHF.cc
@@ -93,6 +93,8 @@ void fold_UHF(struct RHO_Params rho_params)
   aocc_sym = moinfo.aocc_sym; avir_sym = moinfo.avir_sym;
   bocc_sym = moinfo.bocc_sym; bvir_sym = moinfo.bvir_sym;
 
+
+  if(params.debug_) {
   outfile->Printf( "\n\tEnergies re-computed from Fock-adjusted CC density:\n");
   outfile->Printf(   "\t---------------------------------------------------\n");
 
@@ -168,7 +170,7 @@ void fold_UHF(struct RHO_Params rho_params)
   one_energy += this_energy;
 
   outfile->Printf( "\tOne-electron energy        = %20.15f\n", one_energy);
-
+  }
 
   global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 0, 0, rho_params.DIJ_lbl);
   global_dpd_->file2_mat_init(&D);
@@ -254,10 +256,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 10, 10, 10, 10, 1, "A <ij|kl>");
   two_energy += 0.25 * global_dpd_->buf4_dot(&Aints, &G);
   global_dpd_->buf4_close(&Aints);
-
+  }
   global_dpd_->buf4_close(&G);
 
   global_dpd_->file2_mat_close(&D);
@@ -332,15 +335,18 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&Aints, PSIF_CC_AINTS, 0, 22, 22, 22, 22, 0, "A <Ij|Kl>");
   two_energy += global_dpd_->buf4_dot(&Aints, &G);
   global_dpd_->buf4_close(&Aints);
+  }
 
   global_dpd_->buf4_close(&G);
 
+  if(params.debug_){
   total_two_energy += two_energy;
   outfile->Printf( "\tIJKL energy                = %20.15f\n", two_energy);
-
+  }
 
   global_dpd_->file2_mat_close(&D);
   global_dpd_->file2_close(&D);
@@ -384,10 +390,12 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   two_energy = 0.0;
   global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 0, 20, 2, 20, 0, "E <IJ||KA> (I>J,KA)");
   two_energy += global_dpd_->buf4_dot(&E, &G);
   global_dpd_->buf4_close(&E);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -434,10 +442,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_wrt(&G, h);
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
+  if(params.debug_){
   global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 10, 30, 12, 30, 0, "E <ij||ka> (i>j,ka)");
   two_energy += global_dpd_->buf4_dot(&E, &G);
   global_dpd_->buf4_close(&E);
-
+  }
   global_dpd_->buf4_close(&G);
 
   global_dpd_->file2_mat_close(&D1);
@@ -481,9 +490,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 23, 27, 23, 27, 0, "E <iJ|kA>");
   two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
   global_dpd_->buf4_close(&E);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -529,21 +540,25 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 22, 24, 22, 24, 0, "E <Ij|Ka>");
   two_energy += 2 * global_dpd_->buf4_dot(&E, &G);
   global_dpd_->buf4_close(&E);
+  }
 
   global_dpd_->buf4_close(&G);
 
+  if(params.debug_){
   total_two_energy += two_energy;
   outfile->Printf( "\tIJKA energy                = %20.15f\n", two_energy);
-
+  }
 
   global_dpd_->file2_mat_close(&D1);
   global_dpd_->file2_close(&D1);
   global_dpd_->file2_mat_close(&D2);
   global_dpd_->file2_close(&D2);
 
+  if(params.debug_){
   two_energy = 0.0;
   global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 2, 7, 2, 7, 0, "D <IJ||AB> (I>J,A>B)");
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 2, 7, 2, 7, 0, "GIJAB");
@@ -567,6 +582,7 @@ void fold_UHF(struct RHO_Params rho_params)
   two_energy *= 2;
   total_two_energy += two_energy;
   outfile->Printf( "\tIJAB energy                = %20.15f\n", two_energy);
+  }
 
 
   global_dpd_->file2_init(&D, PSIF_CC_OEI, 0, 1, 1, rho_params.DAB_lbl);
@@ -601,10 +617,12 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   two_energy = 0.0;
   global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 20, 20, 20, 20, 0, "C <IA||JB>");
   two_energy += global_dpd_->buf4_dot(&C, &G);
   global_dpd_->buf4_close(&C);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -644,9 +662,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 30, 30, 30, 30, 0, "C <ia||jb>");
   two_energy += global_dpd_->buf4_dot(&C, &G);
   global_dpd_->buf4_close(&C);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -686,9 +706,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 24, 24, 24, 24, 0, "C <Ia|Jb>");
   two_energy += global_dpd_->buf4_dot(&C, &G);
   global_dpd_->buf4_close(&C);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -727,9 +749,11 @@ void fold_UHF(struct RHO_Params rho_params)
     global_dpd_->buf4_mat_irrep_close(&G, h);
   }
 
+  if(params.debug_){
   global_dpd_->buf4_init(&C, PSIF_CC_CINTS, 0, 27, 27, 27, 27, 0, "C <iA|jB>");
   two_energy += global_dpd_->buf4_dot(&C, &G);
   global_dpd_->buf4_close(&C);
+  }
 
   global_dpd_->buf4_close(&G);
 
@@ -737,6 +761,7 @@ void fold_UHF(struct RHO_Params rho_params)
   global_dpd_->file2_close(&D);
 
 
+  if(params.debug_){
   global_dpd_->buf4_init(&DInts, PSIF_CC_DINTS, 0, 24, 27, 24, 27, 0, "D <Ij|Ab> (Ib,jA)");
   global_dpd_->buf4_init(&G, PSIF_CC_GAMMA, 0, 24, 27, 24, 27, 0, "GIbjA");
   two_energy -= global_dpd_->buf4_dot(&G, &DInts);
@@ -813,6 +838,7 @@ void fold_UHF(struct RHO_Params rho_params)
 	  one_energy + total_two_energy);
   outfile->Printf( "\tTotal %7s energy       = %20.15f\n", params.wfn == "CCSD_T" ? "CCSD(T)" : params.wfn.c_str(),
 	  one_energy + total_two_energy + moinfo.eref);
+   }
 }
 
 }} // namespace psi::ccdensity

--- a/psi4/src/psi4/ccdensity/get_params.cc
+++ b/psi4/src/psi4/ccdensity/get_params.cc
@@ -138,6 +138,7 @@ void get_params( Options& options)
     params.connect_xi = options.get_bool("XI_CONNECT");
 
   params.write_nos = options.get_bool("WRITE_NOS");
+  params.debug_ = options.get_int("DEBUG");
 
   outfile->Printf( "\n\tInput parameters:\n");
   outfile->Printf( "\t-----------------\n");

--- a/psi4/src/psi4/ccresponse/get_params.cc
+++ b/psi4/src/psi4/ccresponse/get_params.cc
@@ -204,10 +204,10 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options)
 
   outfile->Printf( "\n\tInput parameters:\n");
   outfile->Printf( "\t-----------------\n");
-  if(params.prop == "ALL")
-    outfile->Printf( "\tProperty         =    POLARIZABILITY + ROTATION\n");
-  else
-    outfile->Printf( "\tProperty         =    %s\n", params.prop.c_str());
+  //if(params.prop == "ALL")
+  //  outfile->Printf( "\tProperty               =    POLARIZABILITY + ROTATION\n");
+  //else
+  outfile->Printf( "\tProperty         =    %s\n", params.prop.c_str());
   outfile->Printf( "\tReference wfn    =    %s\n",
           (params.ref == 0) ? "RHF" : ((params.ref == 1) ? "ROHF" : "UHF"));
   outfile->Printf( "\tMemory (Mbytes)  =    %5.1f\n",params.memory/1e6);
@@ -226,12 +226,19 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options)
   outfile->Printf( "\tIrrep RX         =    %s\n", moinfo.labels[moinfo.l_irreps[0]]);
   outfile->Printf( "\tIrrep RY         =    %s\n", moinfo.labels[moinfo.l_irreps[1]]);
   outfile->Printf( "\tIrrep RZ         =    %s\n", moinfo.labels[moinfo.l_irreps[2]]);
+  /*  Only length gauge calculations for polarizabilities */
+  if (params.prop == "POLARIZABILITY")
+  outfile->Printf( "\tGauge            =    LENGTH\n");
+  else { 
   outfile->Printf( "\tGauge            =    %s\n", params.gauge.c_str());
+  }
+
   for(i=0; i < params.nomega; i++) {
     if(params.omega[i] == 0.0)
-      outfile->Printf( "\tApplied field %2d =  0.000\n", i);
+       outfile->Printf( "\tApplied field %2d =  0.000\n", i);
+
     else
-      outfile->Printf( "\tApplied field %2d =    %5.3f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", i, params.omega[i],
+       outfile->Printf( "\tApplied field %2d =    %5.3f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", i, params.omega[i],
               (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), pc_hartree2ev*params.omega[i],
               pc_hartree2wavenumbers*params.omega[i]);
   }

--- a/psi4/src/psi4/ccresponse/pertbar.cc
+++ b/psi4/src/psi4/ccresponse/pertbar.cc
@@ -69,7 +69,7 @@ void pertbar(const char *pert, int irrep, int anti)
   global_dpd_->file2_init(&f, PSIF_CC_OEI, irrep, 0, 1, lbl);
   sprintf(lbl, "%s_ME", prefix2);
   global_dpd_->file2_copy(&f, PSIF_CC_OEI, lbl);
-  global_dpd_->file2_print(&f, "outfile");
+  //global_dpd_->file2_print(&f, "outfile");
   global_dpd_->file2_close(&f);
 
   /** XXBAR_MI **/
@@ -87,7 +87,7 @@ void pertbar(const char *pert, int irrep, int anti)
   global_dpd_->contract222(&f, &t1, &fbar1, 0, 0, 1, 1);
   global_dpd_->file2_close(&t1);
   global_dpd_->file2_close(&f);
-  global_dpd_->file2_print(&fbar1, "outfile");
+  //global_dpd_->file2_print(&fbar1, "outfile");
   global_dpd_->file2_close(&fbar1);
 
   /** XXBAR_AE **/
@@ -105,7 +105,7 @@ void pertbar(const char *pert, int irrep, int anti)
   global_dpd_->contract222(&t1, &f, &fbar1, 1, 1, -1, 1);
   global_dpd_->file2_close(&t1);
   global_dpd_->file2_close(&f);
-  global_dpd_->file2_print(&fbar1, "outfile");
+  //global_dpd_->file2_print(&fbar1, "outfile");
   global_dpd_->file2_close(&fbar1);
 
   /** XXBAR_IA **/
@@ -151,7 +151,7 @@ void pertbar(const char *pert, int irrep, int anti)
   global_dpd_->file2_close(&t1);
   global_dpd_->file2_close(&z);
 
-  global_dpd_->file2_print(&fbar1, "outfile");
+  //global_dpd_->file2_print(&fbar1, "outfile");
   global_dpd_->file2_close(&fbar1);
 
   /** LBAR_MbIj **/

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -115,9 +115,9 @@ void polar(void)
       }
 
     if (params.wfn == "CC2")
-      outfile->Printf( "\n                 CC2 Dipole Polarizability [(e^2 a0^2)/E_h]:\n");
+      outfile->Printf( "\n                 CC2 Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
     else
-      outfile->Printf( "\n                 CCSD Dipole Polarizability [(e^2 a0^2)/E_h]:\n");
+      outfile->Printf( "\n                 CCSD Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
     outfile->Printf( "  -------------------------------------------------------------------------\n");
     if(params.omega[i] != 0.0)
       omega_nm = (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1938,11 +1938,14 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     /*- Caching level for libdpd -*/
     options.add_int("CACHELEVEL",2);
     /*- Specifies the choice of representation of the electric dipole operator.
-    Acceptable values are ``LENGTH`` for the usual length-gauge representation,
+    For polarizability, this keyword is ignored and ``LENGTH`` gauge is computed. 
+    For optical rotation and raman optical activity, this keyword is active, and 
+    acceptable values are ``LENGTH`` for the usual length-gauge representation,
     ``VELOCITY``(default) for the modified velocity-gauge representation in which the
     static-limit optical rotation tensor is subtracted from the frequency-
-    dependent tensor, or ``BOTH``. Note that, for optical rotation calculations,
-    only the choices of ``VELOCITY`` or ``BOTH`` will yield origin-independent results. -*/
+    dependent tensor, or ``BOTH``. Note that, for optical rotation and raman optical 
+    activity calculations, only the choices of ``VELOCITY`` or ``BOTH`` will yield 
+    origin-independent results. -*/
     options.add_str("GAUGE","VELOCITY", "LENGTH VELOCITY BOTH");
     /*- Maximum number of iterations to converge perturbed amplitude equations -*/
     options.add_int("MAXITER",50);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1699,6 +1699,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_double("ONEPDM_GRID_STEPSIZE", 0.1);
     /* Do Write NOs (molden) */
     options.add_bool("WRITE_NOS",false);
+    /* Reproducing energies from densities ? */
+    options.add_int("DEBUG", 0);
   }
   if(name == "CCLAMBDA"|| options.read_globals()) {
      /*- MODULEDESCRIPTION Solves for the Lagrange multipliers, which are needed whenever coupled cluster properties
@@ -1937,7 +1939,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_int("CACHELEVEL",2);
     /*- Specifies the choice of representation of the electric dipole operator.
     Acceptable values are ``LENGTH`` for the usual length-gauge representation,
-    ``VELOCITY`` for the modified velocity-gauge representation in which the
+    ``VELOCITY``(default) for the modified velocity-gauge representation in which the
     static-limit optical rotation tensor is subtracted from the frequency-
     dependent tensor, or ``BOTH``. Note that, for optical rotation calculations,
     only the choices of ``VELOCITY`` or ``BOTH`` will yield origin-independent results. -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1941,7 +1941,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     static-limit optical rotation tensor is subtracted from the frequency-
     dependent tensor, or ``BOTH``. Note that, for optical rotation calculations,
     only the choices of ``VELOCITY`` or ``BOTH`` will yield origin-independent results. -*/
-    options.add_str("GAUGE","LENGTH", "LENGTH VELOCITY BOTH");
+    options.add_str("GAUGE","VELOCITY", "LENGTH VELOCITY BOTH");
     /*- Maximum number of iterations to converge perturbed amplitude equations -*/
     options.add_int("MAXITER",50);
     /*- Convergence criterion for wavefunction (change) in perturbed CC equations. -*/


### PR DESCRIPTION
## Description
1. Default gauge has been set to "velocity" for ccresponse calculations. Un-necessary
printing removed from pertbar.cc
2. cc-energies are reproduced from densities only when debug's value is non-zero.

## Status
- [x] Ready to go
