### PR TITLE
Desymmetrize SCF for non-symmetry-aware modules

### DIFF
--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -60,8 +60,8 @@ Installation
 
 **Binary**
 
-* .. image:: https://anaconda.org/psi4/libint/badges/version.svg
-     :target: https://anaconda.org/psi4/libint
+* .. image:: https://anaconda.org/evaleev/libint/badges/version.svg
+     :target: https://anaconda.org/evaleev/libint
 
 * Libint is available as a conda package for Linux and macOS (and Windows, through the Ubuntu shell).
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1193,18 +1193,19 @@ def scf_helper(name, post_scf=True, **kwargs):
         p4util.banner('  Computing high-spin triplet guess  ')
         core.print_out('\n')
 
-
-#    # If we force c1 copy the active molecule
-#    if use_c1:
-#        scf_molecule.update_geometry()
-#        if scf_molecule.schoenflies_symbol() != 'c1':
-#            core.print_out("""  A requested method does not make use of molecular symmetry: """
-#                           """further calculations in C1 point group.\n""")
-#            scf_molecule = scf_molecule.clone()
-#            scf_molecule.reset_point_group('c1')
-#            scf_molecule.fix_orientation(True)
-#            scf_molecule.fix_com(True)
-#            scf_molecule.update_geometry()
+    # C1: OLD WAY
+    # If we force c1 copy the active molecule
+    if use_c1:
+        scf_molecule.update_geometry()
+        if scf_molecule.schoenflies_symbol() != 'c1':
+            core.print_out("""  A requested method does not make use of molecular symmetry: """
+                           """further calculations in C1 point group.\n""")
+            scf_molecule = scf_molecule.clone()
+            scf_molecule.reset_point_group('c1')
+            scf_molecule.fix_orientation(True)
+            scf_molecule.fix_com(True)
+            scf_molecule.update_geometry()
+    # C1: NEW WAY: comment out above
 
     # If GUESS is auto guess what it should be
     if core.get_option('SCF', 'GUESS') == "AUTO":
@@ -1426,7 +1427,11 @@ def scf_helper(name, post_scf=True, **kwargs):
     if not use_c1:
         return scf_wfn
     else:
-        return scf_wfn.c1_deep_copy()
+        # C1: OLD WAY
+        return scf_wfn
+        # C1: NEW WAY
+        #return scf_wfn.deep_copy(scf_wfn)
+
 #        # If we force c1 copy the active molecule
 #        scf_molecule.update_geometry()
 #        if scf_molecule.schoenflies_symbol() != 'c1':

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1422,8 +1422,8 @@ def scf_helper(name, post_scf=True, **kwargs):
         c1_molecule.fix_orientation(True)
         c1_molecule.fix_com(True)
         c1_molecule.update_geometry()
-        c1_basis, c1_ecpbasis = core.BasisSet.build(c1_molecule, "ORBITAL", core.get_global_option('BASIS'))
-        return scf_wfn.deep_copy(scf_wfn, c1_basis)
+        c1_basis = core.BasisSet.build(c1_molecule, "ORBITAL", core.get_global_option('BASIS'))
+        return core.Wavefunction.c1_deep_copy(scf_wfn, c1_basis)
 
 
 def run_dcft(name, **kwargs):

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1194,17 +1194,17 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.print_out('\n')
 
 
-    # If we force c1 copy the active molecule
-    if use_c1:
-        scf_molecule.update_geometry()
-        if scf_molecule.schoenflies_symbol() != 'c1':
-            core.print_out("""  A requested method does not make use of molecular symmetry: """
-                           """further calculations in C1 point group.\n""")
-            scf_molecule = scf_molecule.clone()
-            scf_molecule.reset_point_group('c1')
-            scf_molecule.fix_orientation(True)
-            scf_molecule.fix_com(True)
-            scf_molecule.update_geometry()
+#    # If we force c1 copy the active molecule
+#    if use_c1:
+#        scf_molecule.update_geometry()
+#        if scf_molecule.schoenflies_symbol() != 'c1':
+#            core.print_out("""  A requested method does not make use of molecular symmetry: """
+#                           """further calculations in C1 point group.\n""")
+#            scf_molecule = scf_molecule.clone()
+#            scf_molecule.reset_point_group('c1')
+#            scf_molecule.fix_orientation(True)
+#            scf_molecule.fix_com(True)
+#            scf_molecule.update_geometry()
 
     # If GUESS is auto guess what it should be
     if core.get_option('SCF', 'GUESS') == "AUTO":
@@ -1422,7 +1422,34 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.tstop()
 
     optstash.restore()
-    return scf_wfn
+
+    if not use_c1:
+        return scf_wfn
+    else:
+        return scf_wfn.c1_deep_copy()
+#        # If we force c1 copy the active molecule
+#        scf_molecule.update_geometry()
+#        if scf_molecule.schoenflies_symbol() != 'c1':
+#            core.print_out("""  A requested method does not make use of molecular symmetry: """
+#                           """transforming Wavefunction so that further calculations in C1 point group.\n""")
+#            scf_molecule = scf_molecule.clone()
+#            scf_molecule.reset_point_group('c1')
+#            scf_molecule.fix_orientation(True)
+#            scf_molecule.fix_com(True)
+#            scf_molecule.update_geometry()
+
+## Not really needed, but we cannot set the orbitals explicitly-- need Python bindings
+#scf_e, nosym_wfn = psi4.energy("SCF", molecule=mol_nosym, return_wfn=True)
+#
+## Copy SCF quantities using built in functions to cast from SO (c2v symmetry) to AO (C1 symmetry).
+#nosym_wfn.Ca().np[:] = sym_wfn.Ca_subset("AO", "ALL")
+#nosym_wfn.Cb().np[:] = sym_wfn.Cb_subset("AO", "ALL")
+#
+#nosym_wfn.epsilon_a().np[:] = sym_wfn.epsilon_a_subset("AO", "ALL")
+#nosym_wfn.epsilon_b().np[:] = sym_wfn.epsilon_b_subset("AO", "ALL")
+#
+## Zip up alpha/beta/nfzc/ndocc/etc, cant actually do this yet. Need Python setters.
+#nosym_wfn.ndocc()[0] = sym_wfn.ndocc().sum()
 
 
 def run_dcft(name, **kwargs):

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1423,7 +1423,12 @@ def scf_helper(name, post_scf=True, **kwargs):
         c1_molecule.fix_com(True)
         c1_molecule.update_geometry()
         c1_basis = core.BasisSet.build(c1_molecule, "ORBITAL", core.get_global_option('BASIS'))
-        return core.Wavefunction.c1_deep_copy(scf_wfn, c1_basis)
+        tmp = scf_wfn.c1_deep_copy(c1_basis)
+        c1_jkbasis = core.BasisSet.build(c1_molecule, "DF_BASIS_SCF", 
+                                         core.get_global_option("DF_BASIS_SCF"),
+                                         "JKFIT", core.get_global_option('BASIS'))
+        tmp.set_basisset("DF_BASIS_SCF", c1_jkbasis)
+        return tmp
 
 
 def run_dcft(name, **kwargs):

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -74,6 +74,8 @@ void export_wavefunction(py::module& m) {
              "Copies the pointers to the internal data.")
         .def("deep_copy", take_sharedwfn(&Wavefunction::deep_copy),
              "Deep copies the internal data.")
