### PR TITLE
Proper update of post-scf wave-functions for fchk interface

### DIFF
--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -514,6 +514,7 @@ double CCEnergyWavefunction::compute_energy()
 #endif
 
     energy_ = moinfo_.ecc + moinfo_.eref;
+    name_  = "CCSD";
     Process::environment.globals["CURRENT ENERGY"] = moinfo_.ecc+moinfo_.eref;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = moinfo_.ecc;
     //Process::environment.globals["CC TOTAL ENERGY"] = moinfo.ecc+moinfo.eref;

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -229,6 +229,7 @@ double DFMP2::compute_energy()
     form_energy();
     timer_off("DFMP2 Energy");
     print_energies();
+    energy_ = variables_["MP2 TOTAL ENERGY"];
 
     return variables_["MP2 TOTAL ENERGY"];
 }
@@ -314,6 +315,7 @@ SharedMatrix DFMP2::compute_gradient()
 
     if(options_.get_bool("ONEPDM")){
         print_energies();
+        energy_ = variables_["MP2 TOTAL ENERGY"];
         return SharedMatrix(new Matrix("NULL", 0, 0));
     }
 
@@ -322,6 +324,7 @@ SharedMatrix DFMP2::compute_gradient()
     timer_off("DFMP2 grad");
 
     print_energies();
+    energy_ = variables_["MP2 TOTAL ENERGY"];
 
     print_gradients();
 

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -2310,6 +2310,9 @@ void RDFMP2::form_Z()
     SharedMatrix AP(new Matrix("A_mn^ls P_ls^(2)", nso, nso));
     double** APp = AP->pointer();
     SharedMatrix Dtemp;
+    SharedMatrix Ca__;
+    SharedVector epsilon_a__;
+    
 
     if(options_.get_bool("OPDM_RELAX")){
         psio_->read_entry(PSIF_DFMP2_AIA, "W", (char*) Wpq1p[0], sizeof(double) * nmo * nmo);
@@ -2403,9 +2406,10 @@ void RDFMP2::form_Z()
         // Add in the reference contribution
         for (int i = 0; i < nocc; ++i)
             Dtemp->add(i, i, 1.0);
-        Ca_ = SharedMatrix(new Matrix("DF-MP2 Natural Orbitals", nsopi_, nmopi_));
-        epsilon_a_ = SharedVector(new Vector("DF-MP2 NO Occupations", nmopi_));
+        Ca__ = SharedMatrix(new Matrix("DF-MP2 Natural Orbitals", nsopi_, nmopi_));
+        epsilon_a__ = SharedVector(new Vector("DF-MP2 NO Occupations", nmopi_));
         Da_ = SharedMatrix(new Matrix("DF-MP2 relaxed density", nsopi_, nsopi_));
+        
     }else{
         // Don't relax the OPDM
         Dtemp = Ppq->clone();
@@ -2414,16 +2418,18 @@ void RDFMP2::form_Z()
         Dtemp->scale(0.5);
 
         // Add in the reference contribution
+
         for (int i = 0; i < nocc; ++i)
             Dtemp->add(i, i, 1.0);
-        Ca_ = SharedMatrix(new Matrix("DF-MP2 (unrelaxed) Natural Orbitals", nsopi_, nmopi_));
-        epsilon_a_ = SharedVector(new Vector("DF-MP2 (unrelaxed) NO Occupations", nmopi_));
+        Ca__ = SharedMatrix(new Matrix("DF-MP2 (unrelaxed) Natural Orbitals", nsopi_, nmopi_));
+        epsilon_a__ = SharedVector(new Vector("DF-MP2 (unrelaxed) NO Occupations", nmopi_));
         Da_ = SharedMatrix(new Matrix("DF-MP2 unrelaxed density", nsopi_, nsopi_));
+        
     }
 
