### PR TITLE
CASSCF: semicanonicalize docc and virt blocks of Favg.

### DIFF
--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -356,7 +356,7 @@ def mcscf_solver(ref_wfn):
     # For orbital invariant methods we transform the orbitals to the natural or
     # semicanonical basis. Frozen doubly occupied and virtual orbitals are not
     # modified.
-    if core.get_local_option("DETCI", "WFN") != "RASSCF":
+    if core.get_option("DETCI", "WFN") == "CASSCF":
         # Do we diagonalize the opdm?
         if core.get_option("DETCI", "NAT_ORBS"):
             ciwfn.ci_nat_orbs()

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -39,6 +39,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/oeprop.h"
+#include "psi4/libfock/soscf.h"
 #include "psi4/psifiles.h"
 #include "psi4/physconst.h"
 #include "psi4/detci/structs.h"
@@ -575,17 +576,58 @@ void CIWavefunction::opdm_block(struct stringwr **alplist, struct stringwr **bet
 void CIWavefunction::ci_nat_orbs() {
   outfile->Printf("\n   Computing CI Natural Orbitals\n");
 
+  // Grab Fock matrices and build the average Fock operator
+  SharedMatrix AFock = somcscf_->current_AFock();
+  SharedMatrix IFock = somcscf_->current_IFock();
+  SharedMatrix Favg = AFock->clone();
+  Favg->add(IFock);
+
+  // Grab orbital dimensions
+  Dimension zero_dim(nirrep_);
+  Dimension noccpi = get_dimension("DOCC");
+  Dimension nactpi = get_dimension("ACT");
+  Dimension nvirpi = get_dimension("VIR");
+
   // Diagonalize the OPDM in the active space
   SharedMatrix NO_vecs(new Matrix("OPDM Eigvecs", opdm_->rowspi(), opdm_->colspi()));
   SharedVector NO_occ(new Vector("OPDM Occuption", opdm_->rowspi()));
   opdm_->diagonalize(NO_vecs, NO_occ, descending);
 
-  // get a copy of the active orbitals
+  // get a copy of the active orbitals and rotate them
   SharedMatrix Cactv = get_orbitals("ACT");
   SharedMatrix Cnat = Matrix::doublet(Cactv, NO_vecs);
 
   // set the active block of Ca_
   set_orbitals("ACT",Cnat);
+
+  // Diagonalize the doubly occupied block of Favg
+  Slice noccpi_slice(zero_dim,noccpi);
+  SharedMatrix Fo = Favg->get_block(noccpi_slice,noccpi_slice);
+  SharedVector evals_o = std::make_shared<Vector>("F Evals", noccpi);
+  SharedMatrix evecs_o = std::make_shared<Matrix>("F Evecs", noccpi, noccpi);
+  Fo->diagonalize(evecs_o, evals_o, ascending);
+
+  // get a copy of the doubly occupied orbitals and rotate them
+  SharedMatrix Cocc = get_orbitals("DOCC");
+  SharedMatrix Cocc_semi = Matrix::doublet(Cocc, evecs_o);
+
+  // set the doubly occupied orbitals block of Ca_
+  set_orbitals("DOCC",Cocc_semi);
+
+  // Diagonalize the virtual block of Favg
+  Slice nvirpi_slice(noccpi + nactpi, noccpi + nactpi + nvirpi);
+  SharedMatrix Fv = Favg->get_block(nvirpi_slice,nvirpi_slice);
+  SharedVector evals_v = std::make_shared<Vector>("F Evals", nvirpi);
+  SharedMatrix evecs_v = std::make_shared<Matrix>("F Evecs", nvirpi, nvirpi);
+  Fv->diagonalize(evecs_v, evals_v, ascending);
+
+  // get a copy of the virtual orbitals and rotate them
+  SharedMatrix Cvir = get_orbitals("VIR");
+  SharedMatrix Cvir_semi = Matrix::doublet(Cvir, evecs_v);
+
+  // set the virtual orbitals block of Ca_
+  set_orbitals("VIR",Cvir_semi);
+
   Cb_ = Ca_;
 }
 

--- a/tests/dfcasscf-fzc-sp/input.dat
+++ b/tests/dfcasscf-fzc-sp/input.dat
@@ -23,8 +23,8 @@ compare_values(-76.07373669020915, casscf_energy, 5, 'FZC CASSCF Energy')  #TEST
 cas_orbs = cas_wfn.get_orbitals("ACT")
 ## Double check NO's were build #TEST
 import numpy as np                                                      #TEST
-nov0 = np.array([0.99497,  0.82469,  0.70392,  1.15089,                 #TEST
-                 2.04234,  2.23589,  4.27168,  1.45200,                 #TEST
-                 2.06391,  1.66824,  3.43443,  3.98434])                #TEST
+nov0 = np.array([ 0.99497009,  0.82468679,  0.70392272,  1.15089075,    #TEST
+                  2.50413646,  2.36814890,  3.81935326,  1.51327793,    #TEST
+                  2.04791335,  1.67156162,  3.53716106,  3.99788137])   #TEST
 
 compare_arrays(nov0, np.linalg.norm(cas_wfn.Ca().nph[0], axis=0), 4, "Nat Orbs") #TEST


### PR DESCRIPTION
## Description
Fixes an issue related to the definition of natural orbitals in CASSCF computations (#740).

- [x] Ready to go