+        .def("c1_deep_copy", take_sharedwfn(&Wavefunction::c1_deep_copy),
+             "Deep copies the internal data, converting internal data to C_1 symmetry.")
         .def("same_a_b_orbs", &Wavefunction::same_a_b_orbs,
              "Returns true if the alpha and beta orbitals are the same.")
         .def("same_a_b_dens", &Wavefunction::same_a_b_dens,

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -74,8 +74,8 @@ void export_wavefunction(py::module& m) {
              "Copies the pointers to the internal data.")
         .def("deep_copy", take_sharedwfn(&Wavefunction::deep_copy),
              "Deep copies the internal data.")
-        .def("c1_deep_copy", take_sharedwfn(&Wavefunction::c1_deep_copy),
-             "Deep copies the internal data, converting internal data to C_1 symmetry.")
+        .def_static("c1_deep_copy", &Wavefunction::c1_deep_copy,
+             "Returns a new wavefunction with internal data converted to C_1 symmetry from *arg0* and pre-c1-constructed BasisSet *arg1*")
         .def("same_a_b_orbs", &Wavefunction::same_a_b_orbs,
              "Returns true if the alpha and beta orbitals are the same.")
         .def("same_a_b_dens", &Wavefunction::same_a_b_dens,

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -74,8 +74,8 @@ void export_wavefunction(py::module& m) {
              "Copies the pointers to the internal data.")
         .def("deep_copy", take_sharedwfn(&Wavefunction::deep_copy),
              "Deep copies the internal data.")
-        .def_static("c1_deep_copy", &Wavefunction::c1_deep_copy,
-             "Returns a new wavefunction with internal data converted to C_1 symmetry from *arg0* and pre-c1-constructed BasisSet *arg1*")
+        .def("c1_deep_copy", &Wavefunction::c1_deep_copy,
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *arg0*")
         .def("same_a_b_orbs", &Wavefunction::same_a_b_orbs,
              "Returns true if the alpha and beta orbitals are the same.")
         .def("same_a_b_dens", &Wavefunction::same_a_b_dens,
@@ -208,19 +208,24 @@ void export_wavefunction(py::module& m) {
              "Semicanonicalizes the orbitals for ROHF.");
 
     py::class_<scf::RHF, std::shared_ptr<scf::RHF>, scf::HF>(m, "RHF", "docstring")
-        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>());
+        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
+        .def("c1_deep_copy", &scf::RHF::c1_deep_copy,
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *arg0*");
 
     py::class_<scf::ROHF, std::shared_ptr<scf::ROHF>, scf::HF>(m, "ROHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("moFeff", &scf::ROHF::moFeff, "docstring")
         .def("moFa", &scf::ROHF::moFa, "docstring")
-        .def("moFb", &scf::ROHF::moFb, "docstring");
+        .def("moFb", &scf::ROHF::moFb, "docstring")
+        .def("c1_deep_copy", &scf::ROHF::c1_deep_copy, "Make de-symmetrized deep copy");
 
     py::class_<scf::UHF, std::shared_ptr<scf::UHF>, scf::HF>(m, "UHF", "docstring")
-        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>());
+        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
+        .def("c1_deep_copy", &scf::UHF::c1_deep_copy, "Make de-symmetrized deep copy");
 
     py::class_<scf::CUHF, std::shared_ptr<scf::CUHF>, scf::HF>(m, "CUHF", "docstring")
-        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>());
+        .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
+        .def("c1_deep_copy", &scf::CUHF::c1_deep_copy, "Make de-symetrized deep copy");
 
     py::class_<dfep2::DFEP2Wavefunction, std::shared_ptr<dfep2::DFEP2Wavefunction>, Wavefunction>(
         m, "DFEP2Wavefunction", "A density-fitted second-order Electron Propagator Wavefunction.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -75,7 +75,7 @@ void export_wavefunction(py::module& m) {
         .def("deep_copy", take_sharedwfn(&Wavefunction::deep_copy),
              "Deep copies the internal data.")
         .def("c1_deep_copy", &Wavefunction::c1_deep_copy,
-             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *arg0*")
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis", py::arg("basis"))
         .def("same_a_b_orbs", &Wavefunction::same_a_b_orbs,
              "Returns true if the alpha and beta orbitals are the same.")
         .def("same_a_b_dens", &Wavefunction::same_a_b_dens,
@@ -210,22 +210,25 @@ void export_wavefunction(py::module& m) {
     py::class_<scf::RHF, std::shared_ptr<scf::RHF>, scf::HF>(m, "RHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("c1_deep_copy", &scf::RHF::c1_deep_copy,
-             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *arg0*");
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<scf::ROHF, std::shared_ptr<scf::ROHF>, scf::HF>(m, "ROHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("moFeff", &scf::ROHF::moFeff, "docstring")
         .def("moFa", &scf::ROHF::moFa, "docstring")
         .def("moFb", &scf::ROHF::moFb, "docstring")
-        .def("c1_deep_copy", &scf::ROHF::c1_deep_copy, "Make de-symmetrized deep copy");
+        .def("c1_deep_copy", &scf::ROHF::c1_deep_copy, 
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<scf::UHF, std::shared_ptr<scf::UHF>, scf::HF>(m, "UHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
-        .def("c1_deep_copy", &scf::UHF::c1_deep_copy, "Make de-symmetrized deep copy");
+        .def("c1_deep_copy", &scf::UHF::c1_deep_copy, 
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<scf::CUHF, std::shared_ptr<scf::CUHF>, scf::HF>(m, "CUHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
-        .def("c1_deep_copy", &scf::CUHF::c1_deep_copy, "Make de-symetrized deep copy");
+        .def("c1_deep_copy", &scf::CUHF::c1_deep_copy,
+             "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<dfep2::DFEP2Wavefunction, std::shared_ptr<dfep2::DFEP2Wavefunction>, Wavefunction>(
         m, "DFEP2Wavefunction", "A density-fitted second-order Electron Propagator Wavefunction.")

--- a/psi4/src/psi4/dfocc/dfocc.h
+++ b/psi4/src/psi4/dfocc/dfocc.h
@@ -1326,10 +1326,6 @@ class DFOCC : public Wavefunction {
     SharedTensor2i vv_idxAB;  // Pair index for all VV
     SharedTensor2i vv_idxBB;  // Pair index for all VV
 
-    SharedMatrix Tso_;
-    SharedMatrix Vso_;
-    SharedMatrix Hso_;
-    SharedMatrix Sso_;
     SharedMatrix bQnn;  // b(Q|mu nu)
     SharedVector e_orbA;
 };

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -340,34 +340,33 @@ void DFOCC::get_moinfo() {
     /************************** Create all required matrice *************************************/
     /********************************************************************************************/
     // Build Hso
-    Hso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis One-electron Ints", nso_, nso_));
-    Tso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Kinetic Energy Ints", nso_, nso_));
-    Vso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Potential Energy Ints", nso_, nso_));
-    Sso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Overlap Ints", nso_, nso_));
-    Hso_->zero();
-    Tso_->zero();
-    Vso_->zero();
-    Sso_->zero();
+    //Hso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis One-electron Ints", nso_, nso_));
+    //Tso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Kinetic Energy Ints", nso_, nso_));
+    //Vso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Potential Energy Ints", nso_, nso_));
+    //Sso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Overlap Ints", nso_, nso_));
+    //Hso_->zero();
+    //Tso_->zero();
+    //Vso_->zero();
+    //Sso_->zero();
 
-    // Read SO-basis one-electron integrals
-    double *so_ints = init_array(ntri_so);
-    IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_T, so_ints, ntri_so, 0, 0, "outfile");
-    Tso_->set(so_ints);
-    IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_V, so_ints, ntri_so, 0, 0, "outfile");
-    Vso_->set(so_ints);
-    IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_S, so_ints, ntri_so, 0, 0, "outfile");
-    Sso_->set(so_ints);
-    free(so_ints);
-    Hso_->copy(Tso_);
-    Hso_->add(Vso_);
-    Tso_.reset();
-    Vso_.reset();
+    //// Read SO-basis one-electron integrals
+    //double *so_ints = init_array(ntri_so);
+    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_T, so_ints, ntri_so, 0, 0, "outfile");
+    //Tso_->set(so_ints);
+    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_V, so_ints, ntri_so, 0, 0, "outfile");
+    //Vso_->set(so_ints);
+    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_S, so_ints, ntri_so, 0, 0, "outfile");
+    //Sso_->set(so_ints);
+    //free(so_ints);
+    //Hso_->copy(Tso_);
+    //Hso_->add(Vso_);
+    //Tso_.reset();
+    //Vso_.reset();
+    // CDS: Migrate these from disk reads to grabbing off Wavefunction
     Hso = SharedTensor2d(new Tensor2d("SO-basis One-electron Ints", nso_, nso_));
-    Hso->set(Hso_);
-    Hso_.reset();
+    Hso->set(H_);
     Sso = SharedTensor2d(new Tensor2d("SO-basis Overlap Ints", nso_, nso_));
-    Sso->set(Sso_);
-    Sso_.reset();
+    Sso->set(S_);
 
     // outfile->Printf("\n get_moinfo is done. \n");
 }  // end get_moinfo

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2708,7 +2708,7 @@ void Matrix::remove_symmetry(const SharedMatrix &a, const SharedMatrix &SO2AO) {
         throw PSIEXCEPTION("Matrix::remove_symmetry: Sizes are not compatible.\n");
     }
 
-    // Ensure we're working with a clea
+    // Ensure we're working with a clean matrix
     zero();
 
     // Create temporary matrix of proper size.

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3260,7 +3260,7 @@ bool Matrix::equal(const Matrix *rhs, double TOL) {
     for (int h = 0; h < nirrep(); ++h) {
         for (int m = 0; m < rowspi()[h]; ++m) {
             for (int n = 0; n < colspi()[h ^ symmetry_]; ++n) {
-                if (fabs(get(h, m, n) - rhs->get(h, m, n)) > TOL)
+                if (std::fabs(get(h, m, n) - rhs->get(h, m, n)) > TOL)
                     return false;
             }
         }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3239,11 +3239,15 @@ void Matrix::load(const std::string &filename) {
     }
 }
 
-bool Matrix::equal(const Matrix &rhs) { return equal(&rhs); }
+bool Matrix::equal(const Matrix &rhs, double TOL) {
+    return equal(&rhs, TOL);
+}
 
-bool Matrix::equal(const SharedMatrix &rhs) { return equal(rhs.get()); }
+bool Matrix::equal(const SharedMatrix &rhs, double TOL) {
+    return equal(rhs.get(), TOL);
+}
 
-bool Matrix::equal(const Matrix *rhs) {
+bool Matrix::equal(const Matrix *rhs, double TOL) {
     // Check dimensions
     if (rhs->nirrep() != nirrep()) return false;
 
@@ -3256,7 +3260,8 @@ bool Matrix::equal(const Matrix *rhs) {
     for (int h = 0; h < nirrep(); ++h) {
         for (int m = 0; m < rowspi()[h]; ++m) {
             for (int n = 0; n < colspi()[h ^ symmetry_]; ++n) {
-                if (get(h, m, n) != rhs->get(h, m, n)) return false;
+                if (fabs(get(h, m, n) - rhs->get(h, m, n)) > TOL)
+                    return false;
             }
         }
     }

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -1118,9 +1118,9 @@ public:
     /// Checks matrix equality.
     /// @param rhs Matrix to compare to.
     /// @returns true if equal, otherwise false.
-    bool equal(const Matrix& rhs);
-    bool equal(const SharedMatrix& rhs);
-    bool equal(const Matrix* rhs);
+    bool equal(const Matrix& rhs, double TOL=1.0e-10);
+    bool equal(const SharedMatrix& rhs, double TOL=1.0e-10);
+    bool equal(const Matrix* rhs, double TOL=1.0e-10);
     /// @}
 
     /// @{

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -940,11 +940,11 @@ void OEProp::compute_multipoles(int order, bool transition)
         aompOBI->compute(mp_ints);
 
         if (same_dens_) {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
             Db = Da;
         } else {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-            Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+            Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
         }
     }
 
@@ -1054,11 +1054,11 @@ void OEProp::compute_esp_over_grid()
 
     outfile->Printf( "\n Electrostatic potential computed on the grid and written to grid_esp.dat\n");
 
-    SharedMatrix Dtot = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+    SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
         Dtot->scale(2.0);
     }else{
-        Dtot->add(wfn_->D_subset_helper(Db_so_, Cb_so_, "AO"));
+        Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
     int nbf = basisset_->nbf();
@@ -1099,11 +1099,11 @@ void OEProp::compute_field_over_grid()
 
     outfile->Printf( "\n Field computed on the grid and written to grid_field.dat\n");
 
-    SharedMatrix Dtot = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+    SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
         Dtot->scale(2.0);
     }else{
-        Dtot->add(wfn_->D_subset_helper(Db_so_, Cb_so_, "AO"));
+        Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
     std::shared_ptr<ElectricFieldInt> field_ints(dynamic_cast<ElectricFieldInt*>(wfn_->integral()->electric_field()));
@@ -1152,11 +1152,11 @@ void OEProp::compute_esp_at_nuclei()
     int nbf = basisset_->nbf();
     int natoms = mol->natom();
 
-    SharedMatrix Dtot = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+    SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
         Dtot->scale(2.0);
     }else{
-        Dtot->add(wfn_->D_subset_helper(Db_so_, Cb_so_, "AO"));
+        Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
     Matrix dist = mol->distance_matrix();
@@ -1220,11 +1220,11 @@ void OEProp::compute_dipole(bool transition)
         aodOBI->set_origin(origin_);
         aodOBI->compute(dipole_ints);
         if (same_dens_) {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
             Db = Da;
         } else {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-            Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+            Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
         }
     }
 
@@ -1310,11 +1310,11 @@ void OEProp::compute_quadrupole(bool transition)
         aoqOBI->set_origin(origin_);
         aoqOBI->compute(qpole_ints);
         if (same_dens_) {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
             Db = Da;
         } else {
-            Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-            Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+            Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+            Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
         }
     }
 
@@ -1545,11 +1545,11 @@ void OEProp::compute_mulliken_charges()
 
 //    Get the Density Matrices for alpha and beta spins
     if (same_dens_) {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
         Db = Da;
     } else {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-        Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+        Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
     }
 
 //    Compute the overlap matrix
@@ -1631,11 +1631,11 @@ void OEProp::compute_lowdin_charges()
 
 //    Get the Density Matrices for alpha and beta spins
     if (same_dens_) {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
         Db = Da;
     } else {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-        Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+        Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
     }
 
 //    Compute the overlap matrix
@@ -1705,11 +1705,11 @@ void OEProp::compute_mayer_indices()
 
 //    Get the Density Matrices for alpha and beta spins
     if (same_dens_) {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
         Db = Da;
     } else {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-        Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+        Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
     }
 
 //    Compute the overlap matrix
@@ -1818,11 +1818,11 @@ void OEProp::compute_wiberg_lowdin_indices()
 
 //    Get the Density Matrices for alpha and beta spins
     if (same_dens_) {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
         Db = Da;
     } else {
-        Da = wfn_->D_subset_helper(Da_so_, Ca_so_, "AO");
-        Db = wfn_->D_subset_helper(Db_so_, Cb_so_, "AO");
+        Da = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D alpha");
+        Db = wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta");
     }
 
 //    Compute the overlap matrix

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -213,118 +213,107 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     }
 }
 
-std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis)
+std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(std::shared_ptr<BasisSet> basis)
 {
-    if (!other->S_) {
+    if (!S_) {
         throw PSIEXCEPTION("Wavefunction::c1_deep_copy must copy an initialized wavefunction.");
     }
 
-    std::shared_ptr <Wavefunction> wfn(new Wavefunction(basis->molecule(), basis, other->options()));
+    auto wfn = std::make_shared<Wavefunction>(basis->molecule(), basis, options_);
   
     /// From typical constructor
     /// Some member data is not clone-able so we will copy
-    wfn->name_ = other->name_;
-    //molecule_ = std::shared_ptr<Molecule>(new Molecule(other->molecule_->clone()));
-    //molecule_->reset_point_group("c1");
-    //molecule_->set_orientation_fixed(true);
-    //molecule_->set_com_fixed(true);
-    //molecule_->update_geometry();
-
-    //basisset_ = other->basisset_; // CDS: think we need to reset this
-                                  // b/c it contains a molecule
-    //basissets_ = other->basissets_; // Still cannot copy basissets
-    //basissets_ // leave at null ptr
-    wfn->integral_ = std::shared_ptr<IntegralFactory>(new IntegralFactory(wfn->basisset_, wfn->basisset_, wfn->basisset_, wfn->basisset_));
-    wfn->sobasisset_ = std::shared_ptr<SOBasisSet>(new SOBasisSet(wfn->basisset_, wfn->integral_));
-    wfn->factory_ = std::shared_ptr<MatrixFactory>(new MatrixFactory);
+    wfn->name_ = name_;
+    wfn->integral_ = std::make_shared<IntegralFactory>(wfn->basisset_, wfn->basisset_, wfn->basisset_, wfn->basisset_);
+    wfn->sobasisset_ = std::make_shared<SOBasisSet>(wfn->basisset_, wfn->integral_);
+    wfn->factory_ = std::make_shared<MatrixFactory>();
 
     Dimension c1_nsopi = Dimension(1);
-    c1_nsopi[0] = other->nsopi_.sum();
+    c1_nsopi[0] = nsopi_.sum();
     wfn->factory_->init_with(c1_nsopi, c1_nsopi);
 
     // Need to re-generate AO2SO_ because the new SO basis is different
     // than the old one (lower symmetry)
-    std::shared_ptr<PetiteList> pet(new PetiteList(wfn->basisset_, wfn->integral_));
+    auto pet = std::make_shared<PetiteList>(wfn->basisset_, wfn->integral_);
     wfn->AO2SO_ = pet->aotoso();
 
-    wfn->psio_ = other->psio_; // We dont actually copy psio
-    wfn->memory_ = other->memory_;
-    wfn->nalpha_ = other->nalpha_;
-    wfn->nbeta_ = other->nbeta_;
-    wfn->nfrzc_ = other->nfrzc_;
+    wfn->psio_ = psio_; // We dont actually copy psio
+    wfn->memory_ = memory_;
+    wfn->nalpha_ = nalpha_;
+    wfn->nbeta_ = nbeta_;
+    wfn->nfrzc_ = nfrzc_;
 
-    wfn->print_ = other->print_;
-    wfn->debug_ = other->debug_;
-    wfn->density_fitted_ = other->density_fitted_;
+    wfn->print_ = print_;
+    wfn->debug_ = debug_;
+    wfn->density_fitted_ = density_fitted_;
 
-    wfn->energy_ = other->energy_;
-    wfn->efzc_ = other->efzc_;
-    wfn->variables_ = other->variables_;
+    wfn->energy_ = energy_;
+    wfn->efzc_ = efzc_;
 
     // collapse all the Dimension objects down to one element
-    wfn->doccpi_.init(1, other->doccpi_.name());
-    wfn->doccpi_[0] = other->doccpi_.sum();
-    wfn->soccpi_.init(1, other->soccpi_.name());
-    wfn->soccpi_[0] = other->soccpi_.sum();
-    wfn->frzcpi_.init(1, other->frzcpi_.name());
-    wfn->frzcpi_[0] = other->frzcpi_.sum();
-    wfn->frzvpi_.init(1, other->frzvpi_.name());
-    wfn->frzvpi_[0] = other->frzvpi_.sum();
-    wfn->nalphapi_.init(1, other->nalphapi_.name());
-    wfn->nalphapi_[0] = other->nalphapi_.sum();
-    wfn->nbetapi_.init(1, other->nbetapi_.name());
-    wfn->nbetapi_[0] = other->nbetapi_.sum();
-    wfn->nsopi_.init(1, other->nsopi_.name());
-    wfn->nsopi_[0] = other->nsopi_.sum();
-    wfn->nmopi_.init(1, other->nmopi_.name());
-    wfn->nmopi_[0] = other->nmopi_.sum();
+    wfn->doccpi_.init(1, doccpi_.name());
+    wfn->doccpi_[0] = doccpi_.sum();
+    wfn->soccpi_.init(1, soccpi_.name());
+    wfn->soccpi_[0] = soccpi_.sum();
+    wfn->frzcpi_.init(1, frzcpi_.name());
+    wfn->frzcpi_[0] = frzcpi_.sum();
+    wfn->frzvpi_.init(1, frzvpi_.name());
+    wfn->frzvpi_[0] = frzvpi_.sum();
+    wfn->nalphapi_.init(1, nalphapi_.name());
+    wfn->nalphapi_[0] = nalphapi_.sum();
+    wfn->nbetapi_.init(1, nbetapi_.name());
+    wfn->nbetapi_[0] = nbetapi_.sum();
+    wfn->nsopi_.init(1, nsopi_.name());
+    wfn->nsopi_[0] = nsopi_.sum();
+    wfn->nmopi_.init(1, nmopi_.name());
+    wfn->nmopi_[0] = nmopi_.sum();
 
-    wfn->nso_ = other->nso_;
-    wfn->nmo_ = other->nmo_;
+    wfn->nso_ = nso_;
+    wfn->nmo_ = nmo_;
     wfn->nirrep_ = 1;
 
-    wfn->same_a_b_dens_ = other->same_a_b_dens_;
-    wfn->same_a_b_orbs_ = other->same_a_b_orbs_;
+    wfn->same_a_b_dens_ = same_a_b_dens_;
+    wfn->same_a_b_orbs_ = same_a_b_orbs_;
 
 
     /// Need the SO2AO matrix for remove_symmetry(), have the AO2SO matrix
-    SharedMatrix other_SO2AO = other->aotoso()->transpose();
+    SharedMatrix SO2AO = aotoso()->transpose();
 
     wfn->S_ = wfn->factory_->create_shared_matrix("S");
-    wfn->S_->remove_symmetry(other->S(), other_SO2AO);
+    wfn->S_->remove_symmetry(S_, SO2AO);
 
     /// Below is not set in the typical constructor
 
     wfn->H_ = wfn->factory_->create_shared_matrix("One-electron Hamiltonian");
-    wfn->H_->remove_symmetry(other->H(), other_SO2AO);
-    // outfile->Printf("new H:");
-    // wfn->H_->print();
+    wfn->H_->remove_symmetry(H_, SO2AO);
 
-    if (other->Ca_) wfn->Ca_ = other->Ca_subset("AO", "ALL");
-    if (other->Cb_) wfn->Cb_ = other->Cb_subset("AO", "ALL");
-    if (other->Da_) wfn->Da_ = other->Da_subset("AO");
-    if (other->Db_) wfn->Db_ = other->Db_subset("AO");
-    if (other->Fa_) wfn->Fa_ = other->Fa_subset("AO");
-    if (other->Fb_) wfn->Fb_ = other->Fb_subset("AO");
-    if (other->epsilon_a_) wfn->epsilon_a_ =
-        other->epsilon_subset_helper(other->epsilon_a_, other->nsopi_, "AO", "ALL");
-    if (other->epsilon_b_) wfn->epsilon_b_ = 
-        other->epsilon_subset_helper(other->epsilon_b_, other->nsopi_, "AO", "ALL");
-
-
-    /*
-    outfile->Printf("New Ca:\n");
-    wfn->Ca_->print();
-    outfile->Printf("Epsilon a's:\n");
-    wfn->epsilon_a_->print();
-    outfile->Printf("Epsilon b's:\n");
-    wfn->epsilon_b_->print();
+    /* This stuff we need to copy in the subclass functions, b/c
+    ** constructors like RHF() just blow these away anyway 
+    if (Ca_) wfn->Ca_ = Ca_subset("AO", "ALL");
+    if (Cb_) wfn->Cb_ = Cb_subset("AO", "ALL");
+    if (Da_) wfn->Da_ = Da_subset("AO");
+    if (Db_) wfn->Db_ = Db_subset("AO");
+    if (Fa_) wfn->Fa_ = Fa_subset("AO");
+    if (Fb_) wfn->Fb_ = Fb_subset("AO");
+    if (epsilon_a_) wfn->epsilon_a_ =
+        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+    if (epsilon_b_) wfn->epsilon_b_ = 
+        epsilon_subset_helper(epsilon_b_, nsopi_, "AO", "ALL");
     */
 
     // these are simple SharedMatrices of size 3*natom_, etc., so should
     // not depend on symmetry ... can just copy them
-    if (other->gradient_) wfn->gradient_ = other->gradient_->clone();
-    if (other->hessian_) wfn->hessian_ = other->hessian_->clone();
+    if (gradient_) wfn->gradient_ = gradient_->clone();
+    if (hessian_) wfn->hessian_ = hessian_->clone();
+
+    wfn->variables_ = variables_;
+    // ok for deep copy?
+    wfn->external_pot_ = external_pot_;
+
+    // Need to explicitly call copy
+    for (auto const &kv : arrays_) {
+        wfn->arrays_[kv.first] = kv.second->clone();
+    }
 
     return wfn;
 }

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -287,12 +287,18 @@ std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction oth
     wfn->same_a_b_orbs_ = other->same_a_b_orbs_;
 
 
+    /// Need the SO2AO matrix for remove_symmetry(), have the AO2SO matrix
+    SharedMatrix other_SO2AO = other->aotoso()->transpose();
+
     wfn->S_ = wfn->factory_->create_shared_matrix("S");
-    wfn->S_->remove_symmetry(other->S(), other->aotoso());
+    wfn->S_->remove_symmetry(other->S(), other_SO2AO);
 
     /// Below is not set in the typical constructor
-    wfn->H_ = factory_->create_shared_matrix("One-electron Hamiltonian");
-    wfn->H_->remove_symmetry(other->H(), other->aotoso());
+
+    wfn->H_ = wfn->factory_->create_shared_matrix("One-electron Hamiltonian");
+    wfn->H_->remove_symmetry(other->H(), other_SO2AO);
+    // outfile->Printf("new H:");
+    // wfn->H_->print();
 
     if (other->Ca_) wfn->Ca_ = other->Ca_subset("AO", "ALL");
     if (other->Cb_) wfn->Cb_ = other->Cb_subset("AO", "ALL");
@@ -305,6 +311,15 @@ std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction oth
     if (other->epsilon_b_) wfn->epsilon_b_ = 
         other->epsilon_subset_helper(other->epsilon_b_, other->nsopi_, "AO", "ALL");
 
+
+    /*
+    outfile->Printf("New Ca:\n");
+    wfn->Ca_->print();
+    outfile->Printf("Epsilon a's:\n");
+    wfn->epsilon_a_->print();
+    outfile->Printf("Epsilon b's:\n");
+    wfn->epsilon_b_->print();
+    */
 
     // these are simple SharedMatrices of size 3*natom_, etc., so should
     // not depend on symmetry ... can just copy them

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -694,7 +694,7 @@ SharedMatrix Wavefunction::F_subset_helper(SharedMatrix F, SharedMatrix C, const
             if (!nsol || !nsor) continue;
             double **Ulp = AO2SO_->pointer(h);
             double **Urp = AO2SO_->pointer(h ^ symm);
-            double **FSOp = F->pointer(h ^ symm);
+            double **FSOp = F->pointer(h);
             double **FAOp = F2->pointer();
             C_DGEMM('N', 'T', nsol, nao, nsor, 1.0, FSOp[0], nsor, Urp[0], nsor, 0.0, temp, nao);
             C_DGEMM('N', 'N', nao, nao, nsol, 1.0, Ulp[0], nsol, temp, nao, 1.0, FAOp[0], nao);
@@ -749,7 +749,7 @@ SharedMatrix Wavefunction::D_subset_helper(SharedMatrix D, SharedMatrix C, const
             if (!nsol || !nsor) continue;
             double **Ulp = AO2SO_->pointer(h);
             double **Urp = AO2SO_->pointer(h ^ symm);
-            double **DSOp = D->pointer(h ^ symm);
+            double **DSOp = D->pointer(h);
             double **DAOp = D2->pointer();
             C_DGEMM('N', 'T', nsol, nao, nsor, 1.0, DSOp[0], nsor, Urp[0], nsor, 0.0, temp, nao);
             C_DGEMM('N', 'N', nao, nao, nsol, 1.0, Ulp[0], nsol, temp, nao, 1.0, DAOp[0], nao);
@@ -776,7 +776,7 @@ SharedMatrix Wavefunction::D_subset_helper(SharedMatrix D, SharedMatrix C, const
             if (!nsol || !nsor) continue;
             double **Ulp = my_aotoso->pointer(h);
             double **Urp = my_aotoso->pointer(h ^ symm);
-            double **DSOp = D->pointer(h ^ symm);
+            double **DSOp = D->pointer(h);
             double **DAOp = D2->pointer();
             C_DGEMM('N', 'T', nsol, nao, nsor, 1.0, DSOp[0], nsor, Urp[0], nsor, 0.0, temp, nao);
             C_DGEMM('N', 'N', nao, nao, nsol, 1.0, Ulp[0], nsol, temp, nao, 1.0, DAOp[0], nao);

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -561,7 +561,7 @@ SharedMatrix Wavefunction::Cb() const {
     return Cb_;
 }
 
-std::vector<std::vector<int>> Wavefunction::subset_occupation(const Dimension &noccpi, const std::string &subset) {
+std::vector<std::vector<int>> Wavefunction::subset_occupation(const Dimension &noccpi, const std::string &subset) const {
     if (!(subset == "FROZEN_OCC" || subset == "FROZEN_VIR" || subset == "ACTIVE_OCC" || subset == "ACTIVE_VIR" ||
           subset == "FROZEN" || subset == "ACTIVE" || subset == "OCC" || subset == "VIR" || subset == "ALL"))
         throw PSIEXCEPTION(
@@ -593,7 +593,7 @@ std::vector<std::vector<int>> Wavefunction::subset_occupation(const Dimension &n
 }
 
 SharedMatrix Wavefunction::C_subset_helper(SharedMatrix C, const Dimension &noccpi, SharedVector epsilon,
-                                           const std::string &basis, const std::string &subset) {
+                                           const std::string &basis, const std::string &subset) const {
     std::vector<std::vector<int>> positions = subset_occupation(noccpi, subset);
 
     Dimension nmopi(nirrep_);
@@ -1054,7 +1054,7 @@ OrbitalSpace Wavefunction::beta_orbital_space(const std::string &id, const std::
     return OrbitalSpace(id, subset, Cb_subset(basis, subset), epsilon_b_subset(basis, subset), basisset_, integral_);
 }
 
-SharedMatrix Wavefunction::Ca_subset(const std::string &basis, const std::string &subset) {
+SharedMatrix Wavefunction::Ca_subset(const std::string &basis, const std::string &subset) const {
     return C_subset_helper(Ca_, nalphapi_, epsilon_a_, basis, subset);
 }
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -213,106 +213,107 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     }
 }
 
-void Wavefunction::c1_deep_copy(SharedWavefunction other) {
-    c1_deep_copy(other.get());
-}
-
-void Wavefunction::c1_deep_copy(const Wavefunction *other) {
+std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis)
+{
     if (!other->S_) {
         throw PSIEXCEPTION("Wavefunction::c1_deep_copy must copy an initialized wavefunction.");
     }
 
+    wfn = std::shared_ptr <Wavefunction>(new Wavefunction(basis.molecule(), basis, other->options()));
+  
     /// From typical constructor
     /// Some member data is not clone-able so we will copy
-    name_ = other->name_;
-    molecule_ = std::shared_ptr<Molecule>(new Molecule(other->molecule_->clone()));
-    molecule_->reset_point_group("c1");
-    molecule_->set_orientation_fixed(true);
-    molecule_->set_com_fixed(true);
-    molecule_->update_geometry();
+    wfn->name_ = other->name_;
+    //molecule_ = std::shared_ptr<Molecule>(new Molecule(other->molecule_->clone()));
+    //molecule_->reset_point_group("c1");
+    //molecule_->set_orientation_fixed(true);
+    //molecule_->set_com_fixed(true);
+    //molecule_->update_geometry();
 
-    basisset_ = other->basisset_; // CDS: think we need to reset this
+    //basisset_ = other->basisset_; // CDS: think we need to reset this
                                   // b/c it contains a molecule
-    basissets_ = other->basissets_; // Still cannot copy basissets
-    integral_ = std::shared_ptr<IntegralFactory>(new IntegralFactory(basisset_, basisset_, basisset_, basisset_));
-    sobasisset_ = std::shared_ptr<SOBasisSet>(new SOBasisSet(basisset_, integral_));
-    factory_ = std::shared_ptr<MatrixFactory>(new MatrixFactory);
+    //basissets_ = other->basissets_; // Still cannot copy basissets
+    //basissets_ // leave at null ptr
+    wfn->integral_ = std::shared_ptr<IntegralFactory>(new IntegralFactory(wfn->basisset_, wfn->basisset_, wfn->basisset_, wfn->basisset_));
+    wfn->sobasisset_ = std::shared_ptr<SOBasisSet>(new SOBasisSet(wfn->basisset_, wfn->integral_));
+    wfn->factory_ = std::shared_ptr<MatrixFactory>(new MatrixFactory);
 
     Dimension c1_nsopi = Dimension(1);
     c1_nsopi[0] = other->nsopi_.sum();
-    factory_->init_with(c1_nsopi, c1_nsopi);
+    wfn->factory_->init_with(c1_nsopi, c1_nsopi);
 
     // Need to re-generate AO2SO_ because the new SO basis is different
     // than the old one (lower symmetry)
-    std::shared_ptr<PetiteList> pet(new PetiteList(basisset_, integral_));
-    AO2SO_ = pet->aotoso();
+    std::shared_ptr<PetiteList> pet(new PetiteList(wfn->basisset_, wfn->integral_));
+    wfn->AO2SO_ = pet->aotoso();
 
-    psio_ = other->psio_; // We dont actually copy psio
-    memory_ = other->memory_;
-    nalpha_ = other->nalpha_;
-    nbeta_ = other->nbeta_;
-    nfrzc_ = other->nfrzc_;
+    wfn->psio_ = other->psio_; // We dont actually copy psio
+    wfn->memory_ = other->memory_;
+    wfn->nalpha_ = other->nalpha_;
+    wfn->nbeta_ = other->nbeta_;
+    wfn->nfrzc_ = other->nfrzc_;
 
-    print_ = other->print_;
-    debug_ = other->debug_;
-    density_fitted_ = other->density_fitted_;
+    wfn->print_ = other->print_;
+    wfn->debug_ = other->debug_;
+    wfn->density_fitted_ = other->density_fitted_;
 
-    energy_ = other->energy_;
-    efzc_ = other->efzc_;
-    variables_ = other->variables_;
+    wfn->energy_ = other->energy_;
+    wfn->efzc_ = other->efzc_;
+    wfn->variables_ = other->variables_;
 
     // collapse all the Dimension objects down to one element
-    doccpi_.init(1, other->doccpi_.name());
-    doccpi_[0] = other->doccpi_.sum();
-    soccpi_.init(1, other->soccpi_.name());
-    soccpi_[0] = other->soccpi_.sum();
-    frzcpi_.init(1, other->frzcpi_.name());
-    frzcpi_[0] = other->frzcpi_.sum();
-    frzvpi_.init(1, other->frzvpi_.name());
-    frzvpi_[0] = other->frzvpi_.sum();
-    nalphapi_.init(1, other->nalphapi_.name());
-    nalphapi_[0] = other->nalphapi_.sum();
-    nbetapi_.init(1, other->nbetapi_.name());
-    nbetapi_[0] = other->nbetapi_.sum();
-    nsopi_.init(1, other->nsopi_.name());
-    nsopi_[0] = other->nsopi_.sum();
-    nmopi_.init(1, other->nmopi_.name());
-    nmopi_[0] = other->nmopi_.sum();
+    wfn->doccpi_.init(1, other->doccpi_.name());
+    wfn->doccpi_[0] = other->doccpi_.sum();
+    wfn->soccpi_.init(1, other->soccpi_.name());
+    wfn->soccpi_[0] = other->soccpi_.sum();
+    wfn->frzcpi_.init(1, other->frzcpi_.name());
+    wfn->frzcpi_[0] = other->frzcpi_.sum();
+    wfn->frzvpi_.init(1, other->frzvpi_.name());
+    wfn->frzvpi_[0] = other->frzvpi_.sum();
+    wfn->nalphapi_.init(1, other->nalphapi_.name());
+    wfn->nalphapi_[0] = other->nalphapi_.sum();
+    wfn->nbetapi_.init(1, other->nbetapi_.name());
+    wfn->nbetapi_[0] = other->nbetapi_.sum();
+    wfn->nsopi_.init(1, other->nsopi_.name());
+    wfn->nsopi_[0] = other->nsopi_.sum();
+    wfn->nmopi_.init(1, other->nmopi_.name());
+    wfn->nmopi_[0] = other->nmopi_.sum();
 
-    nso_ = other->nso_;
-    nmo_ = other->nmo_;
-    nirrep_ = 1;
+    wfn->nso_ = other->nso_;
+    wfn->nmo_ = other->nmo_;
+    wfn->nirrep_ = 1;
 
-    same_a_b_dens_ = other->same_a_b_dens_;
-    same_a_b_orbs_ = other->same_a_b_orbs_;
+    wfn->same_a_b_dens_ = other->same_a_b_dens_;
+    wfn->same_a_b_orbs_ = other->same_a_b_orbs_;
 
 
-    S_ = factory_->create_shared_matrix("S");
-    S_->remove_symmetry(other->S(), other->aotoso());
+    wfn->S_ = wfn->factory_->create_shared_matrix("S");
+    wfn->S_->remove_symmetry(other->S(), other->aotoso());
 
     /// Below is not set in the typical constructor
-    H_ = factory_->create_shared_matrix("One-electron Hamiltonian");
-    H_->remove_symmetry(other->H(), other->aotoso());
+    wfn->H_ = factory_->create_shared_matrix("One-electron Hamiltonian");
+    wfn->H_->remove_symmetry(other->H(), other->aotoso());
 
-    if (other->Ca_) Ca_ = other->Ca_subset("AO", "ALL");
-    if (other->Cb_) Cb_ = other->Cb_subset("AO", "ALL");
-    if (other->Da_) Da_ = other->Da_subset("AO");
-    if (other->Db_) Db_ = other->Db_subset("AO");
-    if (other->Fa_) Fa_ = other->Fa_subset("AO");
-    if (other->Fb_) Fb_ = other->Fb_subset("AO");
-    if (other->epsilon_a_) epsilon_a_ =
+    if (other->Ca_) wfn->Ca_ = other->Ca_subset("AO", "ALL");
+    if (other->Cb_) wfn->Cb_ = other->Cb_subset("AO", "ALL");
+    if (other->Da_) wfn->Da_ = other->Da_subset("AO");
+    if (other->Db_) wfn->Db_ = other->Db_subset("AO");
+    if (other->Fa_) wfn->Fa_ = other->Fa_subset("AO");
+    if (other->Fb_) wfn->Fb_ = other->Fb_subset("AO");
+    if (other->epsilon_a_) wfn->epsilon_a_ =
         other->epsilon_subset_helper(other->epsilon_a_, other->nsopi_, "AO", "ALL");
-    if (other->epsilon_b_) epsilon_b_ = 
+    if (other->epsilon_b_) wfn->epsilon_b_ = 
         other->epsilon_subset_helper(other->epsilon_b_, other->nsopi_, "AO", "ALL");
 
 
     // these are simple SharedMatrices of size 3*natom_, etc., so should
     // not depend on symmetry ... can just copy them
-    if (other->gradient_) gradient_ = other->gradient_->clone();
-    if (other->hessian_) hessian_ = other->hessian_->clone();
+    if (other->gradient_) wfn->gradient_ = other->gradient_->clone();
+    if (other->hessian_) wfn->hessian_ = other->hessian_->clone();
     if (other->tpdm_gradient_contribution_)
-        tpdm_gradient_contribution_ = other->tpdm_gradient_contribution_->clone();
+        wfn->tpdm_gradient_contribution_ = other->tpdm_gradient_contribution_->clone();
 
+    return wfn;
 }
 
 void Wavefunction::common_init() {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -217,7 +217,7 @@ void Wavefunction::c1_deep_copy(SharedWavefunction other) {
     c1_deep_copy(other.get());
 }
 
-void Wavefunction::c1_deep_copy(Wavefunction *other) {
+void Wavefunction::c1_deep_copy(const Wavefunction *other) {
     if (!S_) {
         throw PSIEXCEPTION("Wavefunction::c1_deep_copy must copy an initialized wavefunction.");
     }
@@ -294,9 +294,7 @@ void Wavefunction::c1_deep_copy(Wavefunction *other) {
     if (other->epsilon_a_) epsilon_a_ = SharedVector(other->epsilon_a_->clone());
     if (other->epsilon_b_) epsilon_b_ = SharedVector(other->epsilon_b_->clone());
 
-    SharedMatrix tmp = other->Ca_subset("AO", "ALL");
-    if (other->Ca_) Ca_ = tmp; //other->Ca_subset("AO", "ALL");
-    //if (other->Ca_) Ca_ = other->Ca_subset("AO", "ALL");
+    if (other->Ca_) Ca_ = other->Ca_subset("AO", "ALL");
 //    SharedMatrix Cocc = Ca_subset("SO", "OCC");
 //    SharedMatrix Cvir = Ca_subset("SO", "VIR");
 //    Dimension virpi = Cvir->colspi();

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -219,7 +219,7 @@ std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction oth
         throw PSIEXCEPTION("Wavefunction::c1_deep_copy must copy an initialized wavefunction.");
     }
 
-    wfn = std::shared_ptr <Wavefunction>(new Wavefunction(basis.molecule(), basis, other->options()));
+    std::shared_ptr <Wavefunction> wfn(new Wavefunction(basis->molecule(), basis, other->options()));
   
     /// From typical constructor
     /// Some member data is not clone-able so we will copy

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1062,19 +1062,19 @@ SharedMatrix Wavefunction::Cb_subset(const std::string &basis, const std::string
 }
 
 SharedMatrix Wavefunction::Da_subset(const std::string &basis) const {
-    return D_subset_helper(Da_, Ca_, basis);
+    return matrix_subset_helper(Da_, Ca_, basis, "D");
 }
 
 SharedMatrix Wavefunction::Db_subset(const std::string &basis) const {
-    return D_subset_helper(Db_, Cb_, basis);
+    return matrix_subset_helper(Db_, Cb_, basis, "D");
 }
 
 SharedMatrix Wavefunction::Fa_subset(const std::string &basis) const {
-    return F_subset_helper(Fa_, Ca_, basis);
+    return matrix_subset_helper(Fa_, Ca_, basis, "Fock");
 }
 
 SharedMatrix Wavefunction::Fb_subset(const std::string &basis) const {
-    return F_subset_helper(Fb_, Cb_, basis);
+    return matrix_subset_helper(Fb_, Cb_, basis, "Fock");
 }
 
 SharedVector Wavefunction::epsilon_a_subset(const std::string &basis, const std::string &subset) const {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -310,8 +310,6 @@ std::shared_ptr <Wavefunction> Wavefunction::c1_deep_copy(SharedWavefunction oth
     // not depend on symmetry ... can just copy them
     if (other->gradient_) wfn->gradient_ = other->gradient_->clone();
     if (other->hessian_) wfn->hessian_ = other->hessian_->clone();
-    if (other->tpdm_gradient_contribution_)
-        wfn->tpdm_gradient_contribution_ = other->tpdm_gradient_contribution_->clone();
 
     return wfn;
 }

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -201,12 +201,12 @@ protected:
 
     /// Helpers for C/D/epsilon transformers
     SharedMatrix C_subset_helper(SharedMatrix C, const Dimension& noccpi, SharedVector epsilon,
-                                 const std::string& basis, const std::string& subset);
-    SharedMatrix F_subset_helper(SharedMatrix F, SharedMatrix C, const std::string& basis);
+                                 const std::string& basis, const std::string& subset) const;
+    SharedMatrix F_subset_helper(SharedMatrix F, SharedMatrix C, const std::string& basis) const;
     SharedVector epsilon_subset_helper(SharedVector epsilon, const Dimension& noccpi,
-                                       const std::string& basis, const std::string& subset);
+                                       const std::string& basis, const std::string& subset) const;
     std::vector<std::vector<int>> subset_occupation(const Dimension& noccpi,
-                                                    const std::string& subset);
+                                                    const std::string& subset) const;
 
     /// If atomic point charges are available they will be here
     std::shared_ptr<std::vector<double>> atomic_point_charges_;
@@ -275,7 +275,7 @@ public:
     * TODO-Matrices and Vectors (Ca,Da,Fa,epsilon_a, etc) are deep copied.
     **/
     void c1_deep_copy(SharedWavefunction other);
-    void c1_deep_copy(Wavefunction* other);
+    void c1_deep_copy(const Wavefunction* other);
 
     virtual ~Wavefunction();
 
@@ -406,7 +406,7 @@ public:
     *  ALL, ACTIVE, FROZEN, OCC, VIR, FROZEN_OCC, ACTIVE_OCC, ACTIVE_VIR, FROZEN_VIR
     * @return the matrix in Pitzer order in the desired basis
     **/
-    SharedMatrix Ca_subset(const std::string& basis = "SO", const std::string& subset = "ALL");
+    SharedMatrix Ca_subset(const std::string& basis = "SO", const std::string& subset = "ALL") const;
 
     /**
     * Return a subset of the Cb matrix in a desired basis

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -193,10 +193,10 @@ protected:
     /// Beta orbital energies
     SharedVector epsilon_b_;
 
-    /// If a gradient is available it will be here:
+    /// gradient, if available, as natom_ x 3 SharedMatrix
     SharedMatrix gradient_;
 
-    /// If a Hessian is available it will be here:
+    /// Hessian, if available, as natom_*3 x natom_*3 SharedMatrix
     SharedMatrix hessian_;
 
     /// Helpers for C/D/epsilon transformers

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -202,7 +202,6 @@ protected:
     /// Helpers for C/D/epsilon transformers
     SharedMatrix C_subset_helper(SharedMatrix C, const Dimension& noccpi, SharedVector epsilon,
                                  const std::string& basis, const std::string& subset) const;
-    SharedMatrix F_subset_helper(SharedMatrix F, SharedMatrix C, const std::string& basis) const;
     SharedVector epsilon_subset_helper(SharedVector epsilon, const Dimension& noccpi,
                                        const std::string& basis, const std::string& subset) const;
     std::vector<std::vector<int>> subset_occupation(const Dimension& noccpi,
@@ -416,7 +415,8 @@ public:
     *  ALL, ACTIVE, FROZEN, OCC, VIR, FROZEN_OCC, ACTIVE_OCC, ACTIVE_VIR, FROZEN_VIR
     * @return the matrix in Pitzer order in the desired basis
     **/
-    SharedMatrix Cb_subset(const std::string& basis = "SO", const std::string& subset = "ALL");
+    SharedMatrix Cb_subset(const std::string& basis = "SO", const std::string&
+subset = "ALL") const;
 
     /**
      * @brief Creates an OrbitalSpace object containing information about the request alpha orbital space.
@@ -445,7 +445,7 @@ public:
     *  AO, SO, MO
     * @return the matrix in the desired basis
     **/
-    SharedMatrix Da_subset(const std::string& basis = "SO");
+    SharedMatrix Da_subset(const std::string& basis = "SO") const;
 
     /**
     * Return the Db matrix in the desired basis
@@ -453,7 +453,7 @@ public:
     *  AO, SO, MO
     * @return the matrix in the desired basis
     **/
-    SharedMatrix Db_subset(const std::string& basis = "SO");
+    SharedMatrix Db_subset(const std::string& basis = "SO") const;
 
     /**
     * Return the D matrix in the desired basis
@@ -463,7 +463,33 @@ public:
     *  AO, SO, MO, CartAO
     * @return the D matrix in the desired basis
     **/
-    SharedMatrix D_subset_helper(SharedMatrix D, SharedMatrix C, const std::string& basis);
+    SharedMatrix D_subset_helper(SharedMatrix D, SharedMatrix C, const std::string& basis) const;
+
+    /**
+    * Return the Fa matrix in the desired basis
+    * @param basis the symmetry basis to use
+    *  AO, SO, MO
+    * @return the matrix in the desired basis
+    **/
+    SharedMatrix Fa_subset(const std::string& basis = "SO") const;
+
+    /**
+    * Return the Fb matrix in the desired basis
+    * @param basis the symmetry basis to use
+    *  AO, SO, MO
+    * @return the matrix in the desired basis
+    **/
+    SharedMatrix Fb_subset(const std::string& basis = "SO") const;
+
+    /**
+    * Return the F matrix in the desired basis
+    * @param F matrix in the SO basis to transform
+    * @param C matrix in the SO basis to use as a transformer
+    * @param basis the symmetry basis to use
+    *  AO, SO, MO, CartAO
+    * @return the F matrix in the desired basis
+    **/
+    SharedMatrix F_subset_helper(SharedMatrix F, SharedMatrix C, const std::string& basis) const;
 
     /**
     * Return the alpha orbital eigenvalues in the desired basis
@@ -472,7 +498,7 @@ public:
     * @param subset the subset of orbitals to return
     *  ALL, ACTIVE, FROZEN, OCC, VIR, FROZEN_OCC, ACTIVE_OCC, ACTIVE_VIR, FROZEN_VIR
     */
-    SharedVector epsilon_a_subset(const std::string& basis = "SO", const std::string& subset = "ALL");
+    SharedVector epsilon_a_subset(const std::string& basis = "SO", const std::string& subset = "ALL") const;
 
     /**
     * Return the beta orbital eigenvalues in the desired basis
@@ -481,7 +507,7 @@ public:
     * @param subset the subset of orbitals to return
     *  ALL, ACTIVE, FROZEN, OCC, VIR, FROZEN_OCC, ACTIVE_OCC, ACTIVE_VIR, FROZEN_VIR
     */
-    SharedVector epsilon_b_subset(const std::string& basis = "SO", const std::string& subset = "ALL");
+    SharedVector epsilon_b_subset(const std::string& basis = "SO", const std::string& subset = "ALL") const;
 
     /**
      * Projects the given orbitals from the old to the new basis

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -458,7 +458,7 @@ subset = "ALL") const;
     /**
     * Return the D matrix in the desired basis
     * @param D matrix in the SO basis to transform
-    * @param C matrix in the SO basis to use as a transformer
+    * @param C matrix in the SO basis to use for transforms to the MO basis
     * @param basis the symmetry basis to use
     *  AO, SO, MO, CartAO
     * @return the D matrix in the desired basis
@@ -484,12 +484,25 @@ subset = "ALL") const;
     /**
     * Return the F matrix in the desired basis
     * @param F matrix in the SO basis to transform
-    * @param C matrix in the SO basis to use as a transformer
+    * @param C matrix in the SO basis to use for transforms to the MO basis
     * @param basis the symmetry basis to use
     *  AO, SO, MO, CartAO
     * @return the F matrix in the desired basis
     **/
     SharedMatrix F_subset_helper(SharedMatrix F, SharedMatrix C, const std::string& basis) const;
+
+
+    /**
+    * Transform a matrix M into the desired basis 
+    * @param M matrix in the SO basis to transform
+    * @param C matrix in the SO basis to use for transforms to MO basis
+    * @param basis the symmetry basis to use
+    *  AO, SO, MO, CartAO
+    * @return the matrix M in the desired basis
+    **/
+    SharedMatrix matrix_subset_helper(SharedMatrix M, 
+        SharedMatrix C, const std::string &basis, 
+        const std::string matrix_basename) const;
 
     /**
     * Return the alpha orbital eigenvalues in the desired basis

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -273,8 +273,7 @@ public:
     * TODO-reference_wavefunction_ is set to other
     * TODO-Matrices and Vectors (Ca,Da,Fa,epsilon_a, etc) are deep copied.
     **/
-    void c1_deep_copy(SharedWavefunction other);
-    void c1_deep_copy(const Wavefunction* other);
+    std::shared_ptr <Wavefunction> c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis);
 
     virtual ~Wavefunction();
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -267,13 +267,19 @@ public:
     void deep_copy(const Wavefunction* other);
 
     /**
-    * TODOCopy the contents of another Wavefunction into this one.
-    * TODOUseful at the beginning of correlated wavefunction computations.
-    * TODO-Does not set options or callbacks
-    * TODO-reference_wavefunction_ is set to other
-    * TODO-Matrices and Vectors (Ca,Da,Fa,epsilon_a, etc) are deep copied.
+    * Creates a new wavefunction in C1-symmetry format from another
+    * Wavefunction that may be in a higher point group symmetry format.
+    *
+    * Note: Unlike the other deep_copy() functions, this one doesn't act on
+    * an empty wavefunction and fill it up, it is a free function that creates
+    * and returns a new Wavefunction object.  Since it doesn't act on a 
+    * *this object, it is declared as a static member function.
+    * 
+    * @param other The Wavefunction to copy
+    * @param basis A C1-symmetry basis set object (we don't yet have
+    *        the ability to copy this straight from the symmetric Wavefunction)
     **/
-    std::shared_ptr <Wavefunction> c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis);
+    static std::shared_ptr <Wavefunction> c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis);
 
     virtual ~Wavefunction();
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -267,6 +267,16 @@ public:
     void deep_copy(SharedWavefunction other);
     void deep_copy(const Wavefunction* other);
 
+    /**
+    * TODOCopy the contents of another Wavefunction into this one.
+    * TODOUseful at the beginning of correlated wavefunction computations.
+    * TODO-Does not set options or callbacks
+    * TODO-reference_wavefunction_ is set to other
+    * TODO-Matrices and Vectors (Ca,Da,Fa,epsilon_a, etc) are deep copied.
+    **/
+    void c1_deep_copy(SharedWavefunction other);
+    void c1_deep_copy(Wavefunction* other);
+
     virtual ~Wavefunction();
 
     /// Compute energy. Subclasses override this function to compute its energy.

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -414,8 +414,7 @@ public:
     *  ALL, ACTIVE, FROZEN, OCC, VIR, FROZEN_OCC, ACTIVE_OCC, ACTIVE_VIR, FROZEN_VIR
     * @return the matrix in Pitzer order in the desired basis
     **/
-    SharedMatrix Cb_subset(const std::string& basis = "SO", const std::string&
-subset = "ALL") const;
+    SharedMatrix Cb_subset(const std::string& basis = "SO", const std::string& subset = "ALL") const;
 
     /**
      * @brief Creates an OrbitalSpace object containing information about the request alpha orbital space.

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -220,7 +220,7 @@ protected:
     bool same_a_b_dens_;
     bool same_a_b_orbs_;
 
-    // The external potenital
+    // The external potential
     std::shared_ptr<ExternalPotential> external_pot_;
 
     // Collection of variables
@@ -267,19 +267,13 @@ public:
     void deep_copy(const Wavefunction* other);
 
     /**
-    * Creates a new wavefunction in C1-symmetry format from another
+    * Creates a new wavefunction in C1-symmetry format from the current
     * Wavefunction that may be in a higher point group symmetry format.
     *
-    * Note: Unlike the other deep_copy() functions, this one doesn't act on
-    * an empty wavefunction and fill it up, it is a free function that creates
-    * and returns a new Wavefunction object.  Since it doesn't act on a 
-    * *this object, it is declared as a static member function.
-    * 
-    * @param other The Wavefunction to copy
     * @param basis A C1-symmetry basis set object (we don't yet have
     *        the ability to copy this straight from the symmetric Wavefunction)
     **/
-    static std::shared_ptr <Wavefunction> c1_deep_copy(SharedWavefunction other, std::shared_ptr<BasisSet> basis);
+    std::shared_ptr <Wavefunction> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 
     virtual ~Wavefunction();
 

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -393,5 +393,32 @@ bool CUHF::stability_analysis() {
     throw PSIEXCEPTION("CUHF stability analysis has not been implemented yet.  Sorry :(");
     return false;
 }
+
+
+std::shared_ptr<CUHF> CUHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
+    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto hf_wfn = std::make_shared<CUHF>(wfn, functional_, wfn->options(), wfn->psio());
+
+    // now just have to copy the matrices that UHF initializes
+    // include only those that are not temporary (some deleted in finalize())
+    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+    if (Cb_) hf_wfn->Cb_ = Cb_subset("AO", "ALL");
+    if (Da_) hf_wfn->Da_ = Da_subset("AO");
+    if (Db_) hf_wfn->Db_ = Db_subset("AO");
+    if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
+    if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
+    if (epsilon_a_) hf_wfn->epsilon_a_ =
+        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+    if (epsilon_b_) hf_wfn->epsilon_b_ =
+        epsilon_subset_helper(epsilon_b_, nsopi_, "AO", "ALL");
+    // H_ ans X_ reset in the HF constructor, copy them over here
+    SharedMatrix SO2AO = aotoso()->transpose();
+    if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
+    if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
+
+    return hf_wfn;
+}
+
+
 }
 }

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -110,6 +110,7 @@ public:
     CUHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional,
          Options& options, std::shared_ptr<PSIO> psio);
     virtual ~CUHF();
+    std::shared_ptr<CUHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };
 
 }}

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -937,5 +937,34 @@ bool RHF::stability_analysis() {
     // FOLLOW is not implemented for RHF
     return false;
 }
+
+std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
+{
+    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto hf_wfn = std::make_shared<RHF>(wfn, functional_, wfn->options(), wfn->psio());
+    // now just have to copy the matrices that RHF initializes
+    // include only those that are not temporary (some deleted in finalize())
+    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+    hf_wfn->Cb_ = hf_wfn->Ca_;
+    if (Da_) hf_wfn->Da_ = Da_subset("AO");
+    hf_wfn->Db_ = hf_wfn->Da_;
+    hf_wfn->D_  = hf_wfn->Da_;
+    if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
+    hf_wfn->Fb_ = hf_wfn->Fa_;
+    if (epsilon_a_) hf_wfn->epsilon_a_ = 
+        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+    hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    // H_ ans X_ reset in the HF constructor, copy them over here
+    SharedMatrix SO2AO = aotoso()->transpose();
+    if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
+    if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
+
+    // pretty sure the next 2 things are really set already
+    same_a_b_dens_ = true;
+    same_a_b_orbs_ = true;
+
+    return hf_wfn;
+}
+
 }
 }

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -946,9 +946,11 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
     // include only those that are not temporary (some deleted in finalize())
     if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
     hf_wfn->Cb_ = hf_wfn->Ca_;
-    if (Da_) hf_wfn->Da_ = Da_subset("AO");
-    hf_wfn->Db_ = hf_wfn->Da_;
-    hf_wfn->D_  = hf_wfn->Da_;
+    if (Da_) {
+        hf_wfn->Da_ = Da_subset("AO");
+        hf_wfn->Db_ = hf_wfn->Da_;
+        hf_wfn->D_  = hf_wfn->Da_;
+    }
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
     hf_wfn->Fb_ = hf_wfn->Fa_;
     if (epsilon_a_) hf_wfn->epsilon_a_ = 
@@ -958,10 +960,6 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
     SharedMatrix SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
-
-    // pretty sure the next 2 things are really set already
-    same_a_b_dens_ = true;
-    same_a_b_orbs_ = true;
 
     return hf_wfn;
 }

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -944,18 +944,23 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
     auto hf_wfn = std::make_shared<RHF>(wfn, functional_, wfn->options(), wfn->psio());
     // now just have to copy the matrices that RHF initializes
     // include only those that are not temporary (some deleted in finalize())
