### PR TITLE
Migrate some existing wiki docs into sphinxman

### DIFF
--- a/doc/sphinxman/CMakeLists.txt
+++ b/doc/sphinxman/CMakeLists.txt
@@ -50,7 +50,8 @@ if(PERL_FOUND AND SPHINX_FOUND AND SPHINX_STUFF_FOUND)
     chemps2.rst fisapt.rst plugin_v2rdm_casscf.rst psi4api.rst
     manage_addon.rst numpy.rst build_planning.rst build_faq.rst
     build_obtaining.rst libint.rst erd.rst simint.rst gcp.rst
-    index_tutorials.rst manage_faq.rst manage_index.rst manage_git.rst
+    index_tutorials.rst prog_faq.rst manage_index.rst manage_git.rst
+    style_c.rst prog_blas.rst
     )
 
     # * compute relative path btwn top_srcdir and objdir/doc/sphinxman

--- a/doc/sphinxman/source/contributing.rst
+++ b/doc/sphinxman/source/contributing.rst
@@ -33,9 +33,11 @@ Contributions: Intro to Programming in |PSIfour|
 ================================================
 
 .. toctree::
+   FAQ <prog_faq>
    plugins
    documentation
    psipep
+   style_c
 
 ..   bestpractices_py
 

--- a/doc/sphinxman/source/manage_addon.rst
+++ b/doc/sphinxman/source/manage_addon.rst
@@ -80,6 +80,7 @@ How to use an Add-On's name in directory structure, build, and distribution
   have a different capitalization for an advertising name. After all,
   that's what |PSIfour| does.
 
+
 .. _`faq:addoncmake`:
 
 How to integrate an Add-On into build, testing, and docs
@@ -204,4 +205,154 @@ else
 
     (6) provide conda download counts independent of |PSIfour|.
 
