### PR TITLE
Changes to psi4 for MDT interface.

### DIFF
--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -11,6 +11,8 @@ else()
         GIT_TAG v2.0.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}  # unused, but needs working compiler
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}  # ditto

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -988,6 +988,15 @@ def optimize(name, **kwargs):
         custom_gradient = False
 
     return_wfn = kwargs.pop('return_wfn', False)
+    return_history = kwargs.pop('return_history', False)
+
+
+#Be sure to add wavefunction functionality later once the deep copy issues are worked out
+    if return_history:
+        step_energies      = []
+        step_gradients     = []
+        step_coordinates   = []
+        #        step_wavefunctions = []
 
     # For CBS wrapper, need to set retention on INTCO file
     if custom_gradient or ('/' in lowername):
@@ -1056,6 +1065,13 @@ def optimize(name, **kwargs):
 
         # above, used to be getting energy as last of energy list from gradient()
         # thisenergy below should ultimately be testing on wfn.energy()
+
+        # Record optimization steps
+        # Add wavefunctions later
+        if return_history:
+            step_energies.append(thisenergy)
+            step_coordinates.append(moleculeclone.geometry())
+            step_gradients.append(G.clone())
 
         # S/R: Quit after getting new displacements or if forming gradient fails
         if opt_mode == 'sow':
@@ -1132,8 +1148,19 @@ def optimize(name, **kwargs):
 
             optstash.restore()
 
-            if return_wfn:
+            if return_history:
+                history = { 'energy'        : step_energies ,
+                            'gradient'      : step_gradients ,
+                            'coordinates'   : step_coordinates #,
+            #                'wavefunctions' : step_wavefunctions
+                          }
+
+            if return_wfn and return_history:
+                return (thisenergy, wfn, history)
+            elif return_wfn and not return_history:
                 return (thisenergy, wfn)
+            elif return_history and not return_wfn:
+                return (thisenergy, history)
             else:
                 return thisenergy
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1430,7 +1430,7 @@ def hessian(name, **kwargs):
 
         # Assemble Hessian from gradients
         #   Final disp is undisp, so wfn has mol, G, H general to freq calc
-        H = core.fd_freq_1(molecule, gradients, irrep)  # TODO or moleculeclone?
+        H = core.fd_freq_1(molecule, wfn, gradients, irrep)  # TODO or moleculeclone?
         wfn.set_hessian(H)
         wfn.set_frequencies(core.get_frequencies())
 
@@ -1565,7 +1565,7 @@ def hessian(name, **kwargs):
             wfn = core.Wavefunction.build(molecule, core.get_global_option('BASIS'))
 
         # Assemble Hessian from energies
-        H = core.fd_freq_0(molecule, energies, irrep)
+        H = core.fd_freq_0(molecule, wfn, energies, irrep)
         wfn.set_hessian(H)
         wfn.set_frequencies(core.get_frequencies())
 

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -139,15 +139,15 @@ PsiReturnType mrcc_load_ccdensities(SharedWavefunction, Options&, const py::dict
 namespace findif {
 std::vector<SharedMatrix> fd_geoms_1_0(std::shared_ptr<Molecule>, Options&);
 std::vector<SharedMatrix> fd_geoms_freq_0(std::shared_ptr<Molecule>, Options&,
-                                          int irrep = -1);
+                                          int irrep);
 std::vector<SharedMatrix> fd_geoms_freq_1(std::shared_ptr<Molecule>, Options&,
-                                          int irrep = -1);
+                                          int irrep);
 std::vector<SharedMatrix> atomic_displacements(std::shared_ptr<Molecule>, Options&);
 
 SharedMatrix fd_1_0(std::shared_ptr<Molecule>, Options&, const py::list&);
