### PR TITLE
ENH: Adds conv thresh for supermolec complex opt

### DIFF
--- a/doc/sphinxman/source/optking.rst
+++ b/doc/sphinxman/source/optking.rst
@@ -410,6 +410,8 @@ with Table :ref:`Geometry Convergence <table:optkingconv>`.
     +-----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
     | MOLPRO [#fb]_ [#fe]_        | :math:`1.0 \times 10^{-6}` | :math:`3.0 \times 10^{-4}` |                            | :math:`3.0 \times 10^{-4}` |                            |
     +-----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
+    | INTERFRAG_TIGHT [#fg]_      | :math:`1.0 \times 10^{-6}` | :math:`1.5 \times 10^{-5}` | :math:`1.0 \times 10^{-5}` | :math:`6.0 \times 10^{-4}` | :math:`4.0 \times 10^{-4}` |
+    +-----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
     | GAU_TIGHT [#fc]_ [#ff]_     |                            | :math:`1.5 \times 10^{-5}` | :math:`1.0 \times 10^{-5}` | :math:`6.0 \times 10^{-5}` | :math:`4.0 \times 10^{-5}` |
     +-----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+----------------------------+
     | GAU_VERYTIGHT [#ff]_        |                            | :math:`2.0 \times 10^{-6}` | :math:`1.0 \times 10^{-6}` | :math:`6.0 \times 10^{-6}` | :math:`4.0 \times 10^{-6}` | 
@@ -426,6 +428,9 @@ with Table :ref:`Geometry Convergence <table:optkingconv>`.
          **Max Disp**, and **RMS Disp**) are fulfilled. To help with flat 
          potential surfaces, alternate convergence achieved when 100\ :math:`\times`\ *rms force* is less 
          than **RMS Force** criterion.
+.. [#fg] Compensates for difficulties in converging geometry optmizations of supermolecular complexes 
+         tightly, where large *rms disp* and *max disp* may result from flat potential surfaces even when
+         *max force* and/or *rms force* are small.
 
 For ultimate control, specifying a value for any of the five monitored options activates that
 criterium and overwrites/appends it to the criteria set by |optking__g_convergence|.

--- a/psi4/src/psi4/optking/set_params.cc
+++ b/psi4/src/psi4/optking/set_params.cc
@@ -322,7 +322,7 @@ void set_params(void)
       Opt_params.conv_max_disp  = 6.0e-4;  Opt_params.i_max_disp = true;
       Opt_params.conv_rms_disp  = 4.0e-4;  Opt_params.i_rms_disp = true;
     }
-if (Opt_params.general_conv == "GAU_VERYTIGHT") {
+    else if (Opt_params.general_conv == "GAU_VERYTIGHT") {
       Opt_params.i_untampered = true;
       Opt_params.conv_max_force = 2.0e-6;  Opt_params.i_max_force = true;
       Opt_params.conv_rms_force = 1.0e-6;  Opt_params.i_rms_force = true;

--- a/psi4/src/psi4/optking/set_params.cc
+++ b/psi4/src/psi4/optking/set_params.cc
@@ -314,7 +314,15 @@ void set_params(void)
       Opt_params.conv_max_disp  = 6.0e-5;  Opt_params.i_max_disp = true;
       Opt_params.conv_rms_disp  = 4.0e-5;  Opt_params.i_rms_disp = true;
     }
-    else if (Opt_params.general_conv == "GAU_VERYTIGHT") {
+    else if (Opt_params.general_conv == "INTERFRAG_GAU_TIGHT") {
+      Opt_params.i_untampered = true;
+      Opt_params.conv_max_DE    = 1.0e-6;  Opt_params.i_max_DE = true;
+      Opt_params.conv_max_force = 1.5e-5;  Opt_params.i_max_force = true;
+      Opt_params.conv_rms_force = 1.0e-5;  Opt_params.i_rms_force = true;
+      Opt_params.conv_max_disp  = 6.0e-4;  Opt_params.i_max_disp = true;
+      Opt_params.conv_rms_disp  = 4.0e-4;  Opt_params.i_rms_disp = true;
+    }
+if (Opt_params.general_conv == "GAU_VERYTIGHT") {
       Opt_params.i_untampered = true;
       Opt_params.conv_max_force = 2.0e-6;  Opt_params.i_max_force = true;
       Opt_params.conv_rms_force = 1.0e-6;  Opt_params.i_rms_force = true;

--- a/psi4/src/psi4/optking/set_params.cc
+++ b/psi4/src/psi4/optking/set_params.cc
@@ -314,7 +314,7 @@ void set_params(void)
       Opt_params.conv_max_disp  = 6.0e-5;  Opt_params.i_max_disp = true;
       Opt_params.conv_rms_disp  = 4.0e-5;  Opt_params.i_rms_disp = true;
     }
-    else if (Opt_params.general_conv == "INTERFRAG_GAU_TIGHT") {
+    else if (Opt_params.general_conv == "INTERFRAG_TIGHT") {
       Opt_params.i_untampered = true;
       Opt_params.conv_max_DE    = 1.0e-6;  Opt_params.i_max_DE = true;
       Opt_params.conv_max_force = 1.5e-5;  Opt_params.i_max_force = true;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2419,7 +2419,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Set of optimization criteria. Specification of any MAX_*_G_CONVERGENCE
       or RMS_*_G_CONVERGENCE options will append to overwrite the criteria set here
       unless |optking__flexible_g_convergence| is also on.      See Table :ref:`Geometry Convergence <table:optkingconv>` for details. -*/
-      options.add_str("G_CONVERGENCE", "QCHEM", "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
+      options.add_str("G_CONVERGENCE", "QCHEM", "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT INTERFRAG_GAU_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
       /*- Convergence criterion for geometry optmization: maximum force
       (internal coordinates, atomic units). -*/
       options.add_double("MAX_FORCE_G_CONVERGENCE", 3.0e-4);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2419,7 +2419,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       /*- Set of optimization criteria. Specification of any MAX_*_G_CONVERGENCE
       or RMS_*_G_CONVERGENCE options will append to overwrite the criteria set here
       unless |optking__flexible_g_convergence| is also on.      See Table :ref:`Geometry Convergence <table:optkingconv>` for details. -*/
-      options.add_str("G_CONVERGENCE", "QCHEM", "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT INTERFRAG_GAU_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
+      options.add_str("G_CONVERGENCE", "QCHEM", "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT INTERFRAG_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
       /*- Convergence criterion for geometry optmization: maximum force
       (internal coordinates, atomic units). -*/
       options.add_double("MAX_FORCE_G_CONVERGENCE", 3.0e-4);


### PR DESCRIPTION
## Description
Adds convergence threshold option for geometry optimization of supermolecular complexes which is slight relaxation of `g_convergence gau_tight` criteria which allows for:
- tight convergence of energy and forces, and
- relaxed convergence of `max_disp` and `rms_disp` displacement criteria. 

These criteria allow for successful optimization on flat potential surfaces, especially those associated with interfragment (supermolecular) geometry optimizations.

## Todos
Adds `interfrag_gau_tight` value to `g_convergence` OPTKING convergence threshold control keyword.  

* **User-Facing for Release Notes**
  - Basic users can use keyword to achieve quality geometry optimizations of supermolecular complexes, without manual manipulation of individual `g_convergence` components.

## Questions
- [x] `interfrag_gau_tight` vs. `gau_tight_interfrag`? One one hand, it's a modification of `gau_tight`, but on the other hand, it has no counterpart within the Gaussian package.

## Status
- [x] Ready to go