-    compute_opdm_and_nos(Dtemp, Da_, Ca_, epsilon_a_);
-    Cb_ = Ca_;
-    epsilon_b_ = epsilon_a_;
+    compute_opdm_and_nos(Dtemp, Da_, Ca__, epsilon_a__);
+    //Cb_ = Ca_;
+    //epsilon_b_ = epsilon_a_;
     Db_ = Da_;
 
     if(options_.get_bool("ONEPDM")){

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -2310,8 +2310,6 @@ void RDFMP2::form_Z()
     SharedMatrix AP(new Matrix("A_mn^ls P_ls^(2)", nso, nso));
     double** APp = AP->pointer();
     SharedMatrix Dtemp;
-    SharedMatrix Ca__;
-    SharedVector epsilon_a__;
     
 
     if(options_.get_bool("OPDM_RELAX")){
@@ -2406,8 +2404,8 @@ void RDFMP2::form_Z()
         // Add in the reference contribution
         for (int i = 0; i < nocc; ++i)
             Dtemp->add(i, i, 1.0);
-        Ca__ = SharedMatrix(new Matrix("DF-MP2 Natural Orbitals", nsopi_, nmopi_));
-        epsilon_a__ = SharedVector(new Vector("DF-MP2 NO Occupations", nmopi_));
+        Ca_ = SharedMatrix(new Matrix("DF-MP2 Natural Orbitals", nsopi_, nmopi_));
+        epsilon_a_ = SharedVector(new Vector("DF-MP2 NO Occupations", nmopi_));
         Da_ = SharedMatrix(new Matrix("DF-MP2 relaxed density", nsopi_, nsopi_));
         
     }else{
@@ -2421,15 +2419,15 @@ void RDFMP2::form_Z()
 
         for (int i = 0; i < nocc; ++i)
             Dtemp->add(i, i, 1.0);
-        Ca__ = SharedMatrix(new Matrix("DF-MP2 (unrelaxed) Natural Orbitals", nsopi_, nmopi_));
-        epsilon_a__ = SharedVector(new Vector("DF-MP2 (unrelaxed) NO Occupations", nmopi_));
+        Ca_ = SharedMatrix(new Matrix("DF-MP2 (unrelaxed) Natural Orbitals", nsopi_, nmopi_));
+        epsilon_a_ = SharedVector(new Vector("DF-MP2 (unrelaxed) NO Occupations", nmopi_));
         Da_ = SharedMatrix(new Matrix("DF-MP2 unrelaxed density", nsopi_, nsopi_));
         
     }
 
-    compute_opdm_and_nos(Dtemp, Da_, Ca__, epsilon_a__);
-    //Cb_ = Ca_;
-    //epsilon_b_ = epsilon_a_;
+    compute_opdm_and_nos(Dtemp, Da_, Ca_, epsilon_a_);
+    Cb_ = Ca_;
+    epsilon_b_ = epsilon_a_;
     Db_ = Da_;
 
     if(options_.get_bool("ONEPDM")){

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -33,6 +33,8 @@
 #include "defines.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsi4util/process.h"
+
 
 
 using namespace psi;
@@ -534,6 +536,9 @@ double DFOCC::compute_energy()
         else if (wfn_type_ == "DF-OMP2.5") Etotal = Emp3L;
         else if (wfn_type_ == "DF-OLCCD") Etotal = ElccdL;
         else if (wfn_type_ == "QCHF") Etotal = Eref;
+
+        /* updates the wavefunction for checkpointing */
+        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
 
         return Etotal;
 

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -33,7 +33,6 @@
 #include "defines.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/liboptions/liboptions.h"
-#include "psi4/libpsi4util/process.h"
 
 
 

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -537,9 +537,6 @@ double DFOCC::compute_energy()
         else if (wfn_type_ == "DF-OLCCD") Etotal = ElccdL;
         else if (wfn_type_ == "QCHF") Etotal = Eref;
 
-        /* updates the wavefunction for checkpointing */
-        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
-
         return Etotal;
 
 } // end of compute_energy

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -511,6 +511,11 @@ void DFOCC::mp2_manager()
         Process::environment.globals["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = Emp2AB;
         Process::environment.globals["MP2 SAME-SPIN CORRELATION ENERGY"] = Emp2AA+Emp2BB;
 
+        /* updates the wavefunction for checkpointing */
+        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
+        name_ = "DF-MP2";
+
+
         // S2
         //if (comput_s2_ == "TRUE" && reference_ == "UNRESTRICTED" && dertype == "NONE") s2_response();
         if (comput_s2_ == "TRUE" && reference_ == "UNRESTRICTED") {

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -1563,6 +1563,9 @@ void DFOCC::ccsdl_t_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = Eccsd_at - Escf;
 	Process::environment.globals["CCSD(AT) TOTAL ENERGY"] = Eccsd_at;
 	Process::environment.globals["(AT) CORRECTION ENERGY"] = E_at;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["CCSD(AT) TOTAL ENERGY"];
+        name_ = "DF-CCSD(AT)";
 
 	/*
         // Compute Analytic Gradients
@@ -1828,6 +1831,9 @@ void DFOCC::ccd_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = Eccd - Escf;
 	Process::environment.globals["CCD TOTAL ENERGY"] = Eccd;
         Process::environment.globals["CCD CORRELATION ENERGY"] = Eccd - Escf;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["CCD TOTAL ENERGY"];
+        name_ = "DF-CCD";
 
         // CCDL
         if (dertype == "FIRST" || cc_lambda_ == "TRUE") {
@@ -2153,6 +2159,9 @@ void DFOCC::omp3_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
 	Process::environment.globals["OMP3 TOTAL ENERGY"] = Emp3L;
         Process::environment.globals["OMP3 CORRELATION ENERGY"] = Emp3L - Escf;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["OMP3 TOTAL ENERGY"];
+        name_ = "DF-OMP3";
 
         // OEPROP
         if (oeprop_ == "TRUE") oeprop();
@@ -2368,6 +2377,9 @@ void DFOCC::mp3_manager()
 	Process::environment.globals["MP3 TOTAL ENERGY"] = Emp3;
         Process::environment.globals["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
 	Emp3L=Emp3;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["MP3 TOTAL ENERGY"];
+        name_ = "DF-MP3";
 
         // Compute Analytic Gradients
         if (dertype == "FIRST" || ekt_ip_ == "TRUE") {
@@ -2677,6 +2689,9 @@ void DFOCC::omp2_5_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
 	Process::environment.globals["OMP2.5 TOTAL ENERGY"] = Emp3L;
         Process::environment.globals["OMP2.5 CORRELATION ENERGY"] = Emp3L - Escf;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["OMP2.5 TOTAL ENERGY"];
+        name_ = "DF-OMP2.5";
 
         // OEPROP
         if (oeprop_ == "TRUE") oeprop();
@@ -2873,6 +2888,9 @@ void DFOCC::mp2_5_manager()
 	Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
         Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
 	Emp3L=Emp3;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["MP2.5 TOTAL ENERGY"];
+        name_ = "DF-MP2.5";
 
         // Compute Analytic Gradients
         if (dertype == "FIRST" || ekt_ip_ == "TRUE") {
@@ -3155,6 +3173,9 @@ void DFOCC::olccd_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = ElccdL - Escf;
 	Process::environment.globals["OLCCD TOTAL ENERGY"] = ElccdL;
         Process::environment.globals["OLCCD CORRELATION ENERGY"] = ElccdL - Escf;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["OLCCD TOTAL ENERGY"];
+        name_ = "DF-OLCCD";
 
         // OEPROP
         if (oeprop_ == "TRUE") oeprop();
@@ -3348,6 +3369,9 @@ void DFOCC::lccd_manager()
 	Process::environment.globals["LCCD TOTAL ENERGY"] = Elccd;
         Process::environment.globals["LCCD CORRELATION ENERGY"] = Elccd - Escf;
 	ElccdL = Elccd;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["LCCD TOTAL ENERGY"];
+        name_ = "DF-LCCD";
 
         // Compute Analytic Gradients
         if (dertype == "FIRST" || ekt_ip_ == "TRUE") {

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -809,6 +809,10 @@ void DFOCC::ccsd_manager()
 	Process::environment.globals["CCSD TOTAL ENERGY"] = Eccsd;
         Process::environment.globals["CCSD CORRELATION ENERGY"] = Eccsd - Escf;
 
+    /* updates the wavefunction for checkpointing */        
+        energy_ = Process::environment.globals["CCSD TOTAL ENERGY"];
+        name_ = "DF-CCSD";
+
         // CCSDL
         if (dertype == "FIRST" || cc_lambda_ == "TRUE") {
 	    // memalloc

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -1180,6 +1180,9 @@ void DFOCC::ccsd_t_manager()
         Process::environment.globals["CURRENT CORRELATION ENERGY"] = Eccsd_t - Escf;
 	Process::environment.globals["CCSD(T) TOTAL ENERGY"] = Eccsd_t;
 	Process::environment.globals["(T) CORRECTION ENERGY"] = E_t;
+    /* updates the wavefunction for checkpointing */        
+	    energy_ = Process::environment.globals["CCSD(T) TOTAL ENERGY"];
+        name_ = "DF-CCSD(T)";
 
 	/*
         // CCSDL

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -201,6 +201,9 @@ double CoupledCluster::compute_energy() {
         Process::environment.globals["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = eccsd_os;
         Process::environment.globals["CCSD SAME-SPIN CORRELATION ENERGY"] = eccsd_ss;
         Process::environment.globals["CCSD TOTAL ENERGY"] = eccsd + escf;
+        /* updates the wavefunction for checkpointing */
+        energy_ = Process::environment.globals["CCSD TOTAL ENERGY"];
+        name_ = "CCSD";
      }else{
         Process::environment.globals["QCISD CORRELATION ENERGY"] = eccsd;
         Process::environment.globals["QCISD OPPOSITE-SPIN CORRELATION ENERGY"] = eccsd_os;

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -102,6 +102,9 @@ double DFCoupledCluster::compute_energy() {
   Process::environment.globals["CCSD SAME-SPIN CORRELATION ENERGY"] = eccsd_ss;
   Process::environment.globals["CCSD TOTAL ENERGY"] = eccsd + escf;
   Process::environment.globals["CURRENT ENERGY"] = eccsd + escf;
+  /* updates the wavefunction for checkpointing */
+  energy_ = Process::environment.globals["CCSD TOTAL ENERGY"];
+  name_ = "DF-CCSD";
 
   if (options_.get_bool("COMPUTE_TRIPLES")){
       long int o = ndoccact;

--- a/psi4/src/psi4/fnocc/fnocc.cc
+++ b/psi4/src/psi4/fnocc/fnocc.cc
@@ -72,9 +72,11 @@ SharedWavefunction fnocc(SharedWavefunction ref_wfn, Options &options) {
       if ( !options.get_bool("RUN_CEPA") ) {
           std::shared_ptr<CoupledCluster> ccsd(new CoupledCluster(wfn,options));
           ccsd->compute_energy();
+          return ccsd;
       } else {
           std::shared_ptr<CoupledPair> cepa (new CoupledPair(wfn,options));
           cepa->compute_energy();
+          return cepa;
       }
 
   }else {
@@ -114,10 +116,11 @@ SharedWavefunction fnocc(SharedWavefunction ref_wfn, Options &options) {
 
       tstop();
 
+      return ccsd;
 
   }
 
-  return wfn;
+  //return wfn;
 } // end fnocc
 
 }} // end namespaces

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -91,6 +91,7 @@ Matrix::Matrix(const Matrix &c)
     matrix_ = NULL;
     nirrep_ = c.nirrep_;
     symmetry_ = c.symmetry_;
+    name_ = c.name();
     alloc();
     copy_from(c.matrix_);
 }
@@ -101,6 +102,7 @@ Matrix::Matrix(const SharedMatrix &c)
     matrix_ = NULL;
     nirrep_ = c->nirrep_;
     symmetry_ = c->symmetry_;
+    name_ = c->name();
     alloc();
     copy_from(c->matrix_);
 }
@@ -111,6 +113,7 @@ Matrix::Matrix(const Matrix *c)
     matrix_ = NULL;
     nirrep_ = c->nirrep_;
     symmetry_ = c->symmetry_;
+    name_ = c->name();
     alloc();
     copy_from(c->matrix_);
 }

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -78,7 +78,6 @@ void GradientWriter::write(const std::string &filename)
 MoldenWriter::MoldenWriter(std::shared_ptr<Wavefunction> wavefunction)
     : wavefunction_(wavefunction)
 {
-
 }
 void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb, std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA, std::shared_ptr<Vector> OccB, bool dovirtual)
 {
@@ -274,6 +273,8 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
 FCHKWriter::FCHKWriter(std::shared_ptr<Wavefunction> wavefunction)
     : wavefunction_(wavefunction)
 {
+    SharedMatrix Ca = wavefunction_->Ca();
+    Ca->print();
 }
 
 
@@ -634,10 +635,14 @@ void FCHKWriter::write(const std::string &filename)
     write_matrix("Contraction coefficients", coefficients);
     write_matrix("Coordinates of each shell", shell_coords);
     write_number("Total Energy", wavefunction_->reference_energy());
-    write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
-    write_matrix("Alpha MO coefficients", reorderedCa);
-    write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
-    write_matrix("Beta MO coefficients", reorderedCb);
+    //write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
+    write_matrix(wavefunction_->epsilon_a()->name().c_str(), wavefunction_->epsilon_a_subset("AO"));
+    //write_matrix("Alpha MO coefficients", reorderedCa);
+    write_matrix(wavefunction_->Ca()->name().c_str(), reorderedCa);
+    //write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
+    write_matrix(wavefunction_->epsilon_b()->name().c_str(), wavefunction_->epsilon_b_subset("AO"));
+    //write_matrix("Beta MO coefficients", reorderedCb);
+    write_matrix(wavefunction_->Cb()->name().c_str(), reorderedCb);
     char* label = new char[256];
     std::string type = name == "DFT" ? "SCF" : name;
     sprintf(label, "Total %s Density", type.c_str());

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -87,9 +87,10 @@ void RHF::common_init()
     // Allocate matrix memory
     Fa_        = SharedMatrix(factory_->create_matrix("F"));
     Fb_        = Fa_;
-    Ca_        = SharedMatrix(factory_->create_matrix("C"));
+    Ca_        = SharedMatrix(factory_->create_matrix("MO coefficients (C)"));
     Cb_        = Ca_;
     epsilon_a_ = SharedVector(factory_->create_vector());
+    epsilon_a_->set_name("orbital energies");
     epsilon_b_ = epsilon_a_;
     Da_        = SharedMatrix(factory_->create_matrix("SCF density"));
     Db_        = Da_;

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -83,8 +83,9 @@ void ROHF::common_init()
     moFeff_  = SharedMatrix(factory_->create_matrix("F effective (MO basis)"));
     soFeff_  = SharedMatrix(factory_->create_matrix("F effective (orthogonalized SO basis)"));
     Ct_      = SharedMatrix(factory_->create_matrix("Orthogonalized Molecular orbitals"));
-    Ca_      = SharedMatrix(factory_->create_matrix("C"));
+    Ca_      = SharedMatrix(factory_->create_matrix("alpha MO coefficients (C)"));
     Cb_      = Ca_;
+    Cb_->set_name("beta MO coefficients (C)");
     Da_      = SharedMatrix(factory_->create_matrix("SCF alpha density"));
     Db_      = SharedMatrix(factory_->create_matrix("SCF beta density"));
     Lagrangian_ = SharedMatrix(factory_->create_matrix("Lagrangian matrix"));
@@ -100,7 +101,9 @@ void ROHF::common_init()
     moFb_    = SharedMatrix(factory_->create_matrix("MO beta Fock Matrix (MO basis)"));
 
     epsilon_a_ = SharedVector(factory_->create_vector());
+    epsilon_a_->set_name("alpha orbital energies");
     epsilon_b_ = epsilon_a_;
+    epsilon_b_->set_name("beta orbital energies");
     same_a_b_dens_ = false;
     same_a_b_orbs_ = true;
 

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -95,8 +95,8 @@ void UHF::common_init()
     Db_old_ = SharedMatrix(factory_->create_matrix("Old beta SCF density"));
     Dt_old_ = SharedMatrix(factory_->create_matrix("D total old"));
     Lagrangian_ = SharedMatrix(factory_->create_matrix("Lagrangian"));
-    Ca_     = SharedMatrix(factory_->create_matrix("C alpha"));
-    Cb_     = SharedMatrix(factory_->create_matrix("C beta"));
+    Ca_     = SharedMatrix(factory_->create_matrix("alpha MO coefficients (C)"));
+    Cb_     = SharedMatrix(factory_->create_matrix("beta MO coefficients (C)"));
     Ga_     = SharedMatrix(factory_->create_matrix("G alpha"));
     Gb_     = SharedMatrix(factory_->create_matrix("G beta"));
     Va_     = SharedMatrix(factory_->create_matrix("V alpha"));
@@ -108,7 +108,9 @@ void UHF::common_init()
     wKb_    = SharedMatrix(factory_->create_matrix("wK beta"));
 
     epsilon_a_ = SharedVector(factory_->create_vector());
+    epsilon_a_->set_name("alpha orbital energies");
     epsilon_b_ = SharedVector(factory_->create_vector());
+    epsilon_b_->set_name("beta orbital energies");
 
     same_a_b_dens_ = false;
     same_a_b_orbs_ = false;

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -385,6 +385,11 @@ void OCCWave::mp2_manager()
              }
 	}
 
