### PR TITLE
Numpy update

### DIFF
--- a/doc/sphinxman/source/numpy.rst
+++ b/doc/sphinxman/source/numpy.rst
@@ -97,12 +97,6 @@ Secondly, these objects have a ``.np`` attribute for easy access to the underlyi
 
 this operation is identical to the above.
 
-.. warning:: The following will lead to reference errors: ``view =
-   psi4.Matrix(3, 3).np``. Here, the Python garbage collection deletes the Matrix
-   object, the view then points to deleted data resulting in the view effectively
-   reading random data. As a general rule, never assign the ``.nph`` or ``.np``
-   accessors.
-
 
 |PSIfour| Data Objects with Irreps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -34,48 +34,16 @@ from .exceptions import *
 
 ### Matrix and Vector properties
 
-# The next three functions make me angry
-def translate_interface(interface):
-    """
-    This is extra stupid with unicode
-    """
-
-    # Not super easy to do this C side, very easy py side
-    interface["shape"] = tuple(interface["shape"])
-
-    # Python3 is awesome
-    if sys.version_info[0] >= 3:
-        return interface
-
-    nouni_interface = {}
-    for k, v in interface.items():
-        if k == 'typestr':
-            nouni_interface[k.encode('ascii', 'ignore')] = v.encode('ascii', 'ignore')
-        else:
-            nouni_interface[k.encode('ascii', 'ignore')] = v
-
-    return nouni_interface
-
-class numpy_holder(object):
-    """
-    Blank object, stupid. Apparently you cannot create a view directly from a dictionary
-    """
-    def __init__(self, interface):
-        self.__array_interface__ = translate_interface(interface)
 
 def _get_raw_views(self, copy=False):
     """
     Gets simple raw view of the passed in object.
     """
-    ret = []
-    for data in self.array_interface():
+    if copy:
+        return tuple([np.array(x) for x in self.array_interface()])
+    else:
+        return tuple(self.array_interface())
 
-        # Watch out for those shapes without data
-        if 0 in data["shape"]:
-            ret.append(np.empty(shape=data["shape"]))
-        else:
-            ret.append(np.array(numpy_holder(data), copy=copy))
-    return ret
 
 def _find_dim(arr, ndim):
     """
@@ -94,6 +62,7 @@ def _find_dim(arr, ndim):
         return [arr.shape[x] for x in range(ndim)]
     else:
         raise ValidationError("Input array does not have a valid shape.")
+
 
 def array_to_matrix(self, arr, name="New Matrix", dim1=None, dim2=None):
     """
@@ -178,7 +147,7 @@ def array_to_matrix(self, arr, name="New Matrix", dim1=None, dim2=None):
             # Build an irreped array back out
             if dim1 is not None:
                 if dim2 is None:
-                    raise ValidationError ("Array_to_Matrix: If dim1 is supplied must supply dim2 also")
+                    raise ValidationError("Array_to_Matrix: If dim1 is supplied must supply dim2 also")
 
                 dim1 = core.Dimension.from_list(dim1)
                 dim2 = core.Dimension.from_list(dim2)
@@ -206,15 +175,14 @@ def array_to_matrix(self, arr, name="New Matrix", dim1=None, dim2=None):
             # Simple case without irreps
             else:
                 ret = self(name, arr.shape[0], arr.shape[1])
-                view = _get_raw_views(ret)[0]
-                view[:] = arr
+                ret.np[:] = arr
                 return ret
 
         elif arr_type == core.Vector:
             # Build an irreped array back out
             if dim1 is not None:
                 if dim2 is not None:
-                    raise ValidationError ("Array_to_Matrix: If dim2 should not be supplied for 1D vectors.")
+                    raise ValidationError("Array_to_Matrix: If dim2 should not be supplied for 1D vectors.")
 
                 dim1 = core.Dimension.from_list(dim1)
                 ret = self(name, dim1)
