### PR TITLE
Much misc

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,31 @@
+The Psi4 package is distributed for free and without any
+guarantee of reliability, accuracy, or suitability for any
+particular purpose. No obligation to provide technical support is
+expressed or implied. As time allows, the developers will attempt
+to answer inquiries on the [forum](http://forum.psicode.org>) or
+[GitHub](https://github.com/psi4/psi4/issues/new). For bug reports,
+specific and detailed information, with example inputs and `psi4
+--version`, would be appreciated.
+
+#### Where-to-post summary
+
+* How do I? -- [ask the forum](http://forum.psicode.org)
+
+* I got this error, why? -- [ask the forum](http://forum.psicode.org)
+
+* I got this error and I'm sure it's a bug -- [file a GitHub issue](https://github.com/psi4/psi4/issues/new)
+
+* Can I open a discussion on this bit of code? -- [file a GitHub issue](https://github.com/psi4/psi4/issues/new)
+
+* I have an idea/request and a plan -- [file a GitHub issue](https://github.com/psi4/psi4/issues/new)
+
+* I have an idea/request -- [ask the forum](http://forum.psicode.org)
+
+* Why do you? -- [ask the forum](http://forum.psicode.org)
+
+* When will you? -- [ask the forum](http://forum.psicode.org)
+
+* I have an experience that can improve the documentation -- [inform the forum](http://forum.psicode.org) or [edit the docs via the little pencil](http://psicode.org/psi4manual/master/index.html) or [add to the documentation itself](doc/sphinxman/source)
+
+* Anything you want to share privately -- psi4aiqc+help at gmail.com
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - gfortran
     env:
       - CXX_COMPILER='clang++-3.6'
-      - PYTHON_VER='3.5'
+      - PYTHON_VER='3.6'
       - C_COMPILER='clang-3.6'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
@@ -174,7 +174,7 @@ before_script:
     -DENABLE_gdma=ON
     -DENABLE_PCMSolver=ON
     -DENABLE_simint=ON
-    -DENABLE_PLUGIN_TESTING=OFF
+    -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,7 @@ before_script:
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh
+- stage/${TRAVIS_BUILD_DIR}/Install/bin/psi4 ../tests/tu1-h2o-energy/input.dat
 script:
 - python ../.scripts/travis_run_test.py
 - python ../.scripts/travis_print_failing.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,8 +178,8 @@ before_script:
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh
-- stage/${TRAVIS_BUILD_DIR}/Install/bin/psi4 ../tests/tu1-h2o-energy/input.dat
 script:
+- ./stage/${TRAVIS_BUILD_DIR}/Install/bin/psi4 ../tests/tu1-h2o-energy/input.dat
 - python ../.scripts/travis_run_test.py
 - python ../.scripts/travis_print_failing.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,14 +167,14 @@ before_script:
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_CheMPS2=ON
+    -DENABLE_CheMPS2=OFF
     -DENABLE_dkh=ON
     -DENABLE_libefp=ON
     -DENABLE_erd=ON
     -DENABLE_gdma=ON
     -DENABLE_PCMSolver=ON
     -DENABLE_simint=ON
-    -DENABLE_PLUGIN_TESTING=OFF
+    -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ before_script:
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_CheMPS2=OFF
+    -DENABLE_CheMPS2=ON
     -DENABLE_dkh=ON
     -DENABLE_libefp=ON
     -DENABLE_erd=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ before_script:
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_CheMPS2=ON
+    -DENABLE_CheMPS2=OFF
     -DENABLE_dkh=ON
     -DENABLE_libefp=ON
     -DENABLE_erd=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ before_script:
     -DENABLE_gdma=ON
     -DENABLE_PCMSolver=ON
     -DENABLE_simint=ON
-    -DENABLE_PLUGIN_TESTING=ON
+    -DENABLE_PLUGIN_TESTING=OFF
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
 - ../.scripts/travis_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,18 +139,14 @@ before_install:
   - df -h
   - ulimit -a
 install:
-- if [[ "$PYTHON_VER" == "2.7" ]]; then
-    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-  else
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  fi
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n p4env python=$PYTHON_VER numpy cmake dftd3 libint=1.2.0 libxc gdma libefp -c psi4 -c psi4/label/dev -c psi4/label/test
+- conda create -q -n p4env python=$PYTHON_VER numpy cmake ci-psi4-lt psi4-lt-mp psi4-rt -c psi4/label/dev -c psi4
 - source activate p4env
 - conda list
 before_script:
@@ -171,8 +167,13 @@ before_script:
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_gdma=ON
+    -DENABLE_CheMPS2=ON
     -DENABLE_dkh=ON
+    -DENABLE_libefp=ON
+    -DENABLE_erd=ON
+    -DENABLE_gdma=ON
+    -DENABLE_PCMSolver=ON
+    -DENABLE_simint=ON
     -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
 - cd build
@@ -185,5 +186,6 @@ script:
 branches:
   only:
   - master
+  - 1.1.x
   - 1.0.x
   - libxc

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n p4env python=$PYTHON_VER numpy cmake ci-psi4-lt psi4-lt-mp psi4-rt -c psi4/label/dev -c psi4
+- conda create -q -n p4env python=$PYTHON_VER numpy cmake ci-psi4-lt psi4-lt-mp dftd3 gcp -c psi4/label/dev -c psi4
 - source activate p4env
 - conda list
 before_script:
@@ -189,4 +189,3 @@ branches:
   - master
   - 1.1.x
   - 1.0.x
-  - libxc

--- a/cmake/math/MathLibs.cmake
+++ b/cmake/math/MathLibs.cmake
@@ -172,7 +172,11 @@ endif()
 
 # LAB Jul 2017: Because gcc thinks that if OpenMP is on, then implicitly one _must_ want their
 #   libgomp, when we'd actually prefer libiomp5 that doesn't give nthread-dependent energies.
-if(ENABLE_OPENMP AND (MKL_COMPILER_BINDINGS MATCHES GNU))
+#   MKL advisor says: Mac: iomp5 for icpc, clang, gcc; Linux: iomp5 for icpc, gomp or iomp5 for gcc
+#   We suppress gomp across the board for Mac/gcc, Linux/gcc, Linux/icpc (uses gcc under the hood
+#   and we want gcc-based plugins to inherit iomp5 properly).
+if(ENABLE_OPENMP AND ((MKL_COMPILER_BINDINGS MATCHES GNU) OR
+                      ((UNIX AND NOT APPLE) AND (MKL_COMPILER_BINDINGS MATCHES Intel))))
     set(_extras "-fno-openmp")
 else()
     set(_extras)

--- a/cmake/math/MathLibsFunctions.cmake
+++ b/cmake/math/MathLibsFunctions.cmake
@@ -202,32 +202,6 @@ macro(config_math_service _SERVICE)
     endif()
 
     if(${_SERVICE}_FOUND)
-
-        # this codeblock is dead
-        # take care of omp flags
-        #if(ENABLE_THREADED_MKL)
-        #    set(_omp_flag)
-        #    if(HAVE_MKL_BLAS OR HAVE_MKL_LAPACK)
-        #        if(MKL_COMPILER_BINDINGS MATCHES Intel)
-        #            set(_omp_flag -qopenmp)
-        #        endif()
-        #        if(MKL_COMPILER_BINDINGS MATCHES GNU)
-        #            set(_omp_flag -fopenmp)
-        #        endif()
-        #        if(MKL_COMPILER_BINDINGS MATCHES PGI)
-        #            set(_omp_flag -mp)
-        #        endif()
-        #    endif()
-        #    if(HAVE_MKL_${_SERVICE})
-        #        if(APPLE)
-        #            set(${_SERVICE}_LIBRARIES ${${_SERVICE}_LIBRARIES} ${_omp_flag})
-        #        else()
-        #            set(${_SERVICE}_LIBRARIES -Wl,--start-group ${${_SERVICE}_LIBRARIES} ${_omp_flag} -Wl,--end-group)
-        #        endif()
-        #    endif()
-        #    unset(_omp_flag)
-        #endif()
-
         find_package_message(${_SERVICE}
             "Found ${_SERVICE}: ${${_SERVICE}_TYPE} (${${_SERVICE}_LIBRARIES})"
             "[${${_SERVICE}_LIBRARIES}]"

--- a/doc/sphinxman/source/introduction.rst
+++ b/doc/sphinxman/source/introduction.rst
@@ -100,7 +100,7 @@ The following citation should be used in any publication utilizing the
   F. Gonthier, A. M. James, H. R. McAlexander, A. Kumar, M. Saitow, X. Wang,
   B. P. Pritchard, P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King,
   E. F. Valeev, F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D.
-  Sherrill, *J. Chem. Theory Comput.*, *in press* (2017).
+  Sherrill, *J. Chem. Theory Comput.*, **13(7)** 3185--3197 (2017).
   (doi: `10.1021/acs.jctc.7b00174
   <http://dx.doi.org/10.1021/acs.jctc.7b00174>`_).
 

--- a/psi4/header.py
+++ b/psi4/header.py
@@ -63,7 +63,7 @@ def print_header():
     H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
     P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
     F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
     (doi: 10.1021/acs.jctc.7b00174)
 
     -----------------------------------------------------------------------

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -503,10 +503,10 @@ void export_mints(py::module& m)
 //Something here is wrong. These will not work with py::args defined, not sure why
     py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
         .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
-             "Returns a new matrix object with default dimensions");
+             "Returns a new matrix object with default dimensions")
 //             "Returns a new matrix object with default dimensions", py::arg("symmetry"));
-//        .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
-//             "Returns a new Matrix object named name with default dimensions", 
+        .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
+             "Returns a new Matrix object named name with default dimensions");
 //              py::arg("name"), py::arg("symmetry"));
 
     py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations")

--- a/psi4/src/psi4/ccenergy/analyze.cc
+++ b/psi4/src/psi4/ccenergy/analyze.cc
@@ -80,7 +80,7 @@ void CCEnergyWavefunction::analyze(void)
 	    tmp[0], nso, 0.0, T2trans[ij], nso);
 
     for(ab=0; ab<nso*nso; ab++) {
-      value = std::fabs(log10(std::fabs(T2trans[ij][ab])));
+      value = std::fabs(std::log10(std::fabs(T2trans[ij][ab])));
       tot2++;
       if ((value >= max) && (value <= (max+width))) {
 	amp_array[num_div-1]++;
@@ -135,7 +135,7 @@ void CCEnergyWavefunction::analyze(void)
   for(i=0; i < nocc; i++) {
     for(a=0; a < nso; a++) {
       /*      value = std::fabs(log10(std::fabs(T1trans[i][a]))); */
-      value = log10(std::fabs(T1.matrix[0][i][a]));
+      value = std::log10(std::fabs(T1.matrix[0][i][a]));
       tot2++;
       if ((value >= max) && (value <= (max+width))) {
 	amp_array[num_div-1]++;

--- a/psi4/src/psi4/ccresponse/analyze.cc
+++ b/psi4/src/psi4/ccresponse/analyze.cc
@@ -91,7 +91,7 @@ void analyze(const char *pert, int irrep, double omega)
 	    tmp[0], nso, 0.0, T2trans[ij], nso);
 
     for(ab=0; ab<nso*nso; ab++) {
-      value = std::fabs(log10(std::fabs(T2trans[ij][ab])));
+      value = std::fabs(std::log10(std::fabs(T2trans[ij][ab])));
       tot2++;
       if ((value >= max) && (value <= (max+width))) {
 	amp_array[num_div-1]++;
@@ -150,7 +150,7 @@ void analyze(const char *pert, int irrep, double omega)
   for(i=0; i < nocc; i++) {
     for(a=0; a < nso; a++) {
       /*      value = std::fabs(log10(std::fabs(T1trans[i][a]))); */
-      value = log10(std::fabs(T1.matrix[0][i][a]));
+      value = std::log10(std::fabs(T1.matrix[0][i][a]));
       tot2++;
       if ((value >= max) && (value <= (max+width))) {
 	amp_array[num_div-1]++;

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -130,7 +130,7 @@ void DFOCC::common_init()
     }
     else {
         double temp;
-        temp = (-0.9 * log10(tol_Eod)) - 1.6;
+        temp = (-0.9 * std::log10(tol_Eod)) - 1.6;
         if (temp < 4.0) {
             temp = 4.0;
         }
@@ -146,7 +146,7 @@ void DFOCC::common_init()
     }
     else {
         double temp2;
-        temp2 = (-0.8 * log10(tol_grad)) - 0.5;
+        temp2 = (-0.8 * std::log10(tol_grad)) - 0.5;
         if (temp2 < 3.0) {
             temp2 = 3.0;
         }

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -27,7 +27,7 @@
  */
 
 #include <fstream>
-#include <math.h>
+#include <cmath>
 #include "psi4/libqt/qt.h"
 #include "dfocc.h"
 #include "defines.h"

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -136,7 +136,7 @@ void OCCWave::common_init()
     }
     else {
         double temp;
-        temp = 2.0 - 0.5 * log10(tol_Eod); // I think (U.B) this is the desirable map balancing accuracy and efficiency.
+        temp = 2.0 - 0.5 * std::log10(tol_Eod); // I think (U.B) this is the desirable map balancing accuracy and efficiency.
         //temp = 3.0 - 0.5 * log10(tol_Eod); // Lori's old map leads unecessary iterations for the omp2-2 test case.
         //temp = 1.74 - 0.71 * log10(tol_Eod); //OLD map for wfn != OMP2
         if (temp < 5.0) {
@@ -154,7 +154,7 @@ void OCCWave::common_init()
     }
     else {
         double temp2;
-        temp2 = -log10(tol_grad) - 1.5;
+        temp2 = -std::log10(tol_grad) - 1.5;
         if (temp2 > 4.0) {
             temp2 = 4.0;
         }

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -27,7 +27,7 @@
  */
 
 #include <fstream>
-#include <math.h>
+#include <cmath>
 
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libtrans/mospace.h"

--- a/tests/extern1/CMakeLists.txt
+++ b/tests/extern1/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(extern1 "psi;quicktests:scf")
+add_regression_test(extern1 "psi;quicktests;scf")

--- a/tests/gcp/pbeh3c/CMakeLists.txt
+++ b/tests/gcp/pbeh3c/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(gcp-pbeh3c "psi;quicktests;gcp;addon")
+add_regression_test(gcp-pbeh3c "psi;gcp;addon")

--- a/tests/pcmsolver/dft/CMakeLists.txt
+++ b/tests/pcmsolver/dft/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(pcmsolver-dft "psi;quicktests;pcmsolver;addon;scf;dft")
+add_regression_test(pcmsolver-dft "psi;pcmsolver;addon;scf;dft")
 


### PR DESCRIPTION
Adds std::log10, SUPPORT file, tests more addons, -fno-openmp for int……el icpc, final psi4 1.1 citation, fix mints3 as mentioned in psi4/psi4#761

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] updates psi4 citation
  - [x] adds `std::log10` as Andy advised
  - [x] removed dead code as AJ advised
  - [x] adds SUPPORT file as [github advised](https://github.com/blog/2400-support-file-support)
  - [x] revises Travis to test all add-ons (except CheMPS2) and from proper channels and to count the travis downloads
  - [x] with MKL, gcc on Mac _must_ have iomp5, gcc on Linux can have either iomp5 or gomp, icpc must have iomp5 but moreover, we want to allow gcc plugins built from icpc psi4 to handle omp consistently, so adding `-fno-openmp` to catch downstream gcc plugins
  - [x] the thing Adam mentioned in psi4/psi4#761 about create_matrix was making mints3 fail, so ameliorated (didn't totally fix) that
* **User-Facing for Release Notes**

## Status
- [x] Ready to go (if passing, RTG. squash, I think)
