### PR TITLE
Rid P::e of envvar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,8 @@ add_subdirectory(external/common)
 add_subdirectory(external/upstream)
 
 # external projects manage their own OpenMP and c++YY flags, so only add to CXX_FLAGS for psi4-core
-include(autocmake_omp)
 include(custom_cxxstandard)
+include(autocmake_omp)
 include(custom_static_library)
 
 ################################  Main Project  ################################

--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -31,7 +31,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
     file(REMOVE ${_testfl})
 
     if (APPLE)
-        if (${GCC_VERSION} VERSION_LESS 6.1)
+        if (${GCC_VERSION} VERSION_LESS 3.6)
             message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of CLANG (detected: ${GCC_VERSION}; required for C++11: 6.1) so this build won't work without CLANG intervention: http://psicode.org/psi4manual/master/build_planning.html\n${ColourReset}")
         endif()
     else ()

--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -26,17 +26,17 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
     try_run(GCCV_COMPILES
             GCCV_RUNS
             ${CMAKE_BINARY_DIR} ${_testfl}
-            RUN_OUTPUT_VARIABLE GCC_VERSION)
-    message(STATUS "Found base compiler version ${GCC_VERSION}")
+            RUN_OUTPUT_VARIABLE CPLR_VERSION)
+    message(STATUS "Found base compiler version ${CPLR_VERSION}")
     file(REMOVE ${_testfl})
 
     if (APPLE)
-        if (${GCC_VERSION} VERSION_LESS 3.6)
-            message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of CLANG (detected: ${GCC_VERSION}; required for C++11: 6.1) so this build won't work without CLANG intervention: http://psicode.org/psi4manual/master/build_planning.html\n${ColourReset}")
+        if (${CPLR_VERSION} VERSION_LESS 3.6)
+            message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of CLANG (detected: ${CPLR_VERSION}; required for C++11: Clang 3.6 or AppleClang 6.1) so this build won't work without CLANG intervention.\n${ColourReset}")
         endif()
     else ()
-        if (${GCC_VERSION} VERSION_LESS 4.9)
-            message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of GCC (detected: ${GCC_VERSION}; required for C++11: 4.9) so this build won't work without GCC intervention: http://psicode.org/psi4manual/master/build_planning.html#faq-modgcc\n${ColourReset}")
+        if (${CPLR_VERSION} VERSION_LESS 4.9)
+            message(FATAL_ERROR "${BoldYellow}Intel ICPC makes use of GCC (detected: ${CPLR_VERSION}; required for C++11: 4.9) so this build won't work without GCC intervention: http://psicode.org/psi4manual/master/build_planning.html#faq-modgcc\n${ColourReset}")
         endif()
     endif()
 

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -48,7 +48,6 @@ data_dir = os.path.abspath(data_dir)
 if not os.path.isdir(data_dir):
     raise KeyError("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable"
                     "      Current value of PSIDATADIR is %s" % data_dir)
-os.environ["PSIDATADIR"] = data_dir
 
 # Init core
 try:
@@ -68,6 +67,8 @@ if "PSI_SCRATCH" in os.environ.keys():
     if not os.path.isdir(envvar_scratch):
         raise Exception("Passed in scratch is not a directory (%s)." % envvar_scratch)
     core.IOManager.shared_object().set_default_path(envvar_scratch)
+
+core.set_datadir(data_dir)
 
 # Cleanup core at exit
 import atexit

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -793,17 +793,11 @@ def process_input(raw_input, print_level=1):
     else:
         psirc = ''
 
-    # Override scratch directory if user specified via env_var
-    scratch = ''
-    scratch_env = core.get_environment('PSI_SCRATCH')
-    if len(scratch_env):
-        scratch += 'psi4_io.set_default_path("%s")\n' % (scratch_env)
-
     blank_mol = 'geometry("""\n'
     blank_mol += '0 1\nH\nH 1 0.74\n'
     blank_mol += '""","blank_molecule_psi4_yo")\n'
 
-    temp = imports + psirc + scratch + blank_mol + temp
+    temp = imports + psirc + blank_mol + temp
 
     # Move up the psi4.core namespace
     for func in dir(core):

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -482,7 +482,7 @@ def _chain_dot(*args, **kwargs):
     return ret
 
 
-# Matirx attributes
+# Matrix attributes
 core.Matrix.from_array = classmethod(array_to_matrix)
 core.Matrix.from_list = classmethod(lambda self, x: array_to_matrix(self, np.array(x)))
 core.Matrix.to_array = _to_array

--- a/psi4/driver/plugin.py
+++ b/psi4/driver/plugin.py
@@ -29,6 +29,7 @@
 import os
 import sys
 
+from psi4 import core
 from psi4.driver.util.filesystem import *
 from psi4.driver.util import tty
 
@@ -87,7 +88,7 @@ def sanitize_name(name):
 
 # Determine the available plugins
 available_plugins = []
-psidatadir = os.environ.get('PSIDATADIR', None)
+psidatadir = core.get_datadir()
 plugin_path = join_path(psidatadir, "plugin")
 for dir in os.listdir(plugin_path):
     if os.path.isdir(join_path(plugin_path, dir)):

--- a/psi4/driver/procrouting/interface_cfour.py
+++ b/psi4/driver/procrouting/interface_cfour.py
@@ -143,8 +143,8 @@ def run_cfour(name, **kwargs):
     lenv = {
         'PATH': ':'.join([os.path.abspath(x) for x in os.environ.get('PSIPATH', '').split(':') if x != '']) + \
                 ':' + os.environ.get('PATH') + \
-                ':' + os.environ.get("PSIDATADIR") + '/basis',
-        'GENBAS_PATH': os.environ.get("PSIDATADIR") + '/basis',
+                ':' + core.get_datadir() + '/basis',
+        'GENBAS_PATH': core.get_datadir() + '/basis',
         'CFOUR_NUM_CORES': os.environ.get('CFOUR_NUM_CORES'),
         'MKL_NUM_THREADS':  os.environ.get('MKL_NUM_THREADS'),
         'OMP_NUM_THREADS':  os.environ.get('OMP_NUM_THREADS'),

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1285,7 +1285,8 @@ def scf_helper(name, post_scf=True, **kwargs):
     core.set_legacy_wavefunction(scf_wfn)
 
     fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
-    read_filename = os.path.join(core.get_environment("PSI_SCRATCH"), fname + ".180.npz")
+    psi_scratch = core.IOManager.shared_object().get_default_path()
+    read_filename = os.path.join(psi_scratch, fname + ".180.npz")
 
     if (core.get_option('SCF', 'GUESS') == 'READ') and os.path.isfile(read_filename):
         data = np.load(read_filename)
@@ -1395,7 +1396,7 @@ def scf_helper(name, post_scf=True, **kwargs):
 
     # Write out orbitals and basis
     fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
-    write_filename = os.path.join(core.get_environment("PSI_SCRATCH"), fname + ".180.npz")
+    write_filename = os.path.join(psi_scratch, fname + ".180.npz")
     data = {}
     data.update(scf_wfn.Ca().np_write(None, prefix="Ca"))
     data.update(scf_wfn.Cb().np_write(None, prefix="Cb"))

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -52,7 +52,7 @@ def run_cfour_module(xmod):
     lenv = {
         'PATH': ':'.join([os.path.abspath(x) for x in os.environ.get('PSIPATH', '').split(':') if x != '']) + \
                 ':' + os.environ.get('PATH') + \
-                ':' + core.Process.environment["PSIDATADIR"] + '/basis' + \
+                ':' + core.get_datadir() + '/basis' + \
                 ':' + core.psi_top_srcdir() + '/share/basis',
         'CFOUR_NUM_CORES': os.environ.get('CFOUR_NUM_CORES'),
         'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH')

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -715,7 +715,12 @@ class BasisSet(object):
         mol.update_geometry()
 
         # Paths to search for gbs files: here + PSIPATH + library
-        psidatadir = os.environ.get('PSIDATADIR', None)
+        try:
+            from psi4 import core
+            psidatadir = core.get_datadir()
+        except ImportError:
+            pass
+        #nolongerenvvar psidatadir = os.environ.get('PSIDATADIR', None)
         #nolongerpredicatble psidatadir = __file__ + '/../../..' if psidatadir is None else psidatadir
         if psidatadir:
             libraryPath = ':' + os.path.abspath(psidatadir) + '/basis'

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -230,7 +230,7 @@ def database(name, db_name, **kwargs):
     kwargs.pop('molecule', None)
 
     # Paths to search for database files: here + PSIPATH + library + PYTHONPATH
-    psidatadir = os.environ.get('PSIDATADIR', None)
+    psidatadir = core.get_datadir()
     #nolongerpredictable psidatadir = __file__ + '/../..' if psidatadir is None else psidatadir
     libraryPath = ':' + os.path.abspath(psidatadir) + '/databases'
     driver_loc = os.path.dirname(os.path.abspath(__file__))

--- a/psi4/header.py
+++ b/psi4/header.py
@@ -45,7 +45,7 @@ def sizeof_fmt(num, suffix='B'):
 def print_header():
     driver_info = version_formatter("""{version} {release}""")
     git_info = version_formatter("""{{{branch}}} {githash} {clean}""")
-    datadir = core.get_environment("PSIDATADIR")
+    datadir = core.get_datadir()
     memory = sizeof_fmt(core.get_memory())
     threads = str(core.get_num_threads())
 

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -204,7 +204,7 @@ psi4.print_header()
 if args["scratch"] is not None:
     if not os.path.isdir(args["scratch"]):
         raise Exception("Passed in scratch is not a directory (%s)." % args["scratch"])
-    psi4.core.set_environment("PSI_SCRATCH", os.path.abspath(os.path.expanduser(args["scratch"])))
+    psi4.core.IOManager.shared_object().set_default_path(os.path.abspath(os.path.expanduser(args["scratch"])))
 
 # If this is a json call, compute and stop
 if args["json"]:

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1191,7 +1191,6 @@ bool psi4_python_module_initialize()
 
     // Setup the environment
     Process::environment.initialize(); // Defaults to obtaining the environment from the global environ variable
-    // Process::environment.set("PSI_SCRATCH", "/tmp/");
     // Process::environment.set("PSIDATADIR", "");
     Process::environment.set_memory(524288000);
 
@@ -1491,8 +1490,6 @@ PYBIND11_PLUGIN(core) {
     core.def("adc", py_psi_adc, "Runs the ADC propagator code, for excited states.");
     core.def("thermo", py_psi_thermo, "Computes thermodynamic data.");
     core.def("opt_clean", py_psi_opt_clean, "Cleans up the optimizer's scratch files.");
-    core.def("set_environment", [](const std::string key, const std::string value){ return Process::environment.set(key, value); }, "Set enviromental vairable");
-    core.def("get_environment", [](const std::string key){ return Process::environment(key); }, "Get enviromental vairable");
     core.def("get_options", py_psi_get_options, py::return_value_policy::reference, "Get options");
     core.def("set_output_file", [](const std::string ofname){
                  outfile = std::shared_ptr<PsiOutStream>(new PsiOutStream(ofname, std::ostream::trunc));

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1110,6 +1110,16 @@ size_t py_psi_get_memory()
     return Process::environment.get_memory();
 }
 
+void py_psi_set_datadir(const std::string& pdd)
+{
+	Process::environment.set_datadir(pdd);
+}
+
+std::string py_psi_get_datadir()
+{
+	return Process::environment.get_datadir();
+}
+
 void py_psi_set_n_threads(size_t nthread, bool quiet)
 {
 #ifdef _OPENMP
@@ -1191,9 +1201,7 @@ bool psi4_python_module_initialize()
 
     // Setup the environment
     Process::environment.initialize(); // Defaults to obtaining the environment from the global environ variable
-    // Process::environment.set("PSIDATADIR", "");
     Process::environment.set_memory(524288000);
-
 
     // There should only be one of these in Psi4
     Wavefunction::initialize_singletons();
@@ -1342,6 +1350,8 @@ PYBIND11_PLUGIN(core) {
         "Assigns the global frequencies to the values stored in the 3N-6 Vector argument.");
     core.def("set_memory_bytes", py_psi_set_memory, py::arg("memory"), py::arg("quiet")=false, "Sets the memory available to Psi (in bytes).");
     core.def("get_memory", py_psi_get_memory, "Returns the amount of memory available to Psi (in bytes).");
+	core.def("set_datadir", &py_psi_set_datadir, "Sets the path to shared text resources, PSIDATADIR");
+	core.def("get_datadir", &py_psi_get_datadir, "Returns the path to shared text resources, PSIDATADIR");
     core.def("set_num_threads", py_psi_set_n_threads, py::arg("nthread"), py::arg("quiet")=false, "Sets the number of threads to use in SMP parallel computations.");
     core.def("get_num_threads", py_psi_get_n_threads, "Returns the number of threads to use in SMP parallel computations.");
 //    core.def("mol_from_file",&LibBabel::ParseFile,"Reads a molecule from another input file");

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1110,16 +1110,6 @@ size_t py_psi_get_memory()
     return Process::environment.get_memory();
 }
 
-void py_psi_set_datadir(const std::string& pdd)
-{
-	Process::environment.set_datadir(pdd);
-}
-
-std::string py_psi_get_datadir()
-{
-	return Process::environment.get_datadir();
-}
-
 void py_psi_set_n_threads(size_t nthread, bool quiet)
 {
 #ifdef _OPENMP
@@ -1350,8 +1340,12 @@ PYBIND11_PLUGIN(core) {
         "Assigns the global frequencies to the values stored in the 3N-6 Vector argument.");
     core.def("set_memory_bytes", py_psi_set_memory, py::arg("memory"), py::arg("quiet")=false, "Sets the memory available to Psi (in bytes).");
     core.def("get_memory", py_psi_get_memory, "Returns the amount of memory available to Psi (in bytes).");
-	core.def("set_datadir", &py_psi_set_datadir, "Sets the path to shared text resources, PSIDATADIR");
-	core.def("get_datadir", &py_psi_get_datadir, "Returns the path to shared text resources, PSIDATADIR");
+    core.def("set_datadir",
+                [](const std::string& pdd) { Process::environment.set_datadir(pdd); },
+                "Returns the amount of memory available to Psi (in bytes).");
+    core.def("get_datadir",
+                []() { return Process::environment.get_datadir(); },
+                "Sets the path to shared text resources, PSIDATADIR");
     core.def("set_num_threads", py_psi_set_n_threads, py::arg("nthread"), py::arg("quiet")=false, "Sets the number of threads to use in SMP parallel computations.");
     core.def("get_num_threads", py_psi_get_n_threads, "Returns the number of threads to use in SMP parallel computations.");
 //    core.def("mol_from_file",&LibBabel::ParseFile,"Reads a molecule from another input file");

--- a/psi4/src/create_new_plugin.cc
+++ b/psi4/src/create_new_plugin.cc
@@ -100,7 +100,7 @@ public:
     void process()
     {
         // The location of the plugin templates, in the Psi4 source
-        std::string psiDataDirName = Process::environment("PSIDATADIR");
+        std::string psiDataDirName = Process::environment.get_datadir();
         std::string psiDataDirWithPlugin = psiDataDirName + "/plugin";
 
         std::string fpath = filesystem::path(psiDataDirWithPlugin).make_absolute().str();

--- a/psi4/src/psi4/lib3index/denominator.cc
+++ b/psi4/src/psi4/lib3index/denominator.cc
@@ -163,7 +163,7 @@ void LaplaceDenominator::decompose()
     double R = B / A;
 
     // Pick appropriate quadrature file and read contents
-    std::string PSIDATADIR = Process::environment("PSIDATADIR");
+    std::string PSIDATADIR = Process::environment.get_datadir();
     std::string err_table_filename = PSIDATADIR + "/quadratures/1_x/error.bin";
     std::string R_filename = PSIDATADIR + "/quadratures/1_x/R_avail.bin";
 
@@ -594,7 +594,7 @@ void SAPTLaplaceDenominator::decompose()
     double R = B / A;
 
     // Pick appropriate quadrature file and read contents
-    std::string PSIDATADIR = Process::environment("PSIDATADIR");
+    std::string PSIDATADIR = Process::environment.get_datadir();
     std::string err_table_filename = PSIDATADIR + "/quadratures/1_x/error.bin";
     std::string R_filename = PSIDATADIR + "/quadratures/1_x/R_avail.bin";
 
@@ -1066,7 +1066,7 @@ void TLaplaceDenominator::decompose()
     double R = B / A;
 
     // Pick appropriate quadrature file and read contents
-    std::string PSIDATADIR = Process::environment("PSIDATADIR");
+    std::string PSIDATADIR = Process::environment.get_datadir();
     std::string err_table_filename = PSIDATADIR + "/quadratures/1_x/error.bin";
     std::string R_filename = PSIDATADIR + "/quadratures/1_x/R_avail.bin";
 

--- a/psi4/src/psi4/libefp_solver/efp_solver.cc
+++ b/psi4/src/psi4/libefp_solver/efp_solver.cc
@@ -114,7 +114,8 @@ void EFP::add_fragments(std::vector<std::string> fnames)
 
     // Paths to search for efp files: here + PSIPATH + library
     std::string libraryPath = Process::environment.get_datadir() + "/efpfrag";
-    // getting cancelled for now std::string efpPath = ".:" + Process::environment("PSIPATH") + ":" + libraryPath;
+    // PSIPATH getting cancelled for now
+	std::string efpPath = ".:" + libraryPath;
 //    boost::char_separator<char> sep(":");
 //    typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
 //    tokenizer tokens(efpPath, sep);

--- a/psi4/src/psi4/libefp_solver/efp_solver.cc
+++ b/psi4/src/psi4/libefp_solver/efp_solver.cc
@@ -113,8 +113,8 @@ void EFP::add_fragments(std::vector<std::string> fnames)
     std::vector<std::string> uniq;
 
     // Paths to search for efp files: here + PSIPATH + library
-    std::string libraryPath = Process::environment("PSIDATADIR") + "/efpfrag";
-    std::string efpPath = ".:" + Process::environment("PSIPATH") + ":" + libraryPath;
+    std::string libraryPath = Process::environment.get_datadir() + "/efpfrag";
+    // getting cancelled for now std::string efpPath = ".:" + Process::environment("PSIPATH") + ":" + libraryPath;
 //    boost::char_separator<char> sep(":");
 //    typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
 //    tokenizer tokens(efpPath, sep);

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -75,9 +75,6 @@
          std::shared_ptr<PointGroup> parent_symmetry() { return parent_symmetry_; }
          /// Set the "parent" symmetry
          void set_parent_symmetry(std::shared_ptr<PointGroup> pg) { parent_symmetry_ = pg; }
-         const std::string& operator()(const std::string& key) const;
-         std::string operator()(const std::string& key);
-         const std::string set(const std::string& key, const std::string& value);
 
          /// Set active molecule
          void set_molecule(const std::shared_ptr<Molecule>& molecule);

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -57,6 +57,7 @@
          std::map<std::string, std::string> environment_;
          size_t memory_;
          int nthread_;
+         std::string datadir_;
 
          std::shared_ptr<Molecule> molecule_;
          SharedMatrix gradient_;
@@ -125,6 +126,10 @@
          /// Memory in bytes
          size_t get_memory() const;
          void set_memory(size_t m);
+
+         /// PSIDATADIR
+         std::string get_datadir() const { return datadir_; }
+         void set_datadir(const std::string pdd) { datadir_ = pdd; }
 
          /// "Global" liboptions object.
          Options options;

--- a/psi4/src/psi4/libpsio/filemanager.cc
+++ b/psi4/src/psi4/libpsio/filemanager.cc
@@ -42,17 +42,7 @@ namespace psi{
 PSIOManager::PSIOManager()
 {
     pid_ = psio_getpid();
-
-    // set the default to /tmp unless one of the
-    // TMP environment variables is set
-    if(std::getenv("TMPDIR"))
-        set_default_path(std::getenv("TMPDIR"));
-    else if(std::getenv("TEMP"))
-        set_default_path(std::getenv("TEMP"));
-    else if(std::getenv("TMP"))
-        set_default_path(std::getenv("TMP"));
-    else
-        set_default_path("/tmp");
+    set_default_path("/tmp");
 }
 
 PSIOManager::~PSIOManager()

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -53,9 +53,7 @@ extern std::shared_ptr<PSIOManager> _default_psio_manager_;
    */
 class PSIOManager {
 private:
-    /// Default path for unspec'd file numbers
-    // (defaults to either $TMP, $TEMPDIR, $TMP or /tmp/ in
-    // that order)
+    /// Default path for unspec'd file numbers. Defaults to /tmp/
     std::string default_path_;
     /// Specific paths for arbitrary file numbers
     std::map<int, std::string> specific_paths_;


### PR DESCRIPTION
## Description
I hit a system that was raising [putenv and setenv not avail](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libpsi4util/process.cc#L136). Rather than solve it, decided (with support) to clean environment variables out of `P::e`. Only active uses were PSI_SCRATCH and PSIDATADIR.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Replaced all the PSI_SCRATCH with calls directly to psio.get_default_path(). Also cleared that fn out so it truly defaults to `/tmp/`, not TMP, TEMP, TMPDIR, then /tmp/.
  - [x] Once all the parsing's py-side might be able to drop PSIDATADIR entirely. But for now, moved it to its own slot as `P::e.[gs]et_datadir()`
  - [x] Can't tell if you're dealing with Clang or AppleClang by `#defines`, so lowered cxxstandard cutoff to permit Intel + !AppleClang to pass.
  - [x] `FindOpenMP.cmake` attaches a lib to try_run that isn't needed just to extract versions. Shift OMP detection so cxxstandard doesn't complain about unfindable lib
* **User-Facing for Release Notes**

## Status
- [x] Ready to go