@@ -279,11 +247,11 @@ def _to_array(matrix, copy=True, dense=False):
         if dense:
             copy = False
 
-        ret = _get_raw_views(matrix, copy=copy)
+        matrix_views = _get_raw_views(matrix, copy=copy)
 
         # Return the list of arrays
         if dense is False:
-            return ret
+            return matrix_views
 
         # Build the dense matrix
         if isinstance(matrix, core.Vector):
@@ -295,7 +263,7 @@ def _to_array(matrix, copy=True, dense=False):
 
         dim1 = []
         dim2 = []
-        for h in ret:
+        for h in matrix_views:
             # Ignore zero dim irreps
             if 0 in h.shape:
                 dim1.append(0)
@@ -310,18 +278,18 @@ def _to_array(matrix, copy=True, dense=False):
         if ret_type == '1D':
             dense_ret = np.zeros(shape=(ndim1))
             start = 0
-            for d1, arr in zip(dim1, ret):
+            for d1, arr in zip(dim1, matrix_views):
                 if d1 == 0: continue
-                dense_ret[start: start + d1] = arr
+                dense_ret[start:start + d1] = arr
                 start += d1
         else:
             dense_ret = np.zeros(shape=(ndim1, ndim2))
             start1 = 0
             start2 = 0
-            for d1, d2, arr in zip(dim1, dim2, ret):
-                if d1 == 0: continue
+            for d1, d2, arr in zip(dim1, dim2, matrix_views):
+                if (d1 == 0) or (d2 == 0): continue
 
-                dense_ret[start1: start1 + d1, start2: start2 + d2] = arr
+                dense_ret[start1:start1 + d1, start2:start2 + d2] = arr
                 start1 += d1
                 start2 += d2
 
@@ -330,33 +298,17 @@ def _to_array(matrix, copy=True, dense=False):
     else:
         return _get_raw_views(matrix, copy=copy)[0]
 
-def _build_view(matrix):
-    """
-    Builds a view of the vector or matrix
-    """
-    views = _to_array(matrix, copy=False, dense=False)
-    if matrix.nirrep() > 1:
-        return tuple(views)
-    else:
-        return views
-
-def get_view(self):
-    if hasattr(self, '_np_view_data'):
-        return self._np_view_data
-    else:
-        self._np_view_data = _build_view(self)
-        return self._np_view_data
-
 @property
 def _np_shape(self):
     """
     Shape of the Psi4 data object
     """
-    view_data = get_view(self)
+    view_data = _get_raw_views(self)
     if self.nirrep() > 1:
         return tuple(view_data[x].shape for x in range(self.nirrep()))
     else:
-        return view_data.shape
+        return view_data[0].shape
+
 
 @property
 def _np_view(self):
@@ -364,27 +316,36 @@ def _np_view(self):
     View without only one irrep
     """
     if self.nirrep() > 1:
-        raise ValidationError("Attempted to call .np on a Psi4 data object with multiple irreps. Please use .nph for objects with irreps.")
-    return get_view(self)
+        raise ValidationError("Attempted to call .np on a Psi4 data object with multiple irreps."
+                              "Please use .nph for objects with irreps.")
+    return _get_raw_views(self)[0]
+
 
 @property
 def _nph_view(self):
     """
     View with irreps.
     """
-    if self.nirrep() > 1:
-        return get_view(self)
-    else:
-        return get_view(self),
+    return _get_raw_views(self)
+
 
 @property
 def _array_conversion(self):
+    """
+    Provides the array interface to simply classes so that np.array(core.Matrix(5, 5)) works flawlessly.
+    """
     if self.nirrep() > 1:
         raise ValidationError("__array__interface__ can only be called on Psi4 data object with only one irrep!")
     else:
         return self.np.__array_interface__
 
+
 def _np_write(self, filename=None, prefix=""):
+    """
+    Writes the irreped matrix to a NumPy zipped file.
+
+    Can return the packed data for saving many matrices into the same file.
+    """
 
     ret = {}
     ret[prefix + "Irreps"] = self.nirrep()
@@ -402,13 +363,16 @@ def _np_write(self, filename=None, prefix=""):
     if isinstance(self, core.Vector):
         ret[prefix + "Dim"] = [self.dim(x) for x in range(self.nirrep())]
 
-
     if filename is None:
         return ret
 
     np.savez(filename, **ret)
 
+
 def _np_read(self, filename, prefix=""):
+    """
+    Reads the data from a NumPy compress file.
+    """
 
     if isinstance(filename, np.lib.npyio.NpzFile):
         data = filename
@@ -446,6 +410,7 @@ def _np_read(self, filename, prefix=""):
 
     return ret
 
+
 def _to_serial(data):
     """
     Converts an object with a .nph accessor to a serialized dictionary