-SharedMatrix fd_freq_0(std::shared_ptr<Molecule>, Options&, const py::list&, int irrep = -1);
-SharedMatrix fd_freq_1(std::shared_ptr<Molecule>, Options&, const py::list&, int irrep = -1);
-SharedMatrix displace_atom(SharedMatrix geom, const int atom,
+SharedMatrix fd_freq_0(std::shared_ptr<Molecule>, std::shared_ptr<Wavefunction>, Options&, const py::list&, int irrep);
+SharedMatrix fd_freq_1(std::shared_ptr<Molecule>, std::shared_ptr<Wavefunction>, Options&, const py::list&, int irrep);
+void displace_atom(SharedMatrix geom, const int atom,
                            const int coord, const int sign,
                            const double disp_size);
 }
@@ -331,23 +331,23 @@ SharedMatrix py_psi_fd_1_0(std::shared_ptr<Molecule> mol, const py::list& energi
     return findif::fd_1_0(mol, Process::environment.options, energies);
 }
 
-SharedMatrix py_psi_fd_freq_0(std::shared_ptr<Molecule> mol, const py::list& energies, int irrep)
+SharedMatrix py_psi_fd_freq_0(std::shared_ptr<Molecule> mol, std::shared_ptr<Wavefunction> wfn, const py::list& energies, int irrep)
 {
     py_psi_prepare_options_for_module("FINDIF");
-    return findif::fd_freq_0(mol, Process::environment.options, energies, irrep);
+    return findif::fd_freq_0(mol, wfn, Process::environment.options, energies, irrep);
 }
 
-SharedMatrix py_psi_fd_freq_1(std::shared_ptr<Molecule> mol, const py::list& grads, int irrep)
+SharedMatrix py_psi_fd_freq_1(std::shared_ptr<Molecule> mol, std::shared_ptr<Wavefunction> wfn, const py::list& grads, int irrep)
 {
     py_psi_prepare_options_for_module("FINDIF");
-    return findif::fd_freq_1(mol, Process::environment.options, grads, irrep);
+    return findif::fd_freq_1(mol, wfn, Process::environment.options, grads, irrep);
 }
 
