### PR TITLE
Fix to dump all rotation and polarizability values calculated to get_variables() dictionary

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -175,6 +175,26 @@ PSI Variables by Alpha
    The three components of the dipole [Debye] for the requested
    coupled cluster level of theory and root.
 
+.. psivar:: CC2 DIPOLE POLARIZABILITY @ xNM
+
+   The dipole polarizability [au] calculated at the CC2 level 
+   for a given (x) wavelength, (x) rounded to nearest integer. 
+
+.. psivar:: CC2 SPECIFIC ROTATION (LEN) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CC2 level in the
+   length gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
+.. psivar:: CC2 SPECIFIC ROTATION (VEL) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CC2 level in the 
+   velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
+.. psivar:: CC2 SPECIFIC ROTATION (MVG) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CC2 level in the 
+   modified velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
 .. psivar:: CC QUADRUPOLE XX
    CC QUADRUPOLE XY
    CC QUADRUPOLE XZ
@@ -254,6 +274,26 @@ PSI Variables by Alpha
    The total electronic energy [H] and correlation energy component [H]
    for the approximate coupled-cluster (CCSD(T)_L, CCSDT(Q)_L, 
    up to CC(\ *n*\ -1)(\ *n*\ )L level of theory.
+
+.. psivar:: CCSD DIPOLE POLARIZABILITY @ xNM
+
+   The dipole polarizability [au] calculated at the CCSD level 
+   for a given (x) wavelength, (x) rounded to nearest integer. 
+
+.. psivar:: CCSD SPECIFIC ROTATION (LEN) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CCSD level in the
+   length gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
+.. psivar:: CCSD SPECIFIC ROTATION (VEL) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CCSD level in the 
+   velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
+.. psivar:: CCSD SPECIFIC ROTATION (MVG) @ xNM
+
+   The specific rotation [deg/(dm (g/cm^3))] calculated at the CCSD level in the 
+   modified velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
 
 .. psivar:: CEPA(0) DIPOLE X
    CEPA(0) DIPOLE Y

--- a/psi4/src/psi4/ccresponse/optrot.cc
+++ b/psi4/src/psi4/ccresponse/optrot.cc
@@ -70,8 +70,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
-#include <cmath> /* needed for lround*/
-#include <sstream> /* needed for stringstream */
+#include <cmath>
+#include <sstream>
 
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"

--- a/psi4/src/psi4/ccresponse/optrot.cc
+++ b/psi4/src/psi4/ccresponse/optrot.cc
@@ -70,6 +70,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <cmath> /* needed for lround*/
+#include <sstream> /* needed for stringstream */
 
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
@@ -447,10 +449,21 @@ void optrot(std::shared_ptr<Molecule> molecule)
       outfile->Printf( "\n   Specific rotation using length-gauge electric-dipole Rosenfeld tensor.\n");
       outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_rl[i]);
 
-      if(params.wfn == "CC2")
-        Process::environment.globals["CC2 SPECIFIC ROTATION (LEN)"] = rotation_rl[i];
-      else if(params.wfn == "CCSD")
-        Process::environment.globals["CCSD SPECIFIC ROTATION (LEN)"] = rotation_rl[i];
+      /* grab omega in nm, rounded to nearest int */
+      long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
+
+      if(params.wfn == "CC2"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_rl[i];
+      }
+      else if(params.wfn == "CCSD"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_rl[i];
+      }
     }
 
     if(compute_pl) {
@@ -474,10 +487,21 @@ void optrot(std::shared_ptr<Molecule> molecule)
       outfile->Printf( "\n   Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.\n");
       outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_pl[i]);
 
-      if(params.wfn == "CC2")
-        Process::environment.globals["CC2 SPECIFIC ROTATION (VEL)"] = rotation_pl[i];
-      else if(params.wfn == "CCSD")
-        Process::environment.globals["CCSD SPECIFIC ROTATION (VEL)"] = rotation_pl[i];
+      /* grab omega in nm, rounded to nearest int */
+      long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
+
+      if(params.wfn == "CC2"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_pl[i];
+      }
+      else if(params.wfn == "CCSD"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_pl[i];
+      }
 
       /* subtract the zero-frequency beta tensor */
       for(j=0; j < 3; j++)
@@ -504,10 +528,18 @@ void optrot(std::shared_ptr<Molecule> molecule)
       outfile->Printf( "\n   Specific rotation using modified velocity-gauge Rosenfeld tensor.\n");
       outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_mod[i]);
 