-    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
-    hf_wfn->Cb_ = hf_wfn->Ca_;
+    if (Ca_) {
+        hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+        hf_wfn->Cb_ = hf_wfn->Ca_;
+    }
     if (Da_) {
         hf_wfn->Da_ = Da_subset("AO");
         hf_wfn->Db_ = hf_wfn->Da_;
         hf_wfn->D_  = hf_wfn->Da_;
     }
-    if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
-    hf_wfn->Fb_ = hf_wfn->Fa_;
-    if (epsilon_a_) hf_wfn->epsilon_a_ = 
-        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
-    hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    if (Fa_) {
+        hf_wfn->Fa_ = Fa_subset("AO");
+        hf_wfn->Fb_ = hf_wfn->Fa_;
+    }
+    if (epsilon_a_) {
+        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+        hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    }
     // H_ ans X_ reset in the HF constructor, copy them over here
     SharedMatrix SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -363,7 +363,7 @@ std::vector<SharedMatrix> RHF::onel_Hx(std::vector<SharedMatrix> x_vec) {
     if (needs_ao) {
         Cocc_ao = Ca_subset("AO", "OCC");
         Cvir_ao = Ca_subset("AO", "VIR");
-        F_ao = F_subset_helper(Fa_, Ca_, "AO");
+        F_ao = matrix_subset_helper(Fa_, Ca_, "AO", "Fock");
     }
     if (needs_so) {
         Cocc_so = Ca_subset("SO", "OCC");
@@ -577,7 +577,7 @@ std::vector<SharedMatrix> RHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
     if (needs_ao) {
         // MO (C1) Fock Matrix (Inactive Fock in Helgaker's language)
         SharedMatrix Cocc_ao = Ca_subset("AO", "ALL");
-        SharedMatrix F_ao = F_subset_helper(Fa_, Ca_, "AO");
+        SharedMatrix F_ao = matrix_subset_helper(Fa_, Ca_, "AO", "Fock");
         SharedMatrix IFock_ao = Matrix::triplet(Cocc_ao, F_ao, Cocc_ao, true, false, false);
         Precon_ao = std::make_shared<Matrix>("Precon", nalpha_, nmo_ - nalpha_);
 

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -92,6 +92,9 @@ public:
     virtual std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec,
                                                  double conv_tol = 1.e-4, int max_iter = 10,
                                                  int print_lvl = 1);
+
+    std::shared_ptr<RHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
+
 };
 
 }}

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1383,4 +1383,32 @@ bool ROHF::stability_analysis()
 }
 
 
