### PR TITLE
Optbug

### DIFF
--- a/psi4/src/psi4/optking/io.h
+++ b/psi4/src/psi4/optking/io.h
@@ -43,7 +43,7 @@ namespace opt {
 enum OPT_IO_FILE_STATUS {OPT_IO_OPEN_NEW, OPT_IO_OPEN_OLD} ;
 
 bool opt_io_is_present(void);
-void opt_io_remove(void);
+void opt_io_remove(bool force=false);
 void opt_io_open(OPT_IO_FILE_STATUS status);
 void opt_io_close(int keep);
 void opt_io_read_entry(const char *key, char *buffer, size_t size);

--- a/psi4/src/psi4/optking/opt_data_io.cc
+++ b/psi4/src/psi4/optking/opt_data_io.cc
@@ -83,13 +83,14 @@ bool opt_io_is_present(void) {
   return file_present;
 }
 
-void opt_io_remove(void) {
+void opt_io_remove(bool force) {
 #if defined(OPTKING_PACKAGE_PSI)
   // check retention setting in .psi4rc - maybe the user likes file 1 !
-  if (! psi::_default_psio_manager_->get_specific_retention(1)) {
+  if (! psi::_default_psio_manager_->get_specific_retention(1) || force) {
     if (!psio_open_check(PSI_OPTDATA_FILE_NUM)) // if not open, open it
       psio_open(PSI_OPTDATA_FILE_NUM, PSIO_OPEN_OLD);
     psio_close(PSI_OPTDATA_FILE_NUM, 0);        // close and delete it
+    oprintf_out("\tRemoving binary optimization data file.\n");
   }
 
 #elif defined(OPTKING_PACKAGE_QCHEM)

--- a/psi4/src/psi4/optking/optking.cc
+++ b/psi4/src/psi4/optking/optking.cc
@@ -554,7 +554,7 @@ OptReturnType optking(void) {
 
       delete p_Opt_data;
       opt_intco_dat_remove(); // rm intco definitions
-      opt_io_remove();        // rm optimization data
+      opt_io_remove(true);        // rm optimization data
 
       //if (Opt_params.fragment_mode == OPT_PARAMS::MULTI)
       //  exc.override_fragment_mode = true;


### PR DESCRIPTION
## Description
Two bug fixes.  First is wrong projected energy change in P-RFO transition state optimization.
Second, is an i/o error that occured because the file1 was not always deleted when the "dynamic level" changed.  Default behavior should be unaffected.
## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
Should resolve issue #789 
 
## Questions
None
## Status
Should be ready to go.