-SharedMatrix py_psi_displace_atom(SharedMatrix geom, const int atom,
+void py_psi_displace_atom(SharedMatrix geom, const int atom,
                                   const int coord, const int sign,
                                   const double disp_size)
 {
-    return findif::displace_atom(geom, atom, coord, sign, disp_size);
+    findif::displace_atom(geom, atom, coord, sign, disp_size);
 }
 
 SharedWavefunction py_psi_dcft(SharedWavefunction ref_wfn)

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -129,6 +129,8 @@ void export_wavefunction(py::module& m) {
              "returns the wavefunction's electronic orbital extents.")
         .def("atomic_point_charges", &Wavefunction::get_atomic_point_charges,
              "Returns the set atomic point charges.")
+        .def("no_occupations", &Wavefunction::get_no_occupations,
+             "returns the natural orbital occupations on the wavefunction.")
         .def("normalmodes", &Wavefunction::get_normalmodes,
              "Returns the normal modes of the Wavefunction.")
         .def("normalmode_displacements", &Wavefunction::get_normalmodes_displacements,

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -1,4 +1,4 @@
-/*
+ /*
  * @BEGIN LICENSE
  *
  * Psi4: an open-source quantum chemistry software package
@@ -123,10 +123,16 @@ void export_wavefunction(py::module& m) {
         .def("frequencies", &Wavefunction::frequencies, "Returns the frequencies of the Hessian.")
         .def("set_frequencies", &Wavefunction::set_frequencies,
              "Sets the frequencies of the Hessian.")
+        .def("esp_at_nuclei", &Wavefunction::get_esp_at_nuclei,
+             "returns electrostatic potentials at nuclei")
+        .def("mo_extents", &Wavefunction::get_mo_extents,
+             "returns the wavefunction's electronic orbital extents.")
         .def("atomic_point_charges", &Wavefunction::get_atomic_point_charges,
              "Returns the set atomic point charges.")
-        .def("normalmodes", &Wavefunction::normalmodes,
+        .def("normalmodes", &Wavefunction::get_normalmodes,
              "Returns the normal modes of the Wavefunction.")
+        .def("normalmode_displacements", &Wavefunction::get_normalmodes_displacements,
+             "Returns the displacements for normalmodes")
         .def("set_name", &Wavefunction::set_name,
              "Sets the level of theory this wavefunction corresponds to.")
         .def("name", &Wavefunction::name, py::return_value_policy::copy,
@@ -204,7 +210,10 @@ void export_wavefunction(py::module& m) {
         .def("occupation_b", &scf::HF::occupation_b, "Returns the Beta occupation numbers.")
         .def("semicanonicalize", &scf::HF::semicanonicalize,
              "Semicanonicalizes the orbitals for ROHF.");
-
+    
+    py::class_<findif::VIBRATION, std::shared_ptr<findif::VIBRATION>>(m, "VIBRATION" , "docstring")
+        .def(py::init<int, int, double>());
+    
     py::class_<scf::RHF, std::shared_ptr<scf::RHF>, scf::HF>(m, "RHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>());
 

--- a/psi4/src/psi4/findif/fd_freq_1.cc
+++ b/psi4/src/psi4/findif/fd_freq_1.cc
@@ -40,6 +40,7 @@
 #include "psi4/libmints/cdsalclist.h"
 #include "psi4/libmints/pointgrp.h"
 #include "psi4/libmints/petitelist.h"
+#include "psi4/libmints/wavefunction.h"
 #include "psi4/physconst.h"
 
 #include "psi4/pybind11.h"
@@ -47,8 +48,8 @@
 namespace psi {
 namespace findif {
 
-SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
-                       const py::list &grad_list, int freq_irrep_only)
+SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, std::shared_ptr<Wavefunction> wfn, Options &options,
+                       const py::list &grad_list, int freq_irrep_only )
 {
     int pts = options.get_int("POINTS");
     double disp_size = options.get_double("DISP_SIZE");
@@ -259,8 +260,8 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
     char **irrep_lbls = mol->irrep_labels();
     double **H_irr[8];
 
-    std::vector < VIBRATION * > modes;
-
+    std::vector <std::shared_ptr<VIBRATION>> modes;
+    
     for (int h = 0; h < Nirrep; ++h) {
 
         if (salcs_pi[h].size() == 0) continue;
@@ -355,16 +356,15 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
         }
 
         for (int i = 0; i < salcs_pi[h].size(); ++i) {
-            double *v = init_array(3 * Natom);
+            std::shared_ptr<VIBRATION> vib(new VIBRATION(h, 3 * Natom, evals[i]));
             for (int x = 0; x < 3 * Natom; ++x)
-                v[x] = normal_irr[x][i];
-            VIBRATION *vib = new VIBRATION(h, evals[i], v);
+                vib->lx->set(0, x, normal_irr[x][i]);
             modes.push_back(vib);
         }
 
-        free(evals);
-        free_block(evects);
-        free_block(normal_irr);
+        //free(evals);
+        //free_block(evects);
+        //free_block(normal_irr);
     }
 
     // This print function also saves frequencies in wavefunction.
@@ -372,12 +372,8 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
 
     // Optionally, save normal modes to file.
     if (options.get_bool("NORMAL_MODES_WRITE")) {
-        save_normal_modes(mol, modes);
+        save_normal_modes(mol, wfn, modes);
     }
-
-    for (int i = 0; i < modes.size(); ++i)
-        delete modes[i];
-    modes.clear();
 
     // Build complete hessian for transformation to cartesians
     double **H = block_matrix(Nsalc_all, Nsalc_all);

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -150,6 +150,7 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<std::shared_ptr
       outfile->Printf( "  %s \t", mol->symbol(a).c_str() );
 
       for (int xyz=0; xyz<3; ++xyz)
+        outfile->Printf( "%8.3f", modes[i]->lx->get(3*a+xyz));
 
       outfile->Printf("%15.6f", mol->mass(a));
 

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -42,6 +42,7 @@
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/writer_file_prefix.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libmints/wavefunction.h"
 
 #include "psi4/libpsi4util/PsiOutStream.h"
 
@@ -49,7 +50,7 @@ namespace psi {
 using SharedMatrix=std::shared_ptr<Matrix>;
 namespace findif {
 
-bool ascending(const VIBRATION *vib1, const VIBRATION *vib2) {
+bool ascending(const std::shared_ptr<VIBRATION> vib1, const std::shared_ptr<VIBRATION> vib2) {
   if (vib1->km < vib2->km)
     return true;
   else
@@ -57,8 +58,9 @@ bool ascending(const VIBRATION *vib1, const VIBRATION *vib2) {
 }
 
 // function to print out (frequencies and normal modes) vector of vibrations
-void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes) {
+void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<std::shared_ptr<VIBRATION>> modes) {
 
+    outfile->Printf("Printing vibrations\n");
   char **irrep_lbls = mol->irrep_labels();
   int Natom = mol->natom();
 
@@ -69,12 +71,21 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
   const double cm_convert = 1.0/(2.0 * pc_pi * pc_c * 100.0);
 
   for (int i=0; i<modes.size(); ++i) {
-    if(modes[i]->km < 0.0)
+    outfile->Printf("modes %d is %f\n" , i , modes[i]->km);
+      if(modes[i]->km < 0.0){
+      outfile->Printf("<print if statement >modes %d is %f\n" , i , modes[i]->km);
       modes[i]->cm = -1*cm_convert * sqrt(-k_convert * modes[i]->km);
-    else
+      }
+              else {
+      outfile->Printf("<print if statement >modes %d is %f\n" , i , modes[i]->km);
       modes[i]->cm =    cm_convert * sqrt( k_convert * modes[i]->km);
+              }
   }
 
+  for (int i=0; i<modes.size(); ++i)
+    outfile->Printf("modes %d is %f\n" , i , modes[i]->km);
+  
+    
   // Sort modes by increasing eigenvalues.
   sort(modes.begin(), modes.end(), ascending);
 
@@ -105,7 +116,7 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
     freq_vector->set(i, modes[i]->cm);
     for (int a=0; a<Natom; ++a) {
         for (int xyz=0; xyz<3; xyz++) {
-            nm_vector->set(count, modes[i]->lx[3*a+xyz]);
+            nm_vector->set(count, modes[i]->lx->get(3*a+xyz));
             count++;
         }
     }
@@ -139,7 +150,6 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
       outfile->Printf( "  %s \t", mol->symbol(a).c_str() );
 
       for (int xyz=0; xyz<3; ++xyz)
-        outfile->Printf( "%8.3f", modes[i]->lx[3*a+xyz]);
 
       outfile->Printf("%15.6f", mol->mass(a));
 
@@ -155,8 +165,9 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
   free(irrep_lbls);
 }
 
-void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes)
+void save_normal_modes(std::shared_ptr<Molecule> mol,std::shared_ptr<Wavefunction> wfn, std::vector<std::shared_ptr<VIBRATION>> modes)
 {
+    wfn->set_normalmodes(modes);
     std::string normal_modes_fname = get_writer_file_prefix(mol->name()) + ".molden_normal_modes";
     std::shared_ptr <PsiOutStream> printer(new PsiOutStream(normal_modes_fname, std::ostream::trunc));
 
@@ -180,13 +191,13 @@ void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> m
         double norm2 = 0.0;
         for (int a = 0; a < Natom; a++) {
             for (int xyz = 0; xyz < 3; ++xyz){
-                norm2 += std::pow(modes[i]->get_lx(3 * a + xyz),2.0);
+                norm2 += std::pow(modes[i]->lx->get(3 * a + xyz),2.0);
             }
         }
         double scaling_factor = 1.0 / std::sqrt(norm2);
         for (int a = 0; a < Natom; a++) {
             for (int xyz = 0; xyz < 3; ++xyz){
-                double scaled_mode = scaling_factor * modes[i]->get_lx(3 * a + xyz);
+                double scaled_mode = scaling_factor * modes[i]->lx->get(3 * a + xyz);
                 printer->Printf(" %.6f",scaled_mode);
             }
             printer->Printf("\n");

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1147,6 +1147,7 @@ void OEProp::compute_esp_at_nuclei()
 {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
+    std::shared_ptr<std::vector<double>> nesps(new std::vector<double>(mol->natom()));
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
 
     int nbf = basisset_->nbf();

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1183,7 +1183,9 @@ void OEProp::compute_esp_at_nuclei()
                 atom1+1, mol->label(atom1).c_str(), nuc+elec);
         /*- Process::environment.globals["ESP AT CENTER n"] -*/
         Process::environment.globals[s.str()] = nuc+elec;
+        (*nesps)[atom1] = nuc+elec;
     }
+    wfn_->set_esp_at_nuclei(nesps);
     outfile->Printf( " ---------------------------------------------\n");
 }
 