-      if(params.wfn == "CC2")
-        Process::environment.globals["CC2 SPECIFIC ROTATION (MVG)"] = rotation_mod[i];
-      else if(params.wfn == "CCSD")
-        Process::environment.globals["CCSD SPECIFIC ROTATION (MVG)"] = rotation_mod[i];
+      if(params.wfn == "CC2"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_mod[i];
+      }
+      else if(params.wfn == "CCSD"){
+        /* build up a string */
+        std::stringstream tag;
+        tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
+        Process::environment.globals[tag.str()] = rotation_mod[i];
+      }
     }
 
     if(params.gauge == "BOTH") {

--- a/psi4/src/psi4/ccresponse/optrot.cc
+++ b/psi4/src/psi4/ccresponse/optrot.cc
@@ -87,544 +87,527 @@
 #include "globals.h"
 #include "psi4/physconst.h"
 
-namespace psi { namespace ccresponse {
+namespace psi {
+namespace ccresponse {
 
 void pertbar(const char *pert, int irrep, int anti);
 void compute_X(const char *pert, int irrep, double omega);
-void linresp(double *tensor, double A, double B,
-             const char *pert_x, int x_irrep, double omega_x,
-             const char *pert_y, int y_irrep, double omega_y);
+void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep, double omega_x, const char *pert_y,
+             int y_irrep, double omega_y);
 
-void optrot(std::shared_ptr<Molecule> molecule)
-{
-  double ***tensor_rl, ***tensor_pl, ***tensor_rp, **tensor0;
-  double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;
-  char **cartcomp, pert[32], pert_x[32], pert_y[32];
-  int alpha, beta, i, j, k;
-  double TrG_rl, TrG_pl, M, nu, bohr2a4, m2a, hbar, prefactor;
-  double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod, **delta;
-  char lbl1[32], lbl2[32], lbl3[32];
-  int compute_rl=0, compute_pl=0;
+void optrot(std::shared_ptr<Molecule> molecule) {
+    double ***tensor_rl, ***tensor_pl, ***tensor_rp, **tensor0;
+    double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;
+    char **cartcomp, pert[32], pert_x[32], pert_y[32];
+    int alpha, beta, i, j, k;
+    double TrG_rl, TrG_pl, M, nu, bohr2a4, m2a, hbar, prefactor;
+    double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod, **delta;
+    char lbl1[32], lbl2[32], lbl3[32];
+    int compute_rl = 0, compute_pl = 0;
 
-  /* Booleans for convenience */
-  if(params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl=1;
-  if(params.gauge == "VELOCITY" || params.gauge == "BOTH") compute_pl=1;
+    /* Booleans for convenience */
+    if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;
+    if (params.gauge == "VELOCITY" || params.gauge == "BOTH") compute_pl = 1;
 
-  cartcomp = (char **) malloc(3 * sizeof(char *));
-  cartcomp[0] = strdup("X");
-  cartcomp[1] = strdup("Y");
-  cartcomp[2] = strdup("Z");
+    cartcomp = (char **)malloc(3 * sizeof(char *));
+    cartcomp[0] = strdup("X");
+    cartcomp[1] = strdup("Y");
+    cartcomp[2] = strdup("Z");
 
-  tensor_rl = (double ***) malloc(params.nomega * sizeof(double **));
-  tensor_pl = (double ***) malloc(params.nomega * sizeof(double **));
-  tensor_rp = (double ***) malloc(params.nomega * sizeof(double **));
-  for(i=0; i < params.nomega; i++) {
-    tensor_rl[i] = block_matrix(3,3);
-    tensor_pl[i] = block_matrix(3,3);
-    tensor_rp[i] = block_matrix(3,3);
-  }
-  tensor0 = block_matrix(3,3);
-  tensor_rl0 = block_matrix(3,3);
-  tensor_rl1 = block_matrix(3,3);
-  tensor_pl0 = block_matrix(3,3);
-  tensor_pl1 = block_matrix(3,3);
-  rotation_rl = init_array(params.nomega);
-  rotation_pl = init_array(params.nomega);
-  rotation_rp = init_array(params.nomega);
-  rotation_mod = init_array(params.nomega);
-  delta = block_matrix(params.nomega,3);
-
-  if(compute_pl) {
-
-    /* compute the zero-frequency Rosenfeld tensor for Koch's modified
-       velocity optical rotation */
-    /* NOTE!!!  The complex conjugation required for the response
-       function is handled *implicitly* in the code below because the
-       velocity-gauge version of the optical rotation tensor contains
-       *two* pure-imaginary operators, p and m.  Thus, even though the
-       corresponding perturbed wave functions change sign when we take
-       complex conjugates of the p and m operators, the signs cancel,
-       giving an identical contribution to the total *zero-frequency*
-       Rosenfeld tensor as the original non-complex-conjugate term. */
-
-    sprintf(lbl1, "<<P;L>>_(%5.3f)", 0.0);
-    if(!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl1)) {
-
-      for(alpha=0; alpha < 3; alpha++) {
-        sprintf(pert, "P_%1s", cartcomp[alpha]);
-        pertbar(pert, moinfo.mu_irreps[alpha], 1);
-        compute_X(pert, moinfo.mu_irreps[alpha], 0);
-
-        sprintf(pert, "L_%1s", cartcomp[alpha]);
-        pertbar(pert, moinfo.l_irreps[alpha], 1);
-        compute_X(pert, moinfo.l_irreps[alpha], 0);
-      }
-
-      outfile->Printf( "\n\tComputing %s tensor.\n", lbl1);
-      for(alpha=0; alpha < 3; alpha ++) {
-        for(beta=0; beta < 3; beta++) {
-          sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-          sprintf(pert_y, "L_%1s", cartcomp[beta]);
-          linresp(&tensor0[alpha][beta], -1.0, 0.0,
-                  pert_x, moinfo.mu_irreps[alpha], 0.0,
-                  pert_y, moinfo.l_irreps[beta], 0.0);
-        }
-      }
-      psio_write_entry(PSIF_CC_INFO, lbl1, (char *) tensor0[0], 9*sizeof(double));
-
-      /* Clean up disk space */
-      psio_close(PSIF_CC_LR, 0);
-      psio_open(PSIF_CC_LR, 0);
-
-      for(j=PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
-        psio_close(j,0);
-        psio_open(j,0);
-      }
+    tensor_rl = (double ***)malloc(params.nomega * sizeof(double **));
+    tensor_pl = (double ***)malloc(params.nomega * sizeof(double **));
+    tensor_rp = (double ***)malloc(params.nomega * sizeof(double **));
+    for (i = 0; i < params.nomega; i++) {
+        tensor_rl[i] = block_matrix(3, 3);
+        tensor_pl[i] = block_matrix(3, 3);
+        tensor_rp[i] = block_matrix(3, 3);
     }
-    else {
-      outfile->Printf( "Using %s tensor found on disk.\n", lbl1);
-      psio_read_entry(PSIF_CC_INFO, lbl1, (char *) tensor0[0], 9*sizeof(double));
-    }
+    tensor0 = block_matrix(3, 3);
+    tensor_rl0 = block_matrix(3, 3);
+    tensor_rl1 = block_matrix(3, 3);
+    tensor_pl0 = block_matrix(3, 3);
+    tensor_pl1 = block_matrix(3, 3);
+    rotation_rl = init_array(params.nomega);
+    rotation_pl = init_array(params.nomega);
+    rotation_rp = init_array(params.nomega);
+    rotation_mod = init_array(params.nomega);
+    delta = block_matrix(params.nomega, 3);
 
-    if (params.wfn == "CC2")
-      outfile->Printf( "\n     CC2 Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-    else if(params.wfn == "CCSD")
-      outfile->Printf( "\n    CCSD Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
+    if (compute_pl) {
+        /* compute the zero-frequency Rosenfeld tensor for Koch's modified
+           velocity optical rotation */
+        /* NOTE!!!  The complex conjugation required for the response
+           function is handled *implicitly* in the code below because the
+           velocity-gauge version of the optical rotation tensor contains
+           *two* pure-imaginary operators, p and m.  Thus, even though the
+           corresponding perturbed wave functions change sign when we take
+           complex conjugates of the p and m operators, the signs cancel,
+           giving an identical contribution to the total *zero-frequency*
+           Rosenfeld tensor as the original non-complex-conjugate term. */
 
-    outfile->Printf( "  -------------------------------------------------------------------------\n");
-    outfile->Printf(   "   Evaluated at omega = 0.00 E_h (Inf nm, 0.0 eV, 0.0 cm-1)\n");
-    outfile->Printf( "  -------------------------------------------------------------------------\n");
-    mat_print(tensor0, 3, 3, "outfile");
+        sprintf(lbl1, "<<P;L>>_(%5.3f)", 0.0);
+        if (!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl1)) {
+            for (alpha = 0; alpha < 3; alpha++) {
+                sprintf(pert, "P_%1s", cartcomp[alpha]);
+                pertbar(pert, moinfo.mu_irreps[alpha], 1);
+                compute_X(pert, moinfo.mu_irreps[alpha], 0);
 
-  }
+                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                pertbar(pert, moinfo.l_irreps[alpha], 1);
+                compute_X(pert, moinfo.l_irreps[alpha], 0);
+            }
 
-  for(i=0; i < params.nomega; i++) {
-    zero_mat(tensor_rl0, 3, 3);
-    zero_mat(tensor_rl1, 3, 3);
-    zero_mat(tensor_pl0, 3, 3);
-    zero_mat(tensor_pl1, 3, 3);
+            outfile->Printf("\n\tComputing %s tensor.\n", lbl1);
+            for (alpha = 0; alpha < 3; alpha++) {
+                for (beta = 0; beta < 3; beta++) {
+                    sprintf(pert_x, "P_%1s", cartcomp[alpha]);
+                    sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                    linresp(&tensor0[alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], 0.0, pert_y,
+                            moinfo.l_irreps[beta], 0.0);
+                }
+            }
+            psio_write_entry(PSIF_CC_INFO, lbl1, (char *)tensor0[0], 9 * sizeof(double));
 
-    sprintf(lbl1, "1/2 <<Mu;L>>_(%5.3f)", params.omega[i]);
-    sprintf(lbl2, "1/2 <<P;L>>_(%5.3f)", params.omega[i]);
-    if(!params.restart || ((compute_rl && !psio_tocscan(PSIF_CC_INFO,lbl1)) || (compute_pl && !psio_tocscan(PSIF_CC_INFO,lbl2)))) {
+            /* Clean up disk space */
+            psio_close(PSIF_CC_LR, 0);
+            psio_open(PSIF_CC_LR, 0);
 
-      /* prepare the dipole-length and/or dipole-velocity integrals */
-      if(compute_rl) {
-        for(alpha=0; alpha < 3; alpha++) {
-          sprintf(pert, "Mu_%1s", cartcomp[alpha]);
-          pertbar(pert, moinfo.mu_irreps[alpha], 0);
+            for (j = PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
+                psio_close(j, 0);
+                psio_open(j, 0);
+            }
+        } else {
+            outfile->Printf("Using %s tensor found on disk.\n", lbl1);
+            psio_read_entry(PSIF_CC_INFO, lbl1, (char *)tensor0[0], 9 * sizeof(double));
         }
-      }
-      if(compute_pl) {
-        for(alpha=0; alpha < 3; alpha++) {
-          sprintf(pert, "P_%1s", cartcomp[alpha]);
-          pertbar(pert, moinfo.mu_irreps[alpha], 1);
-        }
-      }
 
-      /* prepare the magnetic-dipole integrals */
-      for(alpha=0; alpha < 3; alpha++) {
-        sprintf(pert, "L_%1s", cartcomp[alpha]);
-        pertbar(pert, moinfo.l_irreps[alpha], 1);
-      }
+        if (params.wfn == "CC2")
+            outfile->Printf("\n     CC2 Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
+        else if (params.wfn == "CCSD")
+            outfile->Printf("\n    CCSD Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
 
-      /* Compute the +omega magnetic-dipole and -omega electric-dipole CC wave functions */
-      for(alpha=0; alpha < 3; alpha++) {
-        if(compute_rl) {
-          sprintf(pert, "Mu_%1s", cartcomp[alpha]);
-          compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
-        }
-
-        if(compute_pl) {
-          sprintf(pert, "P_%1s", cartcomp[alpha]);
-          compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
-        }
-
-        sprintf(pert, "L_%1s", cartcomp[alpha]);
-        compute_X(pert, moinfo.l_irreps[alpha], params.omega[i]);
-      }
-
-      outfile->Printf( "\n");
-      if(compute_rl) {
-        outfile->Printf( "\tComputing %s tensor.\n", lbl1);
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "L_%1s", cartcomp[beta]);
-            linresp(&tensor_rl0[alpha][beta], +0.5, 0.0,
-                    pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
-                    pert_y, moinfo.l_irreps[beta], params.omega[i]);
-          }
-        }
-        psio_write_entry(PSIF_CC_INFO, lbl1, (char *) tensor_rl0[0], 9*sizeof(double));
-      }
-      if(compute_pl) {
-        outfile->Printf( "\tComputing %s tensor.\n", lbl2);
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "L_%1s", cartcomp[beta]);
-            linresp(&tensor_pl0[alpha][beta], -0.5, 0.0,
-                    pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
-                    pert_y, moinfo.l_irreps[beta], params.omega[i]);
-          }
-        }
-        psio_write_entry(PSIF_CC_INFO, lbl2, (char *) tensor_pl0[0], 9*sizeof(double));
-      }
-
-      /* Clean up disk space */
-      if(params.gauge != "BOTH") { /* don't clean up if we want both gauges */
-        psio_close(PSIF_CC_LR, 0);
-        psio_open(PSIF_CC_LR, 0);
-      }
-
-      for(j=PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
-        psio_close(j,0);
-        psio_open(j,0);
-      }
-    }
-    else {
-      outfile->Printf( "\n");
-      if(compute_rl) {
-        outfile->Printf( "\tUsing %s tensor found on disk.\n", lbl1);
-        psio_read_entry(PSIF_CC_INFO, lbl1, (char *) tensor_rl0[0], 9*sizeof(double));
-      }
-      if(compute_pl) {
-        outfile->Printf( "\tUsing %s tensor found on disk.\n", lbl2);
-        psio_read_entry(PSIF_CC_INFO, lbl2, (char *) tensor_pl0[0], 9*sizeof(double));
-      }
-
+        outfile->Printf("  -------------------------------------------------------------------------\n");
+        outfile->Printf("   Evaluated at omega = 0.00 E_h (Inf nm, 0.0 eV, 0.0 cm-1)\n");
+        outfile->Printf("  -------------------------------------------------------------------------\n");
+        mat_print(tensor0, 3, 3, "outfile");
     }
 
-    sprintf(lbl1, "1/2 <<Mu;L*>>_(%5.3f)", params.omega[i]);
-    sprintf(lbl2, "1/2 <<P*;L*>>_(%5.3f)", params.omega[i]);
-    sprintf(lbl3, "<<P;Mu>>_(%5.3f)", params.omega[i]);
-    if(!params.restart || ((compute_rl && !psio_tocscan(PSIF_CC_INFO,lbl1)) || (compute_pl && !psio_tocscan(PSIF_CC_INFO,lbl2)))) {
+    for (i = 0; i < params.nomega; i++) {
+        zero_mat(tensor_rl0, 3, 3);
+        zero_mat(tensor_rl1, 3, 3);
+        zero_mat(tensor_pl0, 3, 3);
+        zero_mat(tensor_pl1, 3, 3);
 
-      /* prepare the dipole-length or dipole-velocity integrals */
-      if(compute_rl) {
-        for(alpha=0; alpha < 3; alpha++) {
-          sprintf(pert, "Mu_%1s", cartcomp[alpha]);
-          pertbar(pert, moinfo.mu_irreps[alpha], 0);
+        sprintf(lbl1, "1/2 <<Mu;L>>_(%5.3f)", params.omega[i]);
+        sprintf(lbl2, "1/2 <<P;L>>_(%5.3f)", params.omega[i]);
+        if (!params.restart ||
+            ((compute_rl && !psio_tocscan(PSIF_CC_INFO, lbl1)) || (compute_pl && !psio_tocscan(PSIF_CC_INFO, lbl2)))) {
+            /* prepare the dipole-length and/or dipole-velocity integrals */
+            if (compute_rl) {
+                for (alpha = 0; alpha < 3; alpha++) {
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    pertbar(pert, moinfo.mu_irreps[alpha], 0);
+                }
+            }
+            if (compute_pl) {
+                for (alpha = 0; alpha < 3; alpha++) {
+                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    pertbar(pert, moinfo.mu_irreps[alpha], 1);
+                }
+            }
+
+            /* prepare the magnetic-dipole integrals */
+            for (alpha = 0; alpha < 3; alpha++) {
+                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                pertbar(pert, moinfo.l_irreps[alpha], 1);
+            }
+
+            /* Compute the +omega magnetic-dipole and -omega electric-dipole CC wave functions */
+            for (alpha = 0; alpha < 3; alpha++) {
+                if (compute_rl) {
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
+                }
+
+                if (compute_pl) {
+                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
+                }
+
+                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                compute_X(pert, moinfo.l_irreps[alpha], params.omega[i]);
+            }
+
+            outfile->Printf("\n");
+            if (compute_rl) {
+                outfile->Printf("\tComputing %s tensor.\n", lbl1);
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        linresp(&tensor_rl0[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
+                                pert_y, moinfo.l_irreps[beta], params.omega[i]);
+                    }
+                }
+                psio_write_entry(PSIF_CC_INFO, lbl1, (char *)tensor_rl0[0], 9 * sizeof(double));
+            }
+            if (compute_pl) {
+                outfile->Printf("\tComputing %s tensor.\n", lbl2);
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "P_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        linresp(&tensor_pl0[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
+                                pert_y, moinfo.l_irreps[beta], params.omega[i]);
+                    }
+                }
+                psio_write_entry(PSIF_CC_INFO, lbl2, (char *)tensor_pl0[0], 9 * sizeof(double));
+            }
+
+            /* Clean up disk space */
+            if (params.gauge != "BOTH") { /* don't clean up if we want both gauges */
+                psio_close(PSIF_CC_LR, 0);
+                psio_open(PSIF_CC_LR, 0);
+            }
+
+            for (j = PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
+                psio_close(j, 0);
+                psio_open(j, 0);
+            }
+        } else {
+            outfile->Printf("\n");
+            if (compute_rl) {
+                outfile->Printf("\tUsing %s tensor found on disk.\n", lbl1);
+                psio_read_entry(PSIF_CC_INFO, lbl1, (char *)tensor_rl0[0], 9 * sizeof(double));
+            }
+            if (compute_pl) {
+                outfile->Printf("\tUsing %s tensor found on disk.\n", lbl2);
+                psio_read_entry(PSIF_CC_INFO, lbl2, (char *)tensor_pl0[0], 9 * sizeof(double));
+            }
         }
-      }
-      if(compute_pl) {
-        for(alpha=0; alpha < 3; alpha++) {
-          sprintf(pert, "P*_%1s", cartcomp[alpha]);
-          pertbar(pert, moinfo.mu_irreps[alpha], 1);
+
+        sprintf(lbl1, "1/2 <<Mu;L*>>_(%5.3f)", params.omega[i]);
+        sprintf(lbl2, "1/2 <<P*;L*>>_(%5.3f)", params.omega[i]);
+        sprintf(lbl3, "<<P;Mu>>_(%5.3f)", params.omega[i]);
+        if (!params.restart ||
+            ((compute_rl && !psio_tocscan(PSIF_CC_INFO, lbl1)) || (compute_pl && !psio_tocscan(PSIF_CC_INFO, lbl2)))) {
+            /* prepare the dipole-length or dipole-velocity integrals */
+            if (compute_rl) {
+                for (alpha = 0; alpha < 3; alpha++) {
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    pertbar(pert, moinfo.mu_irreps[alpha], 0);
+                }
+            }
+            if (compute_pl) {
+                for (alpha = 0; alpha < 3; alpha++) {
+                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    pertbar(pert, moinfo.mu_irreps[alpha], 1);
+                }
+            }
+
+            /* prepare the complex-conjugate of the magnetic-dipole integrals */
+            for (alpha = 0; alpha < 3; alpha++) {
+                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                pertbar(pert, moinfo.l_irreps[alpha], 1);
+            }
+
+            /* Compute the -omega magnetic-dipole and +omega electric-dipole CC wave functions */
+            for (alpha = 0; alpha < 3; alpha++) {
+                if (compute_rl) {
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
+                }
+                if (compute_pl) {
+                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
+                }
+
+                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                compute_X(pert, moinfo.l_irreps[alpha], -params.omega[i]);
+            }
+
+            outfile->Printf("\n");
+            if (compute_rl) {
+                outfile->Printf("\tComputing %s tensor.\n", lbl1);
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        linresp(&tensor_rl1[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
+                                pert_y, moinfo.l_irreps[beta], -params.omega[i]);
+                    }
+                }
+                psio_write_entry(PSIF_CC_INFO, lbl1, (char *)tensor_rl1[0], 9 * sizeof(double));
+            }
+            if (compute_pl) {
+                outfile->Printf("\tComputing %s tensor.\n", lbl2);
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        linresp(&tensor_pl1[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
+                                pert_y, moinfo.l_irreps[beta], -params.omega[i]);
+                    }
+                }
+                psio_write_entry(PSIF_CC_INFO, lbl2, (char *)tensor_pl1[0], 9 * sizeof(double));
+            }
+
+            if (params.gauge == "BOTH") {
+                outfile->Printf("\tComputing %s tensor.\n", lbl3);
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "P_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                        linresp(&tensor_rp[i][alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha],
+                                -params.omega[i], pert_y, moinfo.mu_irreps[beta], params.omega[i]);
+                    }
+                }
+                for (alpha = 0; alpha < 3; alpha++) {
+                    for (beta = 0; beta < 3; beta++) {
+                        sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
+                        sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                        linresp(&tensor_rp[i][alpha][beta], -0.5, 1.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
+                                pert_y, moinfo.mu_irreps[beta], -params.omega[i]);
+                    }
+                }
+                psio_write_entry(PSIF_CC_INFO, lbl3, (char *)tensor_rp[i][0], 9 * sizeof(double));
+            }
+
+            /* Clean up disk space */
+            psio_close(PSIF_CC_LR, 0);
+            psio_open(PSIF_CC_LR, 0);
+
+            for (j = PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
+                psio_close(j, 0);
+                psio_open(j, 0);
+            }
+
+        } else {
+            outfile->Printf("\n");
+            if (compute_rl) {
+                outfile->Printf("\tUsing %s tensor found on disk.\n", lbl1);
+                psio_read_entry(PSIF_CC_INFO, lbl1, (char *)tensor_rl1[0], 9 * sizeof(double));
+            }
+            if (compute_pl) {
+                outfile->Printf("\tUsing %s tensor found on disk.\n", lbl2);
+                psio_read_entry(PSIF_CC_INFO, lbl2, (char *)tensor_pl1[0], 9 * sizeof(double));
+            }
+            if (params.gauge == "BOTH") {
+                outfile->Printf("\tUsing %s tensor found on disk.\n", lbl3);
+                psio_read_entry(PSIF_CC_INFO, lbl3, (char *)tensor_rp[i][0], 9 * sizeof(double));
+            }
         }
-      }
 
-      /* prepare the complex-conjugate of the magnetic-dipole integrals */
-      for(alpha=0; alpha < 3; alpha++) {
-        sprintf(pert, "L*_%1s", cartcomp[alpha]);
-        pertbar(pert, moinfo.l_irreps[alpha], 1);
-      }
+        /* sum the two 1/2 tensors */
+        for (j = 0; j < 3; j++)
+            for (k = 0; k < 3; k++) {
+                if (compute_rl) tensor_rl[i][j][k] = tensor_rl0[j][k] + tensor_rl1[j][k];
+                if (compute_pl) tensor_pl[i][j][k] = tensor_pl0[j][k] + tensor_pl1[j][k];
+            }
 
-      /* Compute the -omega magnetic-dipole and +omega electric-dipole CC wave functions */
-      for(alpha=0; alpha < 3; alpha++) {
-        if(compute_rl) {
-          sprintf(pert, "Mu_%1s", cartcomp[alpha]);
-          compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
+        /* compute the specific rotation */
+        for (j = 0, M = 0.0; j < moinfo.natom; j++) M += molecule->mass(j); /* amu */
+        nu = params.omega[i];                                               /* hartree */
+        bohr2a4 = pc_bohr2angstroms * pc_bohr2angstroms * pc_bohr2angstroms * pc_bohr2angstroms;
+        m2a = pc_bohr2angstroms * 1.0e-10;
+        hbar = pc_h / (2.0 * pc_pi);
+        prefactor = 1.0e-2 * hbar / (pc_c * 2.0 * pc_pi * pc_me * m2a * m2a);
+        prefactor *= prefactor;
+        prefactor *= 288.0e-30 * pc_pi * pc_pi * pc_na * bohr2a4;
+
+        if (compute_rl) {
+            if (params.wfn == "CC2")
+                outfile->Printf("\n            CC2 Optical Rotation Tensor (Length Gauge):\n");
+            else if (params.wfn == "CCSD")
+                outfile->Printf("\n           CCSD Optical Rotation Tensor (Length Gauge):\n");
+
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
+                            (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), pc_hartree2ev * params.omega[i],
+                            pc_hartree2wavenumbers * params.omega[i]);
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            mat_print(tensor_rl[i], 3, 3, "outfile");
+
+            TrG_rl = -(tensor_rl[i][0][0] + tensor_rl[i][1][1] + tensor_rl[i][2][2]) / (3.0 * params.omega[i]);
+
+            rotation_rl[i] = prefactor * TrG_rl * nu * nu / M;
+            outfile->Printf("\n   Specific rotation using length-gauge electric-dipole Rosenfeld tensor.\n");
+            outfile->Printf("\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_rl[i]);
+
+            /* grab omega in nm, rounded to nearest int */
+            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
+
+            if (params.wfn == "CC2") {
+                std::stringstream tag;
+                tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_rl[i];
+            } else if (params.wfn == "CCSD") {
+                std::stringstream tag;
+                tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_rl[i];
+            }
         }
-        if(compute_pl) {
-          sprintf(pert, "P*_%1s", cartcomp[alpha]);
-          compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
+
+        if (compute_pl) {
+            if (params.wfn == "CC2")
+                outfile->Printf("\n          CC2 Optical Rotation Tensor (Velocity Gauge):\n");
+            else if (params.wfn == "CCSD")
+                outfile->Printf("\n         CCSD Optical Rotation Tensor (Velocity Gauge):\n");
+
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
+                            (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), pc_hartree2ev * params.omega[i],
+                            pc_hartree2wavenumbers * params.omega[i]);
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            mat_print(tensor_pl[i], 3, 3, "outfile");
+
+            TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2]) / (3.0 * params.omega[i]);
+            TrG_pl /= params.omega[i];
+
+            rotation_pl[i] = prefactor * TrG_pl * nu * nu / M;
+            outfile->Printf("\n   Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.\n");
+            outfile->Printf("\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_pl[i]);
+
+            /* grab omega in nm, rounded to nearest int */
+            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
+
+            if (params.wfn == "CC2") {
+                std::stringstream tag;
+                tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_pl[i];
+            } else if (params.wfn == "CCSD") {
+                std::stringstream tag;
+                tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_pl[i];
+            }
+
+            /* subtract the zero-frequency beta tensor */
+            for (j = 0; j < 3; j++)
+                for (k = 0; k < 3; k++) tensor_pl[i][j][k] -= tensor0[j][k];
+
+            if (params.wfn == "CC2")
+                outfile->Printf("\n        CC2 Optical Rotation Tensor (Modified Velocity Gauge):\n");
+            else if (params.wfn == "CCSD")
+                outfile->Printf("\n        CCSD Optical Rotation Tensor (Modified Velocity Gauge):\n");
+
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
+                            (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), pc_hartree2ev * params.omega[i],
+                            pc_hartree2wavenumbers * params.omega[i]);
+            outfile->Printf("  -------------------------------------------------------------------------\n");
+            mat_print(tensor_pl[i], 3, 3, "outfile");
+
+            /* compute the specific rotation */
+            TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2]) / (3.0 * params.omega[i]);
+            TrG_pl /= params.omega[i];
+
+            rotation_mod[i] = prefactor * TrG_pl * nu * nu / M;
+            outfile->Printf("\n   Specific rotation using modified velocity-gauge Rosenfeld tensor.\n");
+            outfile->Printf("\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_mod[i]);
+
+            if (params.wfn == "CC2") {
+                std::stringstream tag;
+                tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_mod[i];
+            } else if (params.wfn == "CCSD") {
+                std::stringstream tag;
+                tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
+                Process::environment.globals[tag.str()] = rotation_mod[i];
+            }
         }
 
-        sprintf(pert, "L*_%1s", cartcomp[alpha]);
-        compute_X(pert, moinfo.l_irreps[alpha], -params.omega[i]);
-      }
-
-      outfile->Printf( "\n");
-      if(compute_rl) {
-        outfile->Printf( "\tComputing %s tensor.\n", lbl1);
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "L*_%1s", cartcomp[beta]);
-            linresp(&tensor_rl1[alpha][beta], +0.5, 0.0,
-                    pert_x, moinfo.mu_irreps[alpha], params.omega[i],
-                    pert_y, moinfo.l_irreps[beta], -params.omega[i]);
-          }
+        if (params.gauge == "BOTH") {
+            delta[i][0] = prefactor * (tensor_rp[i][1][2] - tensor_rp[i][2][1]) * nu * nu / M;
+            delta[i][1] = prefactor * (tensor_rp[i][2][0] - tensor_rp[i][0][2]) * nu * nu / M;
+            delta[i][2] = prefactor * (tensor_rp[i][0][1] - tensor_rp[i][1][0]) * nu * nu / M;
+            delta[i][0] /= 6.0 * params.omega[i];
+            delta[i][1] /= 6.0 * params.omega[i];
+            delta[i][2] /= 6.0 * params.omega[i];
+            outfile->Printf("\n   Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.\n");
+            outfile->Printf("     Delta_x = %6.2f   Delta_y = %6.2f   Delta_z = %6.2f\n", delta[i][0], delta[i][1],
+                            delta[i][2]);
         }
-        psio_write_entry(PSIF_CC_INFO, lbl1, (char *) tensor_rl1[0], 9*sizeof(double));
-      }
-      if(compute_pl) {
-        outfile->Printf( "\tComputing %s tensor.\n", lbl2);
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "L*_%1s", cartcomp[beta]);
-            linresp(&tensor_pl1[alpha][beta], -0.5, 0.0,
-                    pert_x, moinfo.mu_irreps[alpha], params.omega[i],
-                    pert_y, moinfo.l_irreps[beta], -params.omega[i]);
-          }
+    } /* loop i over nomega */
+
+    if (params.nomega > 1) { /* print a summary table for multi-wavelength calcs */
+
+        if (compute_rl) {
+            outfile->Printf("\n   ------------------------------------------\n");
+            if (params.wfn == "CC2")
+                outfile->Printf("       CC2 Length-Gauge Optical Rotation\n");
+            else
+                outfile->Printf("       CCSD Length-Gauge Optical Rotation\n");
+            outfile->Printf("   ------------------------------------------\n");
+
+            if (params.gauge == "BOTH") {
+                outfile->Printf("       Omega           alpha                        Delta\n");
+                outfile->Printf("    E_h      nm   deg/[dm (g/cm^3)]        deg/[dm (g/cm^3)]/bohr\n");
+                outfile->Printf("   -----   ------ ------------------  ----------------------------------\n");
+                outfile->Printf("                                          x           y           z      \n");
+                for (i = 0; i < params.nomega; i++)
+                    outfile->Printf("   %5.3f   %6.2f      %10.5f    %10.5f  %10.5f  %10.5f\n", params.omega[i],
+                                    (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), rotation_rl[i], delta[i][0],
+                                    delta[i][1], delta[i][2]);
+            } else {
+                outfile->Printf("       Omega           alpha\n");
+                outfile->Printf("    E_h      nm   deg/[dm (g/cm^3)]\n");
+                outfile->Printf("   -----   ------ ------------------\n");
+                for (i = 0; i < params.nomega; i++)
+                    outfile->Printf("   %5.3f   %6.2f      %10.5f\n", params.omega[i],
+                                    (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), rotation_rl[i]);
+            }
         }
-        psio_write_entry(PSIF_CC_INFO, lbl2, (char *) tensor_pl1[0], 9*sizeof(double));
-      }
 