+         /* updates the wavefunction for checkpointing */
+        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
+        name_ = "MP2";
+
+
         // S2
         //if (comput_s2_ == "TRUE" && reference_ == "UNRESTRICTED") s2_response();
 

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -593,7 +593,7 @@ void OCCWave::mem_release()
         delete oo_pairidxAA;
         delete vv_pairidxAA;
 
-    Ca_.reset();
+    //Ca_.reset();
     Ca_ref.reset();
     Hso.reset();
     Tso.reset();

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -478,10 +478,6 @@ double OCCWave::compute_energy()
         else if (wfn_type_ == "OCEPA") return EcepaL;
         else if (wfn_type_ == "CEPA") return Ecepa;
 
-        /* updates the wavefunction for checkpointing */                  
-        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
-
-
         return 0.0;
 } // end of compute_energy
 

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -478,6 +478,10 @@ double OCCWave::compute_energy()
         else if (wfn_type_ == "OCEPA") return EcepaL;
         else if (wfn_type_ == "CEPA") return Ecepa;
 
+        /* updates the wavefunction for checkpointing */                  
+        energy_ = Process::environment.globals["MP2 TOTAL ENERGY"];
+
+
         return 0.0;
 } // end of compute_energy
 


### PR DESCRIPTION
## Description
This pull request aims to properly update energy, orbital energies, densities etc of the wave function for (conventional and density-fitted Mp2) and density-fitted CCSD calculations, so as to ensure proper checkpointing using FCHK interface. 
Also, there seems to be a problem in using FCHKWriter for conventional mp2 gradient calculations as I get a segmentation fault. This PR is meant to fix these problems which was pointed out by abdale on the psi4 forum. http://forum.psicode.org/t/problems-with-wavefunction-object-and-fchk-interface/532

## Status
- [x] Ready to go