+std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
+{
+    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto hf_wfn = std::make_shared<ROHF>(wfn, functional_, wfn->options(), wfn->psio());
+
+    // now just have to copy the matrices that RHF initializes
+    // include only those that are not temporary (some deleted in finalize())
+    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+    hf_wfn->Cb_ = hf_wfn->Ca_;
+    hf_wfn->Cb_->set_name("beta MO coefficients (C)");
+    if (Da_) hf_wfn->Da_ = Da_subset("AO");
+    if (Db_) hf_wfn->Db_ = Db_subset("AO");
+    if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
+    if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
+    if (epsilon_a_) hf_wfn->epsilon_a_ =
+        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+    hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    hf_wfn->epsilon_b_->set_name("beta orbital energies");
+    // H_ ans X_ reset in the HF constructor, copy them over here
+    SharedMatrix SO2AO = aotoso()->transpose();
+    if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
+    if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
+
+
+    return hf_wfn;
+}
+
+
 }}

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1388,20 +1388,22 @@ std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
 
     // now just have to copy the matrices that RHF initializes
     // include only those that are not temporary (some deleted in finalize())
-    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
-    hf_wfn->Cb_ = hf_wfn->Ca_;
+    if (Ca_) {
+        hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+        hf_wfn->Cb_ = hf_wfn->Ca_;
+    }
     if (Da_) hf_wfn->Da_ = Da_subset("AO");
     if (Db_) hf_wfn->Db_ = Db_subset("AO");
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
     if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
