### PR TITLE
FIX: Tightens up a few tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,8 +71,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   omp3-3 omp3-4 omp3-5 omp3-grad1 omp3-grad2 opt-lindep-change 
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9 
                   opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-freeze-coords 
-                  #props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2 
-                  props1 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2 
+                  props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2 
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1 
                   psimrcc-fd-freq2 psimrcc-pt2 psimrcc-sp1 psithon1 psithon2 
                   pubchem1 pubchem2 pywrap-alias pywrap-all pywrap-basis 

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -57,7 +57,7 @@ for R in Rvals:
     dimer.Oy = R
     dimer.Hy = R + 0.35
     
-    # Force COM for pole computation
+    # Force COM translation so multipole origin (0, 0, 0) and COM will be identical
     dimer.move_to_com()
 
     set BASIS sto-3g
@@ -81,7 +81,7 @@ for R in Rvals:
 
     monoB = dimer.extract_subsets(2)
 
-    # Force COM for pole computation
+    # Force COM translation so multipole origin (0, 0, 0) and COM will be identical
     monoB.move_to_com()
 
     eehf, hf_wfn = energy('scf', return_wfn=True)

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -48,6 +48,7 @@ for R in Rvals:
                H          0.494974746831    Hy     0.857321409974
                H         -0.989949493661    Hy     0.000000000000
     units angstrom
+    no_reorient
     }
     #dimer.Bz = -4.794637665924 + R
     #dimer.Oy = -0.794637665924 + R
@@ -55,6 +56,9 @@ for R in Rvals:
     dimer.Bz = 0.0
     dimer.Oy = R
     dimer.Hy = R + 0.35
+    
+    # Force COM for pole computation
+    dimer.move_to_com()
 
     set BASIS sto-3g
     set DF_BASIS_SCF cc-pVDZ-JKFIT
@@ -75,8 +79,10 @@ for R in Rvals:
     clean()
     count = count + 1                                                                                #TEST
 
-
     monoB = dimer.extract_subsets(2)
+
+    # Force COM for pole computation
+    monoB.move_to_com()
 
     eehf, hf_wfn = energy('scf', return_wfn=True)
     oeprop(hf_wfn, "DIPOLE", "QUADRUPOLE",title="H3O+ SCF")

--- a/tests/props3/input.dat
+++ b/tests/props3/input.dat
@@ -45,8 +45,8 @@ set {
     basis cc-pVDZ
     SCF_TYPE DF
     REFERENCE RHF
-    e_convergence 9
-    d_convergence 9
+    e_convergence 11
+    d_convergence 11
 }
 
 

--- a/tests/scf-coverage/input.dat
+++ b/tests/scf-coverage/input.dat
@@ -5,6 +5,9 @@ molecule li_anion {
 Li
 }
 
+set sad_frac_occ true
+set e_convergence 8
+set d_convergence 8
 set stability_analysis check
 set basis cc-pVDZ
 set scf_type out_of_core
@@ -14,11 +17,13 @@ scf_e = energy("SCF")
 compare_values(-7.41681960717086, scf_e, 6, "Lithium anion stability")
 
 # Run several perturbations
-molecule helium {
-O
-H 1 1.1
-H 1 1.1 2 104
+molecule water {
+O  0.000000000000  0.000000000000 -0.075791843589
+H  0.000000000000 -0.866811828967  0.601435779270
+H  0.000000000000  0.866811828967  0.601435779270
 symmetry c1
+no_reorient
+no_com
 }
 
 set scf_type df
@@ -42,9 +47,11 @@ compare_values(-76.00108612517847, scf_e, 6, "Water Perturn Spherical RHF") #TES
 # Try out UHF NOS
 molecule water_anion {
 -1 2
-O
-H 1 1.1
-H 1 1.1 2 104
+O  0.000000000000  0.000000000000 -0.075791843589
+H  0.000000000000 -0.866811828967  0.601435779270
+H  0.000000000000  0.866811828967  0.601435779270
+no_reorient
+no_com
 }
 
 set perturb_h false


### PR DESCRIPTION
Based off the forums and a few issues there are a few tests that are not quite robust enough to test the code rather than a operational tweaks.
 - `props2` - The new orientation code requires that this be moved to the COM at every step.
 - `props3` - Overall convergence needs to be tightened to move flutter in 64-pole below test threshold.
 - `scf-cov` - Convergence needs to be tightened in addition to not using a C2v molecule during a orientation check.