### PR TITLE
Adds pragma diagnostic macros for clang

### DIFF
--- a/psi4/include/psi4/pragma.h
+++ b/psi4/include/psi4/pragma.h
@@ -31,67 +31,80 @@
 #ifndef PULSAR_GUARD_PULSAR__PRAGMA_H_
 #define PULSAR_GUARD_PULSAR__PRAGMA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
-
 #if defined(__ICC) || defined(__INTEL_COMPILER)
 
-    // pragmas for Intel
-    #define PRAGMA_WARNING_POP                                 _Pragma("warning(pop)")
-    #define PRAGMA_WARNING_PUSH                                _Pragma("warning(push)")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_PARAMETERS            _Pragma("warning(disable:869)")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_VARIABLES             _Pragma("warning(disable:177)")
-    #define PRAGMA_WARNING_IGNORE_FP_EQUALITY                  _Pragma("warning(disable:1572)")
-    #define PRAGMA_WARNING_IGNORE_FP_CONVERT                   _Pragma("warning(disable:264 173)")
-    #define PRAGMA_WARNING_IGNORE_CONVERT                      _Pragma("warning(disable:2259)")
-    #define PRAGMA_WARNING_IGNORE_SWITCH_MISSING_DEFAULT       _Pragma("warning(disable:2338)")
-    #define PRAGMA_WARNING_IGNORE_POINTLESS_COMPARISON_UINT_0  _Pragma("warning(disable:186)")
-    #define PRAGMA_WARNING_IGNORE_STATEMENT_UNREACHABLE        _Pragma("warning(disable:111)")
-    #define PRAGMA_WARNING_IGNORE_SHADOW                       _Pragma("warning(disable:1599)")
-    #define PRAGMA_WARNING_IGNORE_SHADOW_MEMBER                _Pragma("warning(disable:3280)")
-    #define PRAGMA_WARNING_IGNORE_EXTRA_SEMICOLON              // does not have warning for intel
-    #define PRAGMA_WARNING_IGNORE_REDECLARED_INLINE            _Pragma("warning(disable:522)")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_LOCAL_TYPEDEFS        //! \todo add me
-    #define PRAGMA_WARNING_IGNORE_GCC_PRAGMA                   _Pragma("warning(disable:2282)")
-    #define PRAGMA_WARNING_IGNORE_NONVIRTUAL_DTOR              _Pragma("warning(disable:444)")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_FUNCTION              //! \todo add me
-    #define PRAGMA_WARNING_IGNORE_UNRECOGNIZED_PRAGMA          _Pragma("warning(disable:161)")
-    #define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("warning(disable:1478)")
+// pragmas for Intel
+#define PRAGMA_WARNING_POP                                 _Pragma("warning(pop)")
+#define PRAGMA_WARNING_PUSH                                _Pragma("warning(push)")
+#define PRAGMA_WARNING_IGNORE_UNUSED_PARAMETERS            _Pragma("warning(disable:869)")
+#define PRAGMA_WARNING_IGNORE_UNUSED_VARIABLES             _Pragma("warning(disable:177)")
+#define PRAGMA_WARNING_IGNORE_FP_EQUALITY                  _Pragma("warning(disable:1572)")
+#define PRAGMA_WARNING_IGNORE_FP_CONVERT                   _Pragma("warning(disable:264 173)")
+#define PRAGMA_WARNING_IGNORE_CONVERT                      _Pragma("warning(disable:2259)")
+#define PRAGMA_WARNING_IGNORE_SWITCH_MISSING_DEFAULT       _Pragma("warning(disable:2338)")
+#define PRAGMA_WARNING_IGNORE_POINTLESS_COMPARISON_UINT_0  _Pragma("warning(disable:186)")
+#define PRAGMA_WARNING_IGNORE_STATEMENT_UNREACHABLE        _Pragma("warning(disable:111)")
+#define PRAGMA_WARNING_IGNORE_SHADOW                       _Pragma("warning(disable:1599)")
+#define PRAGMA_WARNING_IGNORE_SHADOW_MEMBER                _Pragma("warning(disable:3280)")
+#define PRAGMA_WARNING_IGNORE_EXTRA_SEMICOLON              // does not have warning for intel
+#define PRAGMA_WARNING_IGNORE_REDECLARED_INLINE            _Pragma("warning(disable:522)")
+#define PRAGMA_WARNING_IGNORE_UNUSED_LOCAL_TYPEDEFS        //! \todo add me
+#define PRAGMA_WARNING_IGNORE_GCC_PRAGMA                   _Pragma("warning(disable:2282)")
+#define PRAGMA_WARNING_IGNORE_NONVIRTUAL_DTOR              _Pragma("warning(disable:444)")
+#define PRAGMA_WARNING_IGNORE_UNUSED_FUNCTION              //! \todo add me
+#define PRAGMA_WARNING_IGNORE_UNRECOGNIZED_PRAGMA          _Pragma("warning(disable:161)")
+#define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("warning(disable:1478)")
+#define PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
+
+#elif defined(__clang__)   // Do clang before GNU because clang defined __GNUC__, too.
+
+#define PRAGMA_WARNING_PUSH                                _Pragma("clang diagnostic push")
+#define PRAGMA_WARNING_POP                                 _Pragma("clang diagnostic pop")
+#define PRAGMA_WARNING_IGNORE_UNUSED_PARAMETERS            _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
+#define PRAGMA_WARNING_IGNORE_UNUSED_VARIABLES             _Pragma("clang diagnostic ignored \"-Wunused-variable\"")
+#define PRAGMA_WARNING_IGNORE_FP_EQUALITY                  _Pragma("clang diagnostic ignored \"-Wfloat-equal\"")
+#define PRAGMA_WARNING_IGNORE_FP_CONVERT                   _Pragma("clang diagnostic ignored \"-Wfloat-conversion\"")
+#define PRAGMA_WARNING_IGNORE_CONVERT                      _Pragma("clang diagnostic ignored \"-Wconversion\"")
+#define PRAGMA_WARNING_IGNORE_SWITCH_MISSING_DEFAULT       _Pragma("clang diagnostic ignored \"-Wswitch-default\"")
+#define PRAGMA_WARNING_IGNORE_POINTLESS_COMPARISON_UINT_0  _Pragma("clang diagnostic ignored \"-Wtype-limits\"")
+#define PRAGMA_WARNING_IGNORE_STATEMENT_UNREACHABLE        //! \todo Is this a warning in clang?
+#define PRAGMA_WARNING_IGNORE_SHADOW                       _Pragma("clang diagnostic ignored \"-Wshadow\"")
+#define PRAGMA_WARNING_IGNORE_SHADOW_MEMBER                //! \todo doesn't seem to warn in clang, or may be a part of -Wshadow
+#define PRAGMA_WARNING_IGNORE_EXTRA_SEMICOLON              _Pragma("clang diagnostic ignored \"-Wpedantic\"")
+#define PRAGMA_WARNING_IGNORE_REDECLARED_INLINE            // does not have warning for clang
+#define PRAGMA_WARNING_IGNORE_UNUSED_LOCAL_TYPEDEFS        _Pragma("clang diagnostic ignored \"-Wunused-local-typedefs\"")
+#define PRAGMA_WARNING_IGNORE_GCC_PRAGMA                   // uh... not a warning in gcc
+#define PRAGMA_WARNING_IGNORE_NONVIRTUAL_DTOR              // Doesn't seem to warn in clang
+#define PRAGMA_WARNING_IGNORE_UNUSED_FUNCTION              _Pragma("clang diagnostic ignored \"-Wunused-function\"")
+#define PRAGMA_WARNING_IGNORE_UNRECOGNIZED_PRAGMA          _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")
+#define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#define PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL           _Pragma("clang diagnostic ignored \"-Woverloaded-virtual\"")
 
 #elif defined(__GNUC__) || defined(__GNUG__)
 
