### PR TITLE
Char star replace for irrep_labels()

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1055,17 +1055,6 @@ void export_mints(py::module& m)
              "Print the bond angle geometrical parameters")
         .def("print_out_of_planes", &Molecule::print_out_of_planes,
              "Print the out-of-plane angle geometrical parameters to output file")
-        /*.def("irrep_labels",
-             [](Molecule& mol) {
-                 std::vector<std::string> ret;
-                 std::vector<std::string> labels = mol.irrep_labels();
-                 int nirrep = mol.point_group()->char_table().nirrep();
-                 for (size_t h = 0; h < nirrep; h++) {
-                     std::string lh(labels[h]);
-                     ret.push_back(lh);
-                 }
-                 return ret;
-             })*/
         .def_property("units", py::cpp_function(&Molecule::units),
                       py::cpp_function(&Molecule::set_units),
                       "Units (Angstrom or Bohr) used to define the geometry")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1055,7 +1055,7 @@ void export_mints(py::module& m)
              "Print the bond angle geometrical parameters")
         .def("print_out_of_planes", &Molecule::print_out_of_planes,
              "Print the out-of-plane angle geometrical parameters to output file")
-        .def("irrep_labels",
+        /*.def("irrep_labels",
              [](Molecule& mol) {
                  std::vector<std::string> ret;
                  std::vector<std::string> labels = mol.irrep_labels();
@@ -1065,7 +1065,7 @@ void export_mints(py::module& m)
                      ret.push_back(lh);
                  }
                  return ret;
-             })
+             })*/
         .def_property("units", py::cpp_function(&Molecule::units),
                       py::cpp_function(&Molecule::set_units),
                       "Units (Angstrom or Bohr) used to define the geometry")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1055,6 +1055,7 @@ void export_mints(py::module& m)
              "Print the bond angle geometrical parameters")
         .def("print_out_of_planes", &Molecule::print_out_of_planes,
              "Print the out-of-plane angle geometrical parameters to output file")
+        .def("irrep_labels", &Molecule::irrep_labels, "Returns Irreducible Representation symmetry labels")
         .def_property("units", py::cpp_function(&Molecule::units),
                       py::cpp_function(&Molecule::set_units),
                       "Units (Angstrom or Bohr) used to define the geometry")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1058,7 +1058,7 @@ void export_mints(py::module& m)
         .def("irrep_labels",
              [](Molecule& mol) {
                  std::vector<std::string> ret;
-                 char** labels = mol.irrep_labels();
+                 std::vector<std::string> labels = mol.irrep_labels();
                  int nirrep = mol.point_group()->char_table().nirrep();
                  for (size_t h = 0; h < nirrep; h++) {
                      std::string lh(labels[h]);

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -45,7 +45,7 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) :
     shallow_copy(ref_wfn);
     reference_wavefunction_ = ref_wfn;
 
-    char **irreps_      = molecule_->irrep_labels();
+    std::vector<std::string> irreps_      = molecule_->irrep_labels();
     aoccpi_             = new int[nirrep_];
     boccpi_             = new int[nirrep_];
     avirpi_             = new int[nirrep_];
@@ -94,7 +94,7 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) :
     outfile->Printf(     "\t*****************************************************\n");
     for(int h = 0; h < nirrep_; h++){
         outfile->Printf( "\t %3s   %3d   %3d   %3d   %3d   %3d   %3d   %3d   %3d\n",
-                irreps_[h], frzcpi_[h], doccpi_[h], soccpi_[h],
+                irreps_[h].c_str(), frzcpi_[h], doccpi_[h], soccpi_[h],
                 aoccpi_[h], avirpi_[h], boccpi_[h], bvirpi_[h], frzvpi_[h]);
     }
     outfile->Printf(     "\t*****************************************************\n\n");

--- a/psi4/src/psi4/adc/compute_energy.cc
+++ b/psi4/src/psi4/adc/compute_energy.cc
@@ -74,8 +74,8 @@ ADCWfn::compute_energy()
     bool first;
     int iter = 0;
     double denom;
-    std::string state_top = "ADC ROOT ";
-    char **irrep_      = molecule_->irrep_labels();
+    std::string state_top             = "ADC ROOT ";
+    std::vector<std::string> irrep_   = molecule_->irrep_labels();
 
     psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
     psio_->open(PSIF_ADC_SEM,      PSIO_OPEN_OLD);
@@ -108,7 +108,7 @@ ADCWfn::compute_energy()
 
                         sprintf(lbl, "V^(%d)_[%d]12", root, irrep);
                         global_dpd_->file2_init(&V, PSIF_ADC, irrep, ID('O'), ID('V'), lbl);
-                        outfile->Printf( "->\t%d%3s state   : %10.7f (a.u.), %10.7f (eV)\n", root+1, irrep_[irrep], omega[root], omega[root]*pc_hartree2ev);
+                        outfile->Printf( "->\t%d%3s state   : %10.7f (a.u.), %10.7f (eV)\n", root+1, irrep_[irrep].c_str(), omega[root], omega[root]*pc_hartree2ev);
                         outfile->Printf( "\tNon-iterative: %10.7f (a.u.), %10.7f (eV)\n", poles_[irrep][root].ps_value, poles_[irrep][root].ps_value*pc_hartree2ev);
                         outfile->Printf( "\t         Occ Vir        Coefficient\n");
                         outfile->Printf( "\t---------------------------------------------\n");

--- a/psi4/src/psi4/adc/prepare_tensors.cc
+++ b/psi4/src/psi4/adc/prepare_tensors.cc
@@ -74,7 +74,7 @@ ADCWfn::rhf_prepare_tensors()
     global_dpd_->buf4_sort_axpy(&V, PSIF_ADC, prqs, ID("[O,V]"), ID("[O,V]"), "A1234", 2.0);
     global_dpd_->buf4_close(&V);
     global_dpd_->buf4_init(&Aovov, PSIF_ADC, 0, ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), 0, "A1234");
-    char **irrep_      = molecule_->irrep_labels();
+    std::vector<std::string> irrep_      = molecule_->irrep_labels();
     for(int h = 0;h < nirrep_;h++){
         global_dpd_->buf4_mat_irrep_init(&Aovov, h);
         global_dpd_->buf4_mat_irrep_rd(&Aovov, h);
@@ -91,7 +91,7 @@ ADCWfn::rhf_prepare_tensors()
         lambda = block_matrix(Aovov.params->rowtot[h], rpi_[h]);
         if(rpi_[h]) david(Aovov.matrix[h], Aovov.params->coltot[h], rpi_[h], omega, lambda, 1e-14, 0);
         for(int root = 0;root < rpi_[h];root++){
-            if(DEBUG_) printf("%d%3s, %10.7f\n", root+1, irrep_[h], omega[root]);
+            if(DEBUG_) printf("%d%3s, %10.7f\n", root+1, irrep_[h].c_str(), omega[root]);
             omega_guess_->set(h,root, omega[root]);
             sprintf(lbl, "B^(%d)_[%d]12", root, h);
             global_dpd_->file2_init(&B, PSIF_ADC, h, ID('O'), ID('V'), lbl);
@@ -107,7 +107,7 @@ ADCWfn::rhf_prepare_tensors()
             }
             global_dpd_->file2_mat_wrt(&B);
             global_dpd_->file2_mat_close(&B);
-            outfile->Printf( "\t%d%3s state: %10.7f (a.u.), %10.7f (eV)\n", root+1, irrep_[h], omega[root], omega[root]*pc_hartree2ev);
+            outfile->Printf( "\t%d%3s state: %10.7f (a.u.), %10.7f (eV)\n", root+1, irrep_[h].c_str(), omega[root], omega[root]*pc_hartree2ev);
             outfile->Printf( "\t---------------------------------------------\n");
             int nprint;
             if(nxspi_[h] < num_amps_) nprint = nxspi_[h];

--- a/psi4/src/psi4/ccdensity/MOInfo.h
+++ b/psi4/src/psi4/ccdensity/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace ccdensity {
 
 struct MOInfo {
@@ -44,7 +47,7 @@ struct MOInfo {
     int *uoccpi;        /* no. of unoccupied orbitals per irrep excl. fruocc */
     int *frdocc;        /* no. of frozen core orbitals per irrep */
     int *fruocc;        /* no. of frozen unoccupied orbitals per irrep */
-    char **labels;      /* irrep labels */
+    std::vector<std::string> labels;      /* irrep labels */
     int nfzc;           /* total no. of frozen core orbitals */
     int nfzv;           /* total no. of frozen virtual orbitals */
     int nclsd;          /* total no. of closd shells excl. frdocc */

--- a/psi4/src/psi4/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/ccdensity/ccdensity.cc
@@ -535,8 +535,8 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options& options)
 
           //- <Lx|O|Ry> (y>x)
           outfile->Printf("\n\t*** Computing <%d%2s|X{pq}}|%d%2s> (LEFT) Transition Density ***\n\n",
-                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep],
-                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep]);
+                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep].c_str(),
+                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep].c_str());
           ex_td_setup(td_params[state1],td_params[state2]);
           outfile->Printf("\t\t*** LTD Setup complete.\n");
 
@@ -548,8 +548,8 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options& options)
 
           //- <Ly|O|Rx> (y>x)
           outfile->Printf("\n\t*** Computing <%d%2s|X{pq}}|%d%2s> (RIGHT) Transition Density ***\n\n",
-                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep],
-                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep]);
+                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep].c_str(),
+                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep].c_str());
           ex_td_setup(td_params[state2],td_params[state1]);
           outfile->Printf("\t\t*** RTD Setup complete.\n");
 
@@ -557,8 +557,8 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options& options)
           ex_tdensity('r',td_params[state2],td_params[state1]);
 
           outfile->Printf("\n\t*** %d%s -> %d%s transition densities complete.\n",
-                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep],
-                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep]);
+                td_params[state1].root+1,moinfo.labels[td_params[state1].irrep].c_str(),
+                td_params[state2].root+1,moinfo.labels[td_params[state2].irrep].c_str());
 
           //ex_oscillator_strength(&(td_params[j]),&(td_params[i+1]), &xtd_data);
           ex_oscillator_strength(ref_wfn, &(td_params[state1]),&(td_params[state2]), &xtd_data);