-    if (epsilon_a_) hf_wfn->epsilon_a_ =
-        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
-    hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    if (epsilon_a_) {
+        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+        hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
+    }
     // H_ ans X_ reset in the HF constructor, copy them over here
     SharedMatrix SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
-
 
     return hf_wfn;
 }

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -82,9 +82,8 @@ void ROHF::common_init()
     moFeff_  = SharedMatrix(factory_->create_matrix("F effective (MO basis)"));
     soFeff_  = SharedMatrix(factory_->create_matrix("F effective (orthogonalized SO basis)"));
     Ct_      = SharedMatrix(factory_->create_matrix("Orthogonalized Molecular orbitals"));
-    Ca_      = SharedMatrix(factory_->create_matrix("alpha MO coefficients (C)"));
+    Ca_      = SharedMatrix(factory_->create_matrix("MO coefficients (C)"));
     Cb_      = Ca_;
-    Cb_->set_name("beta MO coefficients (C)");
     Da_      = SharedMatrix(factory_->create_matrix("SCF alpha density"));
     Db_      = SharedMatrix(factory_->create_matrix("SCF beta density"));
     Lagrangian_ = SharedMatrix(factory_->create_matrix("Lagrangian matrix"));
@@ -100,9 +99,8 @@ void ROHF::common_init()
     moFb_    = SharedMatrix(factory_->create_matrix("MO beta Fock Matrix (MO basis)"));
 
     epsilon_a_ = SharedVector(factory_->create_vector());
