### PR TITLE
SNS-MP2 Plugin Addition

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -386,3 +386,7 @@ Bibliography
 .. [Tomasi:2005:2999]
    J. Tomasi, B. Mennucci, and R. Cammi
    *Chem. Rev.* **105**, 2999 (2005).
+
+.. [McGibbon:2017:161725]
+   R. T. McGibbon, A. G. Taube, A. G. Donchev, K. Siva, F. Hernández, C. Hargus, K. H. Law, J. L. Klepeis, D. E. Shaw
+   *J. Chem. Phys.* **147**, 161725 (2017).

--- a/doc/sphinxman/source/plugin_snsmp2.rst
+++ b/doc/sphinxman/source/plugin_snsmp2.rst
@@ -49,7 +49,7 @@ Spin-Network-Scaled MP2 (SNS-MP2) by D. E. Shaw
 This plugin is an implementation of the SNS-MP2 algorithm developed by McGibbon 
 et. al. [McGibbon:2017:161725]_. The SNS-MP2 method uses neural networking to 
 improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimer molecules. 
-The plugin is distributed under the BSD-2 license.
+The plugin is distributed under the 2-clause BSD license.
 
 Installation
 ~~~~~~~~~~~~

--- a/doc/sphinxman/source/plugin_snsmp2.rst
+++ b/doc/sphinxman/source/plugin_snsmp2.rst
@@ -33,7 +33,7 @@
 Spin-Network-Scaled MP2 (SNS-MP2) by D. E. Shaw
 ===============================================
 
-.. codeauthor:: D. E. Shaw
+.. codeauthor:: D. E. Shaw Research
 .. sectionauthor:: Shannon E. Houck
 
 .. image:: https://img.shields.io/badge/home-sns--mp2-5077AB.svg
@@ -46,11 +46,9 @@ Spin-Network-Scaled MP2 (SNS-MP2) by D. E. Shaw
 .. image:: https://img.shields.io/badge/docs-latest-5077AB.svg
    :target: https://github.com/DEShawResearch/sns-mp2/blob/master/README.md
 
-This plugin is an implementation of the SNS-MP2 algorithm, originally 
-developed by McGibbon et. al. [McGibbon:2017:161725]_, which uses neural networking to 
-improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimers. 
-This |PSIfour| plugin allows the user to compute both energies and 
-confidence intervals.
+This plugin is an implementation of the SNS-MP2 algorithm developed by McGibbon 
+et. al. [McGibbon:2017:161725]_. The SNS-MP2 method uses neural networking to 
+improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimer molecules.
 
 Installation
 ~~~~~~~~~~~~
@@ -77,7 +75,7 @@ Installation
 Sample Input
 ~~~~~~~~~~~~
 
-A sample input file, borrowed from D. E. Shaw's documentation, is shown below::
+A sample input file, adapted from the documentation, is shown below::
 
    # Sample SNS-MP2 calculation for two helium atoms
 
@@ -89,7 +87,7 @@ A sample input file, borrowed from D. E. Shaw's documentation, is shown below::
 
    energy('sns-mp2')
     
-Note that these two atoms are separated by double dashes, indicating that
+Note that the two monomers are separated by double dashes, indicating that
 they should be treated as separate molecules. (See 
 :ref:`sec:analysis-of-intermolecular-interactions` for more details on 
 setting up dimer molecules.) This input file can be run in the usual fashion:

--- a/doc/sphinxman/source/plugin_snsmp2.rst
+++ b/doc/sphinxman/source/plugin_snsmp2.rst
@@ -48,7 +48,8 @@ Spin-Network-Scaled MP2 (SNS-MP2) by D. E. Shaw
 
 This plugin is an implementation of the SNS-MP2 algorithm developed by McGibbon 
 et. al. [McGibbon:2017:161725]_. The SNS-MP2 method uses neural networking to 
-improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimer molecules.
+improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimer molecules. 
+The plugin is distributed under the BSD-2 license.
 
 Installation
 ~~~~~~~~~~~~