-    // pragmas for GCC
-    #define PRAGMA_WARNING_PUSH                                _Pragma("GCC diagnostic push")
-    #define PRAGMA_WARNING_POP                                 _Pragma("GCC diagnostic pop")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_PARAMETERS            _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
-    #define PRAGMA_WARNING_IGNORE_UNUSED_VARIABLES             _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
-    #define PRAGMA_WARNING_IGNORE_FP_EQUALITY                  _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
-    #define PRAGMA_WARNING_IGNORE_FP_CONVERT                   _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")
-    #define PRAGMA_WARNING_IGNORE_CONVERT                      _Pragma("GCC diagnostic ignored \"-Wconversion\"")
-    #define PRAGMA_WARNING_IGNORE_SWITCH_MISSING_DEFAULT       _Pragma("GCC diagnostic ignored \"-Wswitch-default\"")
-    #define PRAGMA_WARNING_IGNORE_POINTLESS_COMPARISON_UINT_0  _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
-    #define PRAGMA_WARNING_IGNORE_STATEMENT_UNREACHABLE        //! \todo Is this a warning in GCC?
-    #define PRAGMA_WARNING_IGNORE_SHADOW                       _Pragma("GCC diagnostic ignored \"-Wshadow\"")
-    #define PRAGMA_WARNING_IGNORE_SHADOW_MEMBER                //! \todo doesn't seem to warn in GCC, or may be a part of -Wshadow 
-    #define PRAGMA_WARNING_IGNORE_EXTRA_SEMICOLON              _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
-    #define PRAGMA_WARNING_IGNORE_REDECLARED_INLINE            // does not have warning for GCC
-    #define PRAGMA_WARNING_IGNORE_UNUSED_LOCAL_TYPEDEFS        _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")
-    #define PRAGMA_WARNING_IGNORE_GCC_PRAGMA                   // uh... not a warning in gcc
-    #define PRAGMA_WARNING_IGNORE_NONVIRTUAL_DTOR              // Doesn't seem to warn in GCC
-    #define PRAGMA_WARNING_IGNORE_UNUSED_FUNCTION              _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-    #define PRAGMA_WARNING_IGNORE_UNRECOGNIZED_PRAGMA          _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
-    #define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#endif
+// pragmas for GCC
+#define PRAGMA_WARNING_PUSH                                _Pragma("GCC diagnostic push")
+#define PRAGMA_WARNING_POP                                 _Pragma("GCC diagnostic pop")
+#define PRAGMA_WARNING_IGNORE_UNUSED_PARAMETERS            _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
+#define PRAGMA_WARNING_IGNORE_UNUSED_VARIABLES             _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
+#define PRAGMA_WARNING_IGNORE_FP_EQUALITY                  _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#define PRAGMA_WARNING_IGNORE_FP_CONVERT                   _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")
+#define PRAGMA_WARNING_IGNORE_CONVERT                      _Pragma("GCC diagnostic ignored \"-Wconversion\"")
+#define PRAGMA_WARNING_IGNORE_SWITCH_MISSING_DEFAULT       _Pragma("GCC diagnostic ignored \"-Wswitch-default\"")
+#define PRAGMA_WARNING_IGNORE_POINTLESS_COMPARISON_UINT_0  _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
+#define PRAGMA_WARNING_IGNORE_STATEMENT_UNREACHABLE        //! \todo Is this a warning in GCC?
+#define PRAGMA_WARNING_IGNORE_SHADOW                       _Pragma("GCC diagnostic ignored \"-Wshadow\"")
+#define PRAGMA_WARNING_IGNORE_SHADOW_MEMBER                //! \todo doesn't seem to warn in GCC, or may be a part of -Wshadow
+#define PRAGMA_WARNING_IGNORE_EXTRA_SEMICOLON              _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define PRAGMA_WARNING_IGNORE_REDECLARED_INLINE            // does not have warning for GCC
+#define PRAGMA_WARNING_IGNORE_UNUSED_LOCAL_TYPEDEFS        _Pragma("GCC diagnostic ignored \"-Wunused-local-typedefs\"")
+#define PRAGMA_WARNING_IGNORE_GCC_PRAGMA                   // uh... not a warning in gcc
+#define PRAGMA_WARNING_IGNORE_NONVIRTUAL_DTOR              // Doesn't seem to warn in GCC
+#define PRAGMA_WARNING_IGNORE_UNUSED_FUNCTION              _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#define PRAGMA_WARNING_IGNORE_UNRECOGNIZED_PRAGMA          _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+#define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
 