-    epsilon_a_->set_name("alpha orbital energies");
+    epsilon_a_->set_name("orbital energies");
     epsilon_b_ = epsilon_a_;
-    epsilon_b_->set_name("beta orbital energies");
     same_a_b_dens_ = false;
     same_a_b_orbs_ = true;
 
@@ -1392,7 +1390,6 @@ std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
     // include only those that are not temporary (some deleted in finalize())
     if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
     hf_wfn->Cb_ = hf_wfn->Ca_;
-    hf_wfn->Cb_->set_name("beta MO coefficients (C)");
     if (Da_) hf_wfn->Da_ = Da_subset("AO");
     if (Db_) hf_wfn->Db_ = Db_subset("AO");
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
@@ -1400,7 +1397,6 @@ std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
     if (epsilon_a_) hf_wfn->epsilon_a_ =
         epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
     hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
-    hf_wfn->epsilon_b_->set_name("beta orbital energies");
     // H_ ans X_ reset in the HF constructor, copy them over here
     SharedMatrix SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -94,6 +94,8 @@ public:
     SharedMatrix moFa() const {return moFa_; }
     SharedMatrix moFb() const {return moFb_; }
 
+    std::shared_ptr<ROHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
+
 };
 
 }}

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -1069,4 +1069,32 @@ void UHF::compute_nos()
     }
 }
 