@@ -1395,7 +1397,13 @@ void OEProp::compute_mo_extents()
         Ca = Ca_ao();
         Cb = Cb_ao();
     }
-
+    
+    std::vector<SharedVector> mo_es;
+    mo_es.push_back(SharedVector(new Vector("<x^2>", basisset_->nbf())));
+    mo_es.push_back(SharedVector(new Vector("<y^2>", basisset_->nbf())));
+    mo_es.push_back(SharedVector(new Vector("<z^2>", basisset_->nbf())));
+    mo_es.push_back(SharedVector(new Vector("<r^2>", basisset_->nbf())));
+    
     // Create a vector of matrices with the proper symmetry
     std::vector<SharedMatrix> ao_Dpole;
     std::vector<SharedMatrix> ao_Qpole;
@@ -1513,6 +1521,10 @@ void OEProp::compute_mo_extents()
                     std::fabs(quadrupole[1]->get(0, i)),
                     std::fabs(quadrupole[2]->get(0, i)),
                     std::fabs(xx + yy + zz));
+                    mo_es[0]->set(0,i,quadrupole[0]->get(0, i));
+                    mo_es[1]->set(0,i,quadrupole[1]->get(0, i));
+                    mo_es[2]->set(0,i,quadrupole[2]->get(0, i));
+                    mo_es[3]->set(0,i,fabs(xx + yy + zz));
         }
 
         outfile->Printf( "\n");
