### PR TITLE
Patch failing tests

### DIFF
--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(pybind11 2.0.0 CONFIG QUIET)
+find_package(pybind11 2.0.0 EXACT CONFIG QUIET)
 
 if(${pybind11_FOUND})
     message(STATUS "${Cyan}Found pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (found version ${pybind11_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 #  <<  Pybind11 & Python  >>
 set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
-find_package(pybind11 2.0.0 CONFIG REQUIRED)
+find_package(pybind11 2.0.0 EXACT CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")
 message(STATUS "${Cyan}Using Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE}")
 

--- a/tests/dft-grad1/CMakeLists.txt
+++ b/tests/dft-grad1/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-grad "psi;dft;scf")
+add_regression_test(dft-grad1 "psi;dft;scf")

--- a/tests/dft-grad1/input.dat
+++ b/tests/dft-grad1/input.dat
@@ -29,7 +29,6 @@ clean()
 
 
 set {
-    dft_functional bp86-d
     reference rks
     dft_radial_points 99
     dft_spherical_points 302

--- a/tests/dft-grad2/CMakeLists.txt
+++ b/tests/dft-grad2/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-grad "psi;shorttests;dft;scf")
+add_regression_test(dft-grad2 "psi;shorttests;dft;scf")

--- a/tests/dftd3/grad/input.dat
+++ b/tests/dftd3/grad/input.dat
@@ -27,11 +27,3 @@ grad = gradient('bp86-d2gr')
 compare_matrices(ref, grad, 7, "Outsourced dft gradients called by name")  #TEST
 clean()
 
-
-set {
-    dft_functional bp86-d2gr
-    reference rks
-}
-
-grad = gradient('bp86-d2gr')
-compare_matrices(ref, grad, 7, "Outsourced dft gradients called by options") #TEST

--- a/tests/ocepa2/input.dat
+++ b/tests/ocepa2/input.dat
@@ -13,10 +13,9 @@ o 1 1.158
 set {
   basis cc-pcvdz
   reference uks
-  dft_functional b3lyp 
   e_convergence 8
 }
-energy('olccd')
+energy('olccd', dft_functional='b3lyp')
 
 compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
 compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST

--- a/tests/omp3-3/input.dat
+++ b/tests/omp3-3/input.dat
@@ -13,9 +13,8 @@ o 1 1.158
 set {
   basis cc-pcvdz
   reference uks
-  dft_functional b3lyp
 }
-energy('omp3')
+energy('omp3', dft_functional='b3lyp')
 
 compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
 compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST


### PR DESCRIPTION
## Description
There were a few more `set dft_functional fctl` in the full test suite. This should polish it off

## Accomplished
- [x] Pin pybind11 to 2.0.0 so psi doesn't pick up any incompatible newer versions lying around
- [x] long tests all pass

## Questions
- [ ] @dgasmith, should `gradient('scf', dft_functional='bp86')` work?

tests/dftd3/grad/input.dat
```
...
grad = gradient('bp86-d2gr')
compare_matrices(ref, grad, 7, "Outsourced dft gradients called by name")  #TEST
clean()

grad = gradient('scf', dft_functional='bp86-d2gr')
compare_matrices(ref, grad, 7, "Outsourced dft gradients called by options") #TEST
```
```
	Outsourced dft gradients called by name...........................PASSED
Traceback (most recent call last):
  File "stage/usr/local/psi4/bin/psi4", line 260, in <module>
    exec(content)
  File "<string>", line 43, in <module>
  File "/home/psilocaluser/gits/hrw-matt/objdir/stage/usr/local/psi4/lib/psi4/driver/driver.py", line 606, in gradient
    wfn = procedures['gradient'][lowername](lowername, molecule=molecule, **kwargs)
  File "/home/psilocaluser/gits/hrw-matt/objdir/stage/usr/local/psi4/lib/psi4/driver/procrouting/proc.py", line 2055, in run_scf_gradient
    grad = core.scfgrad(ref_wfn)

RuntimeError: 
Fatal Error: V: RKS should have only one D Matrix
Error occurred in file: /home/psilocaluser/gits/hrw-matt/psi4/src/psi4/libfock/v.cc on line: 915
The most recent 5 function calls were:

psi::PsiException::PsiException(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, char const*, int)
psi::RV::compute_gradient()
psi::scfgrad::SCFGrad::compute_gradient()
psi::scfgrad::scfgrad(std::shared_ptr<psi::Wavefunction>, psi::Options&)
py_psi_scfgrad(std::shared_ptr<psi::Wavefunction>)
```

## Status
- [x] Ready to go
