### PR TITLE
Make Psi4 buildable with Ninja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ metadata.out.py
 # Compilation directories that people use
 obj*
 *objdir
-build
+build*
 debug
 debug_latest
 *.sh

--- a/.scripts/travis_build.sh
+++ b/.scripts/travis_build.sh
@@ -2,7 +2,7 @@
 
 # The return code will capture an error from ANY of the functions in the pipe
 set -o pipefail
-cmake --build . -- -j 2 --trace 2>&1 | tee build.log | grep "Building"
+cmake --build . -- -j 2 VERBOSE=1 2>&1 | tee build.log | grep "Building"
 RESULT=$?
 
 if [ $RESULT -eq 0 ]; then

--- a/.scripts/travis_build.sh
+++ b/.scripts/travis_build.sh
@@ -2,7 +2,7 @@
 
 # The return code will capture an error from ANY of the functions in the pipe
 set -o pipefail
-make VERBOSE=1 -j2 2>&1 | tee build.log | grep "Building"
+cmake --build . -- -j 2 --trace 2>&1 | tee build.log | grep "Building"
 RESULT=$?
 
 if [ $RESULT -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
         sources:
         - llvm-toolchain-precise-3.6
         - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
         packages:
         - liblapack-dev
         - clang-3.6
@@ -43,7 +42,6 @@ matrix:
   #      sources:
   #      - llvm-toolchain-precise-3.9
   #      - ubuntu-toolchain-r-test
-  #      - george-edison55-precise-backports
   #      packages:
   #      - liblapack-dev
   #      - clang-3.9
@@ -64,7 +62,6 @@ matrix:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
         packages:
         - python-numpy
         - cmake
@@ -89,7 +86,6 @@ matrix:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        - george-edison55-precise-backports
         packages:
         - python-numpy
         - cmake
@@ -114,7 +110,6 @@ matrix:
 #      apt:
 #        sources:
 #        - ubuntu-toolchain-r-test
-#        - george-edison55-precise-backports
 #        packages:
 #        - python3
 #        - cmake
@@ -160,11 +155,11 @@ before_script:
 - ${CXX_COMPILER} --version
 - ${Fortran_COMPILER} --version
 - ${C_COMPILER} --version
-- > 
-    cmake -Bbuild -H. 
-    -DCMAKE_CXX_COMPILER=${CXX_COMPILER} 
-    -DCMAKE_C_COMPILER=${C_COMPILER} 
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
+- >
+    cmake -Bbuild -H.
+    -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+    -DCMAKE_C_COMPILER=${C_COMPILER}
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
     -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
     -DENABLE_CheMPS2=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,8 +223,7 @@ ExternalProject_Add(psi4-core
               -DDESTDIR=${CMAKE_BINARY_DIR}/stage
    CMAKE_CACHE_ARGS -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
    BUILD_ALWAYS 1
-   INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-                   DESTDIR=${CMAKE_BINARY_DIR}/stage)
+   INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
 add_subdirectory(external/downstream)
 add_subdirectory(doc)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -13,7 +13,7 @@ set(CTEST_DROP_LOCATION "/cdash/submit.php?project=Psi")
 set(CTEST_DROP_SITE_CDASH TRUE)
 
 if(DEFINED ENV{CTEST_MAKE_NUM_PROCS})
-    set(MAKECOMMAND "make -j$ENV{CTEST_MAKE_NUM_PROCS}" CACHE STRING "Custom make command")
+  set(MAKECOMMAND "${CMAKE_MAKE_PROGRAM} -j$ENV{CTEST_MAKE_NUM_PROCS}" CACHE STRING "Custom make command")
 endif()
 
 # total allowed time for all tests in seconds

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -214,7 +214,7 @@ macro(add_skeleton_plugin PLUG TEMPLATE TESTLABELS)
         DEPENDS psi4-core
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CCBD}/${PLUG}
         COMMAND ${PSIEXE} --plugin-name ${PLUG} --plugin-template ${TEMPLATE}
-        COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" cmake -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake "-DCMAKE_PREFIX_PATH=${DIR_2_PASS}" .
+        COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_COMMAND} -C ${STAGED_INSTALL_PREFIX}/share/cmake/psi4/psi4PluginCache.cmake "-DCMAKE_PREFIX_PATH=${DIR_2_PASS}" -G "${CMAKE_GENERATOR}" .
         COMMAND ${CMAKE_COMMAND} -E chdir "${CCBD}/${PLUG}" ${CMAKE_MAKE_PROGRAM}
         COMMAND ${CMAKE_COMMAND} -E create_symlink ${CCBD}/${PLUG}/input.dat ${CCSD}/input.dat
         COMMAND ${CMAKE_COMMAND} -E create_symlink "${PLUG}/${PLUG}.so" "${PLUG}.so"

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -59,8 +59,7 @@ if(${ENABLE_ambit})
                        -DTargetHDF5_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(ambit_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/ambit CACHE PATH "path to internally built ambitConfig.cmake" FORCE)
     endif()