@@ -468,6 +433,7 @@ def _to_serial(data):
 
     return json_data
 
+
 def _from_serial(self, json_data):
     """
     Converts serialized data to the correct Psi4 data type
@@ -489,7 +455,6 @@ def _from_serial(self, json_data):
     return ret
 
 
-# Matrix attributes
 def _chain_dot(*args, **kwargs):
     """
     Chains dot products together from a series of Psi4 Matrix classes.
@@ -502,7 +467,8 @@ def _chain_dot(*args, **kwargs):
         trans = [False for x in range(len(args))]
     else:
         if len(trans) != len(args):
-            raise ValidationError("Chain dot: The length of the transpose arguements is not equal to the length of args.")
+            raise ValidationError(
+                "Chain dot: The length of the transpose arguements is not equal to the length of args.")
 
     # Setup chain
     ret = args[0]
@@ -514,7 +480,6 @@ def _chain_dot(*args, **kwargs):
         ret = core.Matrix.doublet(ret, mat, False, trans[n + 1])
 
     return ret
-
 
 
 # Matirx attributes
@@ -546,14 +511,19 @@ core.Vector.from_serial = classmethod(_from_serial)
 
 ### CIVector properties
 
+
 @property
 def _civec_view(self):
-    "Returns a view of the CIVector's buffer"
+    """
+    Returns a view of the CIVector's buffer
+    """
     return np.asarray(self)
+
 
 core.CIVector.np = _civec_view
 
 ### Dimension properties
+
 
 @classmethod
 def _dimension_from_list(self, dims, name="New Dimension"):
@@ -574,6 +544,7 @@ def _dimension_from_list(self, dims, name="New Dimension"):
         ret[i] = dims[i]
     return ret
 
+
 def _dimension_to_tuple(dim):
     """
     Converts a core.Dimension object to a tuple.
@@ -588,6 +559,7 @@ def _dimension_to_tuple(dim):
         ret.append(dim[i])
     return tuple(ret)
 
+
 def _dimension_iter(dim):
     """
     Provides an iterator class for the Dimension object.
@@ -599,6 +571,7 @@ def _dimension_iter(dim):
 
     for i in range(dim.n()):
         yield dim[i]
+
 
 # Dimension attributes
 core.Dimension.from_list = _dimension_from_list

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -452,7 +452,6 @@ void export_mints(py::module& m)
             }
 
             return ret;
-        // });
     }, py::return_value_policy::reference_internal);
 
     py::class_<Deriv, std::shared_ptr<Deriv>>(m, "Deriv", "docstring")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -223,6 +223,7 @@ void export_mints(py::module& m)
     py::class_<Dimension>(m, "Dimension", "docstring")
         .def(py::init<int>())
         .def(py::init<int, const std::string&>())
+        .def(py::init<const std::vector<int>&>())
         .def("print_out", &Dimension::print, "docstring")
         .def("init", &Dimension::init, "Re-initializes the dimension object")
         .def("n", &Dimension::n,
@@ -261,28 +262,31 @@ void export_mints(py::module& m)
                     throw PSIEXCEPTION("Vector::array_interface numpy shape with more than one irrep is not valid.");
                 }
 
