### PR TITLE
Add clang-format/YAPF style files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+SortIncludes: false

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+COLUMN_LIMIT = 119
+INDENT_WIDTH = 4
+USE_TABS = False


### PR DESCRIPTION
## Description
Adds a .clang-format file to psi4 based on discussion of issues #752. (closes #752)

To format C++ files (with inplace edit) run:
```
 clang-format -style=file -i [<file> ...]
```

## Questions
- [x] All agree on style?
- [x] Add YAPF file.

## Status
- [x] Ready to go