@@ -1524,6 +1536,7 @@ void OEProp::compute_mo_extents()
         // TODO: Both alpha and beta orbitals are reported separately
         // This helps identify symmetry breaking
     }
+    wfn_->set_mo_extents(mo_es);
 }
 
 void OEProp::compute_mulliken_charges()
@@ -1697,6 +1710,8 @@ void OEProp::compute_mayer_indices()
     outfile->Printf( "\n\n  Mayer Bond Indices:\n\n");
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
+    
+    SharedMatrix bis;
 
     int nbf = basisset_->nbf();
 
@@ -1798,7 +1813,8 @@ void OEProp::compute_mayer_indices()
         outfile->Printf( "  Atomic Valences: \n");
         MBI_valence->print();
     }
-
+    
+    wfn_->set_array("MAYER_INDICES", MBI_total);
 
 }
 void OEProp::compute_wiberg_lowdin_indices()
@@ -1808,7 +1824,7 @@ void OEProp::compute_wiberg_lowdin_indices()
 //    We may wanna get rid of these if we have NAOs...
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
-
+    
     int nbf = basisset_->nbf();
 
     SharedMatrix Da;
@@ -1912,6 +1928,7 @@ void OEProp::compute_wiberg_lowdin_indices()
         outfile->Printf( "  Atomic Valences: \n");
         WBI_valence->print();
     }
+    wfn_->set_array("WIBERG_LOWDIN_INDICES", WBI_total);
 }
 
 void OEProp::compute_no_occupations()
@@ -1919,8 +1936,12 @@ void OEProp::compute_no_occupations()
     char** labels = basisset_->molecule()->irrep_labels();
 
     outfile->Printf( "  Natural Orbital Occupations:\n\n");
+    
+    // Terminally, it will be [metric_a , metric_b, metric] or [metric] depending on same_dens
+    std::vector<std::vector<std::tuple<double, int, int> >> metrics;
 
     if (!same_dens_) {
+        
 
         SharedVector Oa;
         SharedVector Ob;
@@ -1940,7 +1961,9 @@ void OEProp::compute_no_occupations()
                 metric_a.push_back(std::tuple<double,int,int>(Oa->get(h,i), i ,h));
             }
         }
-
+        
+        metrics.push_back(metric_a);
+        
         std::sort(metric_a.begin(), metric_a.end(), std::greater<std::tuple<double,int,int> >());
         int offset_a = wfn_->nalpha();
         int start_occ_a = offset_a - max_noon_;
@@ -1968,6 +1991,8 @@ void OEProp::compute_no_occupations()
                 metric_b.push_back(std::tuple<double,int,int>(Ob->get(h,i), i ,h));
             }
         }
+        
+        metrics.push_back(metric_b);
 
         std::sort(metric_b.begin(), metric_b.end(), std::greater<std::tuple<double,int,int> >());
 
@@ -2002,6 +2027,8 @@ void OEProp::compute_no_occupations()
             metric.push_back(std::tuple<double,int,int>(Ot->get(h,i), i ,h));
         }
     }
+    
+    metrics.push_back(metric);
 
     std::sort(metric.begin(), metric.end(), std::greater<std::tuple<double,int,int> >());
 
@@ -2024,7 +2051,9 @@ void OEProp::compute_no_occupations()
         }
     }
     outfile->Printf( "\n");
-
+    
+    wfn_->set_no_occupations(metrics);
+    
     //for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
 
 }

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -47,6 +47,9 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/findif/findif.h"
+
+#include <typeinfo>
 
 #include <cstdlib>
 #include <cstdio>

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1017,26 +1017,100 @@ SharedVector Wavefunction::frequencies() const
     return frequencies_;
 }
 
-SharedVector Wavefunction::normalmodes() const
-{
-    return normalmodes_;
-}
-
-void Wavefunction::set_frequencies(SharedVector &freqs)
+void Wavefunction::set_frequencies(std::shared_ptr<Vector> &freqs)
 {
     frequencies_ = freqs;
 }
-
-void Wavefunction::set_normalmodes(SharedVector &norms)
+/*
+void Wavefunction::set_normalmodes(std::vector<std::shared_ptr<findif::VIBRATION>> modes)
 {
-    normalmodes_ = norms;
+    for (int i =0; i<sizeof(modes); i++) {
+        double *displacements = new double[modes[i]->size_lx()];
+        for (int j =0; j<modes[i]->size_lx(); j++)
+            displacements[j]=1.1;  //modes[i]->get_lx(j);
+        
+        std::shared_ptr<findif::VIBRATION> vib = std::make_shared<findif::VIBRATION>(i, modes[i]->get_km(), displacements);
+        
+        outfile->Printf("Well, you tried\n");
+        
+        normalmodes_.push_back(vib) ;
+    }
+    outfile->Printf("for loop exited\n");
+}
+*/
+
+std::vector<std::shared_ptr<findif::VIBRATION>> Wavefunction::get_normalmodes() const
+{
+    
+    std::vector<std::shared_ptr<findif::VIBRATION>> n_modes = normalmodes();
+    std::vector<std::shared_ptr<findif::VIBRATION>> normodes;
+    
+    //for (int i =0; i<sizeof(normalmodes_); i++) {
+    for (int i =0; i<3; i++) {
+        
+        std::shared_ptr<findif::VIBRATION> vib = std::make_shared<findif::VIBRATION>(i,n_modes[i]->get_km(), n_modes[i]->lx->dim());
+        
+        normodes.push_back(vib);
+    }
+    return normodes;
+}
+
+std::vector<Vector> Wavefunction::get_normalmodes_displacements() const
+{
+    std::vector<std::shared_ptr<findif::VIBRATION>> n_modes = normalmodes();
+    std::vector<Vector> disps;
+    int count =1;
+    
+    for (int i=0; i< 3*molecule_->natom() -6; i++) {
+        Vector my_vector(3*molecule_->natom());
+        for (int j = 0; j< 3 * molecule_->natom() ; j++) {
+            
+            my_vector.set(j, n_modes[i]->lx->get(0,j));
+            count++;
+            
+        }
+        disps.push_back(my_vector);
+    }
+    
+    return disps;
 }
 
 void Wavefunction::save() const
 {
 }
 