@@ -70,7 +71,7 @@ Installation
 
      >>> cd {top-level-sns-mp2-directory}
      >>> PSI4_PYTHON=$(head $(which psi4) -n 1 | sed -r 's/^.{2}//')
-     >>> PSI4_PYTHON -m pip install .
+     >>> $PSI4_PYTHON -m pip install .
 
 Sample Input
 ~~~~~~~~~~~~

--- a/doc/sphinxman/source/plugin_snsmp2.rst
+++ b/doc/sphinxman/source/plugin_snsmp2.rst
@@ -1,0 +1,101 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. index:: SNS-MP2
+
+Spin-Network-Scaled MP2 (SNS-MP2) by D. E. Shaw
+===============================================
+
+.. codeauthor:: D. E. Shaw
+.. sectionauthor:: Shannon E. Houck
+
+.. image:: https://img.shields.io/badge/home-sns--mp2-5077AB.svg
+   :target: https://github.com/DEShawResearch/sns-mp2
+
+.. raw:: html
+
+   <br>
+
+.. image:: https://img.shields.io/badge/docs-latest-5077AB.svg
+   :target: https://github.com/DEShawResearch/sns-mp2/blob/master/README.md
+
+This plugin is an implementation of the SNS-MP2 algorithm, originally 
+developed by McGibbon et. al. [McGibbon:2017:161725]_, which uses neural networking to 
+improve the accuracy of MP2 (:ref:`dfmp2`) interaction energies for dimers. 
+This |PSIfour| plugin allows the user to compute both energies and 
+confidence intervals.
+
+Installation
+~~~~~~~~~~~~
+
+**Source**
+
+* .. image:: https://img.shields.io/github/tag/DEShawResearch/sns-mp2.svg?maxAge=2592000
+   :target: https://github.com/DEShawResearch/sns-mp2
+
+* Download the plugin from the GitHub repository:
+
+  .. code-block:: bash
+
+     >>> git clone https://github.com/DEShawResearch/sns-mp2
+
+* Once dowloaded, the plugin can be installed as outlined in the documentation:
+
+  .. code-block:: bash
+
+     >>> cd {top-level-sns-mp2-directory}
+     >>> PSI4_PYTHON=$(head $(which psi4) -n 1 | sed -r 's/^.{2}//')
+     >>> PSI4_PYTHON -m pip install .
+
+Sample Input
+~~~~~~~~~~~~
+
+A sample input file, borrowed from D. E. Shaw's documentation, is shown below::
+
+   # Sample SNS-MP2 calculation for two helium atoms
+
+   molecule dimer {
+   He 0 0 0
+   --
+   He 2 0 0
+   }
+
+   energy('sns-mp2')
+    
+Note that these two atoms are separated by double dashes, indicating that
+they should be treated as separate molecules. (See 
+:ref:`sec:analysis-of-intermolecular-interactions` for more details on 
+setting up dimer molecules.) This input file can be run in the usual fashion:
+
+.. code-block:: bash
+
+   >>> psi4 input.dat
+
+

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -37,3 +37,8 @@ try:
     import forte
 except ImportError:
     pass
+
+try:
+    import snsmp2
+except ImportError:
+    pass


### PR DESCRIPTION
## Description
This PR adds the [SNS-MP2 plugin](https://github.com/DEShawResearch/sns-mp2) to the list of endorsed Psi4 plugins such that the SNS-MP2 method can be called by energy() without the use of any import statements.

## Todos
  - [x] Added SNS-MP2 (via endorsed_plugins.py)
  - [x] Added documentation for SNS-MP2
  - [ ] Make sure a full Psi4 install includes SNS-MP2
  - [ ] Add tests

## Questions
- [ ] Is there anything I should add to or change about the documentation? (Tagging @rmcgibbo because he wrote the code, as well as @dgasmith and @loriab because of their general Psi4 and documentation knowledge.)
- [ ] The plugin itself comes with several tests already. Should I incorporate those tests into the standard Psi4 test suite?
- [ ] I've borrowed several lines of code for the installation and example [from the plugin's README](https://github.com/DEShawResearch/sns-mp2/blob/master/README.md). Is this ok, or should I change it?

## Status
- [ ] Ready to go