### PR TITLE
Update numpy_helper.py

### DIFF
--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -392,7 +392,7 @@ def _np_write(self, filename=None, prefix=""):
     for h, v in enumerate(self.nph):
         # If returning arrays to user, we want to return copies (snapshot), not
         # views of the core.Matrix's memory.
-        if filename == None and not v.flags['OWNDATA']:
+        if filename is None and not v.flags['OWNDATA']:
             v = np.copy(v)
         ret[prefix + "IrrepData" + str(h)] = v
 

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -390,6 +390,10 @@ def _np_write(self, filename=None, prefix=""):
     ret[prefix + "Irreps"] = self.nirrep()
     ret[prefix + "Name"] = self.name
     for h, v in enumerate(self.nph):
+        # If returning arrays to user, we want to return copies (snapshot), not
+        # views of the core.Matrix's memory.
+        if filename == None:
+            v = np.asarray(v, copy=True)
         ret[prefix + "IrrepData" + str(h)] = v
 
     if isinstance(self, core.Matrix):

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -392,8 +392,8 @@ def _np_write(self, filename=None, prefix=""):
     for h, v in enumerate(self.nph):
         # If returning arrays to user, we want to return copies (snapshot), not
         # views of the core.Matrix's memory.
-        if filename == None:
-            v = np.asarray(v, copy=True)
+        if filename == None and not v.flags['OWNDATA']:
+            v = np.copy(v)
         ret[prefix + "IrrepData" + str(h)] = v
 
     if isinstance(self, core.Matrix):


### PR DESCRIPTION
## Description
Make `core.Matrix.np_write(filename=None)` safer. The method returns a `dict` whose values are `np.ndarray`s. Currently, those arrays are views of memory owned by the `core.Matrix`, which means code like this is actually broken:

```
def function():
    matrix = function_that_returns_a_core_Matrix()
    return matrix.np_write(filename=None)
```

This PR changes `np_write` to return copies of the data when `filename=None`, so it's less of a footgun. Eventually the need for this might go away, once the numpy->core.Matrix reference counting integration is accomplished, but that's much tricker.

## Status
- [x] Ready to go