-
-
-
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif

--- a/psi4/src/psi4/libmints/electrostatic.h
+++ b/psi4/src/psi4/libmints/electrostatic.h
@@ -28,7 +28,9 @@
 
 #ifndef _psi_src_lib_libmints_electrostatic_h_
 #define _psi_src_lib_libmints_electrostatic_h_
+
 #include "psi4/libmints/potential.h"
+#include "psi4/pragma.h"
 
 namespace psi {
 
@@ -61,15 +63,12 @@ public:
     /// Computes integrals between two shells.
     void compute_pair(const GaussianShell&, const GaussianShell&, const Vector3&);
 
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
+    PRAGMA_WARNING_PUSH
+    PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
     /// Computes integrals and stores in result.
     void compute(SharedMatrix& result, const Vector3&);
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    PRAGMA_WARNING_POP
+
     /// Does the method provide first derivatives?
     bool has_deriv1() { return false; }
 

--- a/psi4/src/psi4/liboptions/liboptions_python.h
+++ b/psi4/src/psi4/liboptions/liboptions_python.h
@@ -30,8 +30,8 @@
 #define _psi_src_lib_liboptions_python_h
 
 #include "liboptions.h"
-
 #include "psi4/pybind11.h"
+#include "psi4/pragma.h"
 
 namespace psi {
 
@@ -46,14 +46,11 @@ public:
     virtual std::string type() const;
 
     const py::object& to_python() const;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
+
+    PRAGMA_WARNING_PUSH
+    PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
     void assign(const py::object& p);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    PRAGMA_WARNING_POP
 };
 
 }


### PR DESCRIPTION
## Description
Adds diagnostic pragmas for clang to pragma.h and updates a couple of places to use them.

## Status
- [x] Ready to go
