### PR TITLE
Implemented skip_timer functions to help avoid timer clutter.

### DIFF
--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -90,6 +90,8 @@ void timer_on(const std::string& key);
 void timer_off(const std::string& key);
 void parallel_timer_on(const std::string& key, int thread_rank);
 void parallel_timer_off(const std::string& key, int thread_rank);
+void start_skip_timers();
+void stop_skip_timers();
 
 void print_block(double *, int, int, FILE *);
 

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -94,8 +94,10 @@ void SADGuess::compute_guess()
 {
 
     timer_on("SAD Guess");
+    start_skip_timers();
     form_D();
     form_C();
+    stop_skip_timers();
     timer_off("SAD Guess");
 }
 void SADGuess::form_D()


### PR DESCRIPTION
## Description
Implemented a pair of functions,
- `void start_skip_timers()`
- `void stop_skip_timers()`
to skip all nested `timer_on` and `timer_off` calls and avoid complicated timing output.

## Todos
  - [x] Implement two functions.

## Status
- [x] Ready to go

## Example
By the following modification to `/psi4/psi4/src/psi4/libscf_solver/sad.cc`:
```
void SADGuess::compute_guess()
{

    timer_on("SAD Guess");
    start_skip_timers(); // Added new line.
    form_D();
    form_C();
    stop_skip_timers(); // Added new line.
    timer_off("SAD Guess");
}
```
the output `timer.dat` shows:
```
HF: Form H                  :      0.000u      0.017s      0.019w      2 calls
HF: Form S/X                :      0.000u      0.000s      0.000w      2 calls
HF: Guess                   :      0.400u      0.000s      0.247w      2 calls
| SAD Guess                 :      0.400u      0.000s      0.238w      2 calls
HF: Form G                  :      2.267u      0.000s      1.363w     31 calls
| JK: D                     :      0.000u      0.000s      0.000w     31 calls
| JK: USO2AO                :      0.000u      0.000s      0.000w     31 calls
| JK: JK                    :      2.267u      0.000s      1.361w     31 calls
| JK: AO2USO                :      0.000u      0.000s      0.000w     31 calls
HF: Form F                  :      0.000u      0.000s      0.000w     31 calls
HF: DIIS                    :      0.000u      0.000s      0.019w     31 calls
| DIISManager::add_entry    :      0.000u      0.000s      0.011w     29 calls
| DIISManager::extrapolate  :      0.000u      0.000s      0.006w     27 calls
| | DIISManager::extrapolate: bMatrix setup:      0.000u      0.000s      0.002w     27 calls
| | DIISManager::extrapolate: bMatrix pseudoinverse:      0.000u      0.000s      0.001w     27 calls
| | DIISManager::extrapolate: form new data:      0.000u      0.000s      0.002w     27 calls
HF: Form C                  :      0.000u      0.000s      0.004w     31 calls
HF: Form D                  :      0.000u      0.000s      0.000w     31 calls
```
which is much more concise than originally:
```
HF: Form H                  :      0.000u      0.033s      0.019w      2 calls
HF: Form S/X                :      0.000u      0.000s      0.000w      2 calls
HF: Guess                   :      0.417u      0.000s      0.251w      2 calls
| SAD Guess                 :      0.383u      0.000s      0.242w      2 calls
| | JK: (A|mn)              :      0.033u      0.000s      0.007w      4 calls
| | JK: (A|Q)^-1/2          :      0.100u      0.000s      0.072w      4 calls
| | JK: (Q|mn)              :      0.000u      0.000s      0.000w      4 calls
| | JK: D                   :      0.000u      0.000s      0.000w     18 calls
| | JK: USO2AO              :      0.000u      0.000s      0.000w     18 calls
| | JK: JK                  :      0.000u      0.000s      0.003w     18 calls
| | | JK: J                 :      0.000u      0.000s      0.000w     18 calls
| | | | JK: J1              :      0.000u      0.000s      0.000w     36 calls
| | | | JK: J2              :      0.000u      0.000s      0.000w     36 calls
| | | JK: K                 :      0.000u      0.000s      0.002w     18 calls
| | | | JK: K1              :      0.000u      0.000s      0.001w     32 calls
| | | | JK: K2              :      0.000u      0.000s      0.001w     32 calls
| | JK: AO2USO              :      0.000u      0.000s      0.000w     18 calls
| | DIISManager::add_entry  :      0.000u      0.000s      0.000w     18 calls
| | DIISManager::extrapolate:      0.000u      0.000s      0.001w     18 calls
| | | DIISManager::extrapolate: bMatrix setup:      0.000u      0.000s      0.000w     18 calls
| | | DIISManager::extrapolate: bMatrix pseudoinverse:      0.000u      0.000s      0.000w     18 calls
| | | DIISManager::extrapolate: form new data:      0.000u      0.000s      0.000w     18 calls
HF: Form G                  :      2.350u      0.000s      1.385w     31 calls
| JK: D                     :      0.000u      0.000s      0.000w     31 calls
| JK: USO2AO                :      0.000u      0.000s      0.000w     31 calls
| JK: JK                    :      2.350u      0.000s      1.383w     31 calls
| JK: AO2USO                :      0.000u      0.000s      0.000w     31 calls
HF: Form F                  :      0.000u      0.000s      0.000w     31 calls
HF: DIIS                    :      0.000u      0.017s      0.020w     31 calls
| DIISManager::add_entry    :      0.000u      0.000s      0.012w     29 calls
| DIISManager::extrapolate  :      0.000u      0.017s      0.006w     27 calls
| | DIISManager::extrapolate: bMatrix setup:      0.000u      0.017s      0.002w     27 calls
| | DIISManager::extrapolate: bMatrix pseudoinverse:      0.000u      0.000s      0.001w     27 calls
| | DIISManager::extrapolate: form new data:      0.000u      0.000s      0.002w     27 calls
HF: Form C                  :      0.000u      0.000s      0.004w     31 calls
HF: Form D                  :      0.000u      0.000s      0.000w     31 calls
```