### PR TITLE
address build issues for FreeBSD packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,12 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #    - PYTHON_INCLUDE_DIR "Path to the python include files (e.g., /path/to/include/python2.7)"
 #    - SPHINX_ROOT "Root directory for Sphinx: 'bin/sphinx-build' (or similar) should be in this dir."
 #
-#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gdma, Libint, PCMSolver, pybind11, simint, LibXC
+#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gdma, Libint, PCMSolver, pybind11, simint, Libxc
 #    - CMAKE_PREFIX_PATH "Set to list of root directories to look for externally built add-ons and dependencies
 #      (e.g., /path/to/install-libint;/path/to/install-gdma where exists /path/to/install-libint/lib/libderiv.a)"
 #    - ${AddOn}_DIR "Set to directory containing ${AddOn}Config.cmake file to facilitate detection of external build"
 #    - CMAKE_DISABLE_FIND_PACKAGE_${AddON} "Set to OFF to force internal build"
+#    - CMAKE_INSIST_FIND_PACKAGE_${AddON} "Set to ON to force external detect"
 
 #  <<<  Detecting BLAS/LAPACK  >>>
 #

--- a/doc/sphinxman/source/chemps2.rst
+++ b/doc/sphinxman/source/chemps2.rst
@@ -162,6 +162,7 @@ How to configure CheMPS2 for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For CheMPS2, set to an installation directory containing ``include/chemps2/DMRG.h``
 * :makevar:`CheMPS2_DIR` |w---w| CMake variable to specify where pre-built CheMPS2 can be found. Set to installation directory containing ``share/cmake/CheMPS2/CheMPS2Config.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_CheMPS2` |w---w| CMake variable to force internal build of CheMPS2 instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_CheMPS2` |w---w| CMake variable to force detecting pre-built CheMPS2 and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/dkh.rst
+++ b/doc/sphinxman/source/dkh.rst
@@ -140,6 +140,7 @@ How to configure dkh for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For dkh, set to an installation directory containing ``include/DKH/DKH_MANGLE.h``
 * :makevar:`dkh_DIR` |w---w| CMake variable to specify where pre-built dkh can be found. Set to installation directory containing ``share/cmake/dkh/dkhConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_dkh` |w---w| CMake variable to force internal build of dkh instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_dkh` |w---w| CMake variable to force detecting pre-built dkh and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/erd.rst
+++ b/doc/sphinxman/source/erd.rst
@@ -118,6 +118,7 @@ How to configure erd for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For erd, set to an installation directory containing ``include/ERD/ERD_MANGLE.h``
 * :makevar:`erd_DIR` |w---w| CMake variable to specify where pre-built erd can be found. Set to installation directory containing ``share/cmake/erd/erdConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_erd` |w---w| CMake variable to force internal build of erd instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_erd` |w---w| CMake variable to force detecting pre-built erd and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/gdma.rst
+++ b/doc/sphinxman/source/gdma.rst
@@ -160,6 +160,7 @@ How to configure gdma for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For gdma, set to an installation directory containing ``include/GDMA/GDMA_MANGLE.h``
 * :makevar:`gdma_DIR` |w---w| CMake variable to specify where pre-built gdma can be found. Set to installation directory containing ``share/cmake/gdma/gdmaConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_gdma` |w---w| CMake variable to force internal build of gdma instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_gdma` |w---w| CMake variable to force detecting pre-built gdma and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/libefp.rst
+++ b/doc/sphinxman/source/libefp.rst
@@ -317,6 +317,7 @@ How to configure libefp for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For libefp, set to an installation directory containing ``include/efp.h``
 * :makevar:`libefp_DIR` |w---w| CMake variable to specify where pre-built libefp can be found. Set to installation directory containing ``share/cmake/libefp/libefpConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_libefp` |w---w| CMake variable to force internal build of libefp instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_libefp` |w---w| CMake variable to force detecting pre-built libefp and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -104,6 +104,7 @@ How to configure Libint for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For Libint, set to an installation directory containing ``include/libint/libint.h``
 * :makevar:`Libint_DIR` |w---w| CMake variable to specify where pre-built Libint can be found. Set to installation directory containing ``share/cmake/Libint/LibintConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_Libint` |w---w| CMake variable to force internal build of Libint instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_Libint` |w---w| CMake variable to force detecting pre-built Libint and not falling back on internal build
 
 **Examples**
 

--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -173,3 +173,25 @@ How to configure PCMSolver for building Psi4
 
 * Upstream Dependencies |w---w| PCMSolver |dr| Fortran, ???
 
+**CMake Variables**
+
+* :makevar:`ENABLE_PCMSolver` |w---w| CMake variable toggling whether Psi4 builds with PCMSolver
+* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For PCMSolver, set to an installation directory containing ``include/PCMSolver/pcmsolver.h``
+* :makevar:`PCMSolver_DIR` |w---w| CMake variable to specify where pre-built PCMSolver can be found. Set to installation directory containing ``share/cmake/PCMSolver/PCMSolverConfig.cmake``
+* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_PCMSolver` |w---w| CMake variable to force internal build of PCMSolver instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_PCMSolver` |w---w| CMake variable to force detecting pre-built PCMSolver and not falling back on internal build
+
+**Examples**
+
+A. Build bundled
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_PCMSolver=ON
+
+B. Build *without* PCMSolver
+
+  .. code-block:: bash
+
+    >>> cmake
+

--- a/doc/sphinxman/source/simint.rst
+++ b/doc/sphinxman/source/simint.rst
@@ -111,6 +111,7 @@ How to configure simint for building Psi4
 * :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For simint, set to an installation directory containing ``include/simint/simint.h``
 * :makevar:`simint_DIR` |w---w| CMake variable to specify where pre-built simint can be found. Set to installation directory containing ``share/cmake/simint/simintConfig.cmake``
 * :makevar:`CMAKE_DISABLE_FIND_PACKAGE_simint` |w---w| CMake variable to force internal build of simint instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_simint` |w---w| CMake variable to force detecting pre-built simint and not falling back on internal build
 * :makevar:`SIMINT_VECTOR` |w---w| CMake variable for simint vectorization (i.e., scalar sse avx avxfma micavx512). Default is ``avx``, *not* detected, so ``sse`` may be required for older chipsets. See http://www.bennyp.org/research/simint/README.txt for details.
 
 **Examples**

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -9,6 +9,10 @@ if(${ENABLE_ambit})
         # reset below necessary as find_package clears it. better solution sought
         set(TargetHDF5_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5 CACHE PATH "path to externally detected ambitConfig.cmake" FORCE)
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_ambit})
+            message(FATAL_ERROR "Suitable ambit could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable ambit could not be located, ${Magenta}Building ambit${ColourReset} instead.")
 

--- a/external/upstream/chemps2/CMakeLists.txt
+++ b/external/upstream/chemps2/CMakeLists.txt
@@ -9,6 +9,10 @@ if(${ENABLE_CheMPS2})
         # reset below necessary as find_package clears it. better solution sought
         set(TargetHDF5_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5 CACHE PATH "path to externally detected CheMPS2Config.cmake" FORCE)
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_CheMPS2})
+            message(FATAL_ERROR "Suitable CheMPS2 could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable CheMPS2 could not be located, ${Magenta}Building CheMPS2${ColourReset} instead.")
 

--- a/external/upstream/dkh/CMakeLists.txt
+++ b/external/upstream/dkh/CMakeLists.txt
@@ -6,6 +6,10 @@ if(${ENABLE_dkh})
         message(STATUS "${Cyan}Found dkh${ColourReset}: ${_loc} (found version ${dkh_VERSION})")
         add_library(dkh_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_dkh})
+            message(FATAL_ERROR "Suitable dkh could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable dkh could not be located, ${Magenta}Building dkh${ColourReset} instead.")
         ExternalProject_Add(dkh_external

--- a/external/upstream/erd/CMakeLists.txt
+++ b/external/upstream/erd/CMakeLists.txt
@@ -6,6 +6,10 @@ if(${ENABLE_erd})
         message(STATUS "${Cyan}Found erd${ColourReset}: ${_loc} (found version ${erd_VERSION})")
         add_library(erd_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_erd})
+            message(FATAL_ERROR "Suitable erd could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable erd could not be located, ${Magenta}Building erd${ColourReset} instead.")
         ExternalProject_Add(erd_external

--- a/external/upstream/gdma/CMakeLists.txt
+++ b/external/upstream/gdma/CMakeLists.txt
@@ -6,6 +6,10 @@ if(${ENABLE_gdma})
         message(STATUS "${Cyan}Found gdma${ColourReset}: ${_loc} (found version ${gdma_VERSION})")
         add_library(gdma_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_gdma})
+            message(FATAL_ERROR "Suitable gdma could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable gdma could not be located, ${Magenta}Building gdma${ColourReset} instead.")
         ExternalProject_Add(gdma_external

--- a/external/upstream/gtfock/CMakeLists.txt
+++ b/external/upstream/gtfock/CMakeLists.txt
@@ -7,6 +7,10 @@ if(${ENABLE_GTFock})
         message(FATAL_ERROR "GTFock has not been hooked back in after the inversion.")
         add_library(gtfock_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_GTFock})
+            message(FATAL_ERROR "Suitable GTFock could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable GTFock could not be located, ${Magenta}Building GTFock${ColourReset} instead.")
         message(FATAL_ERROR "GTFock has not been hooked back in after the inversion.")

--- a/external/upstream/libefp/CMakeLists.txt
+++ b/external/upstream/libefp/CMakeLists.txt
@@ -6,6 +6,10 @@ if(${ENABLE_libefp})
         message(STATUS "${Cyan}Found libefp${ColourReset}: ${_loc} (found version ${libefp_VERSION})")
         add_library(libefp_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_libefp})
+            message(FATAL_ERROR "Suitable libefp could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable libefp could not be located, ${Magenta}Building libefp${ColourReset} instead.")
         ExternalProject_Add(libefp_external

--- a/external/upstream/libint/CMakeLists.txt
+++ b/external/upstream/libint/CMakeLists.txt
@@ -5,6 +5,10 @@ if(${Libint_FOUND})
     message(STATUS "${Cyan}Found Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (found version ${Libint_VERSION})")
     add_library(libint_external INTERFACE)  # dummy
 else()
+    if(${CMAKE_INSIST_FIND_PACKAGE_Libint})
+        message(FATAL_ERROR "Suitable Libint could not be externally located as user insists")
+    endif()
+
     include(ExternalProject)
     message(STATUS "Suitable Libint could not be located, ${Magenta}Building Libint${ColourReset} instead.")
     ExternalProject_Add(libint_external

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -5,6 +5,10 @@ if(${Libxc_FOUND})
     message(STATUS "${Cyan}Found Libxc${ColourReset}: ${_loc} (found version ${Libxc_VERSION})")
     add_library(libxc_external INTERFACE)  # dummy
 else()
+    if(${CMAKE_INSIST_FIND_PACKAGE_Libxc})
+        message(FATAL_ERROR "Suitable Libxc could not be externally located as user insists")
+    endif()
+
     include(ExternalProject)
     message(STATUS "Suitable Libxc could not be located, ${Magenta}Building Libxc${ColourReset} instead.")
     ExternalProject_Add(libxc_external

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -6,6 +6,10 @@ if(${ENABLE_PCMSolver})
         message(STATUS "${Cyan}Found PCMSolver${ColourReset}: ${_loc} (found version ${PCMSolver_VERSION})")
         add_library(pcmsolver_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_PCMSolver})
+            message(FATAL_ERROR "Suitable PCMSolver could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable PCMSolver could not be located, ${Magenta}Building PCMSolver${ColourReset} instead.")
 

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -4,6 +4,10 @@ if(${pybind11_FOUND})
     message(STATUS "${Cyan}Found pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (found version ${pybind11_VERSION})")
     add_library(pybind11_external INTERFACE)  # dummy
 else()
+    if(${CMAKE_INSIST_FIND_PACKAGE_pybind11})
+        message(FATAL_ERROR "Suitable pybind11 could not be externally located as user insists")
+    endif()
+
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external

--- a/external/upstream/simint/CMakeLists.txt
+++ b/external/upstream/simint/CMakeLists.txt
@@ -8,6 +8,10 @@ if(${ENABLE_simint})
         message(STATUS "${Cyan}Found simint ${simint_MAXAM}${ColourReset}: ${_loc} (found version ${simint_VERSION}; vectorization ${simint_VECTOR})")
         add_library(simint_external INTERFACE)  # dummy
     else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_simint})
+            message(FATAL_ERROR "Suitable simint could not be externally located as user insists")
+        endif()
+
         include(ExternalProject)
         message(STATUS "Suitable simint could not be located, ${Magenta}Building simint${ColourReset} instead.")
         ExternalProject_Add(simint_external

--- a/psi4/src/psi4/libpsi4util/process.cc
+++ b/psi4/src/psi4/libpsi4util/process.cc
@@ -46,11 +46,6 @@
 #include <omp.h>
 #endif
 
-// Apple doesn't provide the environ global variable
-#if defined(__APPLE__) && !defined(environ)
-#   include <crt_externs.h>
-#   define environ (*_NSGetEnviron())
-#endif
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 


### PR DESCRIPTION
## Description
address build issues for FreeBSD packaging @yurivict 

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Killed off the Apple `environ` setting that wasn't being used anymore
* **User-Facing for Release Notes**
  - [x] AddOns now have a `CMAKE_INSIST_FIND_PACKAGE_${AddON}` variable whereby you can fail configuration when the right package not detected. That is, no falling back to internal build

## Status
- [x] Ready to go