+
+std::shared_ptr<UHF> UHF::c1_deep_copy(std::shared_ptr<BasisSet> basis)
+{
+    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto hf_wfn = std::make_shared<UHF>(wfn, functional_, wfn->options(), wfn->psio());
+
+    // now just have to copy the matrices that UHF initializes
+    // include only those that are not temporary (some deleted in finalize())
+    if (Ca_) hf_wfn->Ca_ = Ca_subset("AO", "ALL");
+    if (Cb_) hf_wfn->Cb_ = Cb_subset("AO", "ALL");
+    if (Da_) hf_wfn->Da_ = Da_subset("AO");
+    if (Db_) hf_wfn->Db_ = Db_subset("AO");
+    if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
+    if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
+    if (epsilon_a_) hf_wfn->epsilon_a_ =
+        epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+    if (epsilon_b_) hf_wfn->epsilon_b_ =
+        epsilon_subset_helper(epsilon_b_, nsopi_, "AO", "ALL");
+    // H_ ans X_ reset in the HF constructor, copy them over here
+    SharedMatrix SO2AO = aotoso()->transpose();
+    if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
+    if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
+
+
+    return hf_wfn;
+}
+
+
 }}

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -103,6 +103,8 @@ public:
     virtual std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec,
                                                  double conv_tol = 1.e-4, int max_iter = 10,
                                                  int print_lvl = 1);
+
+    std::shared_ptr<UHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };
 
 }}


### PR DESCRIPTION
## Description
Allow symmetry to be used in SCF, but then convert the symmetrized wavefunction to a desymmetrized (C1) format for use by non-symmetry-aware modules

## Todos
* **Developer Interest**
  - [x] Correct bug in D_subset_helper() and F_subset_helper() for nonsymmetric matrices
  - [x] Refactor D_subset_helper() and F_subset_helper() to a generic matrix_subset_helper()
  - [x] Implement Wavefunction::c1_deep_copy() function
  - [ ] Update bassisset_ to be C1 inside c1_deep_copy() function
  - [ ] Call the new c1 deep copy from the driver in the appropriate places

* **User-Facing for Release Notes**
  - [ ] Allow symmetry to be used in SCF even when post-SCF module is C1-only

## Questions
- [x] The wavefunction object has a bassiset_ member that needs to be updated to C1

## Status
- [x] Ready to go
