### PR TITLE
Pybind11 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,8 +169,8 @@ before_script:
     -DENABLE_gdma=ON
     -DENABLE_PCMSolver=ON
     -DENABLE_simint=ON
-    -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
+    #-DENABLE_PLUGIN_TESTING=ON
 - cd build
 - ../.scripts/travis_build.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,7 @@ before_script:
     -DENABLE_PCMSolver=ON
     -DENABLE_simint=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
-    #-DENABLE_PLUGIN_TESTING=ON
+    -DENABLE_PLUGIN_TESTING=ON
 - cd build
 - ../.scripts/travis_build.sh
 script:

--- a/external/upstream/chemps2/CMakeLists.txt
+++ b/external/upstream/chemps2/CMakeLists.txt
@@ -28,7 +28,7 @@ if(${ENABLE_CheMPS2})
             DEPENDS lapack_external
                     hdf5_external
             GIT_REPOSITORY https://github.com/SebWouters/CheMPS2
-            GIT_TAG 55d6b38  # v1.8.3-12
+            GIT_TAG v1.8.4
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/libefp/CMakeLists.txt
+++ b/external/upstream/libefp/CMakeLists.txt
@@ -30,6 +30,7 @@ if(${ENABLE_libefp})
                        -DBUILD_FPIC=${BUILD_FPIC}
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
+                       -DINSTALL_DEVEL_HEADERS=ON
                        -DFRAGLIB_UNDERSCORE_L=OFF
                        -DFRAGLIB_DEEP=OFF
                        -DTargetLAPACK_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetLAPACK

--- a/external/upstream/libint/CMakeLists.txt
+++ b/external/upstream/libint/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
     message(STATUS "Suitable Libint could not be located, ${Magenta}Building Libint${ColourReset} instead.")
     ExternalProject_Add(libint_external
         GIT_REPOSITORY https://github.com/evaleev/libint
-        GIT_TAG 024738cf # v1.2.1 release-1-2-1
+        GIT_TAG 024738c  # v1.2.1+2 release-1-2-1
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(pybind11 2.0.0 EXACT CONFIG QUIET)
+find_package(pybind11 2.2.1 EXACT CONFIG QUIET)
 
 if(${pybind11_FOUND})
     message(STATUS "${Cyan}Found pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (found version ${pybind11_VERSION})")
@@ -12,7 +12,7 @@ else()
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
         GIT_REPOSITORY https://github.com/pybind/pybind11
-        GIT_TAG v2.0.0
+        GIT_TAG v2.2.1
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 #  <<  Pybind11 & Python  >>
 set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
-find_package(pybind11 2.0.0 EXACT CONFIG REQUIRED)
+find_package(pybind11 2.2.1 EXACT CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")
 message(STATUS "${Cyan}Using Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE}")
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -366,19 +366,22 @@ def scf_finalize_energy(self):
         # compute it if needed
         if core.get_option('SCF', 'REFERENCE') != "UHF":
             psio = core.IO.shared_object()
-            psio.open(constants.PSIF_SO_TEI, 1)  # PSIO_OPEN_OLD
-            try:
-                psio.tocscan(constants.PSIF_SO_TEI, "IWL Buffers")
-            except TypeError:
-                # "IWL Buffers" actually found but psio_tocentry can't be returned to Py
-                psio.close(constants.PSIF_SO_TEI, 1)
-            else:
-                # tocscan returned None
-                psio.close(constants.PSIF_SO_TEI, 1)
-                core.print_out("    SO Integrals not on disk, computing...")
-                mints = core.MintsHelper(self.basisset())
-                mints.integrals()
-                core.print_out("done.\n")
+            #psio.open(constants.PSIF_SO_TEI, 1)  # PSIO_OPEN_OLD
+            #try:
+            #    psio.tocscan(constants.PSIF_SO_TEI, "IWL Buffers")
+            #except TypeError:
+            #    # "IWL Buffers" actually found but psio_tocentry can't be returned to Py
+            #    psio.close(constants.PSIF_SO_TEI, 1)
+            #else:
+            #    # tocscan returned None
+            #    psio.close(constants.PSIF_SO_TEI, 1)
+
+            # logic above foiled by psio_tocentry not returning None<--nullptr in pb11 2.2.1
+            #   so forcibly recomputing for now until stability revamp
+            core.print_out("    SO Integrals not on disk, computing...")
+            mints = core.MintsHelper(self.basisset())
+            mints.integrals()
+            core.print_out("done.\n")
 
             # Q: Not worth exporting all the layers of psio, right?
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -378,7 +378,7 @@ def scf_finalize_energy(self):
 
             # logic above foiled by psio_tocentry not returning None<--nullptr in pb11 2.2.1
             #   so forcibly recomputing for now until stability revamp
-            core.print_out("    SO Integrals not on disk, computing...")
+            core.print_out("    SO Integrals not on disk. Computing...")
             mints = core.MintsHelper(self.basisset())
             mints.integrals()
             core.print_out("done.\n")

--- a/psi4/include/psi4/pragma.h
+++ b/psi4/include/psi4/pragma.h
@@ -56,7 +56,7 @@
 #define PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS      _Pragma("warning(disable:1478)")
 #define PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
 
-#elif defined(__clang__)   // Do clang before GNU because clang defined __GNUC__, too.
+#elif defined(__clang__)   // Do clang before GNU because clang defines __GNUC__, too.
 
 #define PRAGMA_WARNING_PUSH                                _Pragma("clang diagnostic push")
 #define PRAGMA_WARNING_POP                                 _Pragma("clang diagnostic pop")
@@ -106,5 +106,26 @@
 #define PRAGMA_WARNING_IGNORE_OVERLOADED_VIRTUAL
 
 #endif
+
+// The following is adapted from https://gcc.gnu.org/wiki/Visibility the step-by-step guide at the very bottom
+// Visibility macros
+#if defined _WIN32 || defined __CYGWIN__
+#   define PSI_HELPER_SO_EXPORT __declspec(dllexport)
+#   define PSI_HELPER_SO_LOCAL
+#else
+#   if __GNUC__ >= 4
+#       define PSI_HELPER_SO_EXPORT __attribute__ ((visibility ("default")))
+#       define PSI_HELPER_SO_LOCAL  __attribute__ ((visibility ("hidden")))
+#   else
+#       define PSI_HELPER_SO_EXPORT
+#       define PSI_HELPER_SO_LOCAL
+#   endif
+#endif
+
+// Use generic helper definitions to define PSI_API and PSI_LOCAL
+// PSI_API is used for the public API symbols.
+// PSI_LOCAL is used for non-API symbols.
+#define PSI_API PSI_HELPER_SO_EXPORT
+#define PSI_LOCAL PSI_HELPER_SO_LOCAL
 
 #endif

--- a/psi4/include/psi4/psi4-dec.h
+++ b/psi4/include/psi4/psi4-dec.h
@@ -37,7 +37,7 @@
 namespace psi {
 
     class PsiOutStream;
-    extern std::shared_ptr<PsiOutStream> outfile;
+    extern PSI_API std::shared_ptr<PsiOutStream> outfile;
     extern std::string outfile_name;
 
     extern char *psi_file_prefix;

--- a/psi4/share/psi4/plugin/ambit/ambit.cc.template
+++ b/psi4/share/psi4/plugin/ambit/ambit.cc.template
@@ -48,7 +48,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options &options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -57,7 +57,7 @@ int read_options(std::string name, Options &options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options &options)
 {
     using namespace ambit;

--- a/psi4/share/psi4/plugin/aointegrals/aointegrals.cc.template
+++ b/psi4/share/psi4/plugin/aointegrals/aointegrals.cc.template
@@ -39,7 +39,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options &options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -53,7 +53,7 @@ int read_options(std::string name, Options &options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     // Grab options from the options object

--- a/psi4/share/psi4/plugin/basic/plugin.cc.template
+++ b/psi4/share/psi4/plugin/basic/plugin.cc.template
@@ -37,7 +37,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options& options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -48,7 +48,7 @@ int read_options(std::string name, Options& options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     int print = options.get_int("PRINT");

--- a/psi4/share/psi4/plugin/dfmp2/plugin.cc.template
+++ b/psi4/share/psi4/plugin/dfmp2/plugin.cc.template
@@ -48,7 +48,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options& options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -65,7 +65,7 @@ int read_options(std::string name, Options& options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     int print = options.get_int("PRINT");

--- a/psi4/share/psi4/plugin/mointegrals/mointegrals.cc.template
+++ b/psi4/share/psi4/plugin/mointegrals/mointegrals.cc.template
@@ -42,8 +42,8 @@
 
 namespace psi{ namespace @plugin@{
 
-extern "C" int
-read_options(std::string name, Options &options)
+extern "C" PSI_API
+int read_options(std::string name, Options &options)
 {
     if (name == "@PLUGIN@" || options.read_globals()) {
         /*- The amount of information printed
@@ -55,7 +55,7 @@ read_options(std::string name, Options &options)
 }
 
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     /*

--- a/psi4/share/psi4/plugin/scf/plugin.cc.template
+++ b/psi4/share/psi4/plugin/scf/plugin.cc.template
@@ -38,7 +38,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options &options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -56,7 +56,7 @@ int read_options(std::string name, Options &options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options &options)
 {
 

--- a/psi4/share/psi4/plugin/sointegrals/sointegrals.cc.template
+++ b/psi4/share/psi4/plugin/sointegrals/sointegrals.cc.template
@@ -40,7 +40,7 @@
 
 namespace psi{ namespace @plugin@ {
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options& options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -71,7 +71,7 @@ public:
     }
 };
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
     int print = options.get_int("PRINT");

--- a/psi4/share/psi4/plugin/wavefunction/wavefunction.cc.template
+++ b/psi4/share/psi4/plugin/wavefunction/wavefunction.cc.template
@@ -81,7 +81,7 @@ double @Plugin@::compute_energy()
     return 0.0;
 }
 
-extern "C"
+extern "C" PSI_API
 int read_options(std::string name, Options& options)
 {
     if (name == "@PLUGIN@"|| options.read_globals()) {
@@ -92,7 +92,7 @@ int read_options(std::string name, Options& options)
     return true;
 }
 
-extern "C"
+extern "C" PSI_API
 SharedWavefunction @plugin@(SharedWavefunction ref_wfn, Options& options)
 {
 

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1086,8 +1086,8 @@ void psi4_python_module_finalize() {
     psi_file_prefix = nullptr;
 }
 
-PYBIND11_PLUGIN(core) {
-    py::module core("core", "C++ Innards of Psi4: Open-Source Quantum Chemistry");
+PYBIND11_MODULE(core, core) {
+    core.doc() = "C++ Innards of Psi4: Open-Source Quantum Chemistry";
     //    py::module core("core", R"pbdoc(
     //
     //        Psi4: An Open-Source Ab Initio Electronic Structure Package
@@ -1365,6 +1365,4 @@ PYBIND11_PLUGIN(core) {
 
     // py::class_<Process>(core, "Process").
     //        def_property_readonly_static("environment", [](py::object /*self*/) { return Process::environment; });
-
-    return core.ptr();
 }

--- a/psi4/src/export_psio.cc
+++ b/psi4/src/export_psio.cc
@@ -43,7 +43,7 @@ void export_psio(py::module &m) {
         .def("tocprint", &PSIO::tocprint, "docstring")
         .def("tocwrite", &PSIO::tocwrite, "docstring")
         .def("tocscan", &PSIO::tocscan,
-             "Seek string in binary file. This export is only good for catching None, as returned sucess object not exported.")
+             "Seek string in binary file. This export is only good for catching None, as returned success object not exported.")
         .def("set_pid", &PSIO::set_pid, "docstring")
         .def_static("shared_object", &PSIO::shared_object, "docstring")
         .def_static("get_default_namespace", &PSIO::get_default_namespace, "docstring")

--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -265,7 +265,7 @@ void buildHamDMRG( std::shared_ptr<IntegralTransform> ints, std::shared_ptr<MOSp
     const int nirrep = wfn->nirrep();
 
     // Econstant and one-electron integrals
-    double Econstant = wfn->molecule()->nuclear_repulsion_energy();
+    double Econstant = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     for (int h = 0; h < iHandler->getNirreps(); h++){
         const int NOCC = iHandler->getNOCC(h);
         for (int froz = 0; froz < NOCC; froz++){

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -46,7 +46,7 @@ class Matrix;
 class ERISieve;
 class TwoBodyAOInt;
 
-class DF_Helper {
+class PSI_API DF_Helper {
    public:
     DF_Helper(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> aux);
     ~DF_Helper();

--- a/psi4/src/psi4/libcubeprop/cubeprop.h
+++ b/psi4/src/psi4/libcubeprop/cubeprop.h
@@ -31,6 +31,7 @@
 
 #include <map>
 
+#include "psi4/pragma.h"
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libmints/wavefunction.h"
 
@@ -38,7 +39,7 @@ namespace psi {
 
 class CubicScalarGrid;
 
-class CubeProperties {
+class PSI_API CubeProperties {
    protected:
     // => Task specification <= //
 

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -523,7 +523,7 @@ public:
  * Static variables/functions to mimic the old C machinery
  */
 extern dpd_gbl dpd_main;
-extern DPD* global_dpd_;
+extern PSI_API DPD* global_dpd_;
 extern int dpd_default;
 extern DPD* dpd_list[2];
 extern int dpd_set_default(int dpd_num);

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -251,7 +251,7 @@ enum indices {pqrs, pqsr, prqs, prsq, psqr, psrq,
 /* Useful for the 3-index sorting function dpd_3d_sort() */
 enum pattern {abc, acb, cab, cba, bca, bac};
 
-class DPD{
+class PSI_API DPD{
 public:
 
     // These used to live in the dpd_data struct
@@ -526,7 +526,7 @@ extern dpd_gbl dpd_main;
 extern PSI_API DPD* global_dpd_;
 extern int dpd_default;
 extern DPD* dpd_list[2];
-extern int dpd_set_default(int dpd_num);
+extern PSI_API int dpd_set_default(int dpd_num);
 extern int dpd_init(int dpd_num, int nirreps, long int memory, int cachetype,
             int *cachefiles, int **cachelist, dpd_file4_cache_entry *priority,
             int num_subspaces, std::vector<int*> &spaceArrays);

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -223,7 +223,7 @@ class PKManager;
  *
  *
  */
-class JK {
+class PSI_API JK {
    protected:
     // => Utility Variables <= //
 

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -63,7 +63,7 @@ class IntegralFactory;
     from the checkpoint file storing the information in an internal Molecule class
     which can be accessed using molecule().
 */
-class BasisSet
+class PSI_API BasisSet
 {
 protected:
     friend class BasisSetParser;

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -109,7 +109,7 @@ bool operator==(const Dimension& a, const Dimension& b) { return (a.blocks_ == b
 
 bool operator!=(const Dimension& a, const Dimension& b) { return !operator==(a, b); }
 
-Dimension operator+(const Dimension& a, const Dimension& b) {
+PSI_API Dimension operator+(const Dimension& a, const Dimension& b) {
     Dimension result = a;
     if (a.n() == b.n()) {
         for (int i = 0, maxi = a.n(); i < maxi; ++i) result[i] += b[i];
@@ -122,7 +122,7 @@ Dimension operator+(const Dimension& a, const Dimension& b) {
     return result;
 }
 
-Dimension operator-(const Dimension& a, const Dimension& b) {
+PSI_API Dimension operator-(const Dimension& a, const Dimension& b) {
     Dimension result = a;
     if (a.n() == b.n()) {
         for (int i = 0, maxi = a.n(); i < maxi; ++i) result[i] -= b[i];

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -33,9 +33,11 @@
 #include <cstdio>
 #include <vector>
 
+#include "psi4/pragma.h"
+
 namespace psi {
 
-class Dimension {
+class PSI_API Dimension {
    private:
     std::string name_;
     std::vector<int> blocks_;

--- a/psi4/src/psi4/libmints/factory.h
+++ b/psi4/src/psi4/libmints/factory.h
@@ -45,7 +45,7 @@ class SOBasisSet;
  * The objects this factory creates can automatically be sized based on information
  * from checkpoint.
  */
-class MatrixFactory {
+class PSI_API MatrixFactory {
     /// Number of irreps
     int nirrep_;
     /// Number of orbitals

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -268,7 +268,7 @@ public:
     AOIntegralsIterator integrals_iterator();
 };
 
-class SOShellCombinationsIterator
+class PSI_API SOShellCombinationsIterator
 {
 private:
     struct ShellQuartet {
@@ -381,7 +381,7 @@ public:
 
 
 /*! \ingroup MINTS */
-class IntegralFactory
+class PSI_API IntegralFactory
 {
 protected:
     /// Center 1 basis set

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -63,7 +63,7 @@ enum diagonalize_order {
  *
  * Using a matrix factory makes creating these a breeze.
  */
-class Matrix : public std::enable_shared_from_this<Matrix> {
+class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 protected:
     /// Matrix data
     double ***matrix_;

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -48,7 +48,7 @@ class OneBodyAOInt;
 * The MintsHelper object, places molecular integrals
 * (and later derivative integrals) on disk
 **/
-class MintsHelper {
+class PSI_API MintsHelper {
 
 private:
     /// The Options reference for basis sets and things

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -59,7 +59,7 @@ const std::string FullPointGroupList[] = {"ATOM", "C_inf_v", "D_inf_h", "C1", "C
  *  \class Molecule
  *  \brief Molecule information class.
  */
-class Molecule
+class PSI_API Molecule
 {
 public:
     /**

--- a/psi4/src/psi4/libmints/sobasis.h
+++ b/psi4/src/psi4/libmints/sobasis.h
@@ -128,7 +128,7 @@ public:
 
 /** An SOBasis object describes the transformation from an atomic orbital basis
     to a symmetry orbital basis. */
-class SOBasisSet
+class PSI_API SOBasisSet
 {
 protected:
     std::shared_ptr<BasisSet> basis_;

--- a/psi4/src/psi4/libmints/sointegral_twobody.h
+++ b/psi4/src/psi4/libmints/sointegral_twobody.h
@@ -74,7 +74,7 @@ class TwoBodySOIntFunctor {
 };
 #endif
 
-class TwoBodySOInt {
+class PSI_API TwoBodySOInt {
    protected:
     std::vector<std::shared_ptr<TwoBodyAOInt> > tb_;
     std::shared_ptr<IntegralFactory> integral_;

--- a/psi4/src/psi4/libmints/twobody.h
+++ b/psi4/src/psi4/libmints/twobody.h
@@ -58,7 +58,7 @@ class GaussianShell;
  *  \class TwoBodyInt
  *  \brief Two body integral base class.
  */
-class TwoBodyAOInt
+class PSI_API TwoBodyAOInt
 {
 protected:
     const IntegralFactory* integral_;

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -45,7 +45,7 @@ class Matrix;
 class VectorIterator;
 
 /*! \ingroup MINTS */
-class Vector
+class PSI_API Vector
 {
 protected:
     /// Actual data, of size dimpi_.sum()

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -82,7 +82,7 @@ class ExternalPotential;
  *  \class Wavefunction
  *  \brief Simple wavefunction base class.
  */
-class Wavefunction : public std::enable_shared_from_this<Wavefunction>
+class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction>
 {
 protected:
     /// Name of the wavefunction
@@ -506,15 +506,15 @@ public:
 
 
     /**
-    * Transform a matrix M into the desired basis 
+    * Transform a matrix M into the desired basis
     * @param M matrix in the SO basis to transform
     * @param C matrix in the SO basis to use for transforms to MO basis
     * @param basis the symmetry basis to use
     *  AO, SO, MO, CartAO
     * @return the matrix M in the desired basis
     **/
-    SharedMatrix matrix_subset_helper(SharedMatrix M, 
-        SharedMatrix C, const std::string &basis, 
+    SharedMatrix matrix_subset_helper(SharedMatrix M,
+        SharedMatrix C, const std::string &basis,
         const std::string matrix_basename) const;
 
     /**

--- a/psi4/src/psi4/liboptions/liboptions.h
+++ b/psi4/src/psi4/liboptions/liboptions.h
@@ -352,7 +352,7 @@ class MapType : public DataType {
     virtual std::string to_string() const;
 };
 
-class Options {
+class PSI_API Options {
     bool edit_globals_;
 
     /// A temporary map used for validation of local options

--- a/psi4/src/psi4/libpsi4util/PsiOutStream.h
+++ b/psi4/src/psi4/libpsi4util/PsiOutStream.h
@@ -29,6 +29,7 @@
 #ifndef _psi_src_lib_libpsi4util_psioutstream_h_
 #define _psi_src_lib_libpsi4util_psioutstream_h_
 
+#include "psi4/pragma.h"
 #include <vector>
 #include <string>
 #include <iostream>
@@ -36,7 +37,7 @@
 
 namespace psi {
 
-class PsiOutStream {
+class PSI_API PsiOutStream {
    private:
     std::ostream* stream_;
     bool is_cout_;

--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -43,6 +43,8 @@
 #define PSI4_CURRENT_FUNCTION "(unknown)"
 #endif
 
+#include "psi4/pragma.h"
+
 namespace psi {
 
 #define PSIEXCEPTION(message) PsiException(message, __FILE__, __LINE__)
@@ -51,7 +53,7 @@ namespace psi {
 /**
     Generic exception class for Psi4
 */
-class PsiException : public std::runtime_error
+class PSI_API PsiException : public std::runtime_error
 {
 
 private:

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -51,9 +51,9 @@
  class EFP;
  }
 
- class Process {
+ class PSI_API Process {
     public:
-     class Environment {
+     class PSI_API Environment {
          std::map<std::string, std::string> environment_;
          size_t memory_;
          int nthread_;

--- a/psi4/src/psi4/libpsio/config.h
+++ b/psi4/src/psi4/libpsio/config.h
@@ -29,6 +29,8 @@
 #ifndef _psi_src_lib_libpsio_config_h_
 #define _psi_src_lib_libpsio_config_h_
 
+#include "psi4/pragma.h"
+
 namespace psi {
 
 #define PSIO_OPEN_NEW 0
@@ -86,7 +88,7 @@ typedef struct {
 } psio_ud;
 
 /** A convenient address initialization struct */
-extern psio_address PSIO_ZERO;
+extern PSI_API psio_address PSIO_ZERO;
 
 }
 

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -41,8 +41,8 @@ namespace psi {
 
 class PSIO;
 class PSIOManager;
-extern std::shared_ptr<PSIO> _default_psio_lib_;
-extern std::shared_ptr<PSIOManager> _default_psio_manager_;
+extern PSI_API std::shared_ptr<PSIO> _default_psio_lib_;
+extern PSI_API std::shared_ptr<PSIOManager> _default_psio_manager_;
 
 /**
     PSIOManager is a class designed to be used as a static object to track all
@@ -51,7 +51,7 @@ extern std::shared_ptr<PSIOManager> _default_psio_manager_;
     This will allow PSICLEAN to be trivially executed.
     Now supports a .psirc and interactive file placement
    */
-class PSIOManager {
+class PSI_API PSIOManager {
 private:
     /// Default path for unspec'd file numbers. Defaults to /tmp/
     std::string default_path_;
@@ -192,7 +192,7 @@ public:
    etc.
 
    */
-class PSIO {
+class PSI_API PSIO {
 public:
     PSIO();
     ~PSIO();

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -140,7 +140,7 @@ void C_DTRMV(char uplo, char trans, char diag, int n, double* a, int lda, double
 void C_DTRSM(char side, char uplo, char transa, char diag, int m, int n, double alpha, double* a, int lda, double* b, int ldb);
 
 // BLAS 3 Double routines
-void C_DGEMM(char transa, char transb, int m, int n, int k, double alpha, double* a, int lda, double* b, int ldb, double beta, double* c, int ldc);
+PSI_API void C_DGEMM(char transa, char transb, int m, int n, int k, double alpha, double* a, int lda, double* b, int ldb, double beta, double* c, int ldc);
 void C_DSYMM(char side, char uplo, int m, int n, double alpha, double* a, int lda, double* b, int ldb, double beta, double* c, int ldc);
 void C_DTRMM(char side, char uplo, char transa, char diag, int m, int n, double alpha, double* a, int lda, double* b, int ldb);
 void C_DSYRK(char uplo, char trans, int n, int k, double alpha, double* a, int lda, double beta, double* c, int ldc);

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -55,7 +55,7 @@ typedef std::vector<std::shared_ptr< MOSpace> > SpaceVec;
      within general spaces
    */
 
-class IntegralTransform{
+class PSI_API IntegralTransform{
 // TODO check usage of restricted, to make sure that it's correct everywhere
     public:
         /**

--- a/psi4/src/psi4/libtrans/mospace.h
+++ b/psi4/src/psi4/libtrans/mospace.h
@@ -39,7 +39,7 @@ namespace psi {
  * The MOSpace class is used to define orbital spaces in which to transform
  * integrals
  */
-class MOSpace {
+class PSI_API MOSpace {
    public:
     MOSpace(const char label);
     ~MOSpace();


### PR DESCRIPTION
## Description
Bump some dependencies. Update psi to pybind11 2.2.1. Deal accompanying visibility issues through Jet's `PSI_API` macro.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] CheMPS2 to 1.8.4
  - [x] ~Libint to latest v1 head~ (RDR already covered this)
  - [x] Pybind11 to 2.2.1
  - [x] had to add some psio unsavoriness (recomputing integrals whether present or not) since pb11-221 won't seem to give me my `None` for `nullptr`. This only affects stability analyses, and I figure they're due for an overhaul anyways.
  - [x] add enough `PSI_API` to get shipped plugins to work.
* **User-Facing for Release Notes**

## Questions
- [ ] Big question here is do we want to make the pybind jump?

  * Not immediately until https://github.com/pybind/pybind11/issues/1121 is cleared up
  * Likely to cause some building headaches and entanglements of 200 and 221 versions at build-time, no matter how tightly I try to instruct CMake where to find it.
  * Pybind folks are [pretty adamant about symbol visibility](http://pybind11.readthedocs.io/en/stable/upgrade.html#stricter-enforcement-of-hidden-symbol-visibility-for-pybind11-modules). We do something they truly disapprove of and use pb as a plain dependency rather than their (very nice) module maker, so I think our plugins (double use of `core.so` as python module and ordinary Linux lib) should be fine, but we'll want to test Forte, @fevangelista.
  * Can take a look at the [Changelog](http://pybind11.readthedocs.io/en/stable/changelog.html) for new goodies. Note that Psi4 is currently pinned at v2.0.0 (1 Jan 2017).
  * When @ryanmrichard was dealing with two pybind projects (Psi4, Pulsar), he came to the conclusion that it was very important to have all pybind projects on exactly the same version. Right now we control all ecosystem projects using pybind (Psi4, Forte, PylibEFP (which needs >=2.2.0, incidentally)) so can just made decisions in consensus. That may not always be the case. I believe some of pybind's asserted control over symbols is actually meant to allow better mixing of pb projects, in which case we should also consider doing as they advise and only exporting the symbols we need.

## Status
- [x] Ready to go. This is now pointing to scfitertopy branch, so ok to merge.