+
+.. _`faq:readoptions`:
+
+How to name keywords in ``psi4/src/read_options.cc``
+----------------------------------------------------
+
+A few guidelines for standardizing option names among modules.
+
+* ``TRIPLES`` (not trip), ``TRIPLETS`` (not trip), ``SINGLES`` (not sing),
+  ``SINGLETS`` (not sing)
+
+* ``CONVERGENCE`` (not conv, not converge) and ``TOLERANCE`` (not tol)
+
+* Convergence of a method should be governed by an ``E_CONVERGENCE`` for
+  energy and either a ``D_CONVERGENCE`` for density or a ``R_CONVERGENCE``
+  for residual/amplitudes. All of these should be doubles- let the input
+  parser handle the flexible input format.
+
+* Diis should have a boolean ``DIIS`` (not do_diis, not use_diis) to turn
+  on/off diis extrapolation, a ``DIIS_MIN_VECS`` and ``DIIS_MAX_VECS`` for
+  minimum and maximum number of diis vectors to use, and a ``DIIS_START``
+  which is the iteration at which to start saving vectors for diis. Not all
+  modules conform to all these at present, but they're as standardized as
+  they can be without changing code.
+
+* ``AMPS`` (not amplitude, not amp) for amplitudes
+
+* ``NUM_`` (not n) for number (e.g., ``NUM_AMPS_PRINT``, ``MAX_NUM_VECS``,
+  ``NUM_THREADS``)
+
+* Some names that could be split into multiple words are staying as one.
+  Use ``MAXITER``, ``CACHELEVEL``, ``PUREAM``, ``DERTYPE``.
+
+* ``INTS`` (not integrals), also ``OEI`` (not oe_integrals) for
+  one-electron integrals and ``TEI`` (not te_integrals) for two-electron
+  integrals
+
+* ``PERTURB`` (not pert) for perturbation
+
+* Use ``PRINT`` options to indicate printing to output file. Use ``WRITE``
+  options to indicate printing to another file. This probably isn't
+  entirely valid now but should be observed in future. The complement to
+  ``WRITE`` is ``READ``. ``PRINT``, ``READ``, and ``WRITE`` will usually
+  be the last words in an option name.
+
+* Use ``FOLLOW_ROOT`` for the state to be followed in geometry optimizations
+
+* ``WFN`` (not wavefunction)
+
+* You're welcome to use ``WFN`` and ``DERTYPE`` as internal options, but
+  plan to have these set by the python driver and mark them as ``!expert``
+  options. Really avoid using ``JOBTYPE``.
+
+* You're not welcome to add ``CHARGE`` or ``MULTP`` options. Plan to get
+  these quantities from the molecule object. Since we frequently use subsets
+  of systems (with their own charge and multiplicity), this is safer.
+
+* Conform. Just grep ``'add' psi4/src/read_options.cc`` to get a list of
+  all the option names in |PSIfour| and try to match any conventions you
+  find.
+
+* If you have a quantity you'd like to call a cutoff, a threshold, a
+  tolerance, or a convergence, consider the following guidelines in naming
+  it.
+
+  * If its value is typically greater than ~0.001, give it a name with ``CUTOFF``.
+
+  * If its value is typically less than ~0.001 and quantities being tested
+    against the option are more valuable with larger values (e.g.,
+    integrals, occupations, eigenvectors), give it a name with ``TOLERANCE``.
+
+  * If its value is typically less than ~0.001 and quantities being tested
+    against the option are more valuable with smaller values (e.g., energy
+    changes, residual errors, gradients), give it a name with
+    ``CONVERGENCE``.
+
+* In deciding how to arrange words in an option name, place the context
+  first (e.g., ``MP2_AMPS_PRINT``, ``TRIPLES_DIIS``). This means ``PRINT``
+  will generally be at the end of an option name.
+
+* Use ``INTS_TOLERANCE`` (not schwarz_cutoff)
+
+* ``H`` in an option name is reserved for Hamiltonian (or hydrogen).
+  Hessian should be ``HESS``.
+
+* All option names should be all caps and separated by underscores.
+
+* If you have an option that instructs your module to do something not too
+  computationally intensive and then quit, append ``_EXIT`` to the option
+  name.
+
+* Scaling terms (like for scs) should follow the pattern ``MP2_SS_SCALE``
+  and ``SAPT_OS_SCALE``.
+
+* ``FRAG`` for fragment.
+
+* ``AVG`` for average.
+
+* For level-shifting, let's try to have it governed by (double)
+  ``LEVEL_SHIFT`` only and not a boolean/double combo since the procedure
+  can be turned on (role of boolean) if the value (role of double) has
+  changed.
+
+* For Tikhonow regularization, use ``TIKONOW_OMEGA``, not regularizer.
+
+* ``SYM`` for symmetry.
+
+* ``OCC`` for occupied/occupation (e.g., ``DOCC``, ``LOCK_OCC``, ``OCC_TOLERANCE``).
+
+* ``COND`` for condition and ``CONDITIONER`` for conditioner.
+
+* ``LOCAL`` (not localize).
+
+* Use ``AO`` and ``MO`` for atomic and molecular orbitals. When 'O' for
+  orbitals is too obsure or would make for too short a keyword, as in
+  "bool NO" for "Do use natural orbitals", use ``ORBS`` for orbitals. So
+  natural orbitals are ``NAT_ORBS`` and Brueckner orbitals are
+  ``BRUECKNER_ORBS``.
+
+* ``LEVEL`` (not ``LVL``, not ``LEV``).
+
+* ``EX`` for excitation.
+
+* ``VAL`` for valence.
+
+* ``GEOM`` (not geo, not geometry).
+
+* ``SYM`` (not symm, not symmetry).
+
+* ``FILE`` (unless truly multiple FILES).
+
+* ``WRITE``/``READ`` for info transfer across jobs. ``SAVE``/``RESTART``
+  for same in context of restart.
+
+* Damping should interface through option (double) ``DAMPING_PERCENTAGE``,
+  where a value of 0.0 indicates no damping.
+
+* Try to avoid ``COMPUTE`` or ``CALC`` in an option name. If it's a
+  boolean like "opdm_compute" for "Do compute the one-particle density
+  matrix", just use ``OPDM``.
+
+* Properties should be governed by a ``PROPERTIES`` array for the root of
+  interest or by a ``PROPERTIES_ALL`` array for all roots in a multi-root
+  calc.  Since no module conforms to this right now, use ``PROPERTY``
+  alone and ``PROP`` in multi-part option as ``PROP_ROOT``, ``PROP_ALL``,
+  ``PROP_SYM`` to conform.
+
+* Use ``DF`` (not ri) for density-fitting and resolution-of-the-identity
+  option names. Only the basis sets are staying as -RI since that's what
+  EMSL uses.
 

--- a/doc/sphinxman/source/manage_index.rst
+++ b/doc/sphinxman/source/manage_index.rst
@@ -35,7 +35,6 @@ Managing: Git, Conda, CMake and all that
 .. toctree::
    :maxdepth: 2
 
-   FAQ <manage_faq>
    manage_addon
    manage_git
 

