### PR TITLE
Fixes basis_guess with -D combo

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1114,7 +1114,7 @@ def scf_helper(name, **kwargs):
 
     if cast:
 
-        # A use can set "BASIS_GUESS" to True and we default to 3-21G
+        # A user can set "BASIS_GUESS" to True and we default to 3-21G
         if cast is True:
             guessbasis = '3-21G'
         else:
@@ -1225,7 +1225,7 @@ def scf_helper(name, **kwargs):
         # Compute dftd3
         if "_disp_functor" in dir(ref_wfn):
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
-            ref_wfn.set_variables("-D Energy", disp_energy)
+            ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
 
     # broken clean-up

--- a/psi4/src/psi4/libdisp/dispersion.cc
+++ b/psi4/src/psi4/libdisp/dispersion.cc
@@ -249,10 +249,10 @@ double Dispersion::compute_energy(std::shared_ptr <Molecule> m)
 
         // -DAS dispersion only involves inter-fragment terms
         if (m->nactive_fragments() == 1) {
-			//Just in case, since auto fragment is not called 
+		//Just in case, since auto fragment is not called 
     		outfile->Printf("\n    Only one fragment provided, no empirical dispersion will be added.\n\n");
-			return 0.0;
-		}
+		return 0.0;
+	}
 
         // need a check if there is only one active fragment ...
 

--- a/psi4/src/psi4/libdisp/dispersion.cc
+++ b/psi4/src/psi4/libdisp/dispersion.cc
@@ -248,7 +248,11 @@ double Dispersion::compute_energy(std::shared_ptr <Molecule> m)
     if (Damping_type_ == Damping_TT) {
 
         // -DAS dispersion only involves inter-fragment terms
-        if (m->nactive_fragments() == 1) return 0.0;
+        if (m->nactive_fragments() == 1) {
+			//Just in case, since auto fragment is not called 
+    		outfile->Printf("\n    Only one fragment provided, no empirical dispersion will be added.\n\n");
+			return 0.0;
+		}
 
         // need a check if there is only one active fragment ...
 

--- a/tests/dftd3/energy/input.dat
+++ b/tests/dftd3/energy/input.dat
@@ -153,3 +153,9 @@ compare_values(ref_pbe_d2[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, '
 eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
 compare_values(ref_pbe_d2[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')      #TEST
 
+print_stdout('  cast-up, -D correction from C-side')                                                         #TEST
+set basis_guess sto-3g
+energy('b3lyp-d3bj')
+compare_values(ref_pbe_d3bj[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
+
+


### PR DESCRIPTION
## Description
DFT-D plus the use of a guess basis set produced an error because of a typo in setting the dispersion energy: set_variables -> set_variable. 


## Status
- [X] Ready to go