-      if(params.gauge == "BOTH") {
-        outfile->Printf( "\tComputing %s tensor.\n", lbl3);
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
-            linresp(&tensor_rp[i][alpha][beta],-0.5, 0.0,
-                    pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
-                    pert_y, moinfo.mu_irreps[beta], params.omega[i]);
-          }
+        if (compute_pl) {
+            outfile->Printf("\n   ------------------------------------------------------\n");
+            if (params.wfn == "CC2")
+                outfile->Printf("            CC2 Velocity-Gauge Optical Rotation\n");
+            else
+                outfile->Printf("            CCSD Velocity-Gauge Optical Rotation\n");
+            outfile->Printf("   ------------------------------------------------------\n");
+            outfile->Printf("       Omega           alpha (deg/[dm (g/cm^3)]\n");
+            outfile->Printf("\n    E_h      nm   Velocity-Gauge  Modified Velocity-Gauge\n");
+            outfile->Printf("   -----   ------ --------------  -----------------------\n");
+            for (i = 0; i < params.nomega; i++)
+                outfile->Printf("   %5.3f   %6.2f   %10.5f          %10.5f\n", params.omega[i],
+                                (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), rotation_pl[i],
+                                rotation_mod[i]);
         }
-        for(alpha=0; alpha < 3; alpha++) {
-          for(beta=0; beta < 3; beta++) {
-            sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
-            sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
-            linresp(&tensor_rp[i][alpha][beta],-0.5, 1.0,
-                    pert_x, moinfo.mu_irreps[alpha], params.omega[i],
-                    pert_y, moinfo.mu_irreps[beta], -params.omega[i]);
-          }
-        }
-        psio_write_entry(PSIF_CC_INFO, lbl3, (char *) tensor_rp[i][0], 9*sizeof(double));
-      }
-
-      /* Clean up disk space */
-      psio_close(PSIF_CC_LR, 0);
-      psio_open(PSIF_CC_LR, 0);
-
-      for(j=PSIF_CC_TMP; j <= PSIF_CC_TMP11; j++) {
-        psio_close(j,0);
-        psio_open(j,0);
-      }
-
     }
