### PR TITLE
minor tweak of finite difference atomic_displacements order

### DIFF
--- a/psi4/driver/procrouting/findif_response_utils/db_helper.py
+++ b/psi4/driver/procrouting/findif_response_utils/db_helper.py
@@ -137,7 +137,8 @@ def initialize_database(database, name, prop, properties_array, additional_kwarg
     molecule = core.get_active_molecule()
     natom = molecule.natom()
     coordinates = ['x', 'y', 'z']
-    step_direction = ['p', 'm']
+    #step_direction = ['p', 'm'] changing due to change in findif atomic_displacements
+    step_direction = ['m', 'p']
 
     for atom in range(1, natom + 1):
         for coord in coordinates:

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -270,36 +270,52 @@ void displace_atom(SharedMatrix geom, const int atom, const int coord, const int
 std::vector< SharedMatrix > atomic_displacements(std::shared_ptr<Molecule> mol, Options &options) {
 
   // This is the size in bohr because geometry is in bohr at this point
-  // This equals 0.1 angstrom displacement
   double disp_size = options.get_double("DISP_SIZE");
+  int pts = options.get_int("POINTS");
 
   int natom = mol->natom();
 
-  // Geometry seems to be in bohr at this point
   Matrix ref_geom_temp = mol->geometry();
   SharedMatrix ref_geom(ref_geom_temp.clone());
 
   std::vector< SharedMatrix > disp_geoms;
 
   // Generate displacements
-  for(int atom=0; atom < natom; ++atom) {
-    for(int coord=0; coord < 3; ++coord) {
-      // plus displacement
-      SharedMatrix p_geom(ref_geom->clone());
-      displace_atom(p_geom, atom, coord, +1, disp_size);
-      disp_geoms.push_back(p_geom);
-      // minus displacement
-      SharedMatrix m_geom(ref_geom->clone());
-      displace_atom(m_geom, atom, coord, -1, disp_size);
-      disp_geoms.push_back(m_geom);
+  if (pts == 3) {
+    for(int atom=0; atom < natom; ++atom) {
+      for(int coord=0; coord < 3; ++coord) {
+        // minus displacement
+        SharedMatrix m_geom(ref_geom->clone());
+        displace_atom(m_geom, atom, coord, -1, disp_size);
+        disp_geoms.push_back(m_geom);
+        // plus displacement
+        SharedMatrix p_geom(ref_geom->clone());
+        displace_atom(p_geom, atom, coord, +1, disp_size);
+        disp_geoms.push_back(p_geom);
+      }
     }
   }
-
-  // put reference geometry in list
-  // disp_geoms.push_back(ref_geom);
-
+  else if (pts == 5) {
+    for(int atom=0; atom < natom; ++atom) {
+      for(int coord=0; coord < 3; ++coord) {
+        // minus displacements
+        SharedMatrix m2_geom(ref_geom->clone());
+        displace_atom(m2_geom, atom, coord, -2, disp_size);
+        disp_geoms.push_back(m2_geom);
+        SharedMatrix m1_geom(ref_geom->clone());
+        displace_atom(m1_geom, atom, coord, -1, disp_size);
+        disp_geoms.push_back(m1_geom);
+        // plus displacements
+        SharedMatrix p1_geom(ref_geom->clone());
+        displace_atom(p1_geom, atom, coord, +1, disp_size);
+        disp_geoms.push_back(p1_geom);
+        SharedMatrix p2_geom(ref_geom->clone());
+        displace_atom(p2_geom, atom, coord, +2, disp_size);
+        disp_geoms.push_back(p2_geom);
+      }
+    }
+  }
   return disp_geoms;
-
 }
 
 }}

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -315,6 +315,9 @@ std::vector< SharedMatrix > atomic_displacements(std::shared_ptr<Molecule> mol, 
       }
     }
   }
+  else {
+    throw PsiException("FINDIF: Number of POINTS not supported", __FILE__, __LINE__);
+  }
   return disp_geoms;
 }
 


### PR DESCRIPTION
## Description
Minor tweaks to finite differences in the atomic_displacements() function that is used only in prototype ROA calculations at present.  

## Todos
Now supports 3-point and 5-point formulae finite differences in the atomic_displacements() function.
Now returns displacements in canonical most negative to most positive order.

* **Developer Interest**
I have used this function in dipole moment derivative/file17 computations.  Further development along these lines is likely.

* **User-Facing for Release Notes**
None at this juncture.

## Questions
None

## Status
Should be ready to go.