--- a/psi4/src/psi4/ccdensity/ex_oscillator_strength.cc
+++ b/psi4/src/psi4/ccdensity/ex_oscillator_strength.cc
@@ -212,7 +212,7 @@ void ex_oscillator_strength(SharedWavefunction wfn, struct TD_Params *S, struct 
   free_block(MUZ_SO);
 
   outfile->Printf("\n\tOscillator Strength for %d%3s to %d%3s\n",S->root+1,
-          moinfo.labels[S->irrep], U->root+1, moinfo.labels[U->irrep]);
+          moinfo.labels[S->irrep].c_str(), U->root+1, moinfo.labels[U->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
 

--- a/psi4/src/psi4/ccdensity/ex_rotational_strength.cc
+++ b/psi4/src/psi4/ccdensity/ex_rotational_strength.cc
@@ -72,7 +72,7 @@ void ex_rotational_strength(MintsHelper &mints, struct TD_Params *S, struct TD_P
   transdip(mints);
 
   outfile->Printf("\n\tLength-Gauge Rotational Strength for %d%3s to %d%3s Transition\n",S->root+1,
-          moinfo.labels[S->irrep], U->root+1, moinfo.labels[U->irrep]);
+          moinfo.labels[S->irrep].c_str(), U->root+1, moinfo.labels[U->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
   lt_x = lt_y = lt_z = 0.0;
@@ -157,7 +157,7 @@ void ex_rotational_strength(MintsHelper &mints, struct TD_Params *S, struct TD_P
 
 
   outfile->Printf("\n\tVelocity-Gauge Rotational Strength for %d%3s\n",S->root+1,
-          moinfo.labels[S->irrep], U->root+1, moinfo.labels[U->irrep]);
+          moinfo.labels[S->irrep].c_str(), U->root+1, moinfo.labels[U->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
   lt_x = lt_y = lt_z = 0.0;

--- a/psi4/src/psi4/ccdensity/ex_td_print.cc
+++ b/psi4/src/psi4/ccdensity/ex_td_print.cc
@@ -54,8 +54,8 @@ void ex_td_print(std::vector<struct XTD_Params> xtd_list)
   for(i=0; i<xtd_list.size(); i++) {
     //outfile->Printf("\t  %d%s->%d%s %7.3lf %9.1lf %7.1lf %10.6lf %8.4lf %8.4lf %8.4lf  %12.1lf\n",
     outfile->Printf("\t  %d%s->%d%s %7.3lf %9.1lf %7.1lf %10.6lf %8.4lf %8.4lf %8.4lf  %7.6E\n",
-            xtd_list[i].root1+1,moinfo.labels[xtd_list[i].irrep1],
-            xtd_list[i].root2+1,moinfo.labels[xtd_list[i].irrep2],
+            xtd_list[i].root1+1,moinfo.labels[xtd_list[i].irrep1].c_str(),
+            xtd_list[i].root2+1,moinfo.labels[xtd_list[i].irrep2].c_str(),
             xtd_list[i].cceom_energy*pc_hartree2ev,
             xtd_list[i].cceom_energy*pc_hartree2wavenumbers,
             1/(xtd_list[i].cceom_energy*_hartree2nm),

--- a/psi4/src/psi4/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/ccdensity/get_moinfo.cc
@@ -304,9 +304,6 @@ void cleanup(void)
     //  free(moinfo.uoccpi);
     //  free(moinfo.fruocc);
     //  free(moinfo.frdocc);
-    for(i=0; i < moinfo.nirreps; i++)
-        free(moinfo.labels[i]);
-    free(moinfo.labels);
 
     if(params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
         free(moinfo.occ_sym);

--- a/psi4/src/psi4/ccdensity/get_rho_params.cc
+++ b/psi4/src/psi4/ccdensity/get_rho_params.cc
@@ -249,7 +249,7 @@ void get_rho_params(Options& options)
   for(i=0; i<params.nstates; i++) {
     outfile->Printf("\t%5s     %d%3s %15.10lf %12.8lf\n",
             (rho_params[i].R_ground ? "Yes":"No"),
-            rho_params[i].L_root+1, moinfo.labels[rho_params[i].L_irr],
+            rho_params[i].L_root+1, moinfo.labels[rho_params[i].L_irr].c_str(),
             rho_params[i].cceom_energy,
             rho_params[i].R0);
   }

--- a/psi4/src/psi4/ccdensity/oscillator_strength.cc
+++ b/psi4/src/psi4/ccdensity/oscillator_strength.cc
@@ -209,7 +209,7 @@ void oscillator_strength(SharedWavefunction wfn, struct TD_Params *S)
   free_block(MUZ_SO);
 
   outfile->Printf("\n\tOscillator Strength for %d%3s\n",S->root+1,
-          moinfo.labels[S->irrep]);
+          moinfo.labels[S->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
   if((params.ref == 0) || (params.ref == 1)) {

--- a/psi4/src/psi4/ccdensity/rotational_strength.cc
+++ b/psi4/src/psi4/ccdensity/rotational_strength.cc
@@ -71,7 +71,7 @@ void rotational_strength(MintsHelper &mints, struct TD_Params *S)
   transdip(mints);
 
   outfile->Printf("\n\tLength-Gauge Rotational Strength for %d%3s\n",S->root+1,
-          moinfo.labels[S->irrep]);
+          moinfo.labels[S->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
   lt_x = lt_y = lt_z = 0.0;
@@ -153,7 +153,7 @@ void rotational_strength(MintsHelper &mints, struct TD_Params *S)
 
 
   outfile->Printf("\n\tVelocity-Gauge Rotational Strength for %d%3s\n",S->root+1,
-          moinfo.labels[S->irrep]);
+          moinfo.labels[S->irrep].c_str());
   outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
   lt_x = lt_y = lt_z = 0.0;

--- a/psi4/src/psi4/ccdensity/td_print.cc
+++ b/psi4/src/psi4/ccdensity/td_print.cc
@@ -54,7 +54,7 @@ void td_print(void)
   for(i=0; i<params.nstates; i++) {
     //outfile->Printf("\t %d%3s %7.3lf %9.1lf %7.1lf %10.6lf %8.4lf %8.4lf %8.4lf  %12.1lf\n",
     outfile->Printf("\t %d%3s %7.3lf %9.1lf %7.1lf %10.6lf %8.4lf %8.4lf %8.4lf  %7.6E\n",
-            td_params[i].root+1,moinfo.labels[td_params[i].irrep],
+            td_params[i].root+1,moinfo.labels[td_params[i].irrep].c_str(),
             td_params[i].cceom_energy*pc_hartree2ev,
             td_params[i].cceom_energy*pc_hartree2wavenumbers,
             1/(td_params[i].cceom_energy*_hartree2nm),

--- a/psi4/src/psi4/ccenergy/MOInfo.h
+++ b/psi4/src/psi4/ccenergy/MOInfo.h
@@ -34,6 +34,9 @@
 #ifndef _psi_src_bin_ccenergy_moinfo_h
 #define _psi_src_bin_ccenergy_moinfo_h
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace ccenergy {
 
 struct MOInfo {
@@ -50,7 +53,7 @@ struct MOInfo {
   int *frdocc;           /* no. of frozen core orbitals per irrep */
   int *fruocc;           /* no. of frozen unoccupied orbitals per irrep */
   int nvirt;             /* total no. of virtual orbitals */
-  char **labels;         /* irrep labels */
+  std::vector<std::string> labels;         /* irrep labels */
   int *occpi;            /* no. of occupied orbs. (incl. open) per irrep */
   int *aoccpi;           /* no. of alpha occupied orbs. (incl. open) per irrep */
   int *boccpi;           /* no. of beta occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/ccenergy/get_moinfo.cc
@@ -359,9 +359,6 @@ void CCEnergyWavefunction::cleanup(void)
 //    free(moinfo.uoccpi);
     //  free(moinfo.fruocc);
     //  free(moinfo.frdocc);
-    for(i=0; i < moinfo_.nirreps; i++)
-        free(moinfo_.labels[i]);
-    free(moinfo_.labels);
     if(params_.ref == 2) {
         free(moinfo_.aoccpi);
         free(moinfo_.boccpi);

--- a/psi4/src/psi4/cceom/MOInfo.h
+++ b/psi4/src/psi4/cceom/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace cceom {
 
 struct MOInfo {
@@ -47,7 +50,8 @@ struct MOInfo {
   int *frdocc;           /* no. of frozen core orbitals per irrep */
   int *fruocc;           /* no. of frozen unoccupied orbitals per irrep */
   int nvirt;             /* total no. of (active) virtual orbitals */
-  char **irr_labs;         /* irrep labels */
+  std::vector<std::string> irr_labs;         /* irrep labels */
+//TMS  char **irr_labs;         /* irrep labels */
   char **irr_labs_lowercase; /* irrep labels */
   int *occpi;            /* no. of occupied orbs. (incl. open) per irrep */
   int *aoccpi;           /* no. of alpha occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/cceom/MOInfo.h
+++ b/psi4/src/psi4/cceom/MOInfo.h
@@ -51,7 +51,6 @@ struct MOInfo {
   int *fruocc;           /* no. of frozen unoccupied orbitals per irrep */
   int nvirt;             /* total no. of (active) virtual orbitals */
   std::vector<std::string> irr_labs;         /* irrep labels */
-//TMS  char **irr_labs;         /* irrep labels */
   char **irr_labs_lowercase; /* irrep labels */
   int *occpi;            /* no. of occupied orbs. (incl. open) per irrep */
   int *aoccpi;           /* no. of alpha occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/cceom/diag.cc
+++ b/psi4/src/psi4/cceom/diag.cc
@@ -171,7 +171,7 @@ timer_off("HBAR_EXTRA");
   if (params.wfn == "EOM_CC3")
     cc3_stage = 0; /* do EOM_CCSD first */
 
-  outfile->Printf("Symmetry of ground state: %s\n", moinfo.irr_labs[moinfo.sym]);
+  outfile->Printf("Symmetry of ground state: %s\n", moinfo.irr_labs[moinfo.sym].c_str());
   /* loop over symmetry of C's */
   for (C_irr=0; C_irr<moinfo.nirreps; ++C_irr) {
 
@@ -184,8 +184,8 @@ timer_off("HBAR_EXTRA");
 #ifdef TIME_CCEOM
 timer_on("INIT GUESS");
 #endif
-    outfile->Printf("Symmetry of excited state: %s\n", moinfo.irr_labs[moinfo.sym ^ C_irr]);
-    outfile->Printf("Symmetry of right eigenvector: %s\n",moinfo.irr_labs[C_irr]);
+    outfile->Printf("Symmetry of excited state: %s\n", moinfo.irr_labs[moinfo.sym ^ C_irr].c_str());
+    outfile->Printf("Symmetry of right eigenvector: %s\n",moinfo.irr_labs[C_irr].c_str());
     if (params.eom_ref == 0)
       outfile->Printf("Seeking states with multiplicity of %d\n", eom_params.mult);
 
@@ -982,7 +982,7 @@ timer_off("INIT GUESS");
 
     if (num_converged > 0) {
       outfile->Printf("\nFinal Energetic Summary for Converged Roots of Irrep %s\n",
-	      moinfo.irr_labs[moinfo.sym^C_irr]);
+	      moinfo.irr_labs[moinfo.sym^C_irr].c_str());
       outfile->Printf("                     Excitation Energy              Total Energy\n");
       outfile->Printf("                (eV)     (cm^-1)     (au)             (au)\n");
       for (i=0;i<eom_params.cs_per_irrep[C_irr];++i) {

--- a/psi4/src/psi4/cceom/diagSS.cc
+++ b/psi4/src/psi4/cceom/diagSS.cc
@@ -246,7 +246,7 @@ void diagSS(int C_irr) {
    if (pf) outfile->Printf("%d initial single excitation guesses\n",C_index);
    if (C_index == 0) {
       outfile->Printf( "No intial guesses obtained for %s state \n",
-	      moinfo.irr_labs[moinfo.sym^C_irr]);
+	      moinfo.irr_labs[moinfo.sym^C_irr].c_str());
       exit(1);
     }
   }

--- a/psi4/src/psi4/cceom/get_eom_params.cc
+++ b/psi4/src/psi4/cceom/get_eom_params.cc
@@ -173,7 +173,7 @@ void get_eom_params(SharedWavefunction ref_wfn, Options &options)
   outfile->Printf( "\t-----------------\n");
   outfile->Printf( "\tStates sought per irrep     =");
   for(int i = 0; i < moinfo.nirreps; ++i)
-    outfile->Printf( " %s %d,", moinfo.irr_labs[i], eom_params.states_per_irrep[i]);
+    outfile->Printf( " %s %d,", moinfo.irr_labs[i].c_str(), eom_params.states_per_irrep[i]);
 
   outfile->Printf("\n");
   outfile->Printf( "\tMax. number of iterations   = %5d\n", eom_params.max_iter);
@@ -186,7 +186,7 @@ void get_eom_params(SharedWavefunction ref_wfn, Options &options)
   outfile->Printf( "\tResidual vector toleranceSS = %5.1e\n", eom_params.residual_tol_SS);
   outfile->Printf( "\tComplex tolerance           = %5.1e\n", eom_params.complex_tol);
   outfile->Printf( "\tRoot for properties         = %5d\n", eom_params.prop_root + 1);
-  outfile->Printf( "\tSym of state for properties = %6s\n", moinfo.irr_labs[eom_params.prop_sym]);
+  outfile->Printf( "\tSym of state for properties = %6s\n", moinfo.irr_labs[eom_params.prop_sym].c_str());
   outfile->Printf( "\tGuess vectors taken from    = %s\n", eom_params.guess.c_str());
   outfile->Printf( "\tRestart EOM CC3             = %s\n", eom_params.restart_eom_cc3?"YES":"NO");
   outfile->Printf( "\tCollapse with last vector   = %s\n", eom_params.collapse_with_last ? "YES":"NO");

--- a/psi4/src/psi4/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cceom/get_moinfo.cc
@@ -283,9 +283,6 @@ void cleanup(void)
 //    free(moinfo.fruocc);
 //    free(moinfo.frdocc);
     for(i=0; i < moinfo.nirreps; i++)
-        free(moinfo.irr_labs[i]);
-    free(moinfo.irr_labs);
-    for(i=0; i < moinfo.nirreps; i++)
         free(moinfo.irr_labs_lowercase[i]);
     free(moinfo.irr_labs_lowercase);
     if(params.ref == 2) {

--- a/psi4/src/psi4/cchbar/MOInfo.h
+++ b/psi4/src/psi4/cchbar/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace cchbar {
 
 struct MOInfo {
@@ -42,7 +45,7 @@ struct MOInfo {
   int *uoccpi;        /* no. of unoccupied orbitals per irrep excl. fruocc */
   int *frdocc;        /* no. of frozen core orbitals per irrep */
   int *fruocc;        /* no. of frozen unoccupied orbitals per irrep */
-  char **labels;      /* irrep labels */
+  std::vector<std::string> labels;      /* irrep labels */
   int *occ_sym;       /* relative occupied index symmetry */
   int *aocc_sym;      /* relative alpha occupied index symmetry */
   int *bocc_sym;      /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cchbar/get_moinfo.cc
+++ b/psi4/src/psi4/cchbar/get_moinfo.cc
@@ -183,9 +183,6 @@ void cleanup(void)
 //  free(moinfo.uoccpi);
 //  free(moinfo.fruocc);
 //  free(moinfo.frdocc);
-  for(i=0; i < moinfo.nirreps; i++)
-    free(moinfo.labels[i]);
-  free(moinfo.labels);
   if(params.ref == 2) {
     free(moinfo.aoccpi);
     free(moinfo.boccpi);

--- a/psi4/src/psi4/cclambda/MOInfo.h
+++ b/psi4/src/psi4/cclambda/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace cclambda {
 
 struct MOInfo {
@@ -47,7 +50,7 @@ struct MOInfo {
   int *frdocc;        /* no. of frozen core orbitals per irrep */
   int *fruocc;        /* no. of frozen unoccupied orbitals per irrep */
   int nvirt;          /* total no. of (active) virtual orbitals */
-  char **labels;      /* irrep labels */
+  std::vector<std::string> labels;      /* irrep labels */
   int *occpi;         /* no. of occupied orbs. (incl. open) per irrep */
   int *aoccpi;        /* no. of alpha occupied orbs. (incl. open) per irrep */
   int *boccpi;        /* no. of beta occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cclambda/cclambda.cc
@@ -243,9 +243,9 @@ double CCLambdaWavefunction::compute_energy()
       }
 
       outfile->Printf("\tSymmetry of left-hand state: %s\n",
-              moinfo.labels[ moinfo.sym^(pL_params[i].irrep) ]);
+              moinfo.labels[ moinfo.sym^(pL_params[i].irrep) ].c_str());
       outfile->Printf("\tSymmetry of left-hand eigenvector: %s\n",
-              moinfo.labels[(pL_params[i].irrep)]);
+              moinfo.labels[(pL_params[i].irrep)].c_str());
 
       denom(pL_params[i]); /* uses L_params.cceom_energy for excited states */
       init_amps(pL_params[i]); /* uses denominators for initial zeta guess */

--- a/psi4/src/psi4/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cclambda/get_moinfo.cc
@@ -270,9 +270,6 @@ void cleanup(void)
 //    free(moinfo.uoccpi);
 //    free(moinfo.fruocc);
 //    free(moinfo.frdocc);
-    for(i=0; i < moinfo.nirreps; i++)
-        free(moinfo.labels[i]);
-    free(moinfo.labels);
     if(params.ref == 2) {
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);

--- a/psi4/src/psi4/cclambda/projections.cc
+++ b/psi4/src/psi4/cclambda/projections.cc
@@ -360,7 +360,7 @@ void projections(struct L_Params *pL_params) {
     projection_tot = projection_0 + projection_S + projection_D;
     ael = projection_S + 2.0 * projection_D;
 
-    outfile->Printf("\n\tProjections for excited state, irrep %s, root %d:\n", moinfo.labels[0], root);
+    outfile->Printf("\n\tProjections for excited state, irrep %s, root %d:\n", moinfo.labels[0].c_str(), root);
     outfile->Printf("\t<0|Le^(-T)|0><0|Re^T|0>  = %15.10lf\n", projection_0);
     outfile->Printf("\t<0|Le^(-T)|S><S|Re^T|0>  = %15.10lf\n", projection_S);
     outfile->Printf("\t<0|Le^(-T)|D><D|Re^T|0>  = %15.10lf\n", projection_D);

--- a/psi4/src/psi4/ccresponse/MOInfo.h
+++ b/psi4/src/psi4/ccresponse/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace ccresponse {
 
 struct MOInfo {
@@ -52,7 +55,7 @@ struct MOInfo {
   int *fruocc;        /* no. of frozen unoccupied orbitals per irrep */
   int nvirt;          /* total no. of (active) virtual orbitals */
   int *actpi;         /* no. of active orbitals per irrep */
-  char **labels;      /* irrep labels */
+  std::vector<std::string> labels;      /* irrep labels */
   int *pitzer2qt;     /* Pitzer -> QT reordering array */
   int *qt2pitzer;     /* QT -> Pitzer reordering array */
   int *occpi;         /* no. of occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/ccresponse/get_moinfo.cc
@@ -315,10 +315,6 @@ void cleanup(void)
 //    free(moinfo.frdocc);
     free(moinfo.actpi);
 
-    for(i=0; i < moinfo.nirreps; i++)
-        free(moinfo.labels[i]);
-    free(moinfo.labels);
-
     free(moinfo.MU);
     free(moinfo.L);
     free(moinfo.P);

--- a/psi4/src/psi4/ccresponse/get_params.cc
+++ b/psi4/src/psi4/ccresponse/get_params.cc
@@ -224,12 +224,12 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options)
   outfile->Printf( "\tModel III        =    %s\n", params.sekino ? "Yes" : "No");
   outfile->Printf( "\tLinear Model     =    %s\n", params.linear ? "Yes" : "No");
   outfile->Printf( "\tABCD             =    %s\n", params.abcd.c_str());
-  outfile->Printf( "\tIrrep X          =    %s\n", moinfo.labels[moinfo.mu_irreps[0]]);
-  outfile->Printf( "\tIrrep Y          =    %s\n", moinfo.labels[moinfo.mu_irreps[1]]);
-  outfile->Printf( "\tIrrep Z          =    %s\n", moinfo.labels[moinfo.mu_irreps[2]]);
-  outfile->Printf( "\tIrrep RX         =    %s\n", moinfo.labels[moinfo.l_irreps[0]]);
-  outfile->Printf( "\tIrrep RY         =    %s\n", moinfo.labels[moinfo.l_irreps[1]]);
-  outfile->Printf( "\tIrrep RZ         =    %s\n", moinfo.labels[moinfo.l_irreps[2]]);
+  outfile->Printf( "\tIrrep X          =    %s\n", moinfo.labels[moinfo.mu_irreps[0]].c_str());
+  outfile->Printf( "\tIrrep Y          =    %s\n", moinfo.labels[moinfo.mu_irreps[1]].c_str());
+  outfile->Printf( "\tIrrep Z          =    %s\n", moinfo.labels[moinfo.mu_irreps[2]].c_str());
+  outfile->Printf( "\tIrrep RX         =    %s\n", moinfo.labels[moinfo.l_irreps[0]].c_str());
+  outfile->Printf( "\tIrrep RY         =    %s\n", moinfo.labels[moinfo.l_irreps[1]].c_str());
+  outfile->Printf( "\tIrrep RZ         =    %s\n", moinfo.labels[moinfo.l_irreps[2]].c_str());
   /*  Only length gauge calculations for polarizabilities */
   if (params.prop == "POLARIZABILITY")
   outfile->Printf( "\tGauge            =    LENGTH\n");

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -109,7 +109,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
 
   int nirreps = ref->nirrep();
   int nmo = ref->nmo();
-  char **labels = ref->molecule()->irrep_labels();
+  std::vector<std::string> labels = ref->molecule()->irrep_labels();
   double enuc = ref->molecule()->nuclear_repulsion_energy();
   double escf;
   if(ref->reference_wavefunction()) {
@@ -347,7 +347,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options& options)
             "\t-----\t-----\t------\t------\t------\t------\t------\n");
   for(int i=0; i < nirreps; i++) {
     outfile->Printf("\t %s\t   %d\t    %d\t    %d\t    %d\t    %d\t    %d\n",
-                    labels[i],nmopi[i],frzcpi[i],clsdpi[i],openpi[i],uoccpi[i],frzvpi[i]);
+                    labels[i].c_str(),nmopi[i],frzcpi[i],clsdpi[i],openpi[i],uoccpi[i],frzvpi[i]);
   }
 
   // Transformation

--- a/psi4/src/psi4/cctriples/MOInfo.h
+++ b/psi4/src/psi4/cctriples/MOInfo.h
@@ -31,6 +31,9 @@
     \brief Enter brief description of file here 
 */
 
+#include <string>
+#include <vector>
+
 namespace psi { namespace cctriples {
 
 struct MOInfo {
@@ -42,7 +45,7 @@ struct MOInfo {
   int *uoccpi;        /* no. of unoccupied orbitals per irrep excl. fruocc */
   int *frdocc;        /* no. of frozen core orbitals per irrep */
   int *fruocc;        /* no. of frozen unoccupied orbitals per irrep */
-  char **labels;      /* irrep labels */
+  std::vector<std::string> labels;      /* irrep labels */
   int *occpi;            /* no. of occupied orbs. (incl. open) per irrep */
   int *aoccpi;           /* no. of alpha occupied orbs. (incl. open) per irrep */
   int *boccpi;           /* no. of beta occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cctriples/get_moinfo.cc
@@ -243,9 +243,9 @@ void cleanup(void)
 //    free(moinfo.uoccpi);
 //    free(moinfo.fruocc);
 //    free(moinfo.frdocc);
-    for(i=0; i < moinfo.nirreps; i++)
-        free(moinfo.labels[i]);
-    free(moinfo.labels);
+    //for(i=0; i < moinfo.nirreps; i++)
+    //    free(moinfo.labels[i]);
+    //free(moinfo.labels);
     if(params.ref == 2) {
         free(moinfo.aoccpi);
         free(moinfo.boccpi);

--- a/psi4/src/psi4/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cctriples/get_moinfo.cc
@@ -243,9 +243,6 @@ void cleanup(void)
 //    free(moinfo.uoccpi);
 //    free(moinfo.fruocc);
 //    free(moinfo.frdocc);
-    //for(i=0; i < moinfo.nirreps; i++)
-    //    free(moinfo.labels[i]);
-    //free(moinfo.labels);
     if(params.ref == 2) {
         free(moinfo.aoccpi);
         free(moinfo.boccpi);

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -243,40 +243,40 @@ namespace psi{ namespace dcft{
 
       int *aIrrepCount = init_int_array(nirrep_);
       int *bIrrepCount = init_int_array(nirrep_);
-      char **irrepLabels = molecule_->irrep_labels();
+      std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
       outfile->Printf( "\n\tOrbital energies (a.u.):\n\t\tAlpha occupied orbitals\n\t\t");
       for (int i = 0, count = 0; i < nalpha_; ++i, ++count) {
           int irrep = aPairs[i].second;
-          outfile->Printf( "%4d%-4s%11.6f  ", ++aIrrepCount[irrep], irrepLabels[irrep], aPairs[i].first);
+          outfile->Printf( "%4d%-4s%11.6f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), aPairs[i].first);
           if (count % 4 == 3 && i != nalpha_)
               outfile->Printf( "\n\t\t");
       }
       outfile->Printf( "\n\n\t\tBeta occupied orbitals\n\t\t");
       for (int i = 0, count = 0; i < nbeta_; ++i, ++count) {
           int irrep = bPairs[i].second;
-          outfile->Printf( "%4d%-4s%11.6f  ", ++bIrrepCount[irrep], irrepLabels[irrep], bPairs[i].first);
+          outfile->Printf( "%4d%-4s%11.6f  ", ++bIrrepCount[irrep], irrepLabels[irrep].c_str(), bPairs[i].first);
           if (count % 4 == 3 && i != nbeta_)
               outfile->Printf( "\n\t\t");
       }
       outfile->Printf( "\n\n\t\tAlpha virtual orbitals\n\t\t");
       for (int i = nalpha_, count = 0; i < nmo_; ++i, ++count) {
           int irrep = aPairs[i].second;
-          outfile->Printf( "%4d%-4s%11.6f  ", ++aIrrepCount[irrep], irrepLabels[irrep], aPairs[i].first);
+          outfile->Printf( "%4d%-4s%11.6f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), aPairs[i].first);
           if (count % 4 == 3 && i != nmo_)
               outfile->Printf( "\n\t\t");
       }
       outfile->Printf( "\n\n\t\tBeta virtual orbitals\n\t\t");
       for (int i = nbeta_, count = 0; i < nmo_; ++i, ++count) {
           int irrep = bPairs[i].second;
-          outfile->Printf( "%4d%-4s%11.6f  ", ++bIrrepCount[irrep], irrepLabels[irrep], bPairs[i].first);
+          outfile->Printf( "%4d%-4s%11.6f  ", ++bIrrepCount[irrep], irrepLabels[irrep].c_str(), bPairs[i].first);
           if (count % 4 == 3 && i != nmo_)
               outfile->Printf( "\n\t\t");
       }
       outfile->Printf( "\n\n");
 
       outfile->Printf( "\n\tIrrep              ");
-      for(int h = 0; h < nirrep_; ++h) outfile->Printf( "%4s ", irrepLabels[h]);
+      for(int h = 0; h < nirrep_; ++h) outfile->Printf( "%4s ", irrepLabels[h].c_str());
       outfile->Printf( "\n\t-------------------");
       for(int h = 0; h < nirrep_; ++h) outfile->Printf( "-----");
       outfile->Printf( "\n\t#Symmetry Orbitals ");
@@ -297,9 +297,9 @@ namespace psi{ namespace dcft{
           Ca_->print();
           Cb_->print();
       }
-      for (int h = 0; h < nirrep_; ++h)
-          delete [] irrepLabels[h];
-      delete[] irrepLabels;
+      //for (int h = 0; h < nirrep_; ++h)
+      //    delete [] irrepLabels[h];
+      //delete[] irrepLabels;
       delete[] aIrrepCount;
       delete[] bIrrepCount;
   }

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -297,9 +297,6 @@ namespace psi{ namespace dcft{
           Ca_->print();
           Cb_->print();
       }
-      //for (int h = 0; h < nirrep_; ++h)
-      //    delete [] irrepLabels[h];
-      //delete[] irrepLabels;
       delete[] aIrrepCount;
       delete[] bIrrepCount;
   }

--- a/psi4/src/psi4/dcft/dcft_tau_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_tau_RHF.cc
@@ -352,26 +352,23 @@ DCFTSolver::print_opdm_RHF()
 
     int *aIrrepCount = init_int_array(nirrep_);
     int *bIrrepCount = init_int_array(nirrep_);
-    char **irrepLabels = molecule_->irrep_labels();
+    std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
     outfile->Printf( "\n\tOrbital occupations:\n\t\tDoubly occupied orbitals\n\t\t");
     for (int i = 0, count = 0; i < nalpha_; ++i, ++count) {
         int irrep = aPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep], 2 * aPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), 2 * aPairs[i].first);
         if (count % 4 == 3 && i != nalpha_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n\t\tVirtual orbitals\n\t\t");
     for (int i = nalpha_, count = 0; i < nmo_; ++i, ++count) {
         int irrep = aPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep], 2 * aPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), 2 * aPairs[i].first);
         if (count % 4 == 3 && i != nmo_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n");
-    for (int h = 0; h < nirrep_; ++h)
-        free(irrepLabels[h]);
-    free(irrepLabels);
     free(aIrrepCount);
     free(bIrrepCount);
 

--- a/psi4/src/psi4/dcft/dcft_tau_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_tau_UHF.cc
@@ -789,40 +789,37 @@ DCFTSolver::print_opdm()
 
     int *aIrrepCount = init_int_array(nirrep_);
     int *bIrrepCount = init_int_array(nirrep_);
-    char **irrepLabels = molecule_->irrep_labels();
+    std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
     outfile->Printf( "\n\tOrbital occupations:\n\t\tAlpha occupied orbitals\n\t\t");
     for (int i = 0, count = 0; i < nalpha_; ++i, ++count) {
         int irrep = aPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep], aPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), aPairs[i].first);
         if (count % 4 == 3 && i != nalpha_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n\t\tBeta occupied orbitals\n\t\t");
     for (int i = 0, count = 0; i < nbeta_; ++i, ++count) {
         int irrep = bPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++bIrrepCount[irrep], irrepLabels[irrep], bPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++bIrrepCount[irrep], irrepLabels[irrep].c_str(), bPairs[i].first);
         if (count % 4 == 3 && i != nbeta_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n\t\tAlpha virtual orbitals\n\t\t");
     for (int i = nalpha_, count = 0; i < nmo_; ++i, ++count) {
         int irrep = aPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep], aPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), aPairs[i].first);
         if (count % 4 == 3 && i != nmo_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n\t\tBeta virtual orbitals\n\t\t");
     for (int i = nbeta_, count = 0; i < nmo_; ++i, ++count) {
         int irrep = bPairs[i].second;
-        outfile->Printf( "%4d%-4s%11.4f  ", ++bIrrepCount[irrep], irrepLabels[irrep], bPairs[i].first);
+        outfile->Printf( "%4d%-4s%11.4f  ", ++bIrrepCount[irrep], irrepLabels[irrep].c_str(), bPairs[i].first);
         if (count % 4 == 3 && i != nmo_)
             outfile->Printf( "\n\t\t");
     }
     outfile->Printf( "\n\n");
-    for (int h = 0; h < nirrep_; ++h)
-        free(irrepLabels[h]);
-    free(irrepLabels);
     free(aIrrepCount);
     free(bIrrepCount);
 }

--- a/psi4/src/psi4/detci/structs.h
+++ b/psi4/src/psi4/detci/structs.h
@@ -359,7 +359,7 @@ struct calcinfo {
    int num_bet;          /* number of beta electrons */
    int num_alp_expl;     /* number of alpha electrons explicitly treated */
    int num_bet_expl;     /* number of beta electrons explicitly treated */
-   char **labels;        /* labels for irreps */
+   std::vector<std::string> labels;   /* labels for irreps */
    int *orbsym;          /* irrep for each orbital */
    std::vector<int> reorder;         /* map Pitzer-ordered orbitals to our ordering */
    std::vector<int> order;           /* map our ordering back to Pitzer ordering */

--- a/psi4/src/psi4/findif/fd_freq_0.cc
+++ b/psi4/src/psi4/findif/fd_freq_0.cc
@@ -149,7 +149,7 @@ SharedMatrix fd_freq_0(std::shared_ptr <Molecule> mol, Options &options,
     // SharedMatrix rot_trans_out = salc_list.matrix_projected_out();
     //int num_projected_out = rot_trans_out->nrow();
 
-    char **irrep_lbls = mol->irrep_labels();
+    std::vector<std::string> irrep_lbls = mol->irrep_labels();
     double **H_irr[8]; // hessian by irrep block
 
     std::vector < VIBRATION * > modes;
@@ -227,7 +227,7 @@ SharedMatrix fd_freq_0(std::shared_ptr <Molecule> mol, Options &options,
         } // i, salc_i
 
         if (print_lvl >= 3) {
-            outfile->Printf("\n\tForce Constants for irrep %s in mass-weighted, ", irrep_lbls[h]);
+            outfile->Printf("\n\tForce Constants for irrep %s in mass-weighted, ", irrep_lbls[h].c_str());
             outfile->Printf("symmetry-adapted cartesian coordinates.\n");
             mat_print(H_irr[h], salcs_pi[h].size(), salcs_pi[h].size(), "outfile");
         }
@@ -253,7 +253,7 @@ SharedMatrix fd_freq_0(std::shared_ptr <Molecule> mol, Options &options,
                 dim, 0, normal_irr[0], dim);
 
         if (print_lvl >= 3) {
-            outfile->Printf("\n\tNormal coordinates (non-mass-weighted) for irrep %s:\n", irrep_lbls[h]);
+            outfile->Printf("\n\tNormal coordinates (non-mass-weighted) for irrep %s:\n", irrep_lbls[h].c_str());
             eivout(normal_irr, evals, 3 * Natom, dim, "outfile");
         }
 

--- a/psi4/src/psi4/findif/fd_freq_1.cc
+++ b/psi4/src/psi4/findif/fd_freq_1.cc
@@ -256,7 +256,7 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
             gradients[i]->print();
     }
 
-    char **irrep_lbls = mol->irrep_labels();
+    std::vector<std::string> irrep_lbls = mol->irrep_labels();
     double **H_irr[8];
 
     std::vector < VIBRATION * > modes;
@@ -327,7 +327,7 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
         }
 
         if (print_lvl >= 3) {
-            outfile->Printf("\n\tForce Constants for irrep %s in mass-weighted, ", irrep_lbls[h]);
+            outfile->Printf("\n\tForce Constants for irrep %s in mass-weighted, ", irrep_lbls[h].c_str());
             outfile->Printf("symmetry-adapted cartesian coordinates.\n");
             mat_print(H_irr[h], salcs_pi[h].size(), salcs_pi[h].size(), "outfile");
         }
@@ -350,7 +350,7 @@ SharedMatrix fd_freq_1(std::shared_ptr <Molecule> mol, Options &options,
                 dim, 0, normal_irr[0], dim);
 
         if (print_lvl >= 2) {
-            outfile->Printf("\n\tNormal coordinates (non-mass-weighted) for irrep %s:\n", irrep_lbls[h]);
+            outfile->Printf("\n\tNormal coordinates (non-mass-weighted) for irrep %s:\n", irrep_lbls[h].c_str());
             eivout(normal_irr, evals, 3 * Natom, dim, "outfile");
         }
 

--- a/psi4/src/psi4/findif/fd_misc.cc
+++ b/psi4/src/psi4/findif/fd_misc.cc
@@ -59,7 +59,7 @@ bool ascending(const VIBRATION *vib1, const VIBRATION *vib2) {
 // function to print out (frequencies and normal modes) vector of vibrations
 void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes) {
 
-  char **irrep_lbls = mol->irrep_labels();
+  std::vector<std::string> irrep_lbls = mol->irrep_labels();
   int Natom = mol->natom();
 
   // compute harmonic frequencies, +/- in wavenumbers
@@ -85,9 +85,9 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
 
   for(int i=0; i<modes.size(); ++i) {
     if(modes[i]->cm < 0.0)
-      outfile->Printf( "\t  %5s   %15.4fi \n", irrep_lbls[modes[i]->irrep], -modes[i]->cm);
+      outfile->Printf( "\t  %5s   %15.4fi \n", irrep_lbls[modes[i]->irrep].c_str(), -modes[i]->cm);
     else
-      outfile->Printf( "\t  %5s   %15.4f  \n", irrep_lbls[modes[i]->irrep], modes[i]->cm);
+      outfile->Printf( "\t  %5s   %15.4f  \n", irrep_lbls[modes[i]->irrep].c_str(), modes[i]->cm);
   }
 
   outfile->Printf(   "\t-----------------------------------------------\n");
@@ -150,9 +150,6 @@ void print_vibrations(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> mo
   // awkward, but need nirrep to free labels
   int Nirrep = mol->point_group()->char_table().nirrep();
 
-  for (int i=0; i<Nirrep; ++i)
-    free(irrep_lbls[i]);
-  free(irrep_lbls);
 }
 
 void save_normal_modes(std::shared_ptr<Molecule> mol, std::vector<VIBRATION *> modes)

--- a/psi4/src/psi4/libfock/apps.cc
+++ b/psi4/src/psi4/libfock/apps.cc
@@ -392,20 +392,17 @@ void RCIS::print_wavefunctions()
     outfile->Printf("  %5s %11s %14s %14s\n",
         "State", "Description", "dE (H)", "dE (eV)");
     outfile->Printf("  -----------------------------------------------\n");
-    char** labels = basisset_->molecule()->irrep_labels();
+    std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
     for (size_t i = 0; i < states_.size(); i++) {
         double E = std::get<0>(states_[i]);
         int    j = std::get<1>(states_[i]);
         int    m = std::get<2>(states_[i]);
         int    h = std::get<3>(states_[i]);
         outfile->Printf("  %-5d %1s%-5d(%3s) %14.6E %14.6E\n",
-            i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h], E, pc_hartree2ev * E);
+            i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h].c_str(), E, pc_hartree2ev * E);
     }
     outfile->Printf("  -----------------------------------------------\n");
     outfile->Printf( "\n");
-
-    for(int h = 0; h < Caocc_->nirrep(); ++h) free(labels[h]); free(labels);
-
 
     if (debug_ > 1) {
         if (singlets_.size()) {
@@ -439,7 +436,7 @@ void RCIS::print_amplitudes()
     outfile->Printf("  %5s %11s %20s %11s\n",
         "State", "Description", "Excitation", "Amplitude");
     outfile->Printf("  --------------------------------------------------\n");
-    char** labels = basisset_->molecule()->irrep_labels();
+    std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
     for (size_t i = 0; i < states_.size(); i++) {
 //        double E = std::get<0>(states_[i]);
         int    j = std::get<1>(states_[i]);
@@ -474,25 +471,24 @@ void RCIS::print_amplitudes()
             std::sort(amps.begin(), amps.end());
             std::reverse(amps.begin(), amps.end());
             outfile->Printf("  %-5d %1s%-5d(%3s) %5d%-3s -> %5d%-3s %11.3E\n",
-                i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h],
-                std::get<1>(amps[0]) + 1, labels[std::get<2>(amps[0])],
-                std::get<3>(amps[0]) + 1, labels[std::get<4>(amps[0])],
+                i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h].c_str(),
+                std::get<1>(amps[0]) + 1, labels[std::get<2>(amps[0])].c_str(),
+                std::get<3>(amps[0]) + 1, labels[std::get<4>(amps[0])].c_str(),
                 std::get<0>(amps[0]));
             for (size_t index = 1; index < amps.size(); index++) {
                 outfile->Printf("                    %5d%-3s -> %5d%-3s %11.3E\n",
-                    std::get<1>(amps[index]) + 1, labels[std::get<2>(amps[index])],
-                    std::get<3>(amps[index]) + 1, labels[std::get<4>(amps[index])],
+                    std::get<1>(amps[index]) + 1, labels[std::get<2>(amps[index])].c_str(),
+                    std::get<3>(amps[index]) + 1, labels[std::get<4>(amps[index])].c_str(),
                     std::get<0>(amps[index]));
             }
         } else {
             outfile->Printf("  %-5d %1s%-5d(%3s) %s\n",
-                i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h], "No Significant Amplitudes");
+                i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h].c_str(), "No Significant Amplitudes");
         }
 
         outfile->Printf("  --------------------------------------------------\n");
     }
     outfile->Printf( "\n");
-    for(int h = 0; h < Caocc_->nirrep(); ++h) free(labels[h]); free(labels);
 }
 void RCIS::print_transitions()
 {
@@ -515,7 +511,7 @@ void RCIS::print_transitions()
     outfile->Printf("  %5s %11s %11s %11s %11s %14s\n",
         "State", "Description", "mu_x", "mu_y", "mu_z", "f");
     outfile->Printf("  --------------------------------------------------------------------\n");
-    char** labels = basisset_->molecule()->irrep_labels();
+    std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
     for (size_t i = 0; i < states_.size(); i++) {
 
         double E = std::get<0>(states_[i]);
@@ -542,11 +538,10 @@ void RCIS::print_transitions()
         double f = 2.0 / 3.0 * E * (mu[0] * mu[0] + mu[1] * mu[1] + mu[2] * mu[2]);
 
         outfile->Printf("  %-5d %1s%-5d(%3s) %11.3E %11.3E %11.3E %14.6E\n",
-            i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h], mu[0],mu[1],mu[2],f);
+            i + 1, (m == 1 ? "S" : "T"), j + 1, labels[h].c_str(), mu[0],mu[1],mu[2],f);
     }
     outfile->Printf("  --------------------------------------------------------------------\n");
     outfile->Printf( "\n");
-    for(int h = 0; h < Caocc_->nirrep(); ++h) free(labels[h]); free(labels);
 }
 void RCIS::print_densities()
 {

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2927,19 +2927,13 @@ std::string Molecule::sym_label()
     return pg_->symbol();
 }
 
-//char **Molecule::irrep_labels()
 std::vector<std::string> Molecule::irrep_labels()
 {
     if (pg_ == NULL) set_point_group(find_point_group());
     int nirreps = pg_->char_table().nirrep();
     std::vector<std::string> irreplabel;
-    //char **irreplabel = (char **) malloc(sizeof(char *) * nirreps);
     for (int i = 0; i < nirreps; i++) {
-        //irreplabel[i] = (char *) malloc(sizeof(char) * 5);
-        //::memset(irreplabel[i], 0, sizeof(char) * 5);
-        ////strcpy(irreplabel[i],pg_->char_table().gamma(i).symbol());
-        //strcpy(irreplabel[i], pg_->char_table().gamma(i).symbol_ns());
-        irreplabel[i]=pg_->char_table().gamma(i).symbol_ns();
+        irreplabel.push_back(pg_->char_table().gamma(i).symbol_ns());
     }
     return irreplabel;
 }

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2927,16 +2927,19 @@ std::string Molecule::sym_label()
     return pg_->symbol();
 }
 
-char **Molecule::irrep_labels()
+//char **Molecule::irrep_labels()
+std::vector<std::string> Molecule::irrep_labels()
 {
     if (pg_ == NULL) set_point_group(find_point_group());
     int nirreps = pg_->char_table().nirrep();
-    char **irreplabel = (char **) malloc(sizeof(char *) * nirreps);
+    std::vector<std::string> irreplabel;
+    //char **irreplabel = (char **) malloc(sizeof(char *) * nirreps);
     for (int i = 0; i < nirreps; i++) {
-        irreplabel[i] = (char *) malloc(sizeof(char) * 5);
-        ::memset(irreplabel[i], 0, sizeof(char) * 5);
-        //strcpy(irreplabel[i],pg_->char_table().gamma(i).symbol());
-        strcpy(irreplabel[i], pg_->char_table().gamma(i).symbol_ns());
+        //irreplabel[i] = (char *) malloc(sizeof(char) * 5);
+        //::memset(irreplabel[i], 0, sizeof(char) * 5);
+        ////strcpy(irreplabel[i],pg_->char_table().gamma(i).symbol());
+        //strcpy(irreplabel[i], pg_->char_table().gamma(i).symbol_ns());
+        irreplabel[i]=pg_->char_table().gamma(i).symbol_ns();
     }
     return irreplabel;
 }

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -489,7 +489,8 @@ public:
     /// Returns the symmetry label
     std::string sym_label();
     /// Returns the irrep labels
-    char** irrep_labels();
+    std::vector<std::string> irrep_labels();
+    //char** irrep_labels();
     const std::string& symmetry_from_input() const { return symmetry_from_input_; }
 
     /**

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -490,7 +490,6 @@ public:
     std::string sym_label();
     /// Returns the irrep labels
     std::vector<std::string> irrep_labels();
-    //char** irrep_labels();
     const std::string& symmetry_from_input() const { return symmetry_from_input_; }
 
     /**

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1485,7 +1485,7 @@ void OEProp::compute_mo_extents()
             quadrupole[2]->set(0, i, std::fabs(sumz));
         }
 #endif
-        char** labels = basisset_->molecule()->irrep_labels();
+        std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
         std::vector<std::tuple<double,int,int> > metric;
         for (int h = 0; h < epsilon_a_->nirrep(); h++) {
             for (int i = 0; i < epsilon_a_->dimpi()[h]; i++) {
@@ -1506,7 +1506,7 @@ void OEProp::compute_mo_extents()
                    zz = quadrupole[2]->get(0, i);
             outfile->Printf( "    %4d%3s%3d%15.10f%15.10f%15.10f%15.10f\n",
                     i,
-                    labels[h],
+                    labels[h].c_str(),
                     n,
                     std::fabs(quadrupole[0]->get(0, i)),
                     std::fabs(quadrupole[1]->get(0, i)),
@@ -1515,8 +1515,6 @@ void OEProp::compute_mo_extents()
         }
 
         outfile->Printf( "\n");
-        for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
-
 
     } else {
 
@@ -1915,7 +1913,7 @@ void OEProp::compute_wiberg_lowdin_indices()
 
 void OEProp::compute_no_occupations()
 {
-    char** labels = basisset_->molecule()->irrep_labels();
+    std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
 
     outfile->Printf( "  Natural Orbital Occupations:\n\n");
 
@@ -1951,11 +1949,11 @@ void OEProp::compute_no_occupations()
         for (int index = start_occ_a; index < stop_vir_a; index++) {
             if (index < offset_a) {
                 outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset_a - index - 1,
-                std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])],
+                std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])].c_str(),
                 std::get<0>(metric_a[index]));
             } else {
                 outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_a,
-                std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])],
+                std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])].c_str(),
                 std::get<0>(metric_a[index]));
             }
         }
@@ -1980,11 +1978,11 @@ void OEProp::compute_no_occupations()
         for (int index = start_occ_b; index < stop_vir_b; index++) {
             if (index < offset_b) {
                 outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset_b - index - 1,
-                std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])],
+                std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])].c_str(),
                 std::get<0>(metric_b[index]));
             } else {
                 outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_b,
-                std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])],
+                std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])].c_str(),
                 std::get<0>(metric_b[index]));
             }
         }
@@ -2014,11 +2012,11 @@ void OEProp::compute_no_occupations()
     for (int index = start_occ; index < stop_vir; index++) {
         if (index < offset) {
             outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset - index - 1,
-            std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])],
+            std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])].c_str(),
             std::get<0>(metric[index]));
         } else {
             outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset,
-            std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])],
+            std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])].c_str(),
             std::get<0>(metric[index]));
         }
     }

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -431,7 +431,7 @@ void MOInfo::print_mo()
     for(int i=nirreps;i<8;i++)
         outfile->Printf("     ");
     for(int i=0;i<nirreps;i++)
-        outfile->Printf("  %s",irr_labs[i]);
+        outfile->Printf("  %s",irr_labs[i].c_str());
     outfile->Printf(" Total");
     outfile->Printf("\n  ------------------------------------------------------------------------------");
     print_mo_space(nmo,mopi,"Total                           ");

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -58,8 +58,8 @@ public:
 
   double      get_nuclear_energy()               const {return(nuclear_energy);}
 
-  char**      get_irr_labs()                     const {return(irr_labs);}
-  char*       get_irr_labs(int i)                const {return(irr_labs[i]);}
+  std::vector<std::string>  get_irr_labs()       const {return(irr_labs);}
+  std::string get_irr_labs(int i)                const {return(irr_labs[i]);}
 
   int         get_nirreps()                      const {return(nirreps);}
   int         get_nso()                          const {return(nso);}
@@ -118,7 +118,7 @@ protected:
   double**    scf;                                   // MO coefficients
   double***   scf_irrep;                             // MO coefficients
 
-  char**      irr_labs;
+  std::vector<std::string>   irr_labs;
 };
 
 }

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -138,7 +138,7 @@ void MOInfoSCF::print_mo()
     for(int i=nirreps;i<8;i++)
         outfile->Printf("     ");
     for(int i=0;i<nirreps;i++)
-        outfile->Printf("  %s",irr_labs[i]);
+        outfile->Printf("  %s",irr_labs[i].c_str());
     outfile->Printf(" Total");
     outfile->Printf("\n  ----------------------------------------------------------------------------");
     print_mo_space(nso,sopi,"Total                         ");

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1242,7 +1242,7 @@ void HF::print_orbitals(const char* header, std::vector<std::pair<double, std::p
 
 void HF::print_orbitals()
 {
-    char **labels = molecule_->irrep_labels();
+    std::vector<std::string> labels = molecule_->irrep_labels();
 
         outfile->Printf( "    Orbital Energies (a.u.)\n    -----------------------\n\n");
 
@@ -1264,9 +1264,9 @@ void HF::print_orbitals()
                 orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occ.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                occ.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
 
         }
         std::sort(occ.begin(), occ.end());
@@ -1295,9 +1295,9 @@ void HF::print_orbitals()
                 orb_orderA[orb_eA[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
+                occA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderA[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                virA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
+                virA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderA[a] + 1)));
 
             std::vector<std::pair<double, int> > orb_eB;
             for (int a = 0; a < nmopi_[h]; a++)
@@ -1309,9 +1309,9 @@ void HF::print_orbitals()
                 orb_orderB[orb_eB[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                occB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
+                occB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderB[a] + 1)));
             for (int a = nbetapi_[h]; a < nmopi_[h]; a++)
-                virB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
+                virB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderB[a] + 1)));
 
         }
         std::sort(occA.begin(), occA.end());
@@ -1342,11 +1342,11 @@ void HF::print_orbitals()
                 orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                docc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                docc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
             for (int a = nbetapi_[h] ; a < nalphapi_[h]; a++)
-                socc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                socc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
             for (int a = nalphapi_[h] ; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
 
         }
         std::sort(docc.begin(), docc.end());
@@ -1360,11 +1360,6 @@ void HF::print_orbitals()
     }else{
         throw PSIEXCEPTION("Unknown reference in HF::print_orbitals");
     }
-
-    for(int h = 0; h < nirrep_; ++h)
-        free(labels[h]);
-    free(labels);
-
 
     outfile->Printf( "    Final Occupation by Irrep:\n");
     print_occupation();
@@ -1929,10 +1924,10 @@ void HF::print_energies()
 void HF::print_occupation()
 {
 
-        char **labels = molecule_->irrep_labels();
+        std::vector<std::string> labels = molecule_->irrep_labels();
         std::string reference = options_.get_str("REFERENCE");
         outfile->Printf( "          ");
-        for(int h = 0; h < nirrep_; ++h) outfile->Printf( " %4s ", labels[h]); outfile->Printf( "\n");
+        for(int h = 0; h < nirrep_; ++h) outfile->Printf( " %4s ", labels[h].c_str()); outfile->Printf( "\n");
         outfile->Printf( "    DOCC [ ");
         for(int h = 0; h < nirrep_-1; ++h) outfile->Printf( " %4d,", doccpi_[h]);
         outfile->Printf( " %4d ]\n", doccpi_[nirrep_-1]);
@@ -1951,7 +1946,6 @@ void HF::print_occupation()
             outfile->Printf( " %4d ]\n", nbetapi_[nirrep_-1]);
         }
 
-        for(int h = 0; h < nirrep_; ++h) free(labels[h]); free(labels);
         outfile->Printf("\n");
 
 }
@@ -2082,11 +2076,11 @@ void HF::print_stability_analysis(std::vector<std::pair<double, int> > &vec)
     std::sort(vec.begin(), vec.end());
     std::vector<std::pair<double, int> >::const_iterator iter = vec.begin();
     outfile->Printf( "    ");
-    char** irrep_labels = molecule_->irrep_labels();
+    std::vector<std::string> irrep_labels = molecule_->irrep_labels();
     int count = 0;
     for(; iter != vec.end(); ++iter){
         ++count;
-        outfile->Printf( "%4s %-10.6f", irrep_labels[iter->second], iter->first);
+        outfile->Printf( "%4s %-10.6f", irrep_labels[iter->second].c_str(), iter->first);
         if(count == 4){
             outfile->Printf( "\n    ");
             count = 0;
@@ -2099,9 +2093,6 @@ void HF::print_stability_analysis(std::vector<std::pair<double, int> > &vec)
     else
         outfile->Printf( "\n");
 
-    for(int h = 0; h < nirrep_; ++h)
-        free(irrep_labels[h]);
-    free(irrep_labels);
 }
 bool HF::stability_analysis()
 {

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1226,18 +1226,16 @@ void HF::compute_fvpi()
     }
 }
 
-void HF::print_orbitals(const char* header, std::vector<std::pair<double, std::pair<const char*, int> > > orbs)
+void HF::print_orbitals(const char* header, std::vector<std::pair<double, std::pair<std::string, int> > > orbs)
 {
-
         outfile->Printf( "    %-70s\n\n    ", header);
         int count = 0;
         for (int i = 0; i < orbs.size(); i++) {
-            outfile->Printf( "%4d%-4s%11.6f  ", orbs[i].second.second, orbs[i].second.first, orbs[i].first);
+            outfile->Printf( "%4d%-4s%11.6f  ", orbs[i].second.second, orbs[i].second.first.c_str(), orbs[i].first);
             if (count++ % 3 == 2 && count != orbs.size())
                 outfile->Printf( "\n    ");
         }
         outfile->Printf( "\n\n");
-
 }
 
 void HF::print_orbitals()
@@ -1249,8 +1247,8 @@ void HF::print_orbitals()
     std::string reference = options_.get_str("REFERENCE");
     if((reference == "RHF") || (reference == "RKS")){
 
-        std::vector<std::pair<double, std::pair<const char*, int> > > occ;
-        std::vector<std::pair<double, std::pair<const char*, int> > > vir;
+        std::vector<std::pair<double, std::pair<std::string, int> > > occ;
+        std::vector<std::pair<double, std::pair<std::string, int> > > vir;
 
         for (int h = 0; h < nirrep_; h++) {
 
@@ -1264,9 +1262,9 @@ void HF::print_orbitals()
                 orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occ.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
+                occ.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
+                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
 
         }
         std::sort(occ.begin(), occ.end());
@@ -1278,10 +1276,10 @@ void HF::print_orbitals()
     }else if((reference == "UHF") || (reference == "UKS") ||
         (reference == "CUHF")){
 
-        std::vector<std::pair<double, std::pair<const char*, int> > > occA;
-        std::vector<std::pair<double, std::pair<const char*, int> > > virA;
-        std::vector<std::pair<double, std::pair<const char*, int> > > occB;
-        std::vector<std::pair<double, std::pair<const char*, int> > > virB;
+        std::vector<std::pair<double, std::pair<std::string, int> > > occA;
+        std::vector<std::pair<double, std::pair<std::string, int> > > virA;
+        std::vector<std::pair<double, std::pair<std::string, int> > > occB;
+        std::vector<std::pair<double, std::pair<std::string, int> > > virB;
 
         for (int h = 0; h < nirrep_; h++) {
 
@@ -1295,9 +1293,9 @@ void HF::print_orbitals()
                 orb_orderA[orb_eA[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderA[a] + 1)));
+                occA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                virA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderA[a] + 1)));
+                virA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
 
             std::vector<std::pair<double, int> > orb_eB;
             for (int a = 0; a < nmopi_[h]; a++)
@@ -1309,9 +1307,9 @@ void HF::print_orbitals()
                 orb_orderB[orb_eB[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                occB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderB[a] + 1)));
+                occB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
             for (int a = nbetapi_[h]; a < nmopi_[h]; a++)
-                virB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h].c_str(),orb_orderB[a] + 1)));
+                virB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
 
         }
         std::sort(occA.begin(), occA.end());
@@ -1326,9 +1324,9 @@ void HF::print_orbitals()
 
     }else if(reference == "ROHF"){
 
-        std::vector<std::pair<double, std::pair<const char*, int> > > docc;
-        std::vector<std::pair<double, std::pair<const char*, int> > > socc;
-        std::vector<std::pair<double, std::pair<const char*, int> > > vir;
+        std::vector<std::pair<double, std::pair<std::string, int> > > docc;
+        std::vector<std::pair<double, std::pair<std::string, int> > > socc;
+        std::vector<std::pair<double, std::pair<std::string, int> > > vir;
 
         for (int h = 0; h < nirrep_; h++) {
 
@@ -1342,11 +1340,11 @@ void HF::print_orbitals()
                 orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                docc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
+                docc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
             for (int a = nbetapi_[h] ; a < nalphapi_[h]; a++)
-                socc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
+                socc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
             for (int a = nalphapi_[h] ; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h].c_str(),orb_order[a] + 1)));
+                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
 
         }
         std::sort(docc.begin(), docc.end());
@@ -1363,7 +1361,9 @@ void HF::print_orbitals()
 
     outfile->Printf( "    Final Occupation by Irrep:\n");
     print_occupation();
+
 }
+
 
 void HF::guess()
 {

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -293,7 +293,7 @@ protected:
 
     /// Prints the orbitals energies and symmetries (helper method)
     void print_orbitals(const char* header, std::vector<std::pair<double,
-                        std::pair<const char*, int> > > orbs);
+                        std::pair< std::string, int> > > orbs);
 
     /// Prints the orbitals in arbitrary order (works with MOM)
     void print_orbitals();

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -977,17 +977,17 @@ void UHF::compute_nos()
     start_occ = (start_occ < 0 ? 0 : start_occ);
     int stop_vir = offset + max_num + 1;
     stop_vir = (int)((size_t)stop_vir >= metric.size() ? metric.size() : stop_vir);
-    char** labels = basisset_->molecule()->irrep_labels();
+    std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
     outfile->Printf( "\n  UHF NO Occupations:\n");
     for (int index = start_occ; index < stop_vir; index++) {
       if (index < offset) {
         outfile->Printf( "  HONO-%-2d: %4d%3s %9.7f\n", offset- index - 1,
-        std::get<2>(metric[index])+1,labels[std::get<1>(metric[index])],
+        std::get<2>(metric[index])+1,labels[std::get<1>(metric[index])].c_str(),
         std::get<0>(metric[index]));
       }
       else {
         outfile->Printf( "  LUNO+%-2d: %4d%3s %9.7f\n", index - offset,
-        std::get<2>(metric[index])+1,labels[std::get<1>(metric[index])],
+        std::get<2>(metric[index])+1,labels[std::get<1>(metric[index])].c_str(),
         std::get<0>(metric[index]));
       }
     }

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -348,7 +348,7 @@ class IntegralTransform{
         // A string describing the spaces in which the integrals are to be transformed
         char *spaces_;
         // An array containing labels for each irrep
-        char **labels_;
+        std::vector<std::string> labels_;
         // The definition of zero
         double tolerance_;
         // The amount of memory, in MB

--- a/psi4/src/psi4/mcscf/scf.cc
+++ b/psi4/src/psi4/mcscf/scf.cc
@@ -171,7 +171,7 @@ void SCF::startup()
     outfile->Printf("\n  TWOCON MOs = [");
     for(int I = 0; I < nci; ++I)
       outfile->Printf("%d (%s)%s",tcscf_mos[I] + block_offset[tcscf_sym[I]],
-                                 moinfo_scf->get_irr_labs(tcscf_sym[I]),
+                                 moinfo_scf->get_irr_labs(tcscf_sym[I]).c_str(),
                                  I != nci - 1 ? "," : "");
     outfile->Printf("]");
 

--- a/psi4/src/psi4/mcscf/scf_pairs.cc
+++ b/psi4/src/psi4/mcscf/scf_pairs.cc
@@ -94,7 +94,7 @@ void SCF::generate_pairs()
 
   outfile->Printf("\n\n  Generated %d pairs\n  Distributed as ",npairs);
   for(int h=0; h< nirreps; ++h)
-    outfile->Printf("[%d %s]",pairpi[h],moinfo_scf->get_irr_labs(h));
+    outfile->Printf("[%d %s]",pairpi[h],moinfo_scf->get_irr_labs(h).c_str());
 }
 
 }} /* End Namespaces */

--- a/psi4/src/psi4/psimrcc/index.cc
+++ b/psi4/src/psi4/psimrcc/index.cc
@@ -425,7 +425,7 @@ void CCIndex::print()
   int index=0;
   for(int h=0;h<nirreps;h++){
     if(tuplespi[h]>0)
-      outfile->Printf("\n\t%s",moinfo->get_irr_labs(h));
+      outfile->Printf("\n\t%s",moinfo->get_irr_labs(h).c_str());
     for(size_t tuple = 0; tuple < tuplespi[h]; ++tuple){
       outfile->Printf("\n\t\t( ");
       for(int k=0;k<nelements;k++)

--- a/psi4/src/psi4/psimrcc/matrix.cc
+++ b/psi4/src/psi4/psimrcc/matrix.cc
@@ -112,7 +112,7 @@ void CCMatrix::print()
   outfile->Printf("\n\n\t\t\t\t\t%s Matrix\n",label.c_str());
   for(int i=0;i<nirreps;i++){
     if(left->get_pairpi(i) * right->get_pairpi(i)){
-      outfile->Printf("\nBlock %d (%s,%s)",i,moinfo->get_irr_labs(i),moinfo->get_irr_labs(i));
+      outfile->Printf("\nBlock %d (%s,%s)",i,moinfo->get_irr_labs(i).c_str(),moinfo->get_irr_labs(i).c_str());
       print_dpdmatrix(i,"outfile");
     }
   }

--- a/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
+++ b/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
@@ -107,7 +107,7 @@ void CCMatrix::allocate_block(int h)
       if(memorypi2[h] < memory_manager->get_FreeMemory()){
         allocate2(double,matrix[h],left_pairpi[h],right_pairpi[h]);
         DEBUGGING(2,
-          outfile->Printf("\n  %s[%s] <- allocated",label.c_str(),moinfo->get_irr_labs(h));
+          outfile->Printf("\n  %s[%s] <- allocated",label.c_str(),moinfo->get_irr_labs(h).c_str());
 
         )
       }else{
@@ -139,7 +139,7 @@ void CCMatrix::free_block(int h)
     if(is_block_allocated(h)){
       release2(matrix[h]);
       DEBUGGING(2,
-        outfile->Printf("\n  %s[%s] <- deallocated",label.c_str(),moinfo->get_irr_labs(h));
+        outfile->Printf("\n  %s[%s] <- deallocated",label.c_str(),moinfo->get_irr_labs(h).c_str());
 
       )
     }

--- a/psi4/src/psi4/psimrcc/transform.cc
+++ b/psi4/src/psi4/psimrcc/transform.cc
@@ -111,7 +111,7 @@ void CCTransform::read_tei_so_integrals()
       allocate1(double,tei_so[h],block_size);
       for(size_t i=0;i<block_size;i++)
         tei_so[h][i]=0.0;
-      outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu",moinfo->get_irr_labs(h),block_size);
+      outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu",moinfo->get_irr_labs(h).c_str(),block_size);
     }
   }
 
@@ -511,7 +511,7 @@ void CCTransform::allocate_tei_mo()
           required_size += sizeof(double) * block_size;
           tei_mo[h] = NULL;
         }
-        outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu bytes (free memory = %14lu bytes)",moinfo->get_irr_labs(h),block_size,memory_manager->get_FreeMemory());
+        outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu bytes (free memory = %14lu bytes)",moinfo->get_irr_labs(h).c_str(),block_size,memory_manager->get_FreeMemory());
       }
     }
     if(failed){
@@ -546,7 +546,7 @@ void CCTransform::allocate_tei_so()
           required_size += sizeof(double) * block_size;
           tei_so[h] = NULL;
         }
-        outfile->Printf("\n\tCCTransform: allocated the %s block of size %d bytes (free memory = %14lu bytes)",moinfo->get_irr_labs(h),block_size,memory_manager->get_FreeMemory());
+        outfile->Printf("\n\tCCTransform: allocated the %s block of size %d bytes (free memory = %14lu bytes)",moinfo->get_irr_labs(h).c_str(),block_size,memory_manager->get_FreeMemory());
       }
     }
     if(failed){
@@ -572,7 +572,7 @@ void CCTransform::allocate_tei_half_transformed()
     for(int h=0;h<moinfo->get_nirreps();h++){
       if(so_indexing->get_pairpi(h)*mo_indexing->get_pairpi(h)>0){
         allocate2(double,tei_half_transformed[h],mo_indexing->get_pairpi(h),so_indexing->get_pairpi(h));
-        outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu*%lu",moinfo->get_irr_labs(h),mo_indexing->get_pairpi(h),so_indexing->get_pairpi(h));
+        outfile->Printf("\n\tCCTransform: allocated the %s block of size %lu*%lu",moinfo->get_irr_labs(h).c_str(),mo_indexing->get_pairpi(h),so_indexing->get_pairpi(h));
       }
     }
   }
@@ -592,7 +592,7 @@ void CCTransform::free_tei_mo()
         size_t block_size = INDEX(indexing->get_pairpi(h)-1,indexing->get_pairpi(h)-1)+1;
         matrix_size += block_size;
         release1(tei_mo[h]);
-        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu",moinfo->get_irr_labs(h),block_size);
+        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu",moinfo->get_irr_labs(h).c_str(),block_size);
       }
     }
     release1(tei_mo);
@@ -611,7 +611,7 @@ void CCTransform::free_tei_so()
         size_t block_size = INDEX(indexing->get_pairpi(h)-1,indexing->get_pairpi(h)-1)+1;
         matrix_size += block_size;
         release1(tei_so[h]);
-        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu",moinfo->get_irr_labs(h),block_size);
+        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu",moinfo->get_irr_labs(h).c_str(),block_size);
       }
     }
     release1(tei_so);
@@ -629,7 +629,7 @@ void CCTransform::free_tei_half_transformed()
       if(rsindx->get_pairpi(h)*ijindx->get_pairpi(h)>0){
         matrix_size += ijindx->get_pairpi(h)*rsindx->get_pairpi(h);
         release2(tei_half_transformed[h]);
-        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu*%lu",moinfo->get_irr_labs(h),ijindx->get_pairpi(h),rsindx->get_pairpi(h));
+        outfile->Printf("\n\tCCTransform: deallocated the %s block of size %lu*%lu",moinfo->get_irr_labs(h).c_str(),ijindx->get_pairpi(h),rsindx->get_pairpi(h));
       }
     }
     release1(tei_half_transformed);


### PR DESCRIPTION
## Description
Replace char** irrep_labels() with std::vector<std::string> irrep_labels()
Convert with .c_str() when needed in print statements.
Remove calls to free()
Removed calls to delete in dcft_scf_UHF.cc

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Part of the change to std::string
* **User-Facing for Release Notes**
  - [ ] None

## Status
- [ ] Test jobs cc1, dfmp2-1, scf-occ  all passed, and Irrep labels printed were the same as the reference.