-    else {
-      outfile->Printf( "\n");
-      if(compute_rl) {
-        outfile->Printf( "\tUsing %s tensor found on disk.\n", lbl1);
-        psio_read_entry(PSIF_CC_INFO, lbl1, (char *) tensor_rl1[0], 9*sizeof(double));
-      }
-      if(compute_pl) {
-        outfile->Printf( "\tUsing %s tensor found on disk.\n", lbl2);
-        psio_read_entry(PSIF_CC_INFO, lbl2, (char *) tensor_pl1[0], 9*sizeof(double));
-      }
-      if(params.gauge == "BOTH") {
-        outfile->Printf( "\tUsing %s tensor found on disk.\n", lbl3);
-        psio_read_entry(PSIF_CC_INFO, lbl3, (char *) tensor_rp[i][0], 9*sizeof(double));
-      }
+
+    free(rotation_rl);
+    free(rotation_pl);
+    free(rotation_rp);
+    free(rotation_mod);
+    free_block(delta);
+
+    for (i = 0; i < params.nomega; i++) {
+        free_block(tensor_rl[i]);
+        free_block(tensor_pl[i]);
+        free_block(tensor_rp[i]);
     }
+    free(tensor_rl);
+    free(tensor_pl);
+    free(tensor_rp);
+    free_block(tensor0);
+    free_block(tensor_rl0);
+    free_block(tensor_rl1);
+    free_block(tensor_pl0);
+    free_block(tensor_pl1);
 
-    /* sum the two 1/2 tensors */
-    for(j=0; j < 3; j++)
-      for(k=0; k < 3; k++) {
-        if(compute_rl) tensor_rl[i][j][k] = tensor_rl0[j][k] + tensor_rl1[j][k];
-        if(compute_pl) tensor_pl[i][j][k] = tensor_pl0[j][k] + tensor_pl1[j][k];
-      }
-
-    /* compute the specific rotation */
-    for(j=0,M=0.0; j < moinfo.natom ;j++) M += molecule->mass(j);  /* amu */
-    nu = params.omega[i]; /* hartree */
-    bohr2a4 = pc_bohr2angstroms * pc_bohr2angstroms * pc_bohr2angstroms * pc_bohr2angstroms;
-    m2a = pc_bohr2angstroms * 1.0e-10;
-    hbar = pc_h/(2.0 * pc_pi);
-    prefactor = 1.0e-2 * hbar/(pc_c * 2.0 * pc_pi * pc_me * m2a * m2a);
-    prefactor *= prefactor;
-    prefactor *= 288.0e-30 * pc_pi * pc_pi * pc_na * bohr2a4;
-
-    if(compute_rl) {
-      if (params.wfn == "CC2")
-        outfile->Printf( "\n            CC2 Optical Rotation Tensor (Length Gauge):\n");
-      else if(params.wfn == "CCSD")
-        outfile->Printf( "\n           CCSD Optical Rotation Tensor (Length Gauge):\n");
-
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      outfile->Printf(   "   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
-              (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), pc_hartree2ev*params.omega[i],
-              pc_hartree2wavenumbers*params.omega[i]);
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      mat_print(tensor_rl[i], 3, 3, "outfile");
-
-      TrG_rl = -(tensor_rl[i][0][0] + tensor_rl[i][1][1] + tensor_rl[i][2][2])/(3.0 * params.omega[i]);
-
-      rotation_rl[i] = prefactor * TrG_rl * nu * nu / M;
-      outfile->Printf( "\n   Specific rotation using length-gauge electric-dipole Rosenfeld tensor.\n");
-      outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_rl[i]);
-
-      /* grab omega in nm, rounded to nearest int */
-      long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
-
-      if(params.wfn == "CC2"){
-        std::stringstream tag;
-        tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_rl[i];
-      }
-      else if(params.wfn == "CCSD"){
-        std::stringstream tag;
-        tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_rl[i];
-      }
-    }
-
-    if(compute_pl) {
-
-      if (params.wfn == "CC2")
-        outfile->Printf( "\n          CC2 Optical Rotation Tensor (Velocity Gauge):\n");
-      else if(params.wfn == "CCSD")
-        outfile->Printf( "\n         CCSD Optical Rotation Tensor (Velocity Gauge):\n");
-
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      outfile->Printf(   "   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
-              (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), pc_hartree2ev*params.omega[i],
-              pc_hartree2wavenumbers*params.omega[i]);
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      mat_print(tensor_pl[i], 3, 3, "outfile");
-
-      TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2])/(3.0 * params.omega[i]);
-      TrG_pl /= params.omega[i];
-
-      rotation_pl[i] = prefactor * TrG_pl * nu * nu / M;
-      outfile->Printf( "\n   Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.\n");
-      outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_pl[i]);
-
-      /* grab omega in nm, rounded to nearest int */
-      long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
-
-      if(params.wfn == "CC2"){
-        std::stringstream tag;
-        tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_pl[i];
-      }
-      else if(params.wfn == "CCSD"){
-        std::stringstream tag;
-        tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_pl[i];
-      }
-
-      /* subtract the zero-frequency beta tensor */
-      for(j=0; j < 3; j++)
-        for(k=0; k < 3; k++)
-          tensor_pl[i][j][k] -= tensor0[j][k];
-
-      if (params.wfn == "CC2")
-        outfile->Printf( "\n        CC2 Optical Rotation Tensor (Modified Velocity Gauge):\n");
-      else if(params.wfn == "CCSD")
-        outfile->Printf( "\n        CCSD Optical Rotation Tensor (Modified Velocity Gauge):\n");
-
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      outfile->Printf(   "   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
-              (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), pc_hartree2ev*params.omega[i],
-              pc_hartree2wavenumbers*params.omega[i]);
-      outfile->Printf( "  -------------------------------------------------------------------------\n");
-      mat_print(tensor_pl[i], 3, 3, "outfile");
-
-      /* compute the specific rotation */
-      TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2])/(3.0 * params.omega[i]);
-      TrG_pl /= params.omega[i];
-
-      rotation_mod[i] = prefactor * TrG_pl * nu * nu / M;
-      outfile->Printf( "\n   Specific rotation using modified velocity-gauge Rosenfeld tensor.\n");
-      outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_mod[i]);
-
-      if(params.wfn == "CC2"){
-        std::stringstream tag;
-        tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_mod[i];
-      }
-      else if(params.wfn == "CCSD"){
-        std::stringstream tag;
-        tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
-        Process::environment.globals[tag.str()] = rotation_mod[i];
-      }
-    }
-
-    if(params.gauge == "BOTH") {
-      delta[i][0] = prefactor * (tensor_rp[i][1][2] - tensor_rp[i][2][1]) * nu * nu / M;
-      delta[i][1] = prefactor * (tensor_rp[i][2][0] - tensor_rp[i][0][2]) * nu * nu / M;
-      delta[i][2] = prefactor * (tensor_rp[i][0][1] - tensor_rp[i][1][0]) * nu * nu / M;
-      delta[i][0] /= 6.0 * params.omega[i];
-      delta[i][1] /= 6.0 * params.omega[i];
-      delta[i][2] /= 6.0 * params.omega[i];
-      outfile->Printf( "\n   Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.\n");
-      outfile->Printf( "     Delta_x = %6.2f   Delta_y = %6.2f   Delta_z = %6.2f\n",
-              delta[i][0], delta[i][1], delta[i][2]);
-    }
-  } /* loop i over nomega */
-
-  if(params.nomega > 1) {  /* print a summary table for multi-wavelength calcs */
-
-    if(compute_rl) {
-      outfile->Printf( "\n   ------------------------------------------\n");
-      if (params.wfn == "CC2")
-        outfile->Printf(   "       CC2 Length-Gauge Optical Rotation\n");
-      else
-        outfile->Printf(   "       CCSD Length-Gauge Optical Rotation\n");
-      outfile->Printf(   "   ------------------------------------------\n");
-
-      if(params.gauge == "BOTH") {
-        outfile->Printf(   "       Omega           alpha                        Delta\n");
-        outfile->Printf(   "    E_h      nm   deg/[dm (g/cm^3)]        deg/[dm (g/cm^3)]/bohr\n");
-        outfile->Printf(   "   -----   ------ ------------------  ----------------------------------\n");
-        outfile->Printf(   "                                          x           y           z      \n");
-        for(i=0; i < params.nomega; i++)
-          outfile->Printf( "   %5.3f   %6.2f      %10.5f    %10.5f  %10.5f  %10.5f\n", params.omega[i], (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]),
-                  rotation_rl[i], delta[i][0], delta[i][1], delta[i][2]);
-      }
-      else {
-        outfile->Printf(   "       Omega           alpha\n");
-        outfile->Printf(   "    E_h      nm   deg/[dm (g/cm^3)]\n");
-        outfile->Printf(   "   -----   ------ ------------------\n");
-        for(i=0; i < params.nomega; i++)
-          outfile->Printf( "   %5.3f   %6.2f      %10.5f\n", params.omega[i], (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]),
-                  rotation_rl[i]);
-      }
-    }
-
-    if(compute_pl) {
-      outfile->Printf( "\n   ------------------------------------------------------\n");
-      if (params.wfn == "CC2")
-        outfile->Printf(   "            CC2 Velocity-Gauge Optical Rotation\n");
-      else
-        outfile->Printf(   "            CCSD Velocity-Gauge Optical Rotation\n");
-      outfile->Printf(   "   ------------------------------------------------------\n");
-      outfile->Printf(   "       Omega           alpha (deg/[dm (g/cm^3)]\n");
-      outfile->Printf( "\n    E_h      nm   Velocity-Gauge  Modified Velocity-Gauge\n");
-      outfile->Printf(   "   -----   ------ --------------  -----------------------\n");
-      for(i=0; i < params.nomega; i++)
-        outfile->Printf( "   %5.3f   %6.2f   %10.5f          %10.5f\n", params.omega[i], (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), rotation_pl[i], rotation_mod[i]);
-    }
-  }
-
-  free(rotation_rl);
-  free(rotation_pl);
-  free(rotation_rp);
-  free(rotation_mod);
-  free_block(delta);
-
-  for(i=0; i < params.nomega; i++) {
-    free_block(tensor_rl[i]);
-    free_block(tensor_pl[i]);
-    free_block(tensor_rp[i]);
-  }
-  free(tensor_rl);
-  free(tensor_pl);
-  free(tensor_rp);
-  free_block(tensor0);
-  free_block(tensor_rl0);
-  free_block(tensor_rl1);
-  free_block(tensor_pl0);
-  free_block(tensor_pl1);
-
-  free(cartcomp[0]);
-  free(cartcomp[1]);
-  free(cartcomp[2]);
-  free(cartcomp);
+    free(cartcomp[0]);
+    free(cartcomp[1]);
+    free(cartcomp[2]);
+    free(cartcomp);
 }
 
