### PR TITLE
Fix cookbook-rohf-orb-rot test

### DIFF
--- a/tests/cookbook/rohf-orb-rot/input.dat
+++ b/tests/cookbook/rohf-orb-rot/input.dat
@@ -73,7 +73,7 @@ compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
 Matrix.rotate_columns(scf_wfn.Ca(), 0, 7, 8, math.pi / 2.0)
 
 fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_wfn.molecule().name())))[1]
-filename = os.path.join(core.get_environment("PSI_SCRATCH"), fname + ".180.npz")
+filename = os.path.join(core.IOManager.shared_object().get_default_path(), fname + ".180.npz")
 data = {}
 data.update(scf_wfn.Ca().np_write(None, prefix="Ca"))
 data.update(scf_wfn.Cb().np_write(None, prefix="Cb"))


### PR DESCRIPTION
## Description
This PR fixes a line in cookbook-rohf-orb-rot test that was previously causing a failure

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Fixes previously failing tests
* **User-Facing for Release Notes**
  - Not sure if this is applicable?

## Questions
- No questions at this time

## Status
- [ ] Ready to go
