### PR TITLE
Preserve current working directory when parsing PCM section

### DIFF
--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -1,5 +1,5 @@
     if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.11 CONFIG QUIET)
+    find_package(PCMSolver 1.1.10 CONFIG QUIET)
 
     if(${PCMSolver_FOUND})
         get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
@@ -23,7 +23,7 @@
 
         ExternalProject_Add(pcmsolver_external
             GIT_REPOSITORY https://github.com/PCMSolver/pcmsolver
-              GIT_TAG v1.1.11
+            GIT_TAG v1.1.11
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.10 CONFIG QUIET)
+    if(${ENABLE_PCMSolver})
+    find_package(PCMSolver 1.1.11 CONFIG QUIET)
 
     if(${PCMSolver_FOUND})
         get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
@@ -23,7 +23,7 @@ if(${ENABLE_PCMSolver})
 
         ExternalProject_Add(pcmsolver_external
             GIT_REPOSITORY https://github.com/PCMSolver/pcmsolver
-            GIT_TAG v1.1.10
+              GIT_TAG v1.1.11
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -119,7 +119,7 @@ list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
 if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.10 CONFIG REQUIRED)
+    find_package(PCMSolver 1.1.11 CONFIG REQUIRED)
     get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using PCMSolver${ColourReset}: ${_loc} (version ${PCMSolver_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -119,7 +119,7 @@ list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
 if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.11 CONFIG REQUIRED)
+    find_package(PCMSolver 1.1.10 CONFIG REQUIRED)
     get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using PCMSolver${ColourReset}: ${_loc} (version ${PCMSolver_VERSION})")

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -225,10 +225,26 @@ def set_module_options(module, options_dict):
     for k, v, in options_dict.items():
         core.set_local_option(module.upper(), k.upper(), v)
 
+
 ## OEProp helpers
 
+
 def pcm_helper(block):
-    """Passes multiline string *block* to PCMSolver parser."""
+    """
+    Passes multiline string *block* to PCMSolver parser.
+
+    Parameters
+    ----------
+    block: multiline string with PCM input in PCMSolver syntax.
+
+    Notes
+    -----
+    !Warning! This function changes directory from launch site to scratch and
+    back. This is needed because PCMSolver does not have a notion of an
+    absolute paths for its input file. If you are looking at this function as
+    an example, remember that changing directories is usually a **bad idea**
+    and **should not be done**.
+    """
 
     # Setup unique scratch directory and move in, as done for other add-ons
     psioh = core.IOManager.shared_object()

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -233,6 +233,7 @@ def pcm_helper(block):
     # Setup unique scratch directory and move in, as done for other add-ons
     psioh = core.IOManager.shared_object()
     psio = core.IO.shared_object()
+    curdir = os.getcwd()
     os.chdir(psioh.get_default_path())
     pcm_tmpdir = 'psi.' + str(os.getpid()) + '.' + psio.get_default_namespace() + \
         'pcmsolver.' + str(uuid.uuid4())[:8]
@@ -243,6 +244,7 @@ def pcm_helper(block):
         handle.write(block)
     import pcmsolver
     pcmsolver.parse_pcm_input('pcmsolver.inp')
+    os.chdir(curdir)
 
 
 def filter_comments(string):


### PR DESCRIPTION
## Description
Parsing the PCM section of the input requires changing directories. As noted in #817 this is not really documented anywhere and affects users.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [x] CWD is saved before parsing PCM section and restored at the end.

## Status
- [x] Ready to go