-                py::dict interface;
-                interface["typestr"] = py::format_descriptor<double>::format();
-                interface["data"] = py::make_tuple((long)v.pointer(0), false);
-                interface["shape"] = v.numpy_shape();
-                ret.append(interface);
+                // Cast up the shape to size_t
+                std::vector<size_t> shape(v.numpy_shape().begin(), v.numpy_shape().end());
+
+                    // Build the array
+                py::array arr(shape, v.pointer(0), py::cast(&v));
+                ret.append(arr);
 
             } else {
                 for (size_t h = 0; h < v.nirrep(); h++) {
-                    py::dict interface;
-                    interface["typestr"] = py::format_descriptor<double>::format();
-                    if (v.dim(h) == 0) {
-                        interface["data"] = py::make_tuple(0, false);
-                    } else {
-                        interface["data"] = py::make_tuple((long)(v.pointer(h)), false);
+
+                    // Hmm, sometimes we need to handle empty ptr's correctly
+                    double* ptr = nullptr;
+                    if (v.dim(h) != 0) {
+                        ptr = v.pointer(h);
                     }
-                    interface["shape"] = py::make_tuple(v.dim(h));
-                    ret.append(interface);
+
+                    // Build the array
+                    std::vector<size_t> shape{(size_t)v.dim(h)};
+                    py::array arr(shape, ptr, py::cast(&v));
+                    ret.append(arr);
                 }
             }
 
             return ret;
-        });
+        }, py::return_value_policy::reference_internal);
 
     typedef void (IntVector::*int_vector_set)(int, int, int);
     py::class_<IntVector, std::shared_ptr<IntVector>>(m, "IntVector", "docstring")
@@ -415,28 +419,31 @@ void export_mints(py::module& m)
                     throw PSIEXCEPTION("Vector::array_interface numpy shape with more than one irrep is not valid.");
                 }
 
-                py::dict interface;
-                interface["typestr"] = py::format_descriptor<double>::format();
-                interface["data"] = py::make_tuple((long)(m.pointer(0)[0]), false);
-                interface["shape"] = m.numpy_shape();
-                ret.append(interface);
+                // Cast up the shape to size_t
+                std::vector<size_t> shape(m.numpy_shape().begin(), m.numpy_shape().end());
+
+                    // Build the array
+                py::array arr(shape, m.pointer(0)[0], py::cast(&m));
+                ret.append(arr);
 
             } else {
                 for (size_t h = 0; h < m.nirrep(); h++) {
-                    py::dict interface;
-                    interface["typestr"] = py::format_descriptor<double>::format();
-                    if ((m.rowdim(h) == 0) || (m.coldim(h) == 0)) {
-                        interface["data"] = py::make_tuple(0, false);
-                    } else {
-                        interface["data"] = py::make_tuple((long)(m.pointer(h)[0]), false);
+
+                    // Hmm, sometimes we need to overload to nullptr
+                    double* ptr = nullptr;
+                    if ((m.rowdim(h) * m.coldim(h)) != 0) {
+                        ptr = m.pointer(h)[0];
                     }
-                    interface["shape"] = py::make_tuple(m.rowdim(h), m.coldim(h));
-                    ret.append(interface);
+
+                    // Build the array
+                    py::array arr({(size_t)m.rowdim(h), (size_t)m.coldim(h)}, ptr, py::cast(&m));
+                    ret.append(arr);
                 }
             }
 
             return ret;
         });