-   // for the edification of the autodoc-er. these set py-side or through oeprop calls
-   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (LEN) @ xNM"] -*/
-   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (VEL) @ xNM"] -*/
-   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (MVG) @ xNM"] -*/
-   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (LEN) @ xNM"] -*/
-   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (VEL) @ xNM"] -*/
-   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (MVG) @ xNM"] -*/
+// for the edification of the autodoc-er. these set py-side or through oeprop calls
+/*- Process::environment.globals["CC2 SPECIFIC ROTATION (LEN) @ xNM"] -*/
+/*- Process::environment.globals["CC2 SPECIFIC ROTATION (VEL) @ xNM"] -*/
+/*- Process::environment.globals["CC2 SPECIFIC ROTATION (MVG) @ xNM"] -*/
+/*- Process::environment.globals["CCSD SPECIFIC ROTATION (LEN) @ xNM"] -*/
+/*- Process::environment.globals["CCSD SPECIFIC ROTATION (VEL) @ xNM"] -*/
+/*- Process::environment.globals["CCSD SPECIFIC ROTATION (MVG) @ xNM"] -*/
 
-}} // namespace psi::ccresponse
+}  // namespace ccresponse
+}  // namespace psi

--- a/psi4/src/psi4/ccresponse/optrot.cc
+++ b/psi4/src/psi4/ccresponse/optrot.cc
@@ -453,13 +453,11 @@ void optrot(std::shared_ptr<Molecule> molecule)
       long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
 
       if(params.wfn == "CC2"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_rl[i];
       }
       else if(params.wfn == "CCSD"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_rl[i];
@@ -491,13 +489,11 @@ void optrot(std::shared_ptr<Molecule> molecule)
       long om_nm = std::lround((pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]));
 
       if(params.wfn == "CC2"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_pl[i];
       }
       else if(params.wfn == "CCSD"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_pl[i];
@@ -529,13 +525,11 @@ void optrot(std::shared_ptr<Molecule> molecule)
       outfile->Printf( "\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_mod[i]);
 
       if(params.wfn == "CC2"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_mod[i];
       }
       else if(params.wfn == "CCSD"){
-        /* build up a string */
         std::stringstream tag;
         tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
         Process::environment.globals[tag.str()] = rotation_mod[i];
@@ -624,5 +618,13 @@ void optrot(std::shared_ptr<Molecule> molecule)
   free(cartcomp[2]);
   free(cartcomp);
 }
+
+   // for the edification of the autodoc-er. these set py-side or through oeprop calls
+   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (LEN) @ xNM"] -*/
+   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (VEL) @ xNM"] -*/
+   /*- Process::environment.globals["CC2 SPECIFIC ROTATION (MVG) @ xNM"] -*/
+   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (LEN) @ xNM"] -*/
+   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (VEL) @ xNM"] -*/
+   /*- Process::environment.globals["CCSD SPECIFIC ROTATION (MVG) @ xNM"] -*/
 
 }} // namespace psi::ccresponse

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -143,13 +143,11 @@ void polar(void)
     long omega_nm_rd = std::lround(omega_nm);
 
     if (params.wfn == "CC2"){
-      /* build up a string */
       std::stringstream tag;
       tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
       Process::environment.globals[tag.str()] = trace[i]/3.0;
     }
     else if(params.wfn == "CCSD"){
-      /* build up a string */
       std::stringstream tag;
       tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
       Process::environment.globals[tag.str()] = trace[i]/3.0;
@@ -182,5 +180,9 @@ void polar(void)
   free(cartcomp[2]);
   free(cartcomp);
 }