--- a/doc/sphinxman/source/prog_blas.rst
+++ b/doc/sphinxman/source/prog_blas.rst
@@ -1,0 +1,426 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. _`sec:blaslapack`:
+
+===========================
+Linear Algebra in |PSIfour|
+===========================
+
+.. _`faq:blaswrappers`:
+
+How to call BLAS & LAPACK in |PSIfour|
+--------------------------------------
+
+Computational chemistry is essentially linear algebra on molecular
+systems, so using stable, portable, scalable, and efficient numerical
+linear algebra methods in PSI4 is critical. To that end, we use BLAS1
+(vector-vector operations, like dot products), BLAS2 (matrix-vector
+operations, like rank-1 update), BLAS3 (matrix-matrix operations, like
+matrix multiplication), and LAPACK (advanced matrix decompositions and
+solutions). The methods provided by BLAS and LAPACK are standard, but the
+performance of actual implementations differ greatly from one version to
+another. Moreover, the standard interfaces to the libraries are Fortran,
+so PSI4 provides a common set of wrappers in libqt/qt.h.
+
+BLAS Wrappers
+^^^^^^^^^^^^^
+
+BLAS wrappers are currently fully supported at double precision.
+
+BLAS commands involving matrices are wrapped so as to be conventional C-style "row-major" indexing, meaning that the column is the fast index like normal.
+
+* The calls to BLAS1 routines are wrapped so as to allow for operations on vectors with more than 2^{31} elements (~16 GB, getting to be a problem). So passing a signed or unsigned long works, though the stride arguments must be integers.
+
+* All routines are declared in ``qt.h``. Each routine is prefixed with a
+  ``C_``, followed by the standard Fortran name of the routine, in capital
+  letters. Input parameters of single primitives (``int``, ``double``,
+  ``unsigned long int``, ``char``, ...) are passed by value. Arrays,
+  including multidimensional arrays, are required to be in contiguous
+  memory (as provided by block_matrix, for example), and are passed by
+  providing a pointer to the first double or int element of the data (this
+  is array[0] if array is ``double**``). BLAS1 routines occasionally
+  return values (DDOT for instance), BLAS2 and BLAS3 always return void.
+  For char arguments, case is insensitive. A few examples are provided::
+
+    // BLAS/LAPACK
+    #include <libqt/qt.h>
+    // block_matrix, init_array
+    #include <libciomr/libciomr.h>
+    
+    using namespace psi;
+    ...
+    
+    // Allocate a,b vectors
+    int n = 100;
+    double* a = init_array(n);
+    double* b = init_array(n);
+    
+    // Allocate A matrix;
+    double** A = block_matrix(n,n);
+    double** B = block_matrix(n,n);
+    double** C = block_matrix(n,n);
+    
+    // Call the BLAS1 dot product between a and b
+    // n can be a ULI with the BLAS1 wrappers,
+    // All strides must be ints though
+    double dot = C_DDOT(n, a, 1, b, 1);
+    
+    // Call the BLAS2 GEMV without transposition
+    // Note this works in row-major order
+    C_DGEMV('N', n, n, 1.0, A[0], n, a, 1, 0.0, b, 1);
+    
+    // Call the BLAS3 GEMM without transposition
+    // Note this works in row-major order
+    C_DGEMM('N','N', n, n, n, 1.0, A[0], n, B[0], n, 0.0, C[0], n);
+    
+    // Array's init'd with init_array must be free'd, not delete[]'d
+    free(a);
+    free(b);
+    
+    // Block matrix should be free_blocked
+    free_block(A);
+    free_block(B);
+    free_block(C);
+
+Important BLAS Routines
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* BLAS1
+
+  * DDOT: dot product
+  * DCOPY: efficient memory copy (with variable stride)
+  * DAXPY: y = y + alpha*x
+  * DROT: Givens Rotation
+  * DNRM2: Vector norm square
+
+* BLAS2
+
+  * DGEMV: General Matrix-Vector product
+  * DTRMV: Triangular Matrix-Vector product (2x faster, not wrapped yet)
+  * DTRSM: Triangular Matrix-Vector solution via back substitution (just as fast as DTRMV)
+  * DGER: Rank-1 update (not wrapped yet)
+
+* BLAS3
+
+  * DGEMM: General Matrix-Matrix product
+  * DTRMM: General Triangular Matrix-General Matrix product
+  * DTRSM: Triangular Matrix-General Matrix solution via back substitution (just as fast as DTRMM)
+  * DSYMM/DSYMV calls are not appreciably faster than DGEMM calls, and should only be used in expert situations (like using the other half of the matrix for some form of other transformation).
+  * DTRMM/DTRMV calls are 2x faster than DGEMM, and should be used where possible.
+
+LAPACK Wrappers
+^^^^^^^^^^^^^^^
+
+All standard LAPACK 3.2 double precision routines are provided.
+
+LAPACK commands remain in Fortran's "column-major" indexing, so all the
+results will be transposed, and leading dimensions may have to be fiddled
+with (using ``lda = n`` in both directions for square matrices is highly
+recommended). An example of the former problem is a Cholesky
+Decomposition: you expect to get back a lower triangular matrix L such
+that ``L L^T = A``, but this is returned in column-major order, so the actual
+recovery of the matrix A with the row-major BLAS wrappers effectively
+involves ``L^T L = A``. On of the biggest consequences is in linear equations:
+The input/output forcing/solution vector must be explicitly formed in
+column-major indexing (each vector is placed in a C++ row, with its
+entries along the C++ column). This is visualized in C++ as the transpose
+of the forcing/solution vector.  All routines are declared in qt.h. Each
+routine is prefixed with a ``C_``, followed by the standard Fortran name of
+the routine, in capital letters. Input parameters of single primitives
+(int, double, unsigned long int, char, ...) are passed by value. Arrays,
+including multidimensional arrays, are required to be in contiguous memory
+(as provided by block_matrix, for example), and are passed by providing a
+pointer to the first double or int element of the data (this is array[0]
+if array is ``double**``). All routines return an int INFO with error and
+calculation information specific to the routine, In Fortran, this is the
+last argument in all LAPACK calls, but should not be provided as an
+argument here. For char arguments, case is insensitive. A Cholesky
+transform example is shown::
+
+    // BLAS/LAPACK
+    #include <libqt/qt.h>
+    // block_matrix, init_array
+    #include <libciomr/libciomr.h>
+    
+    using namespace psi;
+    ...
+    int n = 100;
+    
+    // Allocate A matrix;
+    double** A = block_matrix(n,n);
+    
+    // Call the LAPACK DPOTRF to get the Cholesky factor
+    // Note this works in column-major order
+    // The result fills like:
+    //   * * * *
+    //     * * *
+    //       * *
+    //         *
+    // instead of the expected:
+    //   *
+    //   * *
+    //   * * *
+    //   * * * *
+    //
+    int info = C_DPOTRF('L', n, A[0], n);
+    
+    // A bit painful, see below
+    fprintf(outfile, "A:\n");
+    print_mat(A,n,n,outfile);
+
+    // Block matrix should be free_blocked
+    free_block(A);
+
+Important Lapack Routines
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* DSYEV: Eigenvalues and, optionally eigenvectors of a symmetric matrix. Eigenvectors take up to 10x longer than eigenvalues.
+* DGEEV: Eigenvalues and, optionally eigenvectors of a general matrix. Up to 10x slower than DSYEV.
+* DGESV: General solver (uses LU decomposition).
+* DGESVD: General singular value decomposition.
+* DGETRF: LU decomposition.
+* DPOTRF: Cholesky decomposition (much more stable/faster)
+* DGETRS: Solver, given LU decomposition by DGETRF
+* DPOTRS: Solver, given Cholesky decomposition by DPOTRF
+* DGETRI: Inverse, given LU decomposition by DGETRF (Warning: it's faster and more stable just to solve with DGETRS)
+* DPOTRI: Inverse, given Cholesky decomposition by DPOTRF (Warning: it's faster and more stable just to solve with DPOTRS)
+
+
+.. _`faq:blasmatrix`:
+
+How to use low-level BLAS/LAPACK with ``psi4.core.Matrix``
+----------------------------------------------------------
+
+Jet's awesome new Matrix object has a lot of simple BLAS/LAPACK built in,
+but you can just as easily use the ``double***`` array underneath if you are
+careful (the outer index is the submatrix for each irrep). Here's an
+example::
+
+    // BLAS/LAPACK
+    #include "psi4/src/psi4/libqt/qt.h"
+    // Matrix
+    #include "psi4/src/psi4/libmints/matrix.h"
+    
+    using namespace psi;
+    ...
+    int n = 100;
+    
+    // Allocate A Matrix (new C1 convenience constructor);
+    shared_ptr<Matrix> A(new Matrix("Still A, but way cooler", n,n));
+    // Get the pointer to the 0 irrep (C1 for now, it errors if you ask for too high of an index)
+    double** A_pointer = A->get_pointer(0);
+    
+    // Call the LAPACK DPOTRF to get the Cholesky factor
+    // Note this works in column-major order
+    // The result fills like:
+    //   * * * *
+    //     * * *
+    //       * *
+    //         *
+    // instead of the expected:
+    //   *
+    //   * *
+    //   * * *
+    //   * * * *
+    //
+    int info = C_DPOTRF('L', n, A_pointer[0], n);
+    
+    // Wow that's a lot easier
+    A->print();
+    
+    // Don't free, it's shared_ptr!
+
+
+.. _`faq:labas`:
+
+How to name orbital bases (e.g., AO & SO)
+-----------------------------------------
+
+Many different working bases (the internal linear algebraic basis, not the
+name of the Gaussian basis) are used within |PSIfour|, each with a unique
+and important purpose. It is critical to keep them all distinct to prevent
+weird results from occurring.
+
+* ``AO`` (Atomic Orbitals): Cartesian Gaussians (6D, 10F, etc.),
+  ``(L + 1)(L + 2)/2`` functions per shell of angular momentum L. The
+  ordering of Cartesian exponents for a given L is given by the standard
+  ordering below (MATLAB code)::
+
+    ncart = (L + 1) * (L + 2) / 2;
+    exps = zeros(ncart,3);
+    index = 1;
+    for i = 0:L
+        for j = 0:i
+            lx = L - i;
+            ly = i - j;
+            lz = j;
+            exps(index,:) = [lx ly lz];
+          index = index + 1;
+        end
+    end
+
+* ``SO`` (Spherical Atomic Orbitals): Pure Gaussians (5D, 7F, etc.) or
+  Cartesian Gaussians, as determined by the user. This is typically the
+  first layer encountered, Libmints handles the transform from AO to SO
+  automatically. If Cartesian functions are used, the number of functions
+  per shell remains ``(L + 1)(L + 2)/2``, and the ordering remains the same
+  as above. Note that the individual functions are not normalized for
+  angular momentum as in most codes: the self-overlap of a PSI4 Cartesian D
+  or higher function with more than one nonzero Cartesian exponent (e.g., lx
+  = 1, ly = 1, lz = 0) will be less than one. If Spherical Harmonics are
+  used, 2L + 1 real combinations of the spherical harmonics are built from
+  the ``(L+1)(L+2)/2`` Cartesian Gaussians, according to H. Schlegel and M.
+  Frish, IJQC, 54, 83-87, 1995. Unlike Cartesian functions these functions
+  are all strictly normalized. Note that in PSI4, the real combinations of
+  spherical harmonic functions (see the paragraph below Eq. 15 in the
+  Schlegel paper) are ordered as: 0, 1+, 1-, 2+, 2-, ....
+
+* ``USO`` (Unique Symmetry-Adapted Orbitals): Spatial symmetry-adapted
+  combinations of SOs, blocked according to irrep. The total number of USOs
+  is the same as the number of SOs, but the number of USOs within each irrep
+  is usually much smaller, which can lead to significant performance
+  improvements. Note that this basis is sometimes unfortunately referred to
+  as the SO basis, so it's a bit context specific.
+
+* ``OSO`` (Orthogonal Symmetry-Adapted Orbitals): USOs orthogonalized by
+  Symmetric or Canonical Orthogonalization. The number of OSOs may be
+  slightly smaller than the total number of USOs, due to removal of linear
+  dependencies via Canonical Orthogonalization. The OSOs are rarely
+  encountered, as usually we go straight from USOs to MOs.
+
+* ``MO`` (Molecular Orbitals): The combination of OSOs that diagonalizes
+  the Fock Matrix, so each basis function is a Hartree-Fock (or Kohn-Sham)
+  molecular orbital. The number of OSOs and MOs is always the same. MOs are
+  orthonormal.
+
+* ``LO`` (Localized Orbitals): Localized occupied orbitals, a different
+  combination of the occupied molecular orbitals which enhances spatial
+  locality. LOs do not diagonalize the occ-occ block of the Fock Matrix, but
+  remain orthonormal to each other and the virtual space.
+
+
+.. _`faq:orbdims`:
+
+How to name orbital dimensions
+------------------------------
+
+There are a number of different names used to refer to the basis set size.
+These may seem redundant, but they have subtly different meanings, as
+detailed below.
+
+A calculation can use either pure (5D, 7F, 9G, etc.) basis functions or
+Cartesian (6D, 10F, 15G, etc.), as dictated by the input file / basis set
+specification. Also, the basis can be represented in terms of atomic
+orbitals (AO) or symmetry-adapted orbitals (SO). Further complications
+come from the fact that a nearly linearly-dependent basis set will have
+functions removed from it to prevent redundancies. With all of these
+factors in mind, here are the conventions used internally:
+
+* nao |w---w| The number of atomic orbitals in Cartesian representation.
+* nso |w---w| The number of atomic orbitals but in the pure representation if the current basis uses pure functions, number of Cartesian AOs otherwise.
+* nbf |w---w| The number of basis functions, which is the same as nso.
+* nmo |w---w| The number of basis functions, after projecting out redundancies in the basis.
+
+When molecular symmetry is utilized, a small array of sizes per irrep is
+usually allocated on the stack, and is named by augmenting the name above
+with a pi (per-irrep), e.g. nmopi. Note that the number of irreps is
+always the singular nirrep, and that the index variable h is always used
+in a for-loop traverse of irreps.
+
+
+.. _`faq:orbspaces`:
+
+How to name orbital spaces (e.g., docc)
+---------------------------------------
+
+As with basis sets, a number of names are used to refer to refer to the
+quantity of electrons, virtuals, and active sub-quantities of a |PSIfour|
+calculation. All of these can be defined per irrep as above. Some common
+conventions are:
+
+* nelec |w---w| The number of electrons, rarely used due to specialization of alphas and betas or soccs and doccs.
+* nalpha |w---w| The number of alpha electrons.
+* nbeta |w---w| The number of beta electrons
+* docc |w---w| The number of doubly-occupied orbitals
+* socc |w---w| The number of singly-occupied orbitals (Almost always alpha, we don't like open-shell singlets much).
+* nvir |w---w| The number of virtual orbitals
+
+Multireference Dimensions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A orbital diagram of the nomenclature used for CI and MCSCF calculations.
+
+Diagrammatically::
+
+    -----------------------------------------------
+           CI       |      RAS      |     CAS
+    -----------------------------------------------
+                    | frozen_uocc   | frozen_uocc
+    dropped_uocc    | rstr_uocc     | rstr_uocc
+    -----------------------------------------------
+                    | RAS IV        |
+                    | RAS III       |
+    active          |               | active
+                    | RAS II        |
+                    | RAS I         |
+    -----------------------------------------------
+    dropped_docc    | rstr_docc     | rstr_docc
+                    | frozen_docc   | frozen_dcc
+    -----------------------------------------------
+
+Notation:
+
+* uocc |w---w| Unoccupied orbitals.
+* active |w---w| Variable occupation orbitals.
+* socc |w---w| Singly occupied orbitals.
+* docc |w---w| Doubly occupied orbitals.
+
+Orbital spaces:
+
+* frozen_uocc |w---w| Absolutely frozen virtual orbital.
+* rstr_uocc |w---w| Can have rotations, no excitations into.
+* dropped_uocc |w---w| rstr_uocc + frozen_uocc
+
+----- end CI active -----
+
+* RAS IV |w---w| uocc, limited number of excitations into.
+* RAS III |w---w| uocc, limited number of excitations into.
+* RAS II |w---w| docc/socc/uocc, equivalent to active in CAS.
+* RAS I |w---w| docc/socc/uocc, limited excitations out of.
+
+----- start CI active -----
+
+* dropped_docc |w---w| rstr_docc + frozen_docc
+* rstr_docc |w---w| Can have rotations, no excitations from.
+* frozen_docc |w---w| Absolutely frozen core orbital.
+
+Orbitals are sorted by space, irrep, eigenvalue.
+

--- a/doc/sphinxman/source/prog_blas.rst
+++ b/doc/sphinxman/source/prog_blas.rst
@@ -41,23 +41,33 @@ How to call BLAS & LAPACK in |PSIfour|
 
 Computational chemistry is essentially linear algebra on molecular
 systems, so using stable, portable, scalable, and efficient numerical
-linear algebra methods in PSI4 is critical. To that end, we use BLAS1
+linear algebra methods in |PSIfour| is critical. To that end, we use BLAS1
 (vector-vector operations, like dot products), BLAS2 (matrix-vector
 operations, like rank-1 update), BLAS3 (matrix-matrix operations, like
 matrix multiplication), and LAPACK (advanced matrix decompositions and
 solutions). The methods provided by BLAS and LAPACK are standard, but the
 performance of actual implementations differ greatly from one version to
 another. Moreover, the standard interfaces to the libraries are Fortran,
-so PSI4 provides a common set of wrappers in libqt/qt.h.
+so |PSIfour| provides a common set of wrappers in :source:`psi4/src/psi4/libqt/qt.h` .
+
+.. warning:: Although block_matrix, init_array, and print_mat are still
+   around, their use is discouraged in favor of operations on
+   `psi4.core.Matrix` itself. The advice in these docs will catch up
+   shortly.
 
 BLAS Wrappers
 ^^^^^^^^^^^^^
 
 BLAS wrappers are currently fully supported at double precision.
 
-BLAS commands involving matrices are wrapped so as to be conventional C-style "row-major" indexing, meaning that the column is the fast index like normal.
+BLAS commands involving matrices are wrapped so as to be conventional
+C-style "row-major" indexing, meaning that the column is the fast index
+like normal.
 
-* The calls to BLAS1 routines are wrapped so as to allow for operations on vectors with more than 2^{31} elements (~16 GB, getting to be a problem). So passing a signed or unsigned long works, though the stride arguments must be integers.
+* The calls to BLAS1 routines are wrapped so as to allow for operations on
+  vectors with more than 2^{31} elements (~16 GB, getting to be a problem).
+  So passing a signed or unsigned long works, though the stride arguments
+  must be integers.
 
 * All routines are declared in ``qt.h``. Each routine is prefixed with a
   ``C_``, followed by the standard Fortran name of the routine, in capital
@@ -71,9 +81,9 @@ BLAS commands involving matrices are wrapped so as to be conventional C-style "r
   For char arguments, case is insensitive. A few examples are provided::
 
     // BLAS/LAPACK
-    #include <libqt/qt.h>
+    #include "psi4/libqt/qt.h"
     // block_matrix, init_array
-    #include <libciomr/libciomr.h>
+    #include "psi4/libciomr/libciomr.h"
     
     using namespace psi;
     ...
@@ -166,9 +176,9 @@ argument here. For char arguments, case is insensitive. A Cholesky
 transform example is shown::
 
     // BLAS/LAPACK
-    #include <libqt/qt.h>
+    #include "psi4/libqt/qt.h"
     // block_matrix, init_array
-    #include <libciomr/libciomr.h>
+    #include "psi4/libciomr/libciomr.h"
     
     using namespace psi;
     ...
@@ -225,9 +235,9 @@ careful (the outer index is the submatrix for each irrep). Here's an
 example::
 
     // BLAS/LAPACK
-    #include "psi4/src/psi4/libqt/qt.h"
+    #include "psi4/libqt/qt.h"
     // Matrix
-    #include "psi4/src/psi4/libmints/matrix.h"
+    #include "psi4/libmints/matrix.h"
     
     using namespace psi;
     ...
@@ -293,13 +303,13 @@ weird results from occurring.
   automatically. If Cartesian functions are used, the number of functions
   per shell remains ``(L + 1)(L + 2)/2``, and the ordering remains the same
   as above. Note that the individual functions are not normalized for
-  angular momentum as in most codes: the self-overlap of a PSI4 Cartesian D
+  angular momentum as in most codes: the self-overlap of a |PSIfour| Cartesian D
   or higher function with more than one nonzero Cartesian exponent (e.g., lx
   = 1, ly = 1, lz = 0) will be less than one. If Spherical Harmonics are
   used, 2L + 1 real combinations of the spherical harmonics are built from
   the ``(L+1)(L+2)/2`` Cartesian Gaussians, according to H. Schlegel and M.
   Frish, IJQC, 54, 83-87, 1995. Unlike Cartesian functions these functions
-  are all strictly normalized. Note that in PSI4, the real combinations of
+  are all strictly normalized. Note that in |PSIfour|, the real combinations of
   spherical harmonic functions (see the paragraph below Eq. 15 in the
   Schlegel paper) are ordered as: 0, 1+, 1-, 2+, 2-, ....
 

--- a/doc/sphinxman/source/prog_faq.rst
+++ b/doc/sphinxman/source/prog_faq.rst
@@ -26,10 +26,29 @@
 .. # @END LICENSE
 .. #
 
-.. _`sec:managefaq`:
 
-Management FAQ
-==============
+.. _`sec:progfaq`:
+
+===============
+Programmers FAQ
+===============
+
+C++ Style in |PSIfour|
+----------------------
+
+#. :ref:`faq:nullptr`
+#. :ref:`faq:automakeshared`
+#. :ref:`faq:autodecl`
+
+Modules in |PSIfour|
+--------------------
+
+#. :ref:`faq:readoptions`
+#. :ref:`faq:blaswrappers`
+#. :ref:`faq:blasmatrix`
+#. :ref:`faq:labas`
+#. :ref:`faq:orbdims`
+#. :ref:`faq:orbspaces`
 
 Interfacing with |PSIfour|
 --------------------------
@@ -44,4 +63,7 @@ Versioning |PSIfour|
 #. :ref:`faq:remotetag`
 #. :ref:`faq:githubworkflow`
 #. :ref:`faq:psi4version`
+
+Miscellaneous
+-------------
 

--- a/doc/sphinxman/source/programming.rst
+++ b/doc/sphinxman/source/programming.rst
@@ -35,6 +35,7 @@ Programming: Using the Core Libraries
 .. toctree::
    optionshandling
    proc_py
+   prog_blas
 
 ..   prog_basissets
 

--- a/doc/sphinxman/source/psiapi.ipynb
+++ b/doc/sphinxman/source/psiapi.ipynb
@@ -16,6 +16,8 @@
     "\n",
     "**Warning:** Although the developers have been using PsiAPI mode stably for months before the 1.1 release and while we believe we've gotten everything nicely arranged within the ``psi4.`` namespace, the API should not be considered completely stable. Most importantly, as we someday deprecate the last of the global variables, options will be added to the method calls (*e.g.*, ``energy('scf', molecule=mol, options=opt)``)\n",
     "\n",
+    "**Note:** Consult [How to run Psi4 as Python module after compilation](http://psicode.org/psi4manual/master/build_planning.html#faq-runordinarymodule) or [How to run Psi4 as a Python module from conda installation](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-psi4-as-executable-or-python-module-from-conda-installation) for assistance in setting up Psi4.\n",
+    "\n",
     "</div>"
    ]
   },

--- a/doc/sphinxman/source/style_c.rst
+++ b/doc/sphinxman/source/style_c.rst
@@ -1,0 +1,110 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. _`sec:style_c`:
+
+C++ Style
+=========
+
+
+.. _`faq:nullptr`:
+
+Prefer ``nullptr`` to ``0`` or ``NULL``
+---------------------------------------
+
+``0`` is an ``int`` not a pointer. Almost the same goes for ``NULL``,
+though implementations of the language can differ in the details. If you
+want to overload on pointer types and/or use pointer types with templates,
+use ``nullptr`` to signal the null pointer. The correct overload/template
+parameter will then be deduced. Using ``nullptr`` also makes the code more
+readable, especially if ``auto`` is used consistently throughout.
+
+*Reference:* Item 8 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+
+
+.. _`faq:automakeshared`:
+
+Prefer ``std::make_shared`` to direct use of ``new``
+----------------------------------------------------
+
+Using ``std::make_shared``::
+
+1. Reduces code verbosity, especially when coupled with ``auto``::
+
+    std::shared_ptr<Matrix> F = std::shared_ptr<Matrix>(new Matrix("Fock matrix", nso, nso));  // Type information written down 3 TIMES!!!
+    std::shared_ptr<Matrix> F = std::make_shared<Matrix>("Fock matrix", nso, nso);  // So much typing...
+    auto F = std::make_shared<Matrix>("Fock matrix", nso, nso);  // Much better!!!!
+
+2. Ensures exception safety and prevents resource leaks. ::
+
+3. Improves efficiency::
+
+    // Performs TWO allocations
+    std::shared_ptr<Matrix> F = std::shared_ptr<Matrix>(new Matrix("Fock matrix", nso, nso)); 
+    // Performs ONE allocation
+    auto F = std::make_shared<Matrix>("Fock matrix", nso, nso); 
+
+*Reference:* Item 21 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+
+
+.. _`faq:autodecl`:
+
+Prefer ``auto`` to explicit type declarations
+---------------------------------------------
+
+Using ``auto`` reduces and/or avoids:
+
+1. Verbosity in variable declarations::
+
+    std::shared_ptr<Matrix> F = std::make_shared<Matrix>("Fock matrix", nso, nso);  // So much typing...
+    auto F = std::make_shared<Matrix>("Fock matrix", nso, nso);  // Much better!
+
+2. Problems with uninitialized variables. auto works like template type
+   deduction, hence the right-hand side of the declaration needs to have an
+   initializer::
+
+    int x1;  // fine, but uninitialized :(
+    auto x2;  // WON'T COMPILE!!!
+    auto x3 = 1;  // fine and initialized
+
+3. Problems with unintended type casts and type mismatches that are hard
+   to impossible to catch::
+
+    std::vector<int> v;
+    // !!! The size of a vector is of type std::vector<int>::size_type and is compiler- AND architecture-DEPENDENT
+    unsigned sz = v.size();  // might not be correct on some compiler/machines
+    auto size = v.size();  // size is ALWAYS of the correct type
+
+*Reference:* Items 2 and 5 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+
+
+
+
+

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -4364,7 +4364,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       computed force-constant matrix is performed, rotationally projected
       frequencies are computed, infrared intensities are determined, and
       zero-point energies (ZPE) are evaluated. -*/
-      options.add_str("CFOUR_VIBRATION", "NO", "NO ANALYTIC FINDIF");
+      options.add_str("CFOUR_VIBRATION", "NO", "NO ANALYTIC FINDIF EXACT");
 
       /*- This keyword defines what type of integral transformation is to
       be performed in the program ``xvtran``. FULL/PARTIAL (=0) allows the


### PR DESCRIPTION
## Description
So all the build docs on the wiki are indeed deprecated as they announce. But all the rest of the docs  are of varying levels of value and states of deprecation. This collects the ones that really shouldn't be lost.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Starts a programmers FAQ
  - [x] Collects orbital naming and options naming items
  - [x] Collects BLAS/LAPACK usage docs
  - [x] Collects the C-style notes that RDR assembled in psi4/psi4#836 comments
* **User-Facing for Release Notes**

## Questions
- [ ] BLAS/LAPACK docs need some editing, as they refer to old ways like `init_array` and `block_matrix`. I'd fix `em up into `Matrix`, but there's another section on `Matrix` + BLAS, so didn't want to duplicate.
- [x] @jturney, you can use, build on, renovate, or ignore any of this, but the options naming section does have to make it into the docs before the Wiki is archived and turned off.
- [x] @jturney, there may be more goodies, particularly in https://github.com/psi4/psi4/wiki/BestPractices that you want to collect. I think that doc originated back in the TRAC days.

## Status
- [ ] Ready to go. Should have BLAS edited before merge. I've no more plans to work on it, so in that sense, ready for review.