-SharedVector Wavefunction::get_atomic_point_charges() const
+std::shared_ptr<Vector> Wavefunction::get_esp_at_nuclei() const
+{
+    std::shared_ptr<std::vector<double>> v = esp_at_nuclei();
+    
+    int n = molecule_->natom();
+    std::shared_ptr<Vector> v_vector(new Vector(n));
+    for (int i = 0; i < n; ++i)
+        v_vector->set(i, (*v)[i]);
+    return v_vector;
+}
+
+std::vector<SharedVector> Wavefunction::get_mo_extents() const
+{
+    std::vector<SharedVector> m = mo_extents();
+    
+    int n = nmo_;
+    std::vector<SharedVector> mo_vectors;
+    mo_vectors.push_back(SharedVector(new Vector("<x^2>" , basisset_->nbf())));
+    mo_vectors.push_back(SharedVector(new Vector("<y^2>" , basisset_->nbf())));
+    mo_vectors.push_back(SharedVector(new Vector("<z^2>" , basisset_->nbf())));
+    mo_vectors.push_back(SharedVector(new Vector("<r^2>" , basisset_->nbf())));
+    for (int i = 0; i<n; i++) {
+        mo_vectors[0]->set(0,i,m[0]->get(0,i));
+        mo_vectors[1]->set(0,i,m[1]->get(0,i));
+        mo_vectors[2]->set(0,i,m[2]->get(0,i));
+        mo_vectors[3]->set(0,i,m[3]->get(0,i));
+    }
+    
+    return mo_vectors;
+}
+
+std::shared_ptr<Vector> Wavefunction::get_atomic_point_charges() const
 {
     std::shared_ptr<std::vector<double>> q = atomic_point_charges();
 
@@ -1047,7 +1121,26 @@ SharedVector Wavefunction::get_atomic_point_charges() const
     }
     return q_vector;
 }
