### PR TITLE
Fix initialization of Fortran run-time

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1217,7 +1217,9 @@ bool psi4_python_module_initialize()
     Process::environment.options.set_read_globals(false);
 
 #ifdef INTEL_Fortran_ENABLED
-    for_rtl_init_(NULL, NULL);
+    static int argc = 1;
+    static char* argv = (char*) "";
+    for_rtl_init_(&argc, &argv);
 #endif
 
     initialized = true;


### PR DESCRIPTION
## Description
Issue reported by @zhi-wang: passing `NULL` pointer to `for_rtl_init_` function in `core.cc` makes program quit silently. Fix also suggested by @zhi-wang. Closes psi4/psi4#771

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Fix initialization of Fortran run-time

## Status
- [x] Ready to go