+
+   // for the edification of the autodoc-er. these set py-side or through oeprop calls
+   /*- Process::environment.globals["CC2 DIPOLE POLARIZABILITY @ xNM"] -*/
+   /*- Process::environment.globals["CCSD DIPOLE POLARIZABILITY @ xNM"] -*/
 
 }} // namespace psi::ccresponse

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -33,6 +33,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <cmath> /* needed for lround*/
+#include <sstream> /* needed for stringstream */
 
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
@@ -137,11 +139,21 @@ void polar(void)
     trace[i] = tensor[i][0][0] + tensor[i][1][1] + tensor[i][2][2];
     outfile->Printf( "\n\talpha_(%5.3f) = %20.12f a.u.\n", params.omega[i], trace[i]/3.0);
 
-    // Need to generalize this for multi-wavelength calcs
-    if (params.wfn == "CC2")
-      Process::environment.globals["CC2 DIPOLE POLARIZABILITY"] = trace[i]/3.0;
-    else
-      Process::environment.globals["CCSD DIPOLE POLARIZABILITY"] = trace[i]/3.0;
+    /* make sure omega in nm is rounded */
+    long omega_nm_rd = std::lround(omega_nm);
+
+    if (params.wfn == "CC2"){
+      /* build up a string */
+      std::stringstream tag;
+      tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
+      Process::environment.globals[tag.str()] = trace[i]/3.0;
+    }
+    else if(params.wfn == "CCSD"){
+      /* build up a string */
+      std::stringstream tag;
+      tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
+      Process::environment.globals[tag.str()] = trace[i]/3.0;
+    }
   }
 
   if(params.nomega > 1) {  /* print a summary table for multi-wavelength calcs */

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -33,8 +33,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
-#include <cmath> /* needed for lround*/
-#include <sstream> /* needed for stringstream */
+#include <cmath>
+#include <sstream>
 
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"

--- a/psi4/src/psi4/ccresponse/polar.cc
+++ b/psi4/src/psi4/ccresponse/polar.cc
@@ -48,141 +48,134 @@
 #define EXTERN
 #include "globals.h"
 
-namespace psi { namespace ccresponse {
+namespace psi {
+namespace ccresponse {
 
 void pertbar(const char *pert, int irrep, int anti);
 void compute_X(const char *pert, int irrep, double omega);
-void linresp(double *tensor, double A, double B,
-	     const char *pert_x, int x_irrep, double omega_x,
-	     const char *pert_y, int y_irrep, double omega_y);
+void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep, double omega_x, const char *pert_y,
+             int y_irrep, double omega_y);
 
-void polar(void)
-{
-  double ***tensor;
-  char **cartcomp, pert[32], pert_x[32], pert_y[32];
-  int alpha, beta, i;
-  double omega_nm, omega_ev, omega_cm, *trace;
-  char lbl[32];
-  double value;
+void polar(void) {
+    double ***tensor;
+    char **cartcomp, pert[32], pert_x[32], pert_y[32];
+    int alpha, beta, i;
+    double omega_nm, omega_ev, omega_cm, *trace;
+    char lbl[32];
+    double value;
 
-  cartcomp = (char **) malloc(3 * sizeof(char *));
-  cartcomp[0] = strdup("X");
-  cartcomp[1] = strdup("Y");
-  cartcomp[2] = strdup("Z");
+    cartcomp = (char **)malloc(3 * sizeof(char *));
+    cartcomp[0] = strdup("X");
+    cartcomp[1] = strdup("Y");
+    cartcomp[2] = strdup("Z");
 
-  tensor = (double ***) malloc(params.nomega * sizeof(double **));
-  for(i=0; i < params.nomega; i++)
-    tensor[i] = block_matrix(3,3);
+    tensor = (double ***)malloc(params.nomega * sizeof(double **));
+    for (i = 0; i < params.nomega; i++) tensor[i] = block_matrix(3, 3);
 
-  trace = init_array(params.nomega);
+    trace = init_array(params.nomega);
 
-  for(i=0; i < params.nomega; i++) {
+    for (i = 0; i < params.nomega; i++) {
+        sprintf(lbl, "<<Mu;Mu>_(%5.3f)", params.omega[i]);
+        if (!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl)) {
+            for (alpha = 0; alpha < 3; alpha++) {
+                sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                pertbar(pert, moinfo.mu_irreps[alpha], 0);
+                compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
+                if (params.omega[i] != 0.0) compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
+            }
 
-    sprintf(lbl, "<<Mu;Mu>_(%5.3f)", params.omega[i]);
-    if(!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl)) {
+            outfile->Printf("\n\tComputing %s tensor.\n", lbl);
+            for (alpha = 0; alpha < 3; alpha++) {
+                for (beta = 0; beta < 3; beta++) {
+                    sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
+                    sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                    linresp(&tensor[i][alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
+                            pert_y, moinfo.mu_irreps[beta], params.omega[i]);
+                }
+            }
 
-      for(alpha=0; alpha < 3; alpha++) {
-        sprintf(pert, "Mu_%1s", cartcomp[alpha]);
-        pertbar(pert, moinfo.mu_irreps[alpha], 0);
-	compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
-	if(params.omega[i] != 0.0) compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
-      }
+            psio_write_entry(PSIF_CC_INFO, lbl, (char *)tensor[i][0], 9 * sizeof(double));
 
-      outfile->Printf( "\n\tComputing %s tensor.\n", lbl);
-      for(alpha=0; alpha < 3; alpha++) {
-        for(beta=0; beta < 3; beta++) {
-          sprintf(pert_x,"Mu_%1s", cartcomp[alpha]);
-          sprintf(pert_y,"Mu_%1s", cartcomp[beta]);
-          linresp(&tensor[i][alpha][beta], -1.0, 0.0,
-                  pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
-                  pert_y, moinfo.mu_irreps[beta], params.omega[i]);
+            psio_close(PSIF_CC_LR, 0);
+            psio_open(PSIF_CC_LR, 0);
+        } else {
+            outfile->Printf("Using %s tensor found on disk.\n", lbl);
+            psio_read_entry(PSIF_CC_INFO, lbl, (char *)tensor[i], 9 * sizeof(double));
         }
-      }
 
-      psio_write_entry(PSIF_CC_INFO, lbl, (char *) tensor[i][0], 9*sizeof(double));
+        /* symmetrize the polarizability */
+        for (alpha = 0; alpha < 3; alpha++)
+            for (beta = 0; beta < alpha; beta++) {
+                if (alpha != beta) {
+                    value = 0.5 * (tensor[i][alpha][beta] + tensor[i][beta][alpha]);
+                    tensor[i][alpha][beta] = value;
+                    tensor[i][beta][alpha] = value;
+                }
+            }
 
-      psio_close(PSIF_CC_LR, 0);
-      psio_open(PSIF_CC_LR, 0);
-    }
-    else {
-      outfile->Printf( "Using %s tensor found on disk.\n", lbl);
-      psio_read_entry(PSIF_CC_INFO, lbl, (char *) tensor[i], 9*sizeof(double));
-    }
+        if (params.wfn == "CC2")
+            outfile->Printf("\n                 CC2 Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
+        else
+            outfile->Printf("\n                 CCSD Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
+        outfile->Printf("  -------------------------------------------------------------------------\n");
+        if (params.omega[i] != 0.0) omega_nm = (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]);
+        omega_ev = pc_hartree2ev * params.omega[i];
+        omega_cm = pc_hartree2wavenumbers * params.omega[i];
+        if (params.omega[i] != 0.0)
+            outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
+                            omega_nm, omega_ev, omega_cm);
+        else
+            outfile->Printf("   Evaluated at omega = %8.6f E_h (Inf nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
+                            omega_ev, omega_cm);
+        outfile->Printf("  -------------------------------------------------------------------------\n");
+        mat_print(tensor[i], 3, 3, "outfile");
+        trace[i] = tensor[i][0][0] + tensor[i][1][1] + tensor[i][2][2];
+        outfile->Printf("\n\talpha_(%5.3f) = %20.12f a.u.\n", params.omega[i], trace[i] / 3.0);
 
-    /* symmetrize the polarizability */
-    for(alpha=0; alpha < 3; alpha++)
-      for(beta=0; beta < alpha; beta++) {
-        if(alpha!=beta) {
-          value = 0.5 * (tensor[i][alpha][beta] + tensor[i][beta][alpha]);
-          tensor[i][alpha][beta] = value;
-          tensor[i][beta][alpha] = value;
+        /* make sure omega in nm is rounded */
+        long omega_nm_rd = std::lround(omega_nm);
+
+        if (params.wfn == "CC2") {
+            std::stringstream tag;
+            tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
+            Process::environment.globals[tag.str()] = trace[i] / 3.0;
+        } else if (params.wfn == "CCSD") {
+            std::stringstream tag;
+            tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
+            Process::environment.globals[tag.str()] = trace[i] / 3.0;
         }
-      }
-
-    if (params.wfn == "CC2")
-      outfile->Printf( "\n                 CC2 Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
-    else
-      outfile->Printf( "\n                 CCSD Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:\n");
-    outfile->Printf( "  -------------------------------------------------------------------------\n");
-    if(params.omega[i] != 0.0)
-      omega_nm = (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]);
-    omega_ev = pc_hartree2ev*params.omega[i];
-    omega_cm = pc_hartree2wavenumbers*params.omega[i];
-    if(params.omega[i] != 0.0)
-      outfile->Printf(   "   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n",
-	      params.omega[i], omega_nm, omega_ev, omega_cm);
-    else
-      outfile->Printf(   "   Evaluated at omega = %8.6f E_h (Inf nm, %5.3f eV, %8.2f cm-1)\n",
-	      params.omega[i], omega_ev, omega_cm);
-    outfile->Printf( "  -------------------------------------------------------------------------\n");
-    mat_print(tensor[i], 3, 3, "outfile");
-    trace[i] = tensor[i][0][0] + tensor[i][1][1] + tensor[i][2][2];
-    outfile->Printf( "\n\talpha_(%5.3f) = %20.12f a.u.\n", params.omega[i], trace[i]/3.0);
-
-    /* make sure omega in nm is rounded */
-    long omega_nm_rd = std::lround(omega_nm);
-
-    if (params.wfn == "CC2"){
-      std::stringstream tag;
-      tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
-      Process::environment.globals[tag.str()] = trace[i]/3.0;
     }
-    else if(params.wfn == "CCSD"){
-      std::stringstream tag;
-      tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
-      Process::environment.globals[tag.str()] = trace[i]/3.0;
+
+    if (params.nomega > 1) { /* print a summary table for multi-wavelength calcs */
+
+        outfile->Printf("\n\t-------------------------------\n");
+        if (params.wfn == "CC2")
+            outfile->Printf("\t      CC2 Polarizability\n");
+        else
+            outfile->Printf("\t      CCSD Polarizability\n");
+        outfile->Printf("\t-------------------------------\n");
+        outfile->Printf("\t    Omega          alpha\n");
+        outfile->Printf("\t E_h      nm        a.u.        \n");
+        outfile->Printf("\t-----   ------ ----------------\n");
+        for (i = 0; i < params.nomega; i++)
+            outfile->Printf("\t%5.3f   %6.2f      %10.5f\n", params.omega[i],
+                            (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), trace[i] / 3.0);
     }
-  }
 
-  if(params.nomega > 1) {  /* print a summary table for multi-wavelength calcs */
+    for (i = 0; i < params.nomega; i++) free_block(tensor[i]);
+    free(tensor);
 
-    outfile->Printf( "\n\t-------------------------------\n");
-    if (params.wfn == "CC2")
-      outfile->Printf(   "\t      CC2 Polarizability\n");
-    else
-      outfile->Printf(   "\t      CCSD Polarizability\n");
-    outfile->Printf(   "\t-------------------------------\n");
-    outfile->Printf(   "\t    Omega          alpha\n");
-    outfile->Printf(   "\t E_h      nm        a.u.        \n");
-    outfile->Printf(   "\t-----   ------ ----------------\n");
-    for(i=0; i < params.nomega; i++)
-      outfile->Printf( "\t%5.3f   %6.2f      %10.5f\n", params.omega[i], (pc_c*pc_h*1e9)/(pc_hartree2J*params.omega[i]), trace[i]/3.0);
-  }
+    free(trace);
 
-  for(i=0; i < params.nomega; i++)
-    free_block(tensor[i]);
-  free(tensor);
-
-  free(trace);
-
-  free(cartcomp[0]);
-  free(cartcomp[1]);
-  free(cartcomp[2]);
-  free(cartcomp);
+    free(cartcomp[0]);
+    free(cartcomp[1]);
+    free(cartcomp[2]);
+    free(cartcomp);
 }
 
-   // for the edification of the autodoc-er. these set py-side or through oeprop calls
-   /*- Process::environment.globals["CC2 DIPOLE POLARIZABILITY @ xNM"] -*/
-   /*- Process::environment.globals["CCSD DIPOLE POLARIZABILITY @ xNM"] -*/
+// for the edification of the autodoc-er. these set py-side or through oeprop calls
+/*- Process::environment.globals["CC2 DIPOLE POLARIZABILITY @ xNM"] -*/
+/*- Process::environment.globals["CCSD DIPOLE POLARIZABILITY @ xNM"] -*/
 
-}} // namespace psi::ccresponse
+}  // namespace ccresponse
+}  // namespace psi

--- a/tests/cc29/input.dat
+++ b/tests/cc29/input.dat
@@ -17,3 +17,17 @@ set {
 }
 
 properties('ccsd',properties=['rotation'])
+
+reflen_589   =    -76.93388  #TEST
+refvel_589   =    850.24712  #TEST
+refmvg_589   =   -179.08820  #TEST
+reflen_355   =   -214.73273  #TEST
+refvel_355   =    384.88786  #TEST
+refmvg_355   =   -644.44746  #TEST
+
+compare_values(reflen_589,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
+compare_values(refvel_589,   get_variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
+compare_values(refmvg_589,   get_variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
+compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
+compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST

--- a/tests/cc39/input.dat
+++ b/tests/cc39/input.dat
@@ -13,3 +13,9 @@ set {
 }
 
 properties('cc2',properties=['polarizability'])
+
+refpol_911   =    5.289283300369  #TEST
+refpol_456   =    5.456588276958  #TEST
+
+compare_values(refpol_911,   get_variable("CC2 DIPOLE POLARIZABILITY @ 911NM"),  3, "CC2 polarizability @ 911nm") #TEST
+compare_values(refpol_456,   get_variable("CC2 DIPOLE POLARIZABILITY @ 456NM"),  3, "CC2 polarizability @ 456nm") #TEST


### PR DESCRIPTION
## Description
Originally, only the last rotation or polarizability values computed were actually dumped to the dictionary accessed by `core.get_variables`. This fix pushes each one into the dictionary with its corresponding wavelength (in NM). I've added a few lines to `tests/cc39/input.dat` and `tests/cc29/input.dat` to test the polarization and rotation variables, respectively. I've run the tests separately since the quick tests on Travis may not cover them, the results can be found [here](https://gist.github.com/bgpeyton/6a7842adb77a03a10bf696c8364a9c54) and [here](https://gist.github.com/bgpeyton/a6654acd0f7fcaa89b5023bebd40b025). 

## Todos
- [x] Make polarizabilities push each calculated value to the dictionary just like I did with rotation
- [x] Add to polarizability / rotation test cases to ensure new variables don't get overwritten by "accident"

## Questions
None

## Status
- [x] Ready to go