+        // }, py::return_value_policy::reference_internal);
 
     py::class_<Deriv, std::shared_ptr<Deriv>>(m, "Deriv", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -253,25 +253,30 @@ void export_mints(py::module& m)
         .def("dim", &Vector::dim, "docstring")
         .def("nirrep", &Vector::nirrep, "docstring")
         .def("array_interface", [](Vector& v) {
-            // Dont ask, hopefully pybind11 will work on this
+
+            // Build a list of NumPy views, used for the .np and .nph accessors.Vy
             py::list ret;
 
             // If we set a NumPy shape
             if (v.numpy_shape().size()) {
-                if (v.nirrep() > 1){
-                    throw PSIEXCEPTION("Vector::array_interface numpy shape with more than one irrep is not valid.");
+                if (v.nirrep() > 1) {
+                    throw PSIEXCEPTION(
+                        "Vector::array_interface numpy shape with more than one irrep is not "
+                        "valid.");
                 }
 
-                // Cast up the shape to size_t
-                std::vector<size_t> shape(v.numpy_shape().begin(), v.numpy_shape().end());
+                // Cast the NumPy shape vector
+                std::vector<size_t> shape;
+                for (int val : v.numpy_shape()){
+                    shape.push_back((size_t)val);
+                }
 
-                    // Build the array
+                // Build the array
                 py::array arr(shape, v.pointer(0), py::cast(&v));
                 ret.append(arr);
 
             } else {
                 for (size_t h = 0; h < v.nirrep(); h++) {
-
                     // Hmm, sometimes we need to handle empty ptr's correctly
                     double* ptr = nullptr;
                     if (v.dim(h) != 0) {
@@ -410,25 +415,30 @@ void export_mints(py::module& m)
         .def("symmetrize_gradient", &Matrix::symmetrize_gradient, "docstring")
         .def("rotate_columns", &Matrix::rotate_columns, "docstring")
         .def("array_interface", [](Matrix& m) {
-            // Dont ask, hopefully pybind11 will work on this
+
+            // Build a list of NumPy views, used for the .np and .nph accessors.Vy
             py::list ret;
 
             // If we set a NumPy shape
             if (m.numpy_shape().size()) {
-                if (m.nirrep() > 1){
-                    throw PSIEXCEPTION("Vector::array_interface numpy shape with more than one irrep is not valid.");
+                if (m.nirrep() > 1) {
+                    throw PSIEXCEPTION(
+                        "Vector::array_interface numpy shape with more than one irrep is not "
+                        "valid.");
                 }
 
-                // Cast up the shape to size_t
-                std::vector<size_t> shape(m.numpy_shape().begin(), m.numpy_shape().end());
+                // Cast the NumPy shape vector
+                std::vector<size_t> shape;
+                for (int val : m.numpy_shape()) {
+                    shape.push_back((size_t)val);
+                }
 
-                    // Build the array
+                // Build the array
                 py::array arr(shape, m.pointer(0)[0], py::cast(&m));
                 ret.append(arr);
 
             } else {
                 for (size_t h = 0; h < m.nirrep(); h++) {
-
                     // Hmm, sometimes we need to overload to nullptr
                     double* ptr = nullptr;
                     if ((m.rowdim(h) * m.coldim(h)) != 0) {
@@ -442,8 +452,8 @@ void export_mints(py::module& m)
             }
 
             return ret;
-        });
-        // }, py::return_value_policy::reference_internal);
+        // });
+    }, py::return_value_policy::reference_internal);
 
     py::class_<Deriv, std::shared_ptr<Deriv>>(m, "Deriv", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())

--- a/psi4/src/psi4/libpsi4util/PsiOutStream.cc
+++ b/psi4/src/psi4/libpsi4util/PsiOutStream.cc
@@ -51,6 +51,8 @@ PsiOutStream::PsiOutStream(std::string fname, std::ios_base::openmode mode) {
         is_cout_ = false;
     }
 
+    // This is sort of big, but vsnprintf does not appear to work correctly on all OS's.
+    // Im looking at YOU CentOS
     buffer_.resize(512000);
 }
 
@@ -61,8 +63,7 @@ PsiOutStream::~PsiOutStream() {
 }
 
 void PsiOutStream::Printf(const char* format, ...) {
-    // We don't know how long the fully expanded string is so lets guess our average print is about
-    // a line
+    // We can check if the buffer is large enough
     va_list args;
     va_start(args, format);
     int left = vsnprintf(buffer_.data(), buffer_.size(), format, args);
@@ -81,10 +82,10 @@ void PsiOutStream::Printf(const char* format, ...) {
     // Everything is cool
 
     va_end(args);
-    (*stream_) << buffer_.data();
+    (*stream_) << buffer_.data() << std::flush;
 }
 void PsiOutStream::Printf(std::string fp) {
-    (*stream_) << fp;
+    (*stream_) << fp << std::flush;
 }
 
 } // End Psi Namespace

--- a/tests/numpy-array-interface/input.dat
+++ b/tests/numpy-array-interface/input.dat
@@ -22,7 +22,6 @@ compare_arrays(np_mat1, mat1.np, 9, "Implicit Non-irreped Array conversion")    
 
 for h in range(mat2.nirrep()):
     compare_arrays(np_mat2[h], mat2.nph[h], 9, "Implicit Irreped (%d) Array conversion" % h)     #TEST
-# Explicit should fail
 
 np_mat1_view = mat1.to_array(copy=False)
 np_mat2_view = mat2.to_array(copy=False)
@@ -190,6 +189,15 @@ residual = sum(np.sum(x) for x in tmp)
 
 compare_values(0, residual, 9, "View pointers are correctly assigned.")     #TEST
 
+tmp = []
+for n in range(1000):
+    view = Matrix(3, 3).np
+    view[:] = 1
+    tmp.append(view)
+residual = sum(np.sum(x) for x in tmp)
+
+compare_values(9000, residual, 9, "Object lifetimes are correctly tied together.")     #TEST
+
 
 # Try out JSON serialization
 json_data = irreped_vec.to_serial()
@@ -206,6 +214,7 @@ B = psi4.core.Matrix.from_array(np.random.rand(3, 5))
 C = psi4.core.Matrix.from_array(np.random.rand(5, 5))
 D = psi4.core.Matrix.from_array(np.random.rand(5, 2))
 
+### Make sure chain dot works
 numpy_result = np.dot(A, B).dot(C).dot(D)
 psi_result = psi4.core.Matrix.chain_dot(A, B, C, D)
 compare_arrays(numpy_result, psi_result, 9, "Chain dot test 1.")     #TEST


### PR DESCRIPTION
## Description
Occasionally we had issues cropping up where users were assigning views that were not tied to the Matrix object. Consider the following:

```
mat = Matrix(5, 5)
view = mat.np
del mat
```

Previously, `mat` and `view` lifetimes were not tied together. The NumPy array would point to deleted memory in the above example. With this PR, the object lifetime are tied together and `mat` is not actually deleted in this example (just a handle to it) so that the `view` remains valid. This also allows operations like `view = Matrix(5, 5).np` and `Cocc = wfn.Ca_subset("AO", "OCC").np` to work without issue.

A small downside is that the views cannot be cached as this would lead to circular nurse/patient relationships and prevent the objects from ever being garbage collected. This makes the `.np` accessors take slightly more time (~2-5us depending on number of irreps vs 0.5us). However, unless you are looping over individual indices and setting values this really shouldn't matter and the `mat.get/mat.set` functionality can be used for this with the ~0.4us latency. There is a chance this is fixable and we can revisit if it comes an issue.

I also was able to delete a great deal of rather hideous code which makes me quite happy.

Special thanks to @rmcgibbo for poking me about this and helping with idea and also to the PyBind11 team for "fixing" this a few months ago (doh!).

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Can now obtain stand-alone views with correct reference counting (`view = Matrix(5, 5).np`).
  - [x] Dimension objects can now be built python-side from list `Dimension([5, 5, 5])`.
* **User-Facing for Release Notes**
  - [x] The NumPy interface is now more robust. 

## Status
- [x] Ready to go