### PR TITLE
VV10 Grid fix

### DIFF
--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -261,8 +261,13 @@ void export_functional(py::module &m) {
         .def("blocks", &MolecularGrid::blocks, "Returns a list of blocks.");
 
     py::class_<DFTGrid, std::shared_ptr<DFTGrid>, MolecularGrid>(m, "DFTGrid", "docstring")
-        .def_static("build", [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis) {
-            return DFTGrid(mol, basis, Process::environment.options);
+        .def_static("build",
+                    [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis) {
+                        return std::shared_ptr<DFTGrid>(new DFTGrid(mol, basis, Process::environment.options));
+                    })
+        .def_static("build", [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis,
+                                std::map<std::string, int> int_opts, std::map<std::string, std::string> string_opts) {
+            return std::shared_ptr<DFTGrid>(new DFTGrid(mol, basis, int_opts, string_opts, Process::environment.options));
         });
 
     py::class_<Dispersion, std::shared_ptr<Dispersion>>(m, "Dispersion", "docstring")

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -263,11 +263,11 @@ void export_functional(py::module &m) {
     py::class_<DFTGrid, std::shared_ptr<DFTGrid>, MolecularGrid>(m, "DFTGrid", "docstring")
         .def_static("build",
                     [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis) {
-                        return std::shared_ptr<DFTGrid>(new DFTGrid(mol, basis, Process::environment.options));
+                        return std::make_shared<DFTGrid>(mol, basis, Process::environment.options);
                     })
         .def_static("build", [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis,
                                 std::map<std::string, int> int_opts, std::map<std::string, std::string> string_opts) {
-            return std::shared_ptr<DFTGrid>(new DFTGrid(mol, basis, int_opts, string_opts, Process::environment.options));
+            return std::make_shared<DFTGrid>(mol, basis, int_opts, string_opts, Process::environment.options);
         });
 
     py::class_<Dispersion, std::shared_ptr<Dispersion>>(m, "Dispersion", "docstring")

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -4103,9 +4103,11 @@ void MolecularGrid::block(int max_points, int min_points, double max_radius)
     // Reassign
     std::shared_ptr<GridBlocker> blocker;
     if (options_.get_str("DFT_BLOCK_SCHEME") == "NAIVE") {
-        blocker = std::shared_ptr<GridBlocker>(new NaiveGridBlocker(npoints_,x_,y_,z_,w_,index_,max_points,min_points,max_radius,extents_));
+        blocker = std::shared_ptr<GridBlocker>(
+            new NaiveGridBlocker(npoints_, x_, y_, z_, w_, index_, max_points, min_points, max_radius, extents_));
     } else if (options_.get_str("DFT_BLOCK_SCHEME") == "OCTREE") {
-        blocker = std::shared_ptr<GridBlocker>(new OctreeGridBlocker(npoints_,x_,y_,z_,w_,index_,max_points,min_points,max_radius,extents_));
+        blocker = std::shared_ptr<GridBlocker>(
+            new OctreeGridBlocker(npoints_, x_, y_, z_, w_, index_, max_points, min_points, max_radius, extents_));
     }
 
     blocker->set_print(options_.get_int("PRINT"));
@@ -4261,7 +4263,7 @@ void NaiveGridBlocker::block()
     ::memcpy((void*)y_,(void*)y_ref_, sizeof(double)*npoints_);
     ::memcpy((void*)z_,(void*)z_ref_, sizeof(double)*npoints_);
     ::memcpy((void*)w_,(void*)w_ref_, sizeof(double)*npoints_);
-    ::memcpy((void*)index_,(void*)index_ref_, sizeof(double)*npoints_);
+    ::memcpy((void*)index_,(void*)index_ref_, sizeof(int)*npoints_);
 
     blocks_.clear();
     for (int Q = 0; Q < npoints_; Q += max_points_) {
@@ -4467,6 +4469,7 @@ void OctreeGridBlocker::block()
     }
 
 
+    blocks_.clear();
     index = 0;
     max_points_ = 0;
     for (size_t A = 0; A < completed_tree.size(); A++) {

--- a/tests/dft-b2plyp/input.dat
+++ b/tests/dft-b2plyp/input.dat
@@ -42,6 +42,7 @@ set reference rks
 set freeze_core false
 set dft_radial_points 99
 set dft_spherical_points 302
+set dft_block_scheme naive
 
 #activate(h2)
 #eb2plyp = energy('dsd-pbep86')
@@ -52,6 +53,8 @@ activate(h2)
 eb2plyp = energy('b2plyp')
 compare_values(-1.1709, eb2plyp, 4, 'H2 with B2PLYP')       #TEST
 clean()
+
+set dft_block_scheme octree
 
 activate(h2o)
 eb2plyp = energy('b2plyp')


### PR DESCRIPTION
## Description
Fixes an issues where VV10 occasionally seg faults due to improperly sized temporary arrays.

Also, spot the error of why the Naive grid blocker has been seg faulting for years in [#9575ede](https://github.com/dgasmith/psi4/commit/9575ede082c5287be1c176a13299829317b3b719). Highly recommend we stop using raw pointers and C functions.

## Status
- [x] Ready to go