-double Wavefunction::get_variable(std::string label) {
+
+std::vector<std::vector< std::tuple<double, int, int> >> Wavefunction::get_no_occupations() const
+{
+    
+    std::vector<std::vector< std::tuple<double, int, int> >> nos = no_occupations();
+    int nfsym = nos.size();
+    std::vector<std::vector< std::tuple<double, int, int> >> no_occs;
+    if (nfsym == 3) {
+        no_occs.push_back(nos[0]);
+        no_occs.push_back(nos[1]);
+        no_occs.push_back(nos[2]);
+    } else {
+        no_occs.push_back(nos[0]);
+    }
+    
+    return no_occs;
+}
+
+double Wavefunction::get_variable(std::string label)
+{
     std::string uc_label = label;
 
     if (variables_.count(uc_label) == 0) {

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -32,6 +32,7 @@
 #include "typedefs.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libmints/dimension.h"
+#include "psi4/findif/findif.h"
 
 #include <stddef.h>
 #include <vector>
@@ -215,7 +216,7 @@ protected:
     SharedVector frequencies_;
 
     /// If normal modes are available, they will be here:
-    SharedVector normalmodes_;
+    std::vector<std::shared_ptr<findif::VIBRATION>> normalmodes_;
 
     /// Same orbs or dens
     bool same_a_b_dens_;
@@ -509,16 +510,42 @@ public:
     void set_atomic_point_charges(const std::shared_ptr<std::vector<double>>& apcs){
        atomic_point_charges_=apcs;
     }
+    
+    /// Returns NO occupations
+    std::vector<std::vector< std::tuple<double, int, int> >> no_occupations()const{
+        return no_occupations_;
+    }
+    
+    /// Returns the NO occupations in vector form for python output
+    std::vector<std::vector< std::tuple<double, int, int> >> get_no_occupations() const;
+    
+    /// Sets the NO occupations
+    void set_no_occupations(const std::vector<std::vector< std::tuple<double, int, int> >> no_ocs){
+        no_occupations_=no_ocs;
+    }
 
     /// Returns the frequencies
     SharedVector frequencies() const;
     /// Set the frequencies for the wavefunction
-    void set_frequencies(SharedVector& freqs);
-
-    /// Returns the normalmodes
-    SharedVector normalmodes() const;
+    void set_frequencies(std::shared_ptr<Vector>& freqs);
+    
+    
+    /// Returns the normodes
+    std::vector<std::shared_ptr<findif::VIBRATION>> normalmodes() const{
+        return normalmodes_;
+    }
+    
+    /// Returns the normalmodes in vector form for python output
+    std::vector<std::shared_ptr<findif::VIBRATION>> get_normalmodes() const;
+    
+    /// Returns the atomic displacements for python output
+    std::vector<Vector>get_normalmodes_displacements() const;
+    
     /// Set the normalmodes for the wavefunction
-    void set_normalmodes(SharedVector& norms);
+    void set_normalmodes(std::vector<std::shared_ptr<findif::VIBRATION>>& modes){
+        normalmodes_= modes;
+    }
+    
 
     /// Set the wavefunction name (e.g. "RHF", "ROHF", "UHF", "CCEnergyWavefunction")
     void set_name(const std::string& name) { name_ = name; }

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -209,9 +209,18 @@ protected:
     std::vector<std::vector<int>> subset_occupation(const Dimension& noccpi,
                                                     const std::string& subset);
 
+    /// Should nuclear electrostatic potentials be available, they will be here
+    std::shared_ptr<std::vector<double>> esp_at_nuclei_;
+    
+    /// Should molecular orbital extents be available, they will be here
+    std::vector<SharedVector> mo_extents_;
+    
     /// If atomic point charges are available they will be here
     std::shared_ptr<std::vector<double>> atomic_point_charges_;
-
+    
+    /// Should natural orbital occupations be available, they will be here
+    std::vector<std::vector< std::tuple<double, int, int> >> no_occupations_;
+    
     /// If frequencies are available, they will be here:
     SharedVector frequencies_;
 
@@ -499,6 +508,32 @@ public:
     /// Set the Hessian for the wavefunction
     void set_hessian(SharedMatrix& hess);
 
+    /// Returns electrostatic potentials at nuclei
+    std::shared_ptr<std::vector<double>> esp_at_nuclei()const{
+        return esp_at_nuclei_;
+    }
+    
+    /// Returns electrostatic potentials at nuclei in Vector form for python output
+    std::shared_ptr<Vector> get_esp_at_nuclei() const;
+    
+    /// Sets the electrostatic potentials at nuclei
+    void set_esp_at_nuclei(const std::shared_ptr<std::vector<double>>& nesps){
+        esp_at_nuclei_=nesps;
+    }
+    
+    /// Returns Molecular orbital extents
+    std::vector<SharedVector> mo_extents()const{
+        return mo_extents_;
+    }
+    
+    /// Returns Molecular orbital extents in Vector form for python output.
+    std::vector<SharedVector> get_mo_extents() const;
+    
+    /// Sets molecular orbital extents
+    void set_mo_extents(const std::vector<SharedVector> mo_es){
+        mo_extents_ = mo_es;
+    }
+    
     /// Returns the atomic point charges
     std::shared_ptr<std::vector<double>> atomic_point_charges()const{
        return atomic_point_charges_;


### PR DESCRIPTION
## Description
Changes to psi4 for MDT interface.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] adds an optional history object to the optimize output. This object contains energies, gradients, and coordinates for the molecule at each step of the optimization. Hooked up to MDT.
  - [x] adds normalmode displacement export to the api and optional saving of normal modes to the wavefunction.
  - [x] Adds handling of several one-electron properties to the API and saves them to the wavefunction.



## Status
- [ ] Ready for comment but not for final merge.