--- a/external/upstream/chemps2/CMakeLists.txt
+++ b/external/upstream/chemps2/CMakeLists.txt
@@ -47,8 +47,7 @@ if(${ENABLE_CheMPS2})
                        -DTargetHDF5_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(CheMPS2_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/CheMPS2 CACHE PATH "path to internally built CheMPS2Config.cmake" FORCE)
     endif()

--- a/external/upstream/dkh/CMakeLists.txt
+++ b/external/upstream/dkh/CMakeLists.txt
@@ -25,8 +25,7 @@ if(${ENABLE_dkh})
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(dkh_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/dkh CACHE PATH "path to internally built dkhConfig.cmake" FORCE)
     endif()

--- a/external/upstream/erd/CMakeLists.txt
+++ b/external/upstream/erd/CMakeLists.txt
@@ -25,8 +25,7 @@ if(${ENABLE_erd})
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(erd_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/erd CACHE PATH "path to internally built erdConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gdma/CMakeLists.txt
+++ b/external/upstream/gdma/CMakeLists.txt
@@ -25,8 +25,7 @@ if(${ENABLE_gdma})
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(gdma_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gdma CACHE PATH "path to internally built gdmaConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gtfock/CMakeLists.txt
+++ b/external/upstream/gtfock/CMakeLists.txt
@@ -28,8 +28,7 @@ if(${ENABLE_GTFock})
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(GTFock_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/GTFock CACHE PATH "path to internally built GTFockConfig.cmake" FORCE)
     endif()

--- a/external/upstream/libefp/CMakeLists.txt
+++ b/external/upstream/libefp/CMakeLists.txt
@@ -30,8 +30,7 @@ if(${ENABLE_libefp})
                        -DFRAGLIB_DEEP=OFF
                        -DTargetLAPACK_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetLAPACK
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(libefp_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/libefp CACHE PATH "path to internally built libefpConfig.cmake" FORCE)
     endif()

--- a/external/upstream/libint/CMakeLists.txt
+++ b/external/upstream/libint/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
     message(STATUS "Suitable Libint could not be located, ${Magenta}Building Libint${ColourReset} instead.")
     ExternalProject_Add(libint_external
         GIT_REPOSITORY https://github.com/evaleev/libint
-        GIT_TAG 3f14ff0  # v1.2.1 release-1-2-1
+        GIT_TAG 024738cf # v1.2.1 release-1-2-1
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -27,8 +27,7 @@ else()
                    -DMERGE_LIBDERIV_INCLUDEDIR=ON
         CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-        INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-        DESTDIR=${CMAKE_BINARY_DIR}/stage)
+        INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
     set(Libint_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/Libint CACHE PATH "path to internally built LibintConfig.cmake" FORCE)
 endif()

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -27,8 +27,7 @@ else()
                    -DLIBC_INTERJECT=${LIBC_INTERJECT}
                    -DBUILD_TESTING=OFF
         CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-        INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-        DESTDIR=${CMAKE_BINARY_DIR}/stage)
+        INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
     set(Libxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/Libxc CACHE PATH "path to internally built LibxcConfig.cmake" FORCE)
 endif()

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -49,8 +49,7 @@ if(${ENABLE_PCMSolver})
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                              -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(PCMSolver_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/PCMSolver CACHE PATH "path to internally built PCMSolverConfig.cmake" FORCE)
     endif()

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -16,8 +16,7 @@ else()
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}  # ditto
                    -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                    -DPYBIND11_TEST=OFF
-        INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-        DESTDIR=${CMAKE_BINARY_DIR}/stage)
+        INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
     set(pybind11_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/pybind11 CACHE PATH "path to internally built pybind11Config.cmake" FORCE)
 endif()

--- a/external/upstream/simint/CMakeLists.txt
+++ b/external/upstream/simint/CMakeLists.txt
@@ -29,8 +29,7 @@ if(${ENABLE_simint})
                        -DSIMINT_MAXAM=${MAX_AM_ERI}
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-            DESTDIR=${CMAKE_BINARY_DIR}/stage)
+            INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(simint_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/simint CACHE PATH "path to internally built simintConfig.cmake" FORCE)
     endif()


### PR DESCRIPTION
## Description
Ninja is supposed to be faster at compiling than make. CMake supports it out-of-the-box, it's enough to pass it as generator:
```
cmake -H. -Bbuild -GNinja
```
I have tried to use Ninja on Travis and the Clang build runs in ~21 minutes. The GCC builds however fail due to a compiler bug.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] `DESTDIR=${CMAKE_BINARY_DIR}/stage` was prepended to `${CMAKE_MAKE_PROGRAM} install` appearing in all instances of `INSTALL_COMMAND`.
  - [x] Same `DESTDIR`-related modifications in Libint and update of the Git commit SHA. PR towards v1 was already merged. 
* **User-Facing for Release Notes**
  - [x] Psi4 core now buildable with Ninja. **Caveat** To build also the addons it might be necessary to use CMake v3.7.2 _and_ the [Kitware-maintained version of Ninja](https://github.com/Kitware/ninja/releases). The official one does not support Fortran.

## Status
- [x] Ready to go
