### PR TITLE
[WIP] Pybind-ing the PCM object

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources_list
         export_blas_lapack.cc
         export_cubeprop.cc
         export_efp.cc
+        export_pcm.cc
         export_fock.cc
         export_functional.cc
         export_mints.cc
@@ -35,6 +36,9 @@ if(TARGET dkh::dkh)
 endif()
 if(TARGET libefp::efp)
     target_compile_definitions(core PRIVATE $<TARGET_PROPERTY:libefp::efp,INTERFACE_COMPILE_DEFINITIONS>)
+endif()
+if(TARGET PCMSolver::pcm)
+    target_compile_definitions(core PRIVATE $<TARGET_PROPERTY:PCMSolver::pcm,INTERFACE_COMPILE_DEFINITIONS>)
 endif()
 target_include_directories(core PRIVATE $<TARGET_PROPERTY:Libxc::xc,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(core PRIVATE ${psi4_binmodules})

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -73,6 +73,7 @@ void export_benchmarks(py::module&);
 void export_blas_lapack(py::module&);
 void export_cubeprop(py::module&);
 void export_efp(py::module&);
+void export_pcm(py::module&);
 void export_fock(py::module&);
 void export_functional(py::module&);
 void export_mints(py::module&);
@@ -1133,6 +1134,9 @@ PYBIND11_PLUGIN(core) {
 
     // EFP
     export_efp(core);
+
+    // PCM
+    export_pcm(core);
 
     // CubeProperties
     export_cubeprop(core);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -29,11 +29,11 @@
 #ifndef _psi_src_lib_libmints_integral_h_
 #define _psi_src_lib_libmints_integral_h_
 
- #include "psi4/pragma.h"
- PRAGMA_WARNING_PUSH
- PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
- #include <memory>
- PRAGMA_WARNING_POP
+#include "psi4/pragma.h"
+PRAGMA_WARNING_PUSH
+PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
+#include <memory>
+PRAGMA_WARNING_POP
 #include <vector>
 
 #include "onebody.h"
@@ -42,27 +42,27 @@
 /*! \def INT_NCART(am)
     Gives the number of cartesian functions for an angular momentum.
 */
-#define INT_NCART(am) ((am>=0)?((((am)+2)*((am)+1))>>1):0)
+#define INT_NCART(am) ((am >= 0) ? ((((am) + 2) * ((am) + 1)) >> 1) : 0)
 /*! \def INT_PURE(am)
     Gives the number of spherical functions for an angular momentum.
 */
-#define INT_NPURE(am) (2*(am)+1)
+#define INT_NPURE(am) (2 * (am) + 1)
 /*! \def INT_NFUNC(pu,am)
     Gives the number of functions for an angular momentum based on pu.
 */
-#define INT_NFUNC(pu,am) ((pu)?INT_NPURE(am):INT_NCART(am))
+#define INT_NFUNC(pu, am) ((pu) ? INT_NPURE(am) : INT_NCART(am))
 /*! \def INT_CARTINDEX(am,i,j)
     Computes offset index for cartesian function.
 */
-#define INT_CARTINDEX(am,i,j) (((i) == (am))? 0 : (((((am) - (i) + 1)*((am) - (i)))>>1) + (am) - (i) - (j)))
+#define INT_CARTINDEX(am, i, j) (((i) == (am)) ? 0 : (((((am) - (i) + 1) * ((am) - (i))) >> 1) + (am) - (i) - (j)))
 /*! \def INT_ICART(a, b, c)
     Given a, b, and c compute a cartesian offset.
 */
-#define INT_ICART(a, b, c) (((((((a)+(b)+(c)+1)<<1)-(a))*((a)+1))>>1)-(b)-1)
+#define INT_ICART(a, b, c) (((((((a) + (b) + (c) + 1) << 1) - (a)) * ((a) + 1)) >> 1) - (b)-1)
 /*! \def INT_IPURE(l, m)
     Given l and m compute a pure function offset.
 */
-#define INT_IPURE(l, m) ((l)+(m))
+#define INT_IPURE(l, m) ((l) + (m))
 
 namespace psi {
 
@@ -81,15 +81,14 @@ class SOBasisSet;
 class CorrelationFactor;
 
 /*! \ingroup MINTS */
-class SphericalTransformComponent
-{
-protected:
+class SphericalTransformComponent {
+   protected:
     int a_, b_, c_;
     int cartindex_, pureindex_;
 
     double coef_;
 
-public:
+   public:
     /// Returns the exponent of x.
     int a() const { return a_; }
     /// Returns the exponent of y.
@@ -109,17 +108,17 @@ public:
 /*! \ingroup MINTS */
 /** This is a base class for a container for a sparse Cartesian to solid
     harmonic basis function transformation. */
-class SphericalTransform
-{
-protected:
+class SphericalTransform {
+   protected:
     std::vector<SphericalTransformComponent> components_;
-    int l_; // The angular momentum this transform is for.
+    int l_;  // The angular momentum this transform is for.
     int subl_;
 
     SphericalTransform();
 
     virtual void init();
-public:
+
+   public:
     SphericalTransform(int l, int subl = -1);
     virtual ~SphericalTransform() {}
 
@@ -143,26 +142,25 @@ public:
 
 /*! \ingroup MINTS */
 /// This describes a solid harmonic to Cartesian transformation.
-class ISphericalTransform : public SphericalTransform
-{
-protected:
+class ISphericalTransform : public SphericalTransform {
+   protected:
     ISphericalTransform();
     virtual void init();
-public:
-    ISphericalTransform(int l, int subl=-1);
+
+   public:
+    ISphericalTransform(int l, int subl = -1);
 };
 
-class SphericalTransformIter
-{
-private:
+class SphericalTransformIter {
+   private:
     const SphericalTransform& trans_;
     int i_;
 
-public:
+   public:
     SphericalTransformIter(const SphericalTransform& trans) : trans_(trans) { i_ = 0; }
 
     void first() { i_ = 0; }
-    void next()  { i_++;   }
+    void next() { i_++; }
     bool is_done() { return i_ < trans_.n() ? false : true; }
 
     /// Returns how many transforms are in this iterator.
@@ -173,21 +171,20 @@ public:
     /// Returns the spherical harmonic basis index of component i
     int pureindex() const { return trans_.pureindex(i_); }
     /// Returns the transformation coefficient of component i
-    double coef()   const { return trans_.coef(i_); }
+    double coef() const { return trans_.coef(i_); }
     /// Returns the Cartesian basis function's x exponent of component i
-    int a()         const { return trans_.a(i_); }
+    int a() const { return trans_.a(i_); }
     /// Returns the Cartesian basis function's y exponent of component i
-    int b()         const { return trans_.b(i_); }
+    int b() const { return trans_.b(i_); }
     /// Returns the Cartesian basis function's z exponent of component i
-    int c()         const { return trans_.c(i_); }
+    int c() const { return trans_.c(i_); }
     /// Return a component of the transform.
-    int l(int i) { return i?(i==1?b():c()):a(); }
+    int l(int i) { return i ? (i == 1 ? b() : c()) : a(); }
 };
 
 /*! \ingroup MINTS */
-class AOIntegralsIterator
-{
-private:
+class AOIntegralsIterator {
+   private:
     struct Integral {
         int i;
         int j;
@@ -207,9 +204,9 @@ private:
     int ii, iimax, jj, jjmax, kk, kkmax, ll, llmax;
     int ni, nj, nk, nl, fii, fij, fik, fil;
 
-public:
-    AOIntegralsIterator(const GaussianShell& s1, const GaussianShell& s2,
-                      const GaussianShell& s3, const GaussianShell& s4);
+   public:
+    AOIntegralsIterator(const GaussianShell& s1, const GaussianShell& s2, const GaussianShell& s3,
+                        const GaussianShell& s4);
 
     void first();
     void next();
@@ -219,14 +216,12 @@ public:
     int j() const { return current.j; }
     int k() const { return current.k; }
     int l() const { return current.l; }
-    int index() const { return current.index;}
+    int index() const { return current.index; }
 };
 
-
 /*! \ingroup MINTS */
-class AOShellCombinationsIterator
-{
-private:
+class AOShellCombinationsIterator {
+   private:
     struct ShellQuartet {
         int P;
         int Q;
@@ -248,12 +243,12 @@ private:
     std::shared_ptr<BasisSet> bs3_;
     std::shared_ptr<BasisSet> bs4_;
 
-public:
-    AOShellCombinationsIterator(std::shared_ptr<BasisSet>bs1, std::shared_ptr<BasisSet>bs2,
-                              std::shared_ptr<BasisSet>bs3, std::shared_ptr<BasisSet>bs4);
+   public:
+    AOShellCombinationsIterator(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
+                                std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
     AOShellCombinationsIterator();
-    void init(std::shared_ptr<BasisSet>bs1, std::shared_ptr<BasisSet>bs2,
-            std::shared_ptr<BasisSet>bs3, std::shared_ptr<BasisSet>bs4);
+    void init(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
+              std::shared_ptr<BasisSet> bs4);
 
     void first();
     void next();
@@ -268,9 +263,8 @@ public:
     AOIntegralsIterator integrals_iterator();
 };
 
-class SOShellCombinationsIterator
-{
-private:
+class SOShellCombinationsIterator {
+   private:
     struct ShellQuartet {
         int P;
         int Q;
@@ -292,12 +286,12 @@ private:
     std::shared_ptr<SOBasisSet> bs3_;
     std::shared_ptr<SOBasisSet> bs4_;
 
-public:
-    SOShellCombinationsIterator(std::shared_ptr<SOBasisSet>bs1, std::shared_ptr<SOBasisSet>bs2,
-                              std::shared_ptr<SOBasisSet>bs3, std::shared_ptr<SOBasisSet>bs4);
+   public:
+    SOShellCombinationsIterator(std::shared_ptr<SOBasisSet> bs1, std::shared_ptr<SOBasisSet> bs2,
+                                std::shared_ptr<SOBasisSet> bs3, std::shared_ptr<SOBasisSet> bs4);
     SOShellCombinationsIterator();
-    void init(std::shared_ptr<SOBasisSet>bs1, std::shared_ptr<SOBasisSet>bs2,
-            std::shared_ptr<SOBasisSet>bs3, std::shared_ptr<SOBasisSet>bs4);
+    void init(std::shared_ptr<SOBasisSet> bs1, std::shared_ptr<SOBasisSet> bs2, std::shared_ptr<SOBasisSet> bs3,
+              std::shared_ptr<SOBasisSet> bs4);
 
     void first();
     void next();
@@ -310,9 +304,8 @@ public:
     int end_of_PK() const { return current.end_of_PK; }
 };
 
-class SO_PQ_Iterator
-{
-private:
+class SO_PQ_Iterator {
+   private:
     struct PQ_Pair {
         int P;
         int Q;
@@ -325,8 +318,8 @@ private:
 
     std::shared_ptr<SOBasisSet> bs1_;
 
-public:
-    SO_PQ_Iterator(std::shared_ptr<SOBasisSet>bs1);
+   public:
+    SO_PQ_Iterator(std::shared_ptr<SOBasisSet> bs1);
     SO_PQ_Iterator();
 
     void first();
@@ -337,9 +330,8 @@ public:
     int q() const { return current.Q; }
 };
 
-class SO_RS_Iterator
-{
-private:
+class SO_RS_Iterator {
+   private:
     struct RS_Pair {
         int P;
         int Q;
@@ -360,12 +352,11 @@ private:
     std::shared_ptr<SOBasisSet> bs3_;
     std::shared_ptr<SOBasisSet> bs4_;
 
-public:
-    SO_RS_Iterator(const int &P, const int &Q,
-                   std::shared_ptr<SOBasisSet>bs1, std::shared_ptr<SOBasisSet>bs2,
-                   std::shared_ptr<SOBasisSet>bs3, std::shared_ptr<SOBasisSet>bs4);
-    SO_RS_Iterator(std::shared_ptr<SOBasisSet>bs1, std::shared_ptr<SOBasisSet>bs2,
-                   std::shared_ptr<SOBasisSet>bs3, std::shared_ptr<SOBasisSet>bs4);
+   public:
+    SO_RS_Iterator(const int& P, const int& Q, std::shared_ptr<SOBasisSet> bs1, std::shared_ptr<SOBasisSet> bs2,
+                   std::shared_ptr<SOBasisSet> bs3, std::shared_ptr<SOBasisSet> bs4);
+    SO_RS_Iterator(std::shared_ptr<SOBasisSet> bs1, std::shared_ptr<SOBasisSet> bs2, std::shared_ptr<SOBasisSet> bs3,
+                   std::shared_ptr<SOBasisSet> bs4);
 
     SO_RS_Iterator();
 
@@ -379,11 +370,9 @@ public:
     int s() const { return current.S; }
 };
 
-
 /*! \ingroup MINTS */
-class IntegralFactory
-{
-protected:
+class IntegralFactory {
+   protected:
     /// Center 1 basis set
     std::shared_ptr<BasisSet> bs1_;
     /// Center 2 basis set
@@ -398,10 +387,10 @@ protected:
     /// Provides ability to transform from sphericals (d=0, f=1, g=2)
     std::vector<ISphericalTransform> ispherical_transforms_;
 
-public:
+   public:
     /** Initialize IntegralFactory object given a BasisSet for each center. */
-    IntegralFactory(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
-                    std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
+    IntegralFactory(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
+                    std::shared_ptr<BasisSet> bs4);
     /** Initialize IntegralFactory object given a BasisSet for two centers. Becomes (bs1 bs1 | bs1 bs1). */
     IntegralFactory(std::shared_ptr<BasisSet> bs1);
 
@@ -417,41 +406,41 @@ public:
     std::shared_ptr<BasisSet> basis4() const;
 
     /// Set the basis set for each center.
-    virtual void set_basis(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
-        std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
+    virtual void set_basis(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
+                           std::shared_ptr<BasisSet> bs4);
 
     /// Returns an OneBodyInt that computes the overlap integral.
-    virtual OneBodyAOInt* ao_overlap(int deriv=0);
+    virtual OneBodyAOInt* ao_overlap(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the overlap integral.
-    virtual OneBodySOInt* so_overlap(int deriv=0);
+    virtual OneBodySOInt* so_overlap(int deriv = 0);
 
     /// Returns a ThreeCenterOverlapINt that computes the overlap between three centers
     virtual ThreeCenterOverlapInt* overlap_3c();
 
     /// Returns an OneBodyInt that computes the kinetic energy integral.
-    virtual OneBodyAOInt* ao_kinetic(int deriv=0);
-    virtual OneBodySOInt* so_kinetic(int deriv=0);
+    virtual OneBodyAOInt* ao_kinetic(int deriv = 0);
+    virtual OneBodySOInt* so_kinetic(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the nuclear attraction integral.
-    virtual OneBodyAOInt* ao_potential(int deriv=0);
-    virtual OneBodySOInt* so_potential(int deriv=0);
-    
+    virtual OneBodyAOInt* ao_potential(int deriv = 0);
+    virtual OneBodySOInt* so_potential(int deriv = 0);
+
     /// Returns an OneBodyInt that computes the ECP integral.
-    virtual OneBodyAOInt* ao_ecp(int deriv=0);
-    virtual OneBodySOInt* so_ecp(int deriv=0);
+    virtual OneBodyAOInt* ao_ecp(int deriv = 0);
+    virtual OneBodySOInt* so_ecp(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the relativistic nuclear attraction integral.
-    virtual OneBodyAOInt* ao_rel_potential(int deriv=0);
-    virtual OneBodySOInt* so_rel_potential(int deriv=0);
+    virtual OneBodyAOInt* ao_rel_potential(int deriv = 0);
+    virtual OneBodySOInt* so_rel_potential(int deriv = 0);
 
     /// Returns the OneBodyInt that computes the pseudospectral grid integrals
     virtual OneBodyAOInt* ao_pseudospectral(int deriv = 0);
     virtual OneBodySOInt* so_pseudospectral(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the dipole integral.
-    virtual OneBodyAOInt* ao_dipole(int deriv=0);
-    virtual OneBodySOInt* so_dipole(int deriv=0);
+    virtual OneBodyAOInt* ao_dipole(int deriv = 0);
+    virtual OneBodySOInt* so_dipole(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the quadrupole integral.
     virtual OneBodyAOInt* ao_quadrupole();
@@ -466,53 +455,55 @@ public:
     virtual OneBodySOInt* so_traceless_quadrupole();
 
     /// Returns an OneBodyInt that computes the nabla integral.
-    virtual OneBodyAOInt* ao_nabla(int deriv=0);
-    virtual OneBodySOInt* so_nabla(int deriv=0);
+    virtual OneBodyAOInt* ao_nabla(int deriv = 0);
+    virtual OneBodySOInt* so_nabla(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the nabla integral.
-    virtual OneBodyAOInt* ao_angular_momentum(int deriv=0);
-    virtual OneBodySOInt* so_angular_momentum(int deriv=0);
+    virtual OneBodyAOInt* ao_angular_momentum(int deriv = 0);
+    virtual OneBodySOInt* so_angular_momentum(int deriv = 0);
 
     /// Returns a OneBodyInt that computes the multipole potential integrals for EFP
-    virtual OneBodyAOInt* ao_efp_multipole_potential(int deriv=0);
-    virtual OneBodySOInt* so_efp_multipole_potential(int deriv=0);
+    virtual OneBodyAOInt* ao_efp_multipole_potential(int deriv = 0);
+    virtual OneBodySOInt* so_efp_multipole_potential(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the electric field
-    virtual OneBodyAOInt *electric_field(int deriv=0);
+    virtual OneBodyAOInt* electric_field(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the point electrostatic potential
-    virtual OneBodyAOInt *electrostatic();
+    virtual OneBodyAOInt* electrostatic();
 
     /// Returns an OneBodyInt that computes the electrostatic potential at desired points
     /// Want to change the name of this after the PCM dust settles
-    virtual OneBodyAOInt *pcm_potentialint();
+    virtual OneBodyAOInt* pcm_potentialint();
 
     /// Returns an ERI integral object
-    virtual TwoBodyAOInt* eri(int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* eri(int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an ERD ERI integral object, if available.  Otherwise returns a libint integral object
-    virtual TwoBodyAOInt* erd_eri(int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* erd_eri(int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an erf ERI integral object (omega integral)
-    virtual TwoBodyAOInt* erf_eri(double omega, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* erf_eri(double omega, int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an erf complement ERI integral object (omega integral)
-    virtual TwoBodyAOInt* erf_complement_eri(double omega, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* erf_complement_eri(double omega, int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an F12 integral object
-    virtual TwoBodyAOInt* f12(std::shared_ptr<CorrelationFactor> cf, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* f12(std::shared_ptr<CorrelationFactor> cf, int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an F12Scaled integral object
-    virtual TwoBodyAOInt* f12_scaled(std::shared_ptr<CorrelationFactor> cf, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* f12_scaled(std::shared_ptr<CorrelationFactor> cf, int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an F12 squared integral object
-    virtual TwoBodyAOInt* f12_squared(std::shared_ptr<CorrelationFactor> cf, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* f12_squared(std::shared_ptr<CorrelationFactor> cf, int deriv = 0,
+                                      bool use_shell_pairs = true);
 
     /// Returns an F12G12 integral object
-    virtual TwoBodyAOInt* f12g12(std::shared_ptr<CorrelationFactor> cf, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* f12g12(std::shared_ptr<CorrelationFactor> cf, int deriv = 0, bool use_shell_pairs = true);
 
     /// Returns an F12 double commutator integral object
-    virtual TwoBodyAOInt* f12_double_commutator(std::shared_ptr<CorrelationFactor> cf, int deriv=0, bool use_shell_pairs=true);
+    virtual TwoBodyAOInt* f12_double_commutator(std::shared_ptr<CorrelationFactor> cf, int deriv = 0,
+                                                bool use_shell_pairs = true);
 
     /// Returns a general ERI iterator object for any (P Q | R S) in shells
     AOIntegralsIterator integrals_iterator(int p, int q, int r, int s);
@@ -531,7 +522,7 @@ public:
     std::vector<SphericalTransform>& spherical_transform() { return spherical_transforms_; }
 
     /// Return a spherical transform iterator object for am
-    SphericalTransformIter* spherical_transform_iter(int am, int inv=0, int subl=-1) const;
+    SphericalTransformIter* spherical_transform_iter(int am, int inv = 0, int subl = -1) const;
 
     /// Return a new Cartesian iterator
     CartesianIter* cartesian_iter(int l) const;
@@ -541,9 +532,8 @@ public:
     RedundantCartesianSubIter* redundant_cartesian_sub_iter(int l) const;
     /** Return the ShellRotation object for a shell of a given angular
         momentum. Pass nonzero to pure to do solid harmonics. */
-    ShellRotation shell_rotation(int am, SymmetryOperation&, int pure=0) const;
+    ShellRotation shell_rotation(int am, SymmetryOperation&, int pure = 0) const;
 };
-
 }
 
 #endif

--- a/psi4/src/psi4/libmints/potentialint.h
+++ b/psi4/src/psi4/libmints/potentialint.h
@@ -36,7 +36,7 @@
 #include "psi4/libmints/osrecur.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-namespace psi{
+namespace psi {
 
 class GaussianShell;
 class SphericalTransform;
@@ -53,28 +53,27 @@ class BasisSet;
  *
  * NB: This code must be specified in the .h file in order for the compiler to properly in-line the functors. (TDC)
  */
-class PCMPotentialInt : public PotentialInt
-{
-public:
-    PCMPotentialInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv=0);
+class PCMPotentialInt : public PotentialInt {
+   public:
+    PCMPotentialInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
+                    int deriv = 0);
     /// Drives the loops over all shell pairs, to compute integrals
-    template<typename PCMPotentialIntFunctor>
+    template <typename PCMPotentialIntFunctor>
     void compute(PCMPotentialIntFunctor &functor);
 };
 
-template<typename PCMPotentialIntFunctor>
-void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor)
-{
+template <typename PCMPotentialIntFunctor>
+void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor) {
     // Do not worry about zeroing out result
     int ns1 = bs1_->nshell();
     int ns2 = bs2_->nshell();
     int bf1_offset = 0;
-    for (int i=0; i<ns1; ++i) {
-        const GaussianShell& s1 = bs1_->shell(i);
+    for (int i = 0; i < ns1; ++i) {
+        const GaussianShell &s1 = bs1_->shell(i);
         int ni = s1.ncartesian();
         int bf2_offset = 0;
-        for (int j=0; j<ns2; ++j) {
-            const GaussianShell& s2 = bs2_->shell(j);
+        for (int j = 0; j < ns2; ++j) {
+            const GaussianShell &s2 = bs2_->shell(j);
             int nj = s2.ncartesian();
             // Compute the shell
 
@@ -104,13 +103,12 @@ void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor)
             AB2 += (A[1] - B[1]) * (A[1] - B[1]);
             AB2 += (A[2] - B[2]) * (A[2] - B[2]);
 
-
             double ***vi = potential_recur_->vi();
 
-            double** Zxyzp = Zxyz_->pointer();
+            double **Zxyzp = Zxyz_->pointer();
             int ncharge = Zxyz_->rowspi()[0];
 
-            for (int atom=0; atom<ncharge; ++atom) {
+            for (int atom = 0; atom < ncharge; ++atom) {
                 memset(buffer_, 0, s1.ncartesian() * s2.ncartesian() * sizeof(double));
                 double PC[3];
 
@@ -120,19 +118,19 @@ void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor)
                 C[0] = Zxyzp[atom][1];
                 C[1] = Zxyzp[atom][2];
                 C[2] = Zxyzp[atom][3];
-                for (int p1=0; p1<nprim1; ++p1) {
+                for (int p1 = 0; p1 < nprim1; ++p1) {
                     double a1 = s1.exp(p1);
                     double c1 = s1.coef(p1);
-                    for (int p2=0; p2<nprim2; ++p2) {
+                    for (int p2 = 0; p2 < nprim2; ++p2) {
                         double a2 = s2.exp(p2);
                         double c2 = s2.coef(p2);
                         double gamma = a1 + a2;
-                        double oog = 1.0/gamma;
+                        double oog = 1.0 / gamma;
 
                         double PA[3], PB[3], P[3];
-                        P[0] = (a1*A[0] + a2*B[0])*oog;
-                        P[1] = (a1*A[1] + a2*B[1])*oog;
-                        P[2] = (a1*A[2] + a2*B[2])*oog;
+                        P[0] = (a1 * A[0] + a2 * B[0]) * oog;
+                        P[1] = (a1 * A[1] + a2 * B[1]) * oog;
+                        P[2] = (a1 * A[2] + a2 * B[2]) * oog;
                         PA[0] = P[0] - A[0];
                         PA[1] = P[1] - A[1];
                         PA[2] = P[2] - A[2];
@@ -143,22 +141,21 @@ void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor)
                         PC[1] = P[1] - C[1];
                         PC[2] = P[2] - C[2];
 
-                        double over_pf = exp(-a1*a2*AB2*oog) * sqrt(M_PI*oog) * M_PI * oog * c1 * c2;
-
+                        double over_pf = exp(-a1 * a2 * AB2 * oog) * sqrt(M_PI * oog) * M_PI * oog * c1 * c2;
 
                         // Do recursion
                         potential_recur_->compute(PA, PB, PC, gamma, am1, am2);
 
                         ao12 = 0;
-                        for(int ii = 0; ii <= am1; ii++) {
+                        for (int ii = 0; ii <= am1; ii++) {
                             int l1 = am1 - ii;
-                            for(int jj = 0; jj <= ii; jj++) {
+                            for (int jj = 0; jj <= ii; jj++) {
                                 int m1 = ii - jj;
                                 int n1 = jj;
                                 /*--- create all am components of sj ---*/
-                                for(int kk = 0; kk <= am2; kk++) {
+                                for (int kk = 0; kk <= am2; kk++) {
                                     int l2 = am2 - kk;
-                                    for(int ll = 0; ll <= kk; ll++) {
+                                    for (int ll = 0; ll <= kk; ll++) {
                                         int m2 = kk - ll;
                                         int n2 = ll;
 
@@ -170,97 +167,80 @@ void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor)
                                 }
                             }
                         }
-                    } // End loop over primitives of shell 2
-                } // End loop over primitives of shell 1
+                    }  // End loop over primitives of shell 2
+                }      // End loop over primitives of shell 1
                 ao12 = 0;
                 int ao1 = 0;
-                for(int ii = 0; ii <= am1; ii++) {
-                    for(int jj = 0; jj <= ii; jj++) {
+                for (int ii = 0; ii <= am1; ii++) {
+                    for (int jj = 0; jj <= ii; jj++) {
                         /*--- create all am components of sj ---*/
                         int ao2 = 0;
-                        for(int kk = 0; kk <= am2; kk++) {
-                            for(int ll = 0; ll <= kk; ll++) {
+                        for (int kk = 0; kk <= am2; kk++) {
+                            for (int ll = 0; ll <= kk; ll++) {
                                 // Compute location in the recursion
                                 double val = buffer_[ao12++];
                                 // Hand the work off to the functor
-                                functor(ao1+bf1_offset, ao2+bf2_offset, atom, val);
+                                functor(ao1 + bf1_offset, ao2 + bf2_offset, atom, val);
                                 ao2++;
                             }
                         }
                         ao1++;
                     }
                 }
-            } // End loop over points
+            }  // End loop over points
             bf2_offset += nj;
-        } // End loop over shell 2
+        }  // End loop over shell 2
         bf1_offset += ni;
-    } // End loop over shell 1
+    }  // End loop over shell 1
 }
 
-class PrintIntegralsFunctor
-{
-    public:
- /**
-  * A functor, to be used with PCMPotentialInt, that just prints the integrals out for debugging
-  */
-  void operator()(int bf1, int bf2, int center, double integral)
-  {
-    outfile->Printf( "bf1: %3d bf2 %3d center (%5d) integral %16.10f\n", bf1, bf2, center, integral);
-  }
+class PrintIntegralsFunctor {
+   public:
+    /**
+     * A functor, to be used with PCMPotentialInt, that just prints the integrals out for debugging
+     */
+    void operator()(int bf1, int bf2, int center, double integral) {
+        outfile->Printf("bf1: %3d bf2 %3d center (%5d) integral %16.10f\n", bf1, bf2, center, integral);
+    }
 };
 
+class ContractOverDensityFunctor {
+    /**
+     * A functor, to be used with PCMPotentialInt, that just contracts potential integrals and the
+     * density matrix, over the basis function indices, giving the charge expectation value.
+     */
+   protected:
+    /// Pointer to the density matrix.
+    double **pD_;
+    /// The array of charges
+    double *charges_;
 
-class ContractOverDensityFunctor
-{
- /**
-  * A functor, to be used with PCMPotentialInt, that just contracts potential integrals and the
-  * density matrix, over the basis function indices, giving the charge expectation value.
-  */
-    protected:
-        /// Pointer to the density matrix.
-        double **pD_;
-        /// The array of charges
-        double *charges_;
-    public:
-        ContractOverDensityFunctor(size_t /*ncenters*/, double *charges, SharedMatrix D):
-            pD_(D->pointer()),
-            charges_(charges)
-        {
-        }
-        void operator()(int bf1, int bf2, int center, double integral)
-        {
-            charges_[center] += pD_[bf1][bf2] * integral;
-        }
+   public:
+    ContractOverDensityFunctor(size_t /*ncenters*/, double *charges, SharedMatrix D)
+        : pD_(D->pointer()), charges_(charges) {}
+    void operator()(int bf1, int bf2, int center, double integral) { charges_[center] += pD_[bf1][bf2] * integral; }
 };
 
+class ContractOverChargesFunctor {
+    /**
+     * A functor, to be used with PCMPotentialInt, that just contracts potential integrals over charges,
+     * leaving a contribution to the Fock matrix
+     */
+   protected:
+    /// Pointer to the matrix that will contribute to the 2e part of the Fock matrix
+    double **pF_;
+    /// The array of charges
+    const double *charges_;
 
-class ContractOverChargesFunctor
-{
- /**
-  * A functor, to be used with PCMPotentialInt, that just contracts potential integrals over charges,
-  * leaving a contribution to the Fock matrix
-  */
-    protected:
-        /// Pointer to the matrix that will contribute to the 2e part of the Fock matrix
-        double **pF_;
-        /// The array of charges
-        const double *charges_;
-    public:
-        ContractOverChargesFunctor(const double* charges, SharedMatrix F):
-            pF_(F->pointer()),
-            charges_(charges)
-        {
-            if(F->rowdim() != F->coldim())
-                throw PSIEXCEPTION("Invalid Fock matrix in ContractOverCharges");
-            int nbf = F->rowdim();
-            ::memset(pF_[0], 0, nbf*nbf*sizeof(double));
-        }
+   public:
+    ContractOverChargesFunctor(const double *charges, SharedMatrix F) : pF_(F->pointer()), charges_(charges) {
+        if (F->rowdim() != F->coldim()) throw PSIEXCEPTION("Invalid Fock matrix in ContractOverCharges");
+        int nbf = F->rowdim();
+        ::memset(pF_[0], 0, nbf * nbf * sizeof(double));
+    }
 
-        void operator()(int bf1, int bf2, int center, double integral)
-        {
-            pF_[bf1][bf2] += integral * charges_[center];
-        }
+    void operator()(int bf1, int bf2, int center, double integral) { pF_[bf1][bf2] += integral * charges_[center]; }
 };
 
-} //Namespace
+}  // Namespace
 #endif

--- a/psi4/src/psi4/libpsipcm/psipcm.cc
+++ b/psi4/src/psi4/libpsipcm/psipcm.cc
@@ -27,417 +27,414 @@
  */
 #ifdef USING_PCMSolver
 
+#include <array>
+#include <memory>
+#include <tuple>
+#include <vector>
+
 #include "psipcm.h"
-#include "psi4/libmints/matrix.h"
-#include "psi4/libmints/vector.h"
-#include "psi4/libmints/molecule.h"
+
+#include "psi4/psi4-dec.h"
+
 #include "psi4/libmints/basisset.h"
-#include "psi4/liboptions/liboptions.h"
 #include "psi4/libmints/integral.h"
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/molecule.h"
 #include "psi4/libmints/petitelist.h"
+#include "psi4/libmints/potentialint.h"
+#include "psi4/libmints/vector.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
 #include <PCMSolver/PCMInput.h>
-
-
 
 namespace psi {
 
-void collect_atoms(std::shared_ptr<Molecule> molecule, double charges[], double centers[])
-{
+namespace detail {
+std::tuple<std::vector<double>, std::vector<double>> collect_atoms(std::shared_ptr<Molecule> molecule) {
     int nat = molecule->natom();
-    for(int i = 0; i < nat; ++i) {
+    std::vector<double> charges(nat);
+    for (int i = 0; i < nat; ++i) {
         charges[i] = molecule->fZ(i);
     }
 
     Matrix geom = molecule->geometry();
-    for(int j =  0; j < 3; ++j) {
-        for(int i = 0; i < nat; ++i) {
+    std::vector<double> centers(3 * nat);
+    for (int j = 0; j < 3; ++j) {
+        for (int i = 0; i < nat; ++i) {
             // Eigen stores matrices in Column-Major order
             centers[j + i * 3] = geom.get(i, j);
         }
     }
+
+    return std::make_tuple(charges, centers);
 }
 
-PCMInput pcmsolver_input()
-{
-  PCMInput host_input;
+PCMInput pcmsolver_input() {
+    PCMInput host_input;
 
-  // These parameters would be set by the host input reading
-  // Length and area parameters are all assumed to be in Angstrom,
-  // the module will convert to Bohr internally
-  strcpy(host_input.cavity_type, "gepol");
-  host_input.patch_level  = 2;
-  host_input.coarsity     = 0.5;
-  host_input.area         = 0.2;
-  host_input.min_distance = 0.1;
-  host_input.der_order    = 4;
-  host_input.scaling      = true;
-  strcpy(host_input.radii_set, "bondi");
-  strcpy(host_input.restart_name, "cavity.npz");
-  host_input.min_radius   = 100.0;
+    // These parameters would be set by the host input reading
+    // Length and area parameters are all assumed to be in Angstrom,
+    // the module will convert to Bohr internally
+    strcpy(host_input.cavity_type, "gepol");
+    host_input.patch_level = 2;
+    host_input.coarsity = 0.5;
+    host_input.area = 0.2;
+    host_input.min_distance = 0.1;
+    host_input.der_order = 4;
+    host_input.scaling = true;
+    strcpy(host_input.radii_set, "bondi");
+    strcpy(host_input.restart_name, "cavity.npz");
+    host_input.min_radius = 100.0;
 
-  strcpy(host_input.solver_type, "iefpcm");
-  strcpy(host_input.solvent, "water");
-  strcpy(host_input.equation_type, "secondkind");
-  host_input.correction    = 0.0;
-  host_input.probe_radius  = 1.0;
+    strcpy(host_input.solver_type, "iefpcm");
+    strcpy(host_input.solvent, "water");
+    strcpy(host_input.equation_type, "secondkind");
+    host_input.correction = 0.0;
+    host_input.probe_radius = 1.0;
 
-  strcpy(host_input.inside_type, "vacuum");
-  host_input.outside_epsilon    = 1.0;
-  strcpy(host_input.outside_type, "uniformdielectric");
+    strcpy(host_input.inside_type, "vacuum");
+    host_input.outside_epsilon = 1.0;
+    strcpy(host_input.outside_type, "uniformdielectric");
 
-  return host_input;
+    return host_input;
 }
 
-void host_writer(const char * message)
-{
-  outfile->Printf(message);
-  outfile->Printf("\n");
+void host_writer(const char *message) {
+    outfile->Printf(message);
+    outfile->Printf("\n");
+}
 }
 
-PCM::PCM(Options &options, std::shared_ptr<PSIO> /* psio */, int nirrep, std::shared_ptr<BasisSet> basisset)
-{
-  if(!pcmsolver_is_compatible_library()) throw PSIEXCEPTION("Incompatible PCMSolver library version.");
-  outfile->Printf("  **PSI4:PCMSOLVER Interface Active**\n");
+PCM::PCM(int print_level, std::shared_ptr<BasisSet> basisset) {
+    if (!pcmsolver_is_compatible_library()) throw PSIEXCEPTION("Incompatible PCMSolver library version.");
 
-  pcm_print_ = options.get_int("PRINT");
+    pcm_print_ = print_level;
 
-  if(nirrep > 1)
-    throw PSIEXCEPTION("You must add\n\n\tsymmetry c1\n\nto the molecule{} block to run the PCM code.");
+    basisset_ = basisset;
+    std::shared_ptr<Molecule> molecule = basisset_->molecule();
+    int natom = molecule->natom();
 
-  basisset_ = basisset;
+    auto integrals = std::make_shared<IntegralFactory>(basisset, basisset, basisset, basisset);
 
-  std::shared_ptr<IntegralFactory>
-    integrals = std::make_shared<IntegralFactory>(basisset, basisset, basisset, basisset);
+    PetiteList petite(basisset, integrals, true);
+    my_aotoso_ = petite.aotoso();
 
-  PetiteList petite(basisset, integrals, true);
-  my_aotoso_ = petite.aotoso();
+    potential_int_ = static_cast<PCMPotentialInt *>(integrals->pcm_potentialint());
 
-  potential_int_ = static_cast<PCMPotentialInt*>(integrals->pcm_potentialint());
+    /* PCMSolver needs to know who has to parse the input.
+     * We should have something like this here:
+     * int PSI4_provides_input = false;
+     * if (PSI4_has_pcmsolver_input) {
+     *    PSI4_provides_input = true;
+     * }
+     */
+    std::vector<double> charges(natom), coordinates(3 * natom);
+    std::tie(charges, coordinates) = detail::collect_atoms(molecule);
+    std::array<int, 4> symmetry_info{{0, 0, 0, 0}};
+    int PSI4_provides_input = false;
+    PCMInput host_input;
+    if (PSI4_provides_input) {
+        host_input = detail::pcmsolver_input();
+        context_ = std::shared_ptr<pcmsolver_context_t>(
+            pcmsolver_new(PCMSOLVER_READER_HOST, natom, charges.data(), coordinates.data(), symmetry_info.data(),
+                          &host_input, detail::host_writer),
+            pcmsolver_delete);
+    } else {
+        context_ = std::shared_ptr<pcmsolver_context_t>(
+            pcmsolver_new(PCMSOLVER_READER_OWN, natom, charges.data(), coordinates.data(), symmetry_info.data(),
+                          &host_input, detail::host_writer),
+            pcmsolver_delete);
+    }
+    outfile->Printf("  **PSI4:PCMSOLVER Interface Active**\n");
+    pcmsolver_print(context_.get());
+    ntess_ = pcmsolver_get_cavity_size(context_.get());
+    ntessirr_ = pcmsolver_get_irreducible_cavity_size(context_.get());
+    outfile->Printf("  There are %d tesserae, %d of which irreducible.\n\n", ntess_, ntessirr_);
+    tess_pot_ = new double[ntess_];
+    tess_pot_e_ = new double[ntess_];
+    tess_pot_n_ = new double[ntess_];
+    tess_charges_e_ = new double[ntess_];
+    tess_charges_n_ = new double[ntess_];
+    tess_charges_ = new double[ntess_];
 
-  std::shared_ptr<Molecule> molecule = basisset->molecule();
+    auto atom_Zxyz_ = std::make_shared<Matrix>("Atom Zxyz", natom, 4);
+    for (int atom = 0; atom < natom; ++atom) {
+        Vector3 xyz = molecule->xyz(atom);
+        atom_Zxyz_->set(atom, 0, molecule->charge(atom));
+        atom_Zxyz_->set(atom, 1, xyz[0]);
+        atom_Zxyz_->set(atom, 2, xyz[1]);
+        atom_Zxyz_->set(atom, 3, xyz[2]);
+    }
 
-  /* PCMSolver needs to know who has to parse the input.
-   * We should have something like this here:
-   * int PSI4_provides_input = false;
-   * if (PSI4_has_pcmsolver_input) {
-   *    PSI4_provides_input = true;
-   * }
-   */
-  double * charges = new double[molecule->natom()];
-  double * coordinates = new double[3*molecule->natom()];
-  collect_atoms(molecule, charges, coordinates);
-  int symmetry_info[4] = {0, 0, 0, 0};
-  int PSI4_provides_input = false;
-  PCMInput host_input;
-  if (PSI4_provides_input) {
-    host_input = pcmsolver_input();
-    context_ = pcmsolver_new(PCMSOLVER_READER_HOST, molecule->natom(), charges, coordinates,
-                             symmetry_info, &host_input, host_writer);
-  } else {
-    context_ = pcmsolver_new(PCMSOLVER_READER_OWN, molecule->natom(), charges, coordinates,
-                             symmetry_info, &host_input, host_writer);
-  }
-  pcmsolver_print(context_);
-  ntess_ = pcmsolver_get_cavity_size(context_);
-  ntessirr_ = pcmsolver_get_irreducible_cavity_size(context_);
-  outfile->Printf("  There are %d tesserae, %d of which irreducible.\n\n",ntess_,ntessirr_);
-  tess_pot_ = new double[ntess_];
-  tess_pot_e_ = new double[ntess_];
-  tess_pot_n_ = new double[ntess_];
-  tess_charges_e_ = new double[ntess_];
-  tess_charges_n_ = new double[ntess_];
-  tess_charges_ = new double[ntess_];
+    // The charge and {x,y,z} coordinates (in bohr) for each tessera
+    tess_Zxyz_ = std::make_shared<Matrix>("Tess Zxyz", ntess_, 4);
+    double **ptess_Zxyz = tess_Zxyz_->pointer();
+    // Set the tesserae's coordinates (note the loop bounds; this function is 1-based)
+    for (int tess = 1; tess <= ntess_; ++tess) pcmsolver_get_center(context_.get(), tess, &(ptess_Zxyz[tess - 1][1]));
 
-  int natom = molecule->natom();
-  auto atom_Zxyz_ = std::make_shared<Matrix>("Atom Zxyz", natom, 4);
-  for(int atom = 0; atom < natom; ++atom){
-    Vector3 xyz = molecule->xyz(atom);
-    atom_Zxyz_->set(atom, 0, molecule->charge(atom));
-    atom_Zxyz_->set(atom, 1, xyz[0]);
-    atom_Zxyz_->set(atom, 2, xyz[1]);
-    atom_Zxyz_->set(atom, 3, xyz[2]);
-  }
+    // Compute the nuclear potentials at the tesserae
+    double **patom_Zxyz = atom_Zxyz_->pointer();
+    ::memset(tess_pot_n_, 0, ntess_ * sizeof(double));
+    for (int atom = 0; atom < natom; ++atom) {
+        double Z = patom_Zxyz[atom][0];
+        for (int tess = 0; tess < ntess_; ++tess) {
+            double dx = ptess_Zxyz[tess][1] - patom_Zxyz[atom][1];
+            double dy = ptess_Zxyz[tess][2] - patom_Zxyz[atom][2];
+            double dz = ptess_Zxyz[tess][3] - patom_Zxyz[atom][3];
+            double r = sqrt(dx * dx + dy * dy + dz * dz);
+            tess_pot_n_[tess] += Z / r;
+            if (r < 1.0E-3) outfile->Printf("Warning! Tessera %d is only %.3f bohr from atom %d!\n", tess, r, atom + 1);
+        }
+    }
 
-  // The charge and {x,y,z} coordinates (in bohr) for each tessera
-  tess_Zxyz_ = std::make_shared<Matrix>("Tess Zxyz", ntess_, 4);
-  double **ptess_Zxyz = tess_Zxyz_->pointer();
-  // Set the tesserae's coordinates (note the loop bounds; this function is 1-based)
-  for(int tess = 1; tess <= ntess_; ++tess)
-      pcmsolver_get_center(context_, tess, &(ptess_Zxyz[tess-1][1]));
+    // A little debug info
+    if (pcm_print_ > 2) {
+        outfile->Printf("Nuclear MEP at each tessera:\n");
+        outfile->Printf("----------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess) outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_n_[tess]);
+    }
 
-  // Compute the nuclear potentials at the tesserae
-  double **patom_Zxyz = atom_Zxyz_->pointer();
-  ::memset(tess_pot_n_, 0, ntess_*sizeof(double));
-  for(int atom = 0; atom < natom; ++atom){
-      double Z = patom_Zxyz[atom][0];
-      for(int tess = 0; tess < ntess_; ++tess){
-          double dx = ptess_Zxyz[tess][1] - patom_Zxyz[atom][1];
-          double dy = ptess_Zxyz[tess][2] - patom_Zxyz[atom][2];
-          double dz = ptess_Zxyz[tess][3] - patom_Zxyz[atom][3];
-          double r = sqrt(dx*dx + dy*dy + dz*dz);
-          tess_pot_n_[tess] += Z / r;
-          if(r < 1.0E-3)
-              outfile->Printf("Warning! Tessera %d is only %.3f bohr from atom %d!\n", tess, r, atom+1);
-      }
-  }
+    // Compute the nuclear charges, since they don't change
+    ::memset(tess_charges_n_, 0, ntess_ * sizeof(double));
+    const char *potential_name = "NucMEP";
+    const char *charge_name = "NucASC";
+    pcmsolver_set_surface_function(context_.get(), ntess_, tess_pot_n_, potential_name);
+    int irrep = 0;
+    pcmsolver_compute_asc(context_.get(), potential_name, charge_name, irrep);
+    pcmsolver_get_surface_function(context_.get(), ntess_, tess_charges_n_, charge_name);
 
-  // A little debug info
-  if(pcm_print_ > 2) {
-    outfile->Printf("Nuclear MEP at each tessera:\n");
-    outfile->Printf("----------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-        outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_n_[tess]);
-  }
+    // A little debug info
+    if (pcm_print_ > 2) {
+        outfile->Printf("Nuclear ASC at each tessera:\n");
+        outfile->Printf("----------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess)
+            outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_charges_n_[tess]);
+    }
 
-  // Compute the nuclear charges, since they don't change
-  ::memset(tess_charges_n_, 0, ntess_*sizeof(double));
-  const char *potential_name = "NucMEP";
-  const char *charge_name = "NucASC";
-  pcmsolver_set_surface_function(context_, ntess_, tess_pot_n_, potential_name);
-  int irrep = 0;
-  pcmsolver_compute_asc(context_, potential_name, charge_name, irrep);
-  pcmsolver_get_surface_function(context_, ntess_, tess_charges_n_, charge_name);
+}  // PCM()
 
-  // A little debug info
-  if(pcm_print_ > 2) {
-    outfile->Printf("Nuclear ASC at each tessera:\n");
-    outfile->Printf("----------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-        outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_charges_n_[tess]);
-  }
-
-} // PCM()
-
-PCM::~PCM()
-{
-  delete [] tess_pot_;
-  delete [] tess_pot_e_;
-  delete [] tess_pot_n_;
-  delete [] tess_charges_;
-  delete [] tess_charges_e_;
-  delete [] tess_charges_n_;
-
-  pcmsolver_delete(context_);
+PCM::~PCM() {
+    delete[] tess_pot_;
+    delete[] tess_pot_e_;
+    delete[] tess_pot_n_;
+    delete[] tess_charges_;
+    delete[] tess_charges_e_;
+    delete[] tess_charges_n_;
 }
 
-double PCM::compute_E(SharedMatrix &D, CalcType type)
-{
-  switch (type)
-  {
-	case Total:
-		return compute_E_total(D);
-	case NucAndEle:
-		return compute_E_separate(D);
-	case EleOnly:
-		return compute_E_electronic(D);
-	default:
-		throw PSIEXCEPTION("Unknown PCM calculation type.");
-  }
+double PCM::compute_E(SharedMatrix &D, CalcType type) {
+    switch (type) {
+        case CalcType::Total:
+            return compute_E_total(D);
+        case CalcType::NucAndEle:
+            return compute_E_separate(D);
+        case CalcType::EleOnly:
+            return compute_E_electronic(D);
+        default:
+            throw PSIEXCEPTION("Unknown PCM calculation type.");
+    }
 }
 
-double PCM::compute_E_total(SharedMatrix &D)
-{
-  double **ptess_Zxyz = tess_Zxyz_->pointer();
-  ::memset(tess_pot_e_, 0, ntess_*sizeof(double));
-  ::memset(tess_charges_, 0, ntess_*sizeof(double));
-  for(int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
-  potential_int_->set_charge_field(tess_Zxyz_);
+double PCM::compute_E_total(SharedMatrix &D) {
+    double **ptess_Zxyz = tess_Zxyz_->pointer();
+    ::memset(tess_pot_e_, 0, ntess_ * sizeof(double));
+    ::memset(tess_charges_, 0, ntess_ * sizeof(double));
+    for (int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
+    potential_int_->set_charge_field(tess_Zxyz_);
 
-  SharedMatrix D_carts;
-  if(basisset_->has_puream()){
-    D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
-    D_carts->back_transform(D,my_aotoso_);
-  }
-  else D_carts = D;
+    SharedMatrix D_carts;
+    if (basisset_->has_puream()) {
+        D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
+        D_carts->back_transform(D, my_aotoso_);
+    } else
+        D_carts = D;
 
-  ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
-  // Add in the electronic contribution to the potential at each tessera
-  potential_int_->compute(contract_density_functor);
+    ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
+    // Add in the electronic contribution to the potential at each tessera
+    potential_int_->compute(contract_density_functor);
 
-  // A little debug info
-  if(pcm_print_ > 2) {
-    outfile->Printf("Electronic MEP at each tessera:\n");
-    outfile->Printf("-------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-      outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
-  }
+    // A little debug info
+    if (pcm_print_ > 2) {
+        outfile->Printf("Electronic MEP at each tessera:\n");
+        outfile->Printf("-------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess) outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
+    }
 
-  // Combine the nuclear and electronic potentials at each tessera
-  for(int tess = 0; tess < ntess_; ++tess) tess_pot_[tess] = tess_pot_n_[tess] + tess_pot_e_[tess];
+    // Combine the nuclear and electronic potentials at each tessera
+    for (int tess = 0; tess < ntess_; ++tess) tess_pot_[tess] = tess_pot_n_[tess] + tess_pot_e_[tess];
 
-  const char *tot_potential_name = "TotMEP";
-  const char *tot_charge_name = "TotASC";
-  pcmsolver_set_surface_function(context_, ntess_, tess_pot_, tot_potential_name);
-  int irrep = 0;
-  pcmsolver_compute_asc(context_, tot_potential_name, tot_charge_name, irrep);
-  pcmsolver_get_surface_function(context_, ntess_, tess_charges_, tot_charge_name);
+    const char *tot_potential_name = "TotMEP";
+    const char *tot_charge_name = "TotASC";
+    pcmsolver_set_surface_function(context_.get(), ntess_, tess_pot_, tot_potential_name);
+    int irrep = 0;
+    pcmsolver_compute_asc(context_.get(), tot_potential_name, tot_charge_name, irrep);
+    pcmsolver_get_surface_function(context_.get(), ntess_, tess_charges_, tot_charge_name);
 
-  if(pcm_print_ > 2) {
-    outfile->Printf("Total MEP & ASC at each tessera:\n");
-    outfile->Printf("-------------------------------------------------\n");
-    outfile->Printf("Tessera# Total MEP       Total ASC\n");
-    outfile->Printf("----------------------------------------------------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-        outfile->Printf("%4d  %16.10f  %16.10f\n", tess, tess_pot_[tess], tess_charges_[tess]);
-  }
+    if (pcm_print_ > 2) {
+        outfile->Printf("Total MEP & ASC at each tessera:\n");
+        outfile->Printf("-------------------------------------------------\n");
+        outfile->Printf("Tessera# Total MEP       Total ASC\n");
+        outfile->Printf("----------------------------------------------------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess)
+            outfile->Printf("%4d  %16.10f  %16.10f\n", tess, tess_pot_[tess], tess_charges_[tess]);
+    }
 
-  // Grab the polarization energy from PCMSolver
-  double Epol = pcmsolver_compute_polarization_energy(context_, tot_potential_name, tot_charge_name);
-  outfile->Printf("   PCM polarization energy = %16.14f\n", Epol);
+    // Grab the polarization energy from PCMSolver
+    double Epol = pcmsolver_compute_polarization_energy(context_.get(), tot_potential_name, tot_charge_name);
+    outfile->Printf("   PCM polarization energy = %16.14f\n", Epol);
 
-  return Epol;
+    return Epol;
 }
 
-double PCM::compute_E_separate(SharedMatrix &D)
-{
-  double **ptess_Zxyz = tess_Zxyz_->pointer();
-  ::memset(tess_pot_e_, 0, ntess_*sizeof(double));
-  ::memset(tess_charges_, 0, ntess_*sizeof(double));
-  ::memset(tess_charges_e_, 0, ntess_*sizeof(double));
-  ::memset(tess_charges_, 0, ntess_*sizeof(double));
-  for(int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
-  potential_int_->set_charge_field(tess_Zxyz_);
+double PCM::compute_E_separate(SharedMatrix &D) {
+    double **ptess_Zxyz = tess_Zxyz_->pointer();
+    ::memset(tess_pot_e_, 0, ntess_ * sizeof(double));
+    ::memset(tess_charges_, 0, ntess_ * sizeof(double));
+    ::memset(tess_charges_e_, 0, ntess_ * sizeof(double));
+    ::memset(tess_charges_, 0, ntess_ * sizeof(double));
+    for (int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
+    potential_int_->set_charge_field(tess_Zxyz_);
 
-  SharedMatrix D_carts;
-  if(basisset_->has_puream()){
-    D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
-    D_carts->back_transform(D,my_aotoso_);
-  }
-  else D_carts = D;
+    SharedMatrix D_carts;
+    if (basisset_->has_puream()) {
+        D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
+        D_carts->back_transform(D, my_aotoso_);
+    } else
+        D_carts = D;
 
-  ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
-  // Add in the electronic contribution to the potential at each tessera
-  potential_int_->compute(contract_density_functor);
+    ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
+    // Add in the electronic contribution to the potential at each tessera
+    potential_int_->compute(contract_density_functor);
 
-  // A little debug info
-  if(pcm_print_ > 2) {
-    outfile->Printf("Electronic MEP at each tessera:\n");
-    outfile->Printf("-------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-      outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
-  }
+    // A little debug info
+    if (pcm_print_ > 2) {
+        outfile->Printf("Electronic MEP at each tessera:\n");
+        outfile->Printf("-------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess) outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
+    }
 
-  const char *e_potential_name = "EleMEP";
-  const char *e_charge_name = "EleASC";
-  pcmsolver_set_surface_function(context_, ntess_, tess_pot_e_, e_potential_name);
-  int irrep = 0;
-  pcmsolver_compute_asc(context_, e_potential_name, e_charge_name, irrep);
-  pcmsolver_get_surface_function(context_, ntess_, tess_charges_e_, e_charge_name);
+    const char *e_potential_name = "EleMEP";
+    const char *e_charge_name = "EleASC";
+    pcmsolver_set_surface_function(context_.get(), ntess_, tess_pot_e_, e_potential_name);
+    int irrep = 0;
+    pcmsolver_compute_asc(context_.get(), e_potential_name, e_charge_name, irrep);
+    pcmsolver_get_surface_function(context_.get(), ntess_, tess_charges_e_, e_charge_name);
 
-  // Combine the nuclear and electronic potentials at each tessera
-  for(int tess = 0; tess < ntess_; ++tess) tess_pot_[tess] = tess_pot_n_[tess] + tess_pot_e_[tess];
+    // Combine the nuclear and electronic potentials at each tessera
+    for (int tess = 0; tess < ntess_; ++tess) tess_pot_[tess] = tess_pot_n_[tess] + tess_pot_e_[tess];
 
-  if(pcm_print_ > 2) {
-    outfile->Printf("Nuclear and Electronic MEP & ASC at each tessera:\n");
-    outfile->Printf("-------------------------------------------------\n");
-    outfile->Printf("Tessera# Nuclear MEP       Nuclear ASC       Elec. MEP         Elec. ASC:\n");
-    outfile->Printf("----------------------------------------------------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-        outfile->Printf("%4d  %16.10f  %16.10f  %16.10f  %16.10f\n", tess, tess_pot_n_[tess], tess_charges_n_[tess], tess_pot_e_[tess], tess_charges_e_[tess]);
-  }
+    if (pcm_print_ > 2) {
+        outfile->Printf("Nuclear and Electronic MEP & ASC at each tessera:\n");
+        outfile->Printf("-------------------------------------------------\n");
+        outfile->Printf("Tessera# Nuclear MEP       Nuclear ASC       Elec. MEP         Elec. ASC:\n");
+        outfile->Printf("----------------------------------------------------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess)
+            outfile->Printf("%4d  %16.10f  %16.10f  %16.10f  %16.10f\n", tess, tess_pot_n_[tess], tess_charges_n_[tess],
+                            tess_pot_e_[tess], tess_charges_e_[tess]);
+    }
 
-  const char *tot_potential_name = "TotMEP";
-  const char *tot_charge_name = "TotASC";
-  pcmsolver_set_surface_function(context_, ntess_, tess_pot_, tot_potential_name);
-  pcmsolver_compute_asc(context_, tot_potential_name, tot_charge_name, irrep);
-  pcmsolver_get_surface_function(context_, ntess_, tess_charges_, tot_charge_name);
+    const char *tot_potential_name = "TotMEP";
+    const char *tot_charge_name = "TotASC";
+    pcmsolver_set_surface_function(context_.get(), ntess_, tess_pot_, tot_potential_name);
+    pcmsolver_compute_asc(context_.get(), tot_potential_name, tot_charge_name, irrep);
+    pcmsolver_get_surface_function(context_.get(), ntess_, tess_charges_, tot_charge_name);
 
-  // Grab the polarization energy from PCMSolver
-  const char * n_potential_name = "NucMEP";
-  const char * n_charge_name = "NucASC";
-  double U_NN = pcmsolver_compute_polarization_energy(context_, n_potential_name, n_charge_name);
-  double U_eN = pcmsolver_compute_polarization_energy(context_, n_potential_name, e_charge_name);
-  double U_Ne = pcmsolver_compute_polarization_energy(context_, e_potential_name, n_charge_name);
-  double U_ee = pcmsolver_compute_polarization_energy(context_, e_potential_name, e_charge_name);
-  outfile->Printf("  Polarization energy components\n");
-  outfile->Printf("  U_ee = %16.14f\n", 2.0*U_ee);
-  outfile->Printf("  U_eN = %16.14f\n", 2.0*U_eN);
-  outfile->Printf("  U_Ne = %16.14f\n", 2.0*U_Ne);
-  outfile->Printf("  U_NN = %16.14f\n", 2.0*U_NN);
-  outfile->Printf("  U_eN - U_Ne = %16.14f\n", U_eN - U_Ne);
-  double Epol = U_NN + U_eN + U_Ne + U_ee;
-  outfile->Printf("   PCM polarization energy = %16.14f\n", Epol);
-  return Epol;
+    // Grab the polarization energy from PCMSolver
+    const char *n_potential_name = "NucMEP";
+    const char *n_charge_name = "NucASC";
+    double U_NN = pcmsolver_compute_polarization_energy(context_.get(), n_potential_name, n_charge_name);
+    double U_eN = pcmsolver_compute_polarization_energy(context_.get(), n_potential_name, e_charge_name);
+    double U_Ne = pcmsolver_compute_polarization_energy(context_.get(), e_potential_name, n_charge_name);
+    double U_ee = pcmsolver_compute_polarization_energy(context_.get(), e_potential_name, e_charge_name);
+    outfile->Printf("  Polarization energy components\n");
+    outfile->Printf("  U_ee = %16.14f\n", 2.0 * U_ee);
+    outfile->Printf("  U_eN = %16.14f\n", 2.0 * U_eN);
+    outfile->Printf("  U_Ne = %16.14f\n", 2.0 * U_Ne);
+    outfile->Printf("  U_NN = %16.14f\n", 2.0 * U_NN);
+    outfile->Printf("  U_eN - U_Ne = %16.14f\n", U_eN - U_Ne);
+    double Epol = U_NN + U_eN + U_Ne + U_ee;
+    outfile->Printf("   PCM polarization energy = %16.14f\n", Epol);
+    return Epol;
 }
 
-double PCM::compute_E_electronic(SharedMatrix &D)
-{
-  double **ptess_Zxyz = tess_Zxyz_->pointer();
-  ::memset(tess_pot_e_, 0, ntess_*sizeof(double));
-  ::memset(tess_charges_e_, 0, ntess_*sizeof(double));
-  for(int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
-  potential_int_->set_charge_field(tess_Zxyz_);
+double PCM::compute_E_electronic(SharedMatrix &D) {
+    double **ptess_Zxyz = tess_Zxyz_->pointer();
+    ::memset(tess_pot_e_, 0, ntess_ * sizeof(double));
+    ::memset(tess_charges_e_, 0, ntess_ * sizeof(double));
+    for (int tess = 0; tess < ntess_; ++tess) ptess_Zxyz[tess][0] = 1.0;
+    potential_int_->set_charge_field(tess_Zxyz_);
 
-  SharedMatrix D_carts;
-  if(basisset_->has_puream()){
-    D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
-    D_carts->back_transform(D,my_aotoso_);
-  }
-  else D_carts = D;
+    SharedMatrix D_carts;
+    if (basisset_->has_puream()) {
+        D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
+        D_carts->back_transform(D, my_aotoso_);
+    } else
+        D_carts = D;
 
-  ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
-  // Add in the electronic contribution to the potential at each tessera
-  potential_int_->compute(contract_density_functor);
+    ContractOverDensityFunctor contract_density_functor(ntess_, tess_pot_e_, D_carts);
+    // Add in the electronic contribution to the potential at each tessera
+    potential_int_->compute(contract_density_functor);
 
-  // A little debug info
-  if(pcm_print_ > 2) {
-    outfile->Printf("Electronic MEP at each tessera:\n");
-    outfile->Printf("-------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-      outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
-  }
+    // A little debug info
+    if (pcm_print_ > 2) {
+        outfile->Printf("Electronic MEP at each tessera:\n");
+        outfile->Printf("-------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess) outfile->Printf("tess[%4d] -> %16.10f\n", tess, tess_pot_e_[tess]);
+    }
 
-  const char *e_potential_name = "EleMEP";
-  const char *e_charge_name = "EleASC";
-  pcmsolver_set_surface_function(context_, ntess_, tess_pot_e_, e_potential_name);
-  int irrep = 0;
-  pcmsolver_compute_asc(context_, e_potential_name, e_charge_name, irrep);
-  pcmsolver_get_surface_function(context_, ntess_, tess_charges_e_, e_charge_name);
+    const char *e_potential_name = "EleMEP";
+    const char *e_charge_name = "EleASC";
+    pcmsolver_set_surface_function(context_.get(), ntess_, tess_pot_e_, e_potential_name);
+    int irrep = 0;
+    pcmsolver_compute_asc(context_.get(), e_potential_name, e_charge_name, irrep);
+    pcmsolver_get_surface_function(context_.get(), ntess_, tess_charges_e_, e_charge_name);
 
-  if(pcm_print_ > 2) {
-    outfile->Printf("Electronic MEP & ASC at each tessera:\n");
-    outfile->Printf("-------------------------------------------------\n");
-    outfile->Printf("Tessera# Elec. MEP         Elec. ASC:\n");
-    outfile->Printf("----------------------------------------------------------------------------\n");
-    for(int tess = 0; tess < ntess_; ++tess)
-        outfile->Printf("%4d  %16.10f  %16.10f\n", tess, tess_pot_e_[tess], tess_charges_e_[tess]);
-  }
+    if (pcm_print_ > 2) {
+        outfile->Printf("Electronic MEP & ASC at each tessera:\n");
+        outfile->Printf("-------------------------------------------------\n");
+        outfile->Printf("Tessera# Elec. MEP         Elec. ASC:\n");
+        outfile->Printf("----------------------------------------------------------------------------\n");
+        for (int tess = 0; tess < ntess_; ++tess)
+            outfile->Printf("%4d  %16.10f  %16.10f\n", tess, tess_pot_e_[tess], tess_charges_e_[tess]);
+    }
 
-  // Grab the polarization energy from PCMSolver
-  double Epol = pcmsolver_compute_polarization_energy(context_, e_potential_name, e_charge_name);
-  outfile->Printf("   PCM polarization energy (electronic only) = %16.14f\n", Epol);
-  return Epol;
+    // Grab the polarization energy from PCMSolver
+    double Epol = pcmsolver_compute_polarization_energy(context_.get(), e_potential_name, e_charge_name);
+    outfile->Printf("   PCM polarization energy (electronic only) = %16.14f\n", Epol);
+    return Epol;
 }
 
-SharedMatrix PCM::compute_V()
-{
-  auto V_pcm_cart = std::make_shared<Matrix>("PCM potential cart", basisset_->nao(), basisset_->nao());
-  ContractOverChargesFunctor contract_charges_functor(tess_charges_, V_pcm_cart);
-  potential_int_->compute(contract_charges_functor);
-  // The potential might need to be transformed to the spherical harmonic basis
-  SharedMatrix V_pcm_pure;
-  if(basisset_->has_puream()){
-      V_pcm_pure = std::make_shared<Matrix>("PCM potential pure", basisset_->nbf(), basisset_->nbf());
-      V_pcm_pure->transform(V_pcm_cart, my_aotoso_);
-  }
-  if(basisset_->has_puream()) return V_pcm_pure;
-  else return V_pcm_cart;
+SharedMatrix PCM::compute_V() {
+    auto V_pcm_cart = std::make_shared<Matrix>("PCM potential cart", basisset_->nao(), basisset_->nao());
+    ContractOverChargesFunctor contract_charges_functor(tess_charges_, V_pcm_cart);
+    potential_int_->compute(contract_charges_functor);
+    // The potential might need to be transformed to the spherical harmonic basis
+    SharedMatrix V_pcm_pure;
+    if (basisset_->has_puream()) {
+        V_pcm_pure = std::make_shared<Matrix>("PCM potential pure", basisset_->nbf(), basisset_->nbf());
+        V_pcm_pure->transform(V_pcm_cart, my_aotoso_);
+    }
+    if (basisset_->has_puream())
+        return V_pcm_pure;
+    else
+        return V_pcm_cart;
 }
 
-SharedMatrix PCM::compute_V_electronic()
-{
-  auto V_pcm_cart = std::make_shared<Matrix>("PCM potential cart", basisset_->nao(), basisset_->nao());
-  ContractOverChargesFunctor contract_charges_functor(tess_charges_e_, V_pcm_cart);
-  potential_int_->compute(contract_charges_functor);
-  // The potential might need to be transformed to the spherical harmonic basis
-  SharedMatrix V_pcm_pure;
-  if(basisset_->has_puream()){
-      V_pcm_pure = std::make_shared<Matrix>("PCM potential pure", basisset_->nbf(), basisset_->nbf());
-      V_pcm_pure->transform(V_pcm_cart, my_aotoso_);
-  }
-  if(basisset_->has_puream()) return V_pcm_pure;
-  else return V_pcm_cart;
+SharedMatrix PCM::compute_V_electronic() {
+    auto V_pcm_cart = std::make_shared<Matrix>("PCM potential cart", basisset_->nao(), basisset_->nao());
+    ContractOverChargesFunctor contract_charges_functor(tess_charges_e_, V_pcm_cart);
+    potential_int_->compute(contract_charges_functor);
+    // The potential might need to be transformed to the spherical harmonic basis
+    SharedMatrix V_pcm_pure;
+    if (basisset_->has_puream()) {
+        V_pcm_pure = std::make_shared<Matrix>("PCM potential pure", basisset_->nbf(), basisset_->nbf());
+        V_pcm_pure->transform(V_pcm_cart, my_aotoso_);
+    }
+    if (basisset_->has_puream())
+        return V_pcm_pure;
+    else
+        return V_pcm_cart;
 }
 
-} // psi namespace
+}  // psi namespace
 #endif

--- a/psi4/src/psi4/libpsipcm/psipcm.h
+++ b/psi4/src/psi4/libpsipcm/psipcm.h
@@ -30,33 +30,34 @@
 #define PCM_H
 #ifdef USING_PCMSolver
 
+#include <memory>
+#include <tuple>
 #include <vector>
-#include "psi4/libpsio/psio.hpp"
-#include "psi4/pragma.h"
-#include "psi4/libmints/potentialint.h"
- PRAGMA_WARNING_PUSH
- PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
- #include <memory>
- PRAGMA_WARNING_POP
 
 #include <PCMSolver/pcmsolver.h>
 
 namespace psi {
 class BasisSet;
+class Matrix;
+class Molecule;
 class Options;
-using SharedMatrix=std::shared_ptr<Matrix>;
+class PCMPotentialInt;
+class Vector;
+
+using SharedMatrix = std::shared_ptr<Matrix>;
+using SharedVector = std::shared_ptr<Vector>;
 
 class PCM {
-  public:
-    enum CalcType {Total, NucAndEle, EleOnly};
-    PCM() {};
-    PCM(Options &options, std::shared_ptr<PSIO> psio, int nirrep, std::shared_ptr<BasisSet> basisset);
+   public:
+    enum class CalcType : int { Total, NucAndEle, EleOnly };
+    PCM() = default;
+    PCM(int print_level, std::shared_ptr<BasisSet> basisset);
     ~PCM();
-    double compute_E(SharedMatrix &D, CalcType type = NucAndEle);//Total); this should be the default (once an advanced option is available)
+    double compute_E(SharedMatrix &D, CalcType type = CalcType::Total);
     SharedMatrix compute_V();
-    SharedMatrix compute_V_electronic(); // This is needed by the CC code (and maybe the LR-SCF code)
+    SharedMatrix compute_V_electronic();  // This is needed by the CC code (and maybe the LR-SCF code)
 
-  protected:
+   protected:
     /// The number of tesserae in PCMSolver.
     int ntess_;
     /// The number of irreducible tesserae in PCMSolver.
@@ -64,17 +65,17 @@ class PCM {
     /// A matrix to hold the charges and {x,y,z} coordinates of the tesserae
     SharedMatrix tess_Zxyz_;
     /// A scratch array to hold the electronic potential values at the tesserae
-    double * tess_pot_e_;
+    double *tess_pot_e_;
     /// A scratch array to hold the nuclear potential values at the tesserae (unchanging)
-    double * tess_pot_n_;
+    double *tess_pot_n_;
     /// A scratch array to hold the total potential values at the tesserae
-    double * tess_pot_;
+    double *tess_pot_;
     /// A scratch array to hold the electronic charges at the tesserae
-    double * tess_charges_e_;
+    double *tess_charges_e_;
     /// A scratch array to hold the nuclear charges at the tesserae
-    double * tess_charges_n_;
+    double *tess_charges_n_;
     /// A scratch array to hold the charges at the tesserae
-    double * tess_charges_;
+    double *tess_charges_;
     /// Calculate energy using total charges and potentials
     double compute_E_total(SharedMatrix &D);
     /// Calculate energy separating between charges and potentials
@@ -90,20 +91,23 @@ class PCM {
     SharedMatrix my_aotoso_;
 
     /// Factory for the electrostatic integrals
-    PCMPotentialInt* potential_int_;
+    PCMPotentialInt *potential_int_;
 
     /// Handle to stuff provided by PCMSolver
-    pcmsolver_context_t * context_;
+    std::shared_ptr<pcmsolver_context_t> context_;
 
     /// print level
     int pcm_print_;
-
 };
 
-typedef std::shared_ptr<PCM> SharedPCM;
+namespace detail {
+std::tuple<std::vector<double>, std::vector<double>> collect_atoms(std::shared_ptr<Molecule>);
 
-void host_writer(const char * message);
+PCMInput pcmsolver_input();
 
-} // psi
+void host_writer(const char *);
+
+}  // detail
+}  // psi
 #endif
 #endif

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -74,25 +74,19 @@
 #include <omp.h>
 #endif
 
-namespace psi { namespace scf {
+namespace psi {
+namespace scf {
 
-HF::HF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> func,
-       Options &options, std::shared_ptr<PSIO> psio)
-    : Wavefunction(options),
-      functional_(func) {
+HF::HF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> func, Options& options, std::shared_ptr<PSIO> psio)
+    : Wavefunction(options), functional_(func) {
     shallow_copy(ref_wfn);
     psio_ = psio;
     common_init();
 }
 
+HF::~HF() {}
 
-HF::~HF()
-{
-}
-
-void HF::common_init()
-{
-
+void HF::common_init() {
     attempt_number_ = 1;
     ref_C_ = false;
     reset_occ_ = false;
@@ -112,23 +106,24 @@ void HF::common_init()
     nmo_ = 0;
     nso_ = 0;
     const Dimension& dimpi = factory_->colspi();
-    for (int h = 0; h< factory_->nirrep(); h++){
+    for (int h = 0; h < factory_->nirrep(); h++) {
         nsopi_[h] = dimpi[h];
-        nmopi_[h] = nsopi_[h]; //For now, may change in S^-1/2
+        nmopi_[h] = nsopi_[h];  // For now, may change in S^-1/2
         nso_ += nsopi_[h];
-        nmo_ += nmopi_[h]; //For now, may change in S^-1/2
+        nmo_ += nmopi_[h];  // For now, may change in S^-1/2
     }
 
     // Read in energy convergence threshold
     energy_threshold_ = options_.get_double("E_CONVERGENCE");
 
     // Read in density convergence threshold
-    density_threshold_ = options_.get_double("D_CONVERGENCE");;
+    density_threshold_ = options_.get_double("D_CONVERGENCE");
+    ;
 
     density_fitted_ = false;
 
-    Eold_    = 0.0;
-    E_       = 0.0;
+    Eold_ = 0.0;
+    E_ = 0.0;
     maxiter_ = 40;
 
     // Read information from input file
@@ -138,7 +133,7 @@ void HF::common_init()
     fail_on_maxiter_ = options_.get_bool("FAIL_ON_MAXITER");
 
     // Set name
-    if(options_.get_str("REFERENCE") == "RKS" || options_.get_str("REFERENCE") == "UKS")
+    if (options_.get_str("REFERENCE") == "RKS" || options_.get_str("REFERENCE") == "UKS")
         name_ = "DFT";
     else
         name_ = "SCF";
@@ -164,8 +159,7 @@ void HF::common_init()
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
-            if (options_["DOCC"].size() != nirreps)
-                throw PSIEXCEPTION("Input DOCC array has the wrong dimensions");
+            if (options_["DOCC"].size() != nirreps) throw PSIEXCEPTION("Input DOCC array has the wrong dimensions");
             for (int h = 0; h < nirreps; ++h) {
                 doccpi_[h] = options_["DOCC"][h].to_integer();
             }
@@ -191,8 +185,7 @@ void HF::common_init()
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
-            if (options_["SOCC"].size() != nirreps)
-                throw PSIEXCEPTION("Input SOCC array has the wrong dimensions");
+            if (options_["SOCC"].size() != nirreps) throw PSIEXCEPTION("Input SOCC array has the wrong dimensions");
             for (int h = 0; h < nirreps; ++h) {
                 soccpi_[h] = options_["SOCC"][h].to_integer();
             }
@@ -200,19 +193,18 @@ void HF::common_init()
     }  // else take the reference wavefunctions soccpi
 
     // Check that we have enough basis functions
-    for(int h = 0; h < nirreps; ++h) {
-      if(doccpi_[h]+soccpi_[h] > nmopi_[h]) {
-    throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
-      }
+    for (int h = 0; h < nirreps; ++h) {
+        if (doccpi_[h] + soccpi_[h] > nmopi_[h]) {
+            throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
+        }
     }
 
     if (input_socc_ || input_docc_) {
         for (int h = 0; h < nirrep_; h++) {
             nalphapi_[h] = doccpi_[h] + soccpi_[h];
-            nbetapi_[h]  = doccpi_[h];
+            nbetapi_[h] = doccpi_[h];
         }
     }
-
 
     // Set additional information
     nuclearrep_ = molecule_->nuclear_repulsion_energy();
@@ -264,71 +256,64 @@ void HF::common_init()
     if (perturb_h_) {
         std::string perturb_with;
 
-
         if (options_["PERTURB_WITH"].has_changed()) {
             perturb_with = options_.get_str("PERTURB_WITH");
             // Do checks to see what perturb_with is.
             if (perturb_with == "DIPOLE_X") {
                 perturb_ = dipole_x;
                 perturb_dipoles_[0] = options_.get_double("PERTURB_MAGNITUDE");
-                nuclearrep_ += perturb_dipoles_[0]*molecule_->nuclear_dipole()[0];
-                outfile->Printf(" WARNING: the DIPOLE_X and PERTURB_MAGNITUDE keywords are deprecated."
-                                "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+                nuclearrep_ += perturb_dipoles_[0] * molecule_->nuclear_dipole()[0];
+                outfile->Printf(
+                    " WARNING: the DIPOLE_X and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
             } else if (perturb_with == "DIPOLE_Y") {
                 perturb_ = dipole_y;
                 perturb_dipoles_[1] = options_.get_double("PERTURB_MAGNITUDE");
-                nuclearrep_ += perturb_dipoles_[1]*molecule_->nuclear_dipole()[1];
-                outfile->Printf(" WARNING: the DIPOLE_Y and PERTURB_MAGNITUDE keywords are deprecated."
-                                "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+                nuclearrep_ += perturb_dipoles_[1] * molecule_->nuclear_dipole()[1];
+                outfile->Printf(
+                    " WARNING: the DIPOLE_Y and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
             } else if (perturb_with == "DIPOLE_Z") {
                 perturb_ = dipole_z;
                 perturb_dipoles_[2] = options_.get_double("PERTURB_MAGNITUDE");
-                nuclearrep_ += perturb_dipoles_[2]*molecule_->nuclear_dipole()[2];
-                outfile->Printf(" WARNING: the DIPOLE_Z and PERTURB_MAGNITUDE keywords are deprecated."
-                                "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+                nuclearrep_ += perturb_dipoles_[2] * molecule_->nuclear_dipole()[2];
+                outfile->Printf(
+                    " WARNING: the DIPOLE_Z and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
             } else if (perturb_with == "DIPOLE") {
                 perturb_ = dipole;
-                if(options_["PERTURB_DIPOLE"].size() !=3)
+                if (options_["PERTURB_DIPOLE"].size() != 3)
                     throw PSIEXCEPTION("The PERTURB dipole should have exactly three floating point numbers.");
-                for(int n = 0; n < 3; ++n)
-                    perturb_dipoles_[n] = options_["PERTURB_DIPOLE"][n].to_double();
+                for (int n = 0; n < 3; ++n) perturb_dipoles_[n] = options_["PERTURB_DIPOLE"][n].to_double();
                 nuclearrep_ += perturb_dipoles_.dot(molecule_->nuclear_dipole());
             } else if (perturb_with == "EMBPOT") {
                 perturb_ = embpot;
                 perturb_dipoles_[0] = 1.0;
-            }
-            else if (perturb_with == "DX") {
+            } else if (perturb_with == "DX") {
                 perturb_ = dx;
                 perturb_dipoles_[0] = 1.0;
-            }
-            else if (perturb_with == "SPHERE") {
+            } else if (perturb_with == "SPHERE") {
                 perturb_ = sphere;
                 perturb_dipoles_[0] = 1.0;
-            }
-            else {
-
-                    outfile->Printf( "Unknown PERTURB_WITH. Applying no perturbation.\n");
-
+            } else {
+                outfile->Printf("Unknown PERTURB_WITH. Applying no perturbation.\n");
             }
         } else {
-
-                outfile->Printf( "PERTURB_H is true, but PERTURB_WITH not found, applying no perturbation.\n");
-
+            outfile->Printf("PERTURB_H is true, but PERTURB_WITH not found, applying no perturbation.\n");
         }
     }
 
     // How much stuff shall we echo to the user?
-    if(options_["PRINT"].has_changed())
-        print_ = options_.get_int("PRINT");
+    if (options_["PRINT"].has_changed()) print_ = options_.get_int("PRINT");
 
-    if(options_["DAMPING_PERCENTAGE"].has_changed()){
+    if (options_["DAMPING_PERCENTAGE"].has_changed()) {
         // The user has asked for damping to be turned on
         damping_enabled_ = true;
         damping_percentage_ = options_.get_double("DAMPING_PERCENTAGE") / 100.0;
-        if(damping_percentage_ < 0.0 || damping_percentage_ > 1.0)
+        if (damping_percentage_ < 0.0 || damping_percentage_ > 1.0)
             throw PSIEXCEPTION("DAMPING_PERCENTAGE must be between 0 and 100.");
         damping_convergence_ = options_.get_double("DAMPING_CONVERGENCE");
-    }else{
+    } else {
         damping_enabled_ = false;
     }
 
@@ -370,12 +355,13 @@ void HF::common_init()
     print_header();
 
     // DFT stuff
-    if (functional_->needs_xc()){
-        potential_ = VBase::build_V(basisset_, functional_, options_, (options_.get_str("REFERENCE") == "RKS" ? "RV" : "UV"));
+    if (functional_->needs_xc()) {
+        potential_ =
+            VBase::build_V(basisset_, functional_, options_, (options_.get_str("REFERENCE") == "RKS" ? "RV" : "UV"));
         potential_->initialize();
 
         // Do the GRAC
-        if (options_.get_double("DFT_GRAC_SHIFT") != 0.0){
+        if (options_.get_double("DFT_GRAC_SHIFT") != 0.0) {
             potential_->set_grac_shift(options_.get_double("DFT_GRAC_SHIFT"));
         }
 
@@ -393,10 +379,14 @@ void HF::common_init()
     cphf_nfock_builds_ = 0;
     cphf_converged_ = false;
 
-    // Initialize PCM object, if requested
+// Initialize PCM object, if requested
 #ifdef USING_PCMSolver
-    if((pcm_enabled_ = (options_.get_bool("PCM"))))
-      hf_pcm_ = std::make_shared<PCM>(options_, psio_, nirrep_, basisset_);
+    if ((pcm_enabled_ = (options_.get_bool("PCM")))) {
+        if (nirrep_ > 1)
+            throw PSIEXCEPTION("You must add\n\n\tsymmetry c1\n\nto the molecule{} block to run the PCM code.");
+
+        hf_pcm_ = std::make_shared<PCM>(options_.get_int("PRINT"), basisset_);
+    }
 #endif
 }
 
@@ -411,28 +401,20 @@ int HF::soscf_update() {
         "Sorry, second-order convergence has not been implemented for this "
         "type of SCF wavefunction yet.");
 }
-void HF::form_V() {
-    throw PSIEXCEPTION(
-        "Sorry, DFT functionals are not suppored for this type of SCF wavefunction.");
-}
-void HF::form_C() {
-    throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct orbitals.");
-}
-void HF::form_D() {
-    throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct densities.");
-}
+void HF::form_V() { throw PSIEXCEPTION("Sorry, DFT functionals are not suppored for this type of SCF wavefunction."); }
+void HF::form_C() { throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct orbitals."); }
+void HF::form_D() { throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct densities."); }
 std::vector<SharedMatrix> HF::onel_Hx(std::vector<SharedMatrix> x) {
     throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct Hx products.");
 }
-std::vector<SharedMatrix> HF::twoel_Hx(std::vector<SharedMatrix> x, bool combine,
-                                       std::string return_basis) {
+std::vector<SharedMatrix> HF::twoel_Hx(std::vector<SharedMatrix> x, bool combine, std::string return_basis) {
     throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct Hx products.");
 }
 std::vector<SharedMatrix> HF::cphf_Hx(std::vector<SharedMatrix> x) {
     throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot construct cphf_Hx products.");
 }
 std::vector<SharedMatrix> HF::cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol, int max_iter,
-                                     int print_lvl) {
+                                         int print_lvl) {
     throw PSIEXCEPTION("Sorry, the base HF wavefunction cannot solve CPHF equations.");
 }
 void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
@@ -442,32 +424,30 @@ void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
 
     // We guess occ x vir block size by the size of x to make this method easy to use
     Dimension tsize = x->colspi() + x->rowspi();
-    if ((reference != "ROHF") && (tsize != nmopi_)){
+    if ((reference != "ROHF") && (tsize != nmopi_)) {
         throw PSIEXCEPTION("HF::rotate_orbitals: x dimensions do not match nmo_ dimension.");
     }
     tsize = x->colspi() + x->rowspi() - soccpi_;
-    if ((reference == "ROHF") && (tsize != nmopi_)){
+    if ((reference == "ROHF") && (tsize != nmopi_)) {
         throw PSIEXCEPTION("HF::rotate_orbitals: x dimensions do not match nmo_ dimension.");
     }
 
     // Form full antisymmetric matrix
-    for (size_t h=0; h<nirrep_; h++){
-
+    for (size_t h = 0; h < nirrep_; h++) {
         // Whatever the dimension are, we set top right/bot left
         size_t doccpih = (size_t)x->rowspi()[h];
         size_t virpih = (size_t)x->colspi()[h];
         if (!doccpih || !virpih) continue;
         double** up = U->pointer(h);
-        double*  xp = x->pointer(h)[0];
+        double* xp = x->pointer(h)[0];
 
         // Matrix::schmidt orthogonalizes rows not columns so we need to transpose
-        for (size_t i=0, target=0; i<doccpih; i++){
-            for (size_t a=(nmopi_[h] - virpih); a < nmopi_[h]; a++){
+        for (size_t i = 0, target = 0; i < doccpih; i++) {
+            for (size_t a = (nmopi_[h] - virpih); a < nmopi_[h]; a++) {
                 up[a][i] = xp[target];
                 up[i][a] = -1.0 * xp[target++];
             }
         }
-
     }
     U->expm(4, true);
 
@@ -478,39 +458,36 @@ void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     U.reset();
     tmp.reset();
 }
-void HF::integrals()
-{
-    if (print_ )
-        outfile->Printf( "  ==> Integral Setup <==\n\n");
+void HF::integrals() {
+    if (print_) outfile->Printf("  ==> Integral Setup <==\n\n");
 
     // Build the JK from options, symmetric type
     // try {
-    if(options_.get_str("SCF_TYPE") == "GTFOCK") {
-      #ifdef HAVE_JK_FACTORY
-        //DGAS is adding to the ghetto, this Python -> C++ -> C -> C++ -> back to C is FUBAR
+    if (options_.get_str("SCF_TYPE") == "GTFOCK") {
+#ifdef HAVE_JK_FACTORY
+        // DGAS is adding to the ghetto, this Python -> C++ -> C -> C++ -> back to C is FUBAR
         std::shared_ptr<Molecule> other_legacy = Process::environment.legacy_molecule();
         Process::environment.set_legacy_molecule(molecule_);
-        if(options_.get_bool("SOSCF"))
-            jk_ = std::make_shared<GTFockJK>(basisset_,2,false);
+        if (options_.get_bool("SOSCF"))
+            jk_ = std::make_shared<GTFockJK>(basisset_, 2, false);
         else
-            jk_ = std::make_shared<GTFockJK>(basisset_,2,true);
+            jk_ = std::make_shared<GTFockJK>(basisset_, 2, true);
         Process::environment.set_legacy_molecule(other_legacy);
-      #else
+#else
         throw PSIEXCEPTION("GTFock was not compiled in this version.\n");
-      #endif
+#endif
     } else {
-        if (options_.get_str("SCF_TYPE") == "DF"){
+        if (options_.get_str("SCF_TYPE") == "DF") {
             jk_ = JK::build_JK(get_basisset("ORBITAL"), get_basisset("DF_BASIS_SCF"), options_);
         } else {
             jk_ = JK::build_JK(get_basisset("ORBITAL"), BasisSet::zero_ao_basis_set(), options_);
-
         }
     }
 
     // Tell the JK to print
     jk_->set_print(print_);
     // Give the JK 75% of the memory
-    jk_->set_memory((size_t)(options_.get_double("SCF_MEM_SAFETY_FACTOR")*(Process::environment.get_memory() / 8L)));
+    jk_->set_memory((size_t)(options_.get_double("SCF_MEM_SAFETY_FACTOR") * (Process::environment.get_memory() / 8L)));
 
     // DFT sometimes needs custom stuff
     // K matrices
@@ -526,61 +503,57 @@ void HF::integrals()
     jk_->print_header();
 }
 
-double HF::compute_energy()
-{
-  initialize();
-  iterations();
-  return finalize_E();
+double HF::compute_energy() {
+    initialize();
+    iterations();
+    return finalize_E();
 }
 
-double HF::finalize_E()
-{
+double HF::finalize_E() {
     // Perform wavefunction stability analysis before doing
     // anything on a wavefunction that may not be truly converged.
-    if(options_.get_str("STABILITY_ANALYSIS") != "NONE") {
+    if (options_.get_str("STABILITY_ANALYSIS") != "NONE") {
         // We need the integral file, make sure it is written and
         // compute it if needed
-        if(options_.get_str("REFERENCE") != "UHF") {
+        if (options_.get_str("REFERENCE") != "UHF") {
             psio_->open(PSIF_SO_TEI, PSIO_OPEN_OLD);
             if (psio_->tocscan(PSIF_SO_TEI, IWL_KEY_BUF) == nullptr) {
-                psio_->close(PSIF_SO_TEI,1);
+                psio_->close(PSIF_SO_TEI, 1);
                 outfile->Printf("    SO Integrals not on disk, computing...");
                 auto mints = std::make_shared<MintsHelper>(basisset_, options_, 0);
                 mints->integrals();
                 outfile->Printf("done.\n");
             } else {
-                psio_->close(PSIF_SO_TEI,1);
+                psio_->close(PSIF_SO_TEI, 1);
             }
-
         }
         bool follow = stability_analysis();
 
-        while ( follow && !(attempt_number_ > max_attempts_) ) {
+        while (follow && !(attempt_number_ > max_attempts_)) {
+            attempt_number_++;
+            outfile->Printf("    Running SCF again with the rotated orbitals.\n");
 
-          attempt_number_++;
-          outfile->Printf("    Running SCF again with the rotated orbitals.\n");
-
-          if(initialized_diis_manager_) diis_manager_->reset_subspace();
-          // Reading the rotated orbitals in before starting iterations
-          form_D();
-          E_ = compute_initial_E();
-          iterations();
-          follow = stability_analysis();
+            if (initialized_diis_manager_) diis_manager_->reset_subspace();
+            // Reading the rotated orbitals in before starting iterations
+            form_D();
+            E_ = compute_initial_E();
+            iterations();
+            follow = stability_analysis();
         }
-        if ( follow && (attempt_number_ > max_attempts_) ) {
-          outfile->Printf( "    There's still a negative eigenvalue. Try modifying FOLLOW_STEP_SCALE\n");
-          outfile->Printf("    or increasing MAX_ATTEMPTS (not available for PK integrals).\n");
+        if (follow && (attempt_number_ > max_attempts_)) {
+            outfile->Printf("    There's still a negative eigenvalue. Try modifying FOLLOW_STEP_SCALE\n");
+            outfile->Printf("    or increasing MAX_ATTEMPTS (not available for PK integrals).\n");
         }
     }
 
-    // At this point, we are not doing any more SCF cycles
-    // and we can compute and print final quantities.
+// At this point, we are not doing any more SCF cycles
+// and we can compute and print final quantities.
 #ifdef USING_libefp
-    if ( Process::environment.get_efp()->get_frag_count() > 0 ) {
+    if (Process::environment.get_efp()->get_frag_count() > 0) {
         Process::environment.get_efp()->compute();
 
-        double efp_wfn_independent_energy = Process::environment.globals["EFP TOTAL ENERGY"] -
-                                            Process::environment.globals["EFP IND ENERGY"];
+        double efp_wfn_independent_energy =
+            Process::environment.globals["EFP TOTAL ENERGY"] - Process::environment.globals["EFP IND ENERGY"];
         energies_["EFP"] = Process::environment.globals["EFP TOTAL ENERGY"];
 
         outfile->Printf("    EFP excluding EFP Induction   %20.12f [Eh]\n", efp_wfn_independent_energy);
@@ -592,7 +565,7 @@ double HF::finalize_E()
     }
 #endif
 
-    outfile->Printf( "\n  ==> Post-Iterations <==\n\n");
+    outfile->Printf("\n  ==> Post-Iterations <==\n\n");
 
     check_phases();
     compute_spin_contamination();
@@ -600,71 +573,69 @@ double HF::finalize_E()
     std::string reference = options_.get_str("REFERENCE");
 
     if (converged_ || !fail_on_maxiter_) {
-
         // Print the orbitals
-        if(print_)
-            print_orbitals();
+        if (print_) print_orbitals();
 
         if (converged_) {
-            outfile->Printf( "  Energy converged.\n\n");
+            outfile->Printf("  Energy converged.\n\n");
         }
         if (!converged_) {
-            outfile->Printf( "  Energy did not converge, but proceeding anyway.\n\n");
+            outfile->Printf("  Energy did not converge, but proceeding anyway.\n\n");
         }
 
         bool df = (options_.get_str("SCF_TYPE") == "DF");
 
-        outfile->Printf( "  @%s%s Final Energy: %20.14f", df ? "DF-" : "", reference.c_str(), E_);
+        outfile->Printf("  @%s%s Final Energy: %20.14f", df ? "DF-" : "", reference.c_str(), E_);
         if (perturb_h_) {
-            outfile->Printf( " with %f %f %f perturbation", perturb_dipoles_[0], perturb_dipoles_[1], perturb_dipoles_[2]);
+            outfile->Printf(" with %f %f %f perturbation", perturb_dipoles_[0], perturb_dipoles_[1],
+                            perturb_dipoles_[2]);
         }
-        outfile->Printf( "\n\n");
+        outfile->Printf("\n\n");
         print_energies();
 
         // Need to recompute the Fock matrices, as they are modified during the SCF iteration
         // and might need to be dumped to checkpoint later
         form_F();
 #ifdef USING_PCMSolver
-        if(pcm_enabled_) {
+        if (pcm_enabled_) {
             // Prepare the density
             SharedMatrix D_pcm(Da_->clone());
-            if(same_a_b_orbs()) {
-              D_pcm->scale(2.0); // PSI4's density doesn't include the occupation
-            }
-            else {
-              D_pcm->add(Db_);
+            if (same_a_b_orbs()) {
+                D_pcm->scale(2.0);  // PSI4's density doesn't include the occupation
+            } else {
+                D_pcm->add(Db_);
             }
 
             // Add the PCM potential to the Fock matrix
             SharedMatrix V_pcm;
             V_pcm = hf_pcm_->compute_V();
-            if(same_a_b_orbs()) Fa_->add(V_pcm);
+            if (same_a_b_orbs())
+                Fa_->add(V_pcm);
             else {
-              Fa_->add(V_pcm);
-              Fb_->add(V_pcm);
+                Fa_->add(V_pcm);
+                Fb_->add(V_pcm);
             }
         }
 #endif
 
         // Properties
-//  Comments so that autodoc utility will find these PSI variables
-//
-//  Process::environment.globals["SCF DIPOLE X"] =
-//  Process::environment.globals["SCF DIPOLE Y"] =
-//  Process::environment.globals["SCF DIPOLE Z"] =
-//  Process::environment.globals["SCF QUADRUPOLE XX"] =
-//  Process::environment.globals["SCF QUADRUPOLE XY"] =
-//  Process::environment.globals["SCF QUADRUPOLE XZ"] =
-//  Process::environment.globals["SCF QUADRUPOLE YY"] =
-//  Process::environment.globals["SCF QUADRUPOLE YZ"] =
-//  Process::environment.globals["SCF QUADRUPOLE ZZ"] =
+        //  Comments so that autodoc utility will find these PSI variables
+        //
+        //  Process::environment.globals["SCF DIPOLE X"] =
+        //  Process::environment.globals["SCF DIPOLE Y"] =
+        //  Process::environment.globals["SCF DIPOLE Z"] =
+        //  Process::environment.globals["SCF QUADRUPOLE XX"] =
+        //  Process::environment.globals["SCF QUADRUPOLE XY"] =
+        //  Process::environment.globals["SCF QUADRUPOLE XZ"] =
+        //  Process::environment.globals["SCF QUADRUPOLE YY"] =
+        //  Process::environment.globals["SCF QUADRUPOLE YZ"] =
+        //  Process::environment.globals["SCF QUADRUPOLE ZZ"] =
 
         save_information();
     } else {
-            outfile->Printf( "  Failed to converge.\n");
+        outfile->Printf("  Failed to converge.\n");
         E_ = 0.0;
-        if(psio_->open_check(PSIF_CHKPT))
-            psio_->close(PSIF_CHKPT, 1);
+        if (psio_->open_check(PSIF_CHKPT)) psio_->close(PSIF_CHKPT, 1);
 
         // Throw if we didn't converge?
         die_if_not_converged();
@@ -675,14 +646,12 @@ double HF::finalize_E()
 
     finalize();
 
-    //outfile->Printf("\nComputation Completed\n");
+    // outfile->Printf("\nComputation Completed\n");
 
     return E_;
-
 }
 
-void HF::finalize()
-{
+void HF::finalize() {
     // Clean memory off, handle diis closeout, etc
 
     // This will be the only one
@@ -691,8 +660,7 @@ void HF::finalize()
     }
 
     // Clean up after DIIS
-    if(initialized_diis_manager_)
-        diis_manager_->delete_diis_file();
+    if (initialized_diis_manager_) diis_manager_->delete_diis_file();
     diis_manager_.reset();
     initialized_diis_manager_ = false;
 
@@ -701,23 +669,17 @@ void HF::finalize()
     compute_fvpi();
     energy_ = E_;
 
-    //Sphalf_.reset();
+    // Sphalf_.reset();
     X_.reset();
     T_.reset();
     diag_temp_.reset();
     diag_F_temp_.reset();
     diag_C_temp_.reset();
-
-
 }
 
-void HF::semicanonicalize()
-{
-    throw PSIEXCEPTION("This type of wavefunction cannot be semicanonicalized!");
-}
+void HF::semicanonicalize() { throw PSIEXCEPTION("This type of wavefunction cannot be semicanonicalized!"); }
 
-void HF::find_occupation()
-{
+void HF::find_occupation() {
     // Don't mess with the occ, MOM's got it!
     if (MOM_started_) {
         MOM();
@@ -725,7 +687,7 @@ void HF::find_occupation()
         std::vector<std::pair<double, int> > pairs_a;
         std::vector<std::pair<double, int> > pairs_b;
         for (int h = 0; h < epsilon_a_->nirrep(); ++h) {
-            for (int i = 0; i < epsilon_a_->dimpi()[h]; ++i){
+            for (int i = 0; i < epsilon_a_->dimpi()[h]; ++i) {
                 pairs_a.push_back(std::make_pair(epsilon_a_->get(h, i), h));
             }
         }
@@ -737,29 +699,26 @@ void HF::find_occupation()
 
         } else {
             for (int h = 0; h < epsilon_b_->nirrep(); ++h) {
-                for (int i = 0; i < epsilon_b_->dimpi()[h]; ++i){
+                for (int i = 0; i < epsilon_b_->dimpi()[h]; ++i) {
                     pairs_b.push_back(std::make_pair(epsilon_b_->get(h, i), h));
                 }
             }
             sort(pairs_b.begin(), pairs_b.end());
         }
 
-        if(!input_docc_ && !input_socc_){
-
+        if (!input_docc_ && !input_socc_) {
             // Alpha
             memset(nalphapi_, 0, sizeof(int) * epsilon_a_->nirrep());
-            for (int i=0; i<nalpha_; ++i)
-                nalphapi_[pairs_a[i].second]++;
+            for (int i = 0; i < nalpha_; ++i) nalphapi_[pairs_a[i].second]++;
 
             // Beta
             memset(nbetapi_, 0, sizeof(int) * epsilon_b_->nirrep());
-            for (int i=0; i<nbeta_; ++i)
-                nbetapi_[pairs_b[i].second]++;
+            for (int i = 0; i < nbeta_; ++i) nbetapi_[pairs_b[i].second]++;
         }
 
         int old_socc[8];
         int old_docc[8];
-        for(int h = 0; h < nirrep_; ++h){
+        for (int h = 0; h < nirrep_; ++h) {
             old_socc[h] = soccpi_[h];
             old_docc[h] = doccpi_[h];
         }
@@ -792,81 +751,70 @@ void HF::find_occupation()
     frac();
 }
 
-void HF::print_header()
-{
+void HF::print_header() {
     int nthread = 1;
-    #ifdef _OPENMP
-        nthread = Process::environment.get_n_threads();
-    #endif
+#ifdef _OPENMP
+    nthread = Process::environment.get_n_threads();
+#endif
 
-
-    outfile->Printf( "\n");
-    outfile->Printf( "         ---------------------------------------------------------\n");
-    outfile->Printf( "                                   SCF\n");
-    outfile->Printf( "            by Justin Turney, Rob Parrish, Andy Simmonett\n");
-    outfile->Printf( "                             and Daniel Smith\n");
-    outfile->Printf( "                             %4s Reference\n", options_.get_str("REFERENCE").c_str());
-    outfile->Printf( "                      %3d Threads, %6ld MiB Core\n", nthread, memory_ / 1048576L);
-    outfile->Printf( "         ---------------------------------------------------------\n");
-    outfile->Printf( "\n");
-    outfile->Printf( "  ==> Geometry <==\n\n");
-
+    outfile->Printf("\n");
+    outfile->Printf("         ---------------------------------------------------------\n");
+    outfile->Printf("                                   SCF\n");
+    outfile->Printf("            by Justin Turney, Rob Parrish, Andy Simmonett\n");
+    outfile->Printf("                             and Daniel Smith\n");
+    outfile->Printf("                             %4s Reference\n", options_.get_str("REFERENCE").c_str());
+    outfile->Printf("                      %3d Threads, %6ld MiB Core\n", nthread, memory_ / 1048576L);
+    outfile->Printf("         ---------------------------------------------------------\n");
+    outfile->Printf("\n");
+    outfile->Printf("  ==> Geometry <==\n\n");
 
     molecule_->print();
 
-
-    outfile->Printf( "  Running in %s symmetry.\n\n", molecule_->point_group()->symbol().c_str());
+    outfile->Printf("  Running in %s symmetry.\n\n", molecule_->point_group()->symbol().c_str());
 
     molecule_->print_rotational_constants();
 
-    outfile->Printf( "  Nuclear repulsion = %20.15f\n\n", nuclearrep_);
-    outfile->Printf( "  Charge       = %d\n", charge_);
-    outfile->Printf( "  Multiplicity = %d\n", multiplicity_);
-    outfile->Printf( "  Electrons    = %d\n", nelectron_);
-    outfile->Printf( "  Nalpha       = %d\n", nalpha_);
-    outfile->Printf( "  Nbeta        = %d\n\n", nbeta_);
+    outfile->Printf("  Nuclear repulsion = %20.15f\n\n", nuclearrep_);
+    outfile->Printf("  Charge       = %d\n", charge_);
+    outfile->Printf("  Multiplicity = %d\n", multiplicity_);
+    outfile->Printf("  Electrons    = %d\n", nelectron_);
+    outfile->Printf("  Nalpha       = %d\n", nalpha_);
+    outfile->Printf("  Nbeta        = %d\n\n", nbeta_);
 
-    outfile->Printf( "  ==> Algorithm <==\n\n");
-    outfile->Printf( "  SCF Algorithm Type is %s.\n", options_.get_str("SCF_TYPE").c_str());
-    outfile->Printf( "  DIIS %s.\n", diis_enabled_ ? "enabled" : "disabled");
+    outfile->Printf("  ==> Algorithm <==\n\n");
+    outfile->Printf("  SCF Algorithm Type is %s.\n", options_.get_str("SCF_TYPE").c_str());
+    outfile->Printf("  DIIS %s.\n", diis_enabled_ ? "enabled" : "disabled");
     if (MOM_excited_)
-        outfile->Printf( "  Excited-state MOM enabled.\n");
+        outfile->Printf("  Excited-state MOM enabled.\n");
     else
-        outfile->Printf( "  MOM %s.\n", MOM_enabled_ ? "enabled" : "disabled");
-    outfile->Printf( "  Fractional occupation %s.\n", frac_enabled_ ? "enabled" : "disabled");
-    outfile->Printf( "  Guess Type is %s.\n", options_.get_str("GUESS").c_str());
-    outfile->Printf( "  Energy threshold   = %3.2e\n", energy_threshold_);
-    outfile->Printf( "  Density threshold  = %3.2e\n", density_threshold_);
-    outfile->Printf( "  Integral threshold = %3.2e\n\n", integral_threshold_);
+        outfile->Printf("  MOM %s.\n", MOM_enabled_ ? "enabled" : "disabled");
+    outfile->Printf("  Fractional occupation %s.\n", frac_enabled_ ? "enabled" : "disabled");
+    outfile->Printf("  Guess Type is %s.\n", options_.get_str("GUESS").c_str());
+    outfile->Printf("  Energy threshold   = %3.2e\n", energy_threshold_);
+    outfile->Printf("  Density threshold  = %3.2e\n", density_threshold_);
+    outfile->Printf("  Integral threshold = %3.2e\n\n", integral_threshold_);
 
-
-    outfile->Printf( "  ==> Primary Basis <==\n\n");
+    outfile->Printf("  ==> Primary Basis <==\n\n");
 
     basisset_->print_by_level("outfile", print_);
 }
 
-
-void HF::print_preiterations()
-{
+void HF::print_preiterations() {
     CharacterTable ct = molecule_->point_group()->char_table();
 
-
-    outfile->Printf( "   -------------------------------------------------------\n");
-    outfile->Printf( "    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc\n");
-    outfile->Printf( "   -------------------------------------------------------\n");
-    for (int h= 0; h < nirrep_; h++) {
-        outfile->Printf("     %-3s   %6d  %6d  %6d  %6d  %6d  %6d\n",
-                        ct.gamma(h).symbol(), nsopi_[h], nmopi_[h],
+    outfile->Printf("   -------------------------------------------------------\n");
+    outfile->Printf("    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc\n");
+    outfile->Printf("   -------------------------------------------------------\n");
+    for (int h = 0; h < nirrep_; h++) {
+        outfile->Printf("     %-3s   %6d  %6d  %6d  %6d  %6d  %6d\n", ct.gamma(h).symbol(), nsopi_[h], nmopi_[h],
                         nalphapi_[h], nbetapi_[h], doccpi_[h], soccpi_[h]);
     }
-    outfile->Printf( "   -------------------------------------------------------\n");
-    outfile->Printf("    Total  %6d  %6d  %6d  %6d  %6d  %6d\n", nso_, nmo_,
-                    nalpha_, nbeta_, nbeta_, nalpha_ - nbeta_);
+    outfile->Printf("   -------------------------------------------------------\n");
+    outfile->Printf("    Total  %6d  %6d  %6d  %6d  %6d  %6d\n", nso_, nmo_, nalpha_, nbeta_, nbeta_, nalpha_ - nbeta_);
     outfile->Printf("   -------------------------------------------------------\n\n");
 }
 
-void HF::form_H()
-{
+void HF::form_H() {
     T_ = SharedMatrix(factory_->create_matrix(PSIF_SO_T));
     V_ = SharedMatrix(factory_->create_matrix(PSIF_SO_V));
 
@@ -874,128 +822,117 @@ void HF::form_H()
     T_->load(psio_, PSIF_OEI);
     V_->load(psio_, PSIF_OEI);
 
-    if (debug_ > 2)
-        T_->print("outfile");
+    if (debug_ > 2) T_->print("outfile");
 
-    if (debug_ > 2)
-        V_->print("outfile");
+    if (debug_ > 2) V_->print("outfile");
 
     if (perturb_h_) {
-      if(perturb_ == embpot || perturb_ == sphere || perturb_ == dx) { // embedding potential read from file
-        if(nirrep_ > 1)
-          throw PSIEXCEPTION("RHF_embed: embedding, dx, and spherical potentials require 'symmetry c1'.");
-        int nso = 0;
-        for(int h=0; h < nirrep_; h++) nso += nsopi_[h];
-        int nao = basisset_->nao();
+        if (perturb_ == embpot || perturb_ == sphere || perturb_ == dx) {  // embedding potential read from file
+            if (nirrep_ > 1)
+                throw PSIEXCEPTION("RHF_embed: embedding, dx, and spherical potentials require 'symmetry c1'.");
+            int nso = 0;
+            for (int h = 0; h < nirrep_; h++) nso += nsopi_[h];
+            int nao = basisset_->nao();
 
-        // Set up AO->SO transformation matrix (u)
-        MintsHelper helper(basisset_, options_, 0);
-        SharedMatrix aotoso = helper.petite_list(true)->aotoso();
-        int *col_offset = new int[nirrep_];
-        col_offset[0] = 0;
-        for(int h=1; h < nirrep_; h++)
-          col_offset[h] = col_offset[h-1] + aotoso->coldim(h-1);
+            // Set up AO->SO transformation matrix (u)
+            MintsHelper helper(basisset_, options_, 0);
+            SharedMatrix aotoso = helper.petite_list(true)->aotoso();
+            int* col_offset = new int[nirrep_];
+            col_offset[0] = 0;
+            for (int h = 1; h < nirrep_; h++) col_offset[h] = col_offset[h - 1] + aotoso->coldim(h - 1);
 
-        double **u = block_matrix(nao, nso);
-        for(int h=0; h < nirrep_; h++)
-          for(int j=0; j < aotoso->coldim(h); j++)
-            for(int i=0; i < nao; i++)
-              u[i][j+col_offset[h]] = aotoso->get(h, i, j);
-        delete[] col_offset;
+            double** u = block_matrix(nao, nso);
+            for (int h = 0; h < nirrep_; h++)
+                for (int j = 0; j < aotoso->coldim(h); j++)
+                    for (int i = 0; i < nao; i++) u[i][j + col_offset[h]] = aotoso->get(h, i, j);
+            delete[] col_offset;
 
-        double *phi_ao, *phi_so, **V_eff;
-        phi_ao = init_array(nao);
-        phi_so = init_array(nso);
-        V_eff = block_matrix(nso, nso);
+            double *phi_ao, *phi_so, **V_eff;
+            phi_ao = init_array(nao);
+            phi_so = init_array(nso);
+            V_eff = block_matrix(nso, nso);
 
-        if(perturb_ == embpot) {
+            if (perturb_ == embpot) {
+                FILE* input = fopen("EMBPOT", "r");
+                int npoints;
+                int statusvalue = fscanf(input, "%d", &npoints);
+                outfile->Printf("  npoints = %d\n", npoints);
+                double x, y, z, w, v;
+                double max = 0;
+                for (int k = 0; k < npoints; k++) {
+                    statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
+                    if (std::fabs(v) > max) max = std::fabs(v);
 
-          FILE* input = fopen("EMBPOT", "r");
-          int npoints;
-          int statusvalue=fscanf(input, "%d", &npoints);
-          outfile->Printf( "  npoints = %d\n", npoints);
-          double x, y, z, w, v;
-          double max = 0;
-          for(int k=0; k < npoints; k++) {
-            statusvalue=fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
-            if(std::fabs(v) > max) max = std::fabs(v);
+                    basisset_->compute_phi(phi_ao, x, y, z);
+                    // Transform phi_ao to SO basis
+                    C_DGEMV('t', nao, nso, 1.0, &(u[0][0]), nso, &(phi_ao[0]), 1, 0.0, &(phi_so[0]), 1);
+                    for (int i = 0; i < nso; i++)
+                        for (int j = 0; j < nso; j++) V_eff[i][j] += w * v * phi_so[i] * phi_so[j];
+                }  // npoints
 
-            basisset_->compute_phi(phi_ao, x, y, z);
-            // Transform phi_ao to SO basis
-            C_DGEMV('t', nao, nso, 1.0, &(u[0][0]), nso, &(phi_ao[0]), 1, 0.0, &(phi_so[0]), 1);
-            for(int i=0; i < nso; i++)
-              for(int j=0; j < nso; j++)
-                V_eff[i][j] += w * v * phi_so[i] * phi_so[j];
-          } // npoints
+                outfile->Printf("  Max. embpot value = %20.10f\n", max);
+                fclose(input);
 
-          outfile->Printf( "  Max. embpot value = %20.10f\n", max);
-          fclose(input);
+            }  // embpot
+            else if (perturb_ == dx) {
+                dx_read(V_eff, phi_ao, phi_so, nao, nso, u);
 
-        } // embpot
-        else if(perturb_ == dx) {
-          dx_read(V_eff, phi_ao, phi_so, nao, nso, u);
+            }  // dx file
+            else if (perturb_ == sphere) {
+                radius_ = options_.get_double("RADIUS");
+                thickness_ = options_.get_double("THICKNESS");
+                r_points_ = options_.get_int("R_POINTS");
+                theta_points_ = options_.get_int("THETA_POINTS");
+                phi_points_ = options_.get_int("PHI_POINTS");
+                outfile->Printf("  Hard spherical potential radius         = %3.2f bohr\n", radius_);
+                outfile->Printf("  Spherical potential thickness           = %3.2f bohr\n", thickness_);
+                outfile->Printf("  Number of radial integration points     = %d\n", r_points_);
+                outfile->Printf("  Number of colatitude integration points = %d\n", theta_points_);
+                outfile->Printf("  Number of azimuthal integration points  = %d\n", phi_points_);
 
-        } // dx file
-        else if(perturb_ == sphere) {
-          radius_ = options_.get_double("RADIUS");
-          thickness_ = options_.get_double("THICKNESS");
-          r_points_ = options_.get_int("R_POINTS");
-          theta_points_ = options_.get_int("THETA_POINTS");
-          phi_points_ = options_.get_int("PHI_POINTS");
-          outfile->Printf( "  Hard spherical potential radius         = %3.2f bohr\n", radius_);
-          outfile->Printf( "  Spherical potential thickness           = %3.2f bohr\n", thickness_);
-          outfile->Printf( "  Number of radial integration points     = %d\n", r_points_);
-          outfile->Printf( "  Number of colatitude integration points = %d\n", theta_points_);
-          outfile->Printf( "  Number of azimuthal integration points  = %d\n", phi_points_);
+                double r_step = thickness_ / r_points_;         // bohr
+                double theta_step = 2 * pc_pi / theta_points_;  // 1 degree in radians
+                double phi_step = 2 * pc_pi / phi_points_;      // 1 degree in radians
+                double weight = r_step * theta_step * phi_step;
+                for (double r = radius_; r < radius_ + thickness_; r += r_step) {
+                    for (double theta = 0.0; theta < pc_pi; theta += theta_step) { /* colatitude */
+                        for (double phi = 0.0; phi < 2 * pc_pi; phi += phi_step) { /* azimuthal */
 
-          double r_step = thickness_/r_points_; // bohr
-          double theta_step = 2*pc_pi/theta_points_; // 1 degree in radians
-          double phi_step = 2*pc_pi/phi_points_; // 1 degree in radians
-          double weight = r_step * theta_step * phi_step;
-          for(double r=radius_; r < radius_+thickness_; r += r_step) {
-            for(double theta=0.0; theta < pc_pi; theta += theta_step) {  /* colatitude */
-              for(double phi=0.0; phi < 2*pc_pi; phi += phi_step) { /* azimuthal */
+                            double x = r * sin(theta) * cos(phi);
+                            double y = r * sin(theta) * sin(phi);
+                            double z = r * cos(theta);
 
-                double x = r * sin(theta) * cos(phi);
-                double y = r * sin(theta) * sin(phi);
-                double z = r * cos(theta);
+                            double jacobian = weight * r * r * sin(theta);
 
-                double jacobian = weight * r * r * sin(theta);
+                            basisset_->compute_phi(phi_ao, x, y, z);
 
-                basisset_->compute_phi(phi_ao, x, y, z);
+                            C_DGEMV('t', nao, nso, 1.0, &(u[0][0]), nso, &(phi_ao[0]), 1, 0.0, &(phi_so[0]), 1);
 
-                C_DGEMV('t', nao, nso, 1.0, &(u[0][0]), nso, &(phi_ao[0]), 1,
-                        0.0, &(phi_so[0]), 1);
+                            for (int i = 0; i < nso; i++)
+                                for (int j = 0; j < nso; j++)
+                                    V_eff[i][j] += jacobian * (-1.0e6) * phi_so[i] * phi_so[j];
+                        }
+                    }
+                }
+            }  // sphere
 
-                for(int i=0; i < nso; i++)
-                  for(int j=0; j < nso; j++)
-                    V_eff[i][j] += jacobian * (-1.0e6) * phi_so[i] * phi_so[j];
-              }
+            outfile->Printf("  Perturbing H by %f %f %f V_eff.\n", perturb_dipoles_[0], perturb_dipoles_[1],
+                            perturb_dipoles_[2]);
+            if (options_.get_int("PRINT") > 3) mat_print(V_eff, nso, nso, "outfile");
+
+            if (perturb_ == dx) {
+                for (int i = 0; i < nso; i++)
+                    for (int j = 0; j < nso; j++) V_->set(i, j, V_eff[i][j]);  // ignore nuclear potential
+            } else {
+                for (int i = 0; i < nso; i++)
+                    for (int j = 0; j < nso; j++) V_->set(i, j, (V_eff[i][j] + V_->get(i, j)));
             }
-          }
-        } // sphere
 
-
-          outfile->Printf( "  Perturbing H by %f %f %f V_eff.\n", perturb_dipoles_[0], perturb_dipoles_[1], perturb_dipoles_[2]);
-          if(options_.get_int("PRINT") > 3) mat_print(V_eff, nso, nso, "outfile");
-
-
-        if(perturb_ == dx) {
-          for(int i=0; i < nso; i++)
-            for(int j=0; j < nso; j++)
-              V_->set(i, j, V_eff[i][j]); // ignore nuclear potential
-        }
-        else {
-          for(int i=0; i < nso; i++)
-            for(int j=0; j < nso; j++)
-              V_->set(i, j, (V_eff[i][j] + V_->get(i,j)));
-        }
-
-        free(phi_ao);
-        free(phi_so);
-        free_block(V_eff);
-      }  // embpot or sphere
-    } // end perturb_h_
+            free(phi_ao);
+            free(phi_so);
+            free_block(V_eff);
+        }  // embpot or sphere
+    }      // end perturb_h_
 
     // If an external field exists, add it to the one-electron Hamiltonian
     if (external_pot_) {
@@ -1015,17 +952,15 @@ void HF::form_H()
             external_pot_->set_print(print_);
             external_pot_->print();
         }
-        if (print_ > 3)
-            Vprime->print();
+        if (print_ > 3) Vprime->print();
         V_->add(Vprime);
-
 
         // Extra nuclear repulsion
         double enuc2 = external_pot_->computeNuclearEnergy(molecule_);
         if (print_) {
-               outfile->Printf( "  Old nuclear repulsion        = %20.15f\n", nuclearrep_);
-               outfile->Printf( "  Additional nuclear repulsion = %20.15f\n", enuc2);
-               outfile->Printf( "  Total nuclear repulsion      = %20.15f\n\n", nuclearrep_ + enuc2);
+            outfile->Printf("  Old nuclear repulsion        = %20.15f\n", nuclearrep_);
+            outfile->Printf("  Additional nuclear repulsion = %20.15f\n", enuc2);
+            outfile->Printf("  Total nuclear repulsion      = %20.15f\n\n", nuclearrep_ + enuc2);
         }
         nuclearrep_ += enuc2;
 
@@ -1037,41 +972,37 @@ void HF::form_H()
     H_->copy(T_);
     H_->add(V_);
 
-    if (print_ > 3)
-        H_->print("outfile");
+    if (print_ > 3) H_->print("outfile");
 }
 
-void HF::form_Shalf()
-{
+void HF::form_Shalf() {
     // ==> SYMMETRIC ORTHOGONALIZATION <== //
 
     // S_ is computed by wavefunction
 
-    SharedMatrix eigvec= factory_->create_shared_matrix("L");
-    SharedMatrix eigtemp= factory_->create_shared_matrix("Temp");
-    SharedMatrix eigtemp2= factory_->create_shared_matrix("Temp2");
-    SharedMatrix eigvec_store= factory_->create_shared_matrix("TempStore");
+    SharedMatrix eigvec = factory_->create_shared_matrix("L");
+    SharedMatrix eigtemp = factory_->create_shared_matrix("Temp");
+    SharedMatrix eigtemp2 = factory_->create_shared_matrix("Temp2");
+    SharedMatrix eigvec_store = factory_->create_shared_matrix("TempStore");
     SharedVector eigval(factory_->create_vector());
     SharedVector eigval_store(factory_->create_vector());
 
-    //Used to do this 3 times, now only once
+    // Used to do this 3 times, now only once
     S_->diagonalize(eigvec, eigval);
     eigvec_store->copy(eigvec);
     eigval_store->copy(eigval.get());
 
     // Convert the eigenvales to 1/sqrt(eigenvalues)
     const Dimension& dimpi = eigval->dimpi();
-    double min_S = std::fabs(eigval->get(0,0));
-    for (int h=0; h<nirrep_; ++h) {
-        for (int i=0; i<dimpi[h]; ++i) {
-            if (min_S > eigval->get(h,i))
-                min_S = eigval->get(h,i);
+    double min_S = std::fabs(eigval->get(0, 0));
+    for (int h = 0; h < nirrep_; ++h) {
+        for (int i = 0; i < dimpi[h]; ++i) {
+            if (min_S > eigval->get(h, i)) min_S = eigval->get(h, i);
             double scale = 1.0 / sqrt(eigval->get(h, i));
             eigval->set(h, i, scale);
         }
     }
-    if (print_ )
-        outfile->Printf("  Minimum eigenvalue in the overlap matrix is %14.10E.\n",min_S);
+    if (print_) outfile->Printf("  Minimum eigenvalue in the overlap matrix is %14.10E.\n", min_S);
     // Create a vector matrix from the converted eigenvalues
     eigtemp2->set_diagonal(eigval);
 
@@ -1083,24 +1014,20 @@ void HF::form_Shalf()
     // Decide symmetric or canonical
     double S_cutoff = options_.get_double("S_TOLERANCE");
     if (min_S > S_cutoff && options_.get_str("S_ORTHOGONALIZATION") == "SYMMETRIC") {
-
-        if (print_)
-            outfile->Printf("  Using Symmetric Orthogonalization.\n\n");
+        if (print_) outfile->Printf("  Using Symmetric Orthogonalization.\n\n");
 
     } else {
+        if (print_) outfile->Printf("  Using Canonical Orthogonalization with cutoff of %14.10E.\n", S_cutoff);
 
-        if (print_)
-            outfile->Printf("  Using Canonical Orthogonalization with cutoff of %14.10E.\n",S_cutoff);
-
-        //Diagonalize S (or just get a fresh copy)
+        // Diagonalize S (or just get a fresh copy)
         eigvec->copy(eigvec_store.get());
         eigval->copy(eigval_store.get());
         int delta_mos = 0;
-        for (int h=0; h<nirrep_; ++h) {
-            //in each irrep, scale significant cols i  by 1.0/sqrt(s_i)
+        for (int h = 0; h < nirrep_; ++h) {
+            // in each irrep, scale significant cols i  by 1.0/sqrt(s_i)
             int start_index = 0;
-            for (int i=0; i<dimpi[h]; ++i) {
-                if (S_cutoff  < eigval->get(h,i)) {
+            for (int i = 0; i < dimpi[h]; ++i) {
+                if (S_cutoff < eigval->get(h, i)) {
                     double scale = 1.0 / sqrt(eigval->get(h, i));
                     eigvec->scale_column(h, i, scale);
                 } else {
@@ -1109,52 +1036,49 @@ void HF::form_Shalf()
                     nmo_--;
                 }
             }
-            if (print_>2)
-                outfile->Printf("  Irrep %d, %d of %d possible MOs eliminated.\n",h,start_index,nsopi_[h]);
+            if (print_ > 2)
+                outfile->Printf("  Irrep %d, %d of %d possible MOs eliminated.\n", h, start_index, nsopi_[h]);
 
             delta_mos += start_index;
         }
 
-        X_->init(nirrep_,nsopi_,nmopi_,"X (Canonical Orthogonalization)");
-        for (int h=0; h<eigval->nirrep(); ++h) {
-            //Copy significant columns of eigvec into X in
-            //descending order
+        X_->init(nirrep_, nsopi_, nmopi_, "X (Canonical Orthogonalization)");
+        for (int h = 0; h < eigval->nirrep(); ++h) {
+            // Copy significant columns of eigvec into X in
+            // descending order
             int start_index = 0;
-            for (int i=0; i<dimpi[h]; ++i) {
-                if (S_cutoff  < eigval->get(h,i)) {
+            for (int i = 0; i < dimpi[h]; ++i) {
+                if (S_cutoff < eigval->get(h, i)) {
                 } else {
                     start_index++;
                 }
             }
-            for (int i=0; i<dimpi[h]-start_index; ++i) {
-                for (int m = 0; m < dimpi[h]; m++)
-                    X_->set(h,m,i,eigvec->get(h,m,dimpi[h]-i-1));
+            for (int i = 0; i < dimpi[h] - start_index; ++i) {
+                for (int m = 0; m < dimpi[h]; m++) X_->set(h, m, i, eigvec->get(h, m, dimpi[h] - i - 1));
             }
         }
 
-        if (print_)
-            outfile->Printf("  Overall, %d of %d possible MOs eliminated.\n\n",delta_mos,nso_);
+        if (print_) outfile->Printf("  Overall, %d of %d possible MOs eliminated.\n\n", delta_mos, nso_);
 
         // Double check occupation vectors
-        for(int h = 0; h < eigval->nirrep(); ++h) {
-          if(doccpi_[h]+soccpi_[h] > nmopi_[h]) {
-            throw PSIEXCEPTION("Not enough molecular orbitals to satisfy requested occupancies");
-          }
+        for (int h = 0; h < eigval->nirrep(); ++h) {
+            if (doccpi_[h] + soccpi_[h] > nmopi_[h]) {
+                throw PSIEXCEPTION("Not enough molecular orbitals to satisfy requested occupancies");
+            }
         }
 
         // Refreshes twice in RHF, no big deal
         epsilon_a_->init(nmopi_);
-        Ca_->init(nirrep_,nsopi_,nmopi_,"Alpha MO coefficients");
+        Ca_->init(nirrep_, nsopi_, nmopi_, "Alpha MO coefficients");
         epsilon_b_->init(nmopi_);
-        Cb_->init(nirrep_,nsopi_,nmopi_,"Beta MO coefficients");
+        Cb_->init(nirrep_, nsopi_, nmopi_, "Beta MO coefficients");
 
         // Extra matrix dimension changes for specific derived classes
         prepare_canonical_orthogonalization();
-
     }
 
     // Temporary variables needed by diagonalize_F
-    diag_temp_   = std::make_shared<Matrix>(nirrep_, nmopi_, nsopi_);
+    diag_temp_ = std::make_shared<Matrix>(nirrep_, nmopi_, nsopi_);
     diag_F_temp_ = std::make_shared<Matrix>(nirrep_, nmopi_, nmopi_);
     diag_C_temp_ = std::make_shared<Matrix>(nirrep_, nmopi_, nmopi_);
 
@@ -1162,11 +1086,9 @@ void HF::form_Shalf()
         S_->print("outfile");
         X_->print("outfile");
     }
-
 }
 
-void HF::compute_fcpi()
-{
+void HF::compute_fcpi() {
     // FROZEN_DOCC takes precedence, FREEZE_CORE directive has second priority
     if (options_["FROZEN_DOCC"].has_changed()) {
         if (options_["FROZEN_DOCC"].size() != epsilon_a_->nirrep()) {
@@ -1176,7 +1098,6 @@ void HF::compute_fcpi()
             frzcpi_[h] = options_["FROZEN_DOCC"][h].to_integer();
         }
     } else {
-
         int nfzc = 0;
         if (options_.get_int("NUM_FROZEN_DOCC") != 0) {
             nfzc = options_.get_int("NUM_FROZEN_DOCC");
@@ -1185,23 +1106,20 @@ void HF::compute_fcpi()
         }
         // Print out orbital energies.
         std::vector<std::pair<double, int> > pairs;
-        for (int h=0; h<epsilon_a_->nirrep(); ++h) {
-            for (int i=0; i<epsilon_a_->dimpi()[h]; ++i)
-                pairs.push_back(std::make_pair(epsilon_a_->get(h, i), h));
+        for (int h = 0; h < epsilon_a_->nirrep(); ++h) {
+            for (int i = 0; i < epsilon_a_->dimpi()[h]; ++i) pairs.push_back(std::make_pair(epsilon_a_->get(h, i), h));
             frzcpi_[h] = 0;
         }
-        sort(pairs.begin(),pairs.end());
+        sort(pairs.begin(), pairs.end());
 
-        for (int i=0; i<nfzc; ++i)
-            frzcpi_[pairs[i].second]++;
+        for (int i = 0; i < nfzc; ++i) frzcpi_[pairs[i].second]++;
     }
     // total frozen core
     nfrzc_ = 0;
     for (int h = 0; h < epsilon_a_->nirrep(); h++) nfrzc_ += frzcpi_[h];
 }
 
-void HF::compute_fvpi()
-{
+void HF::compute_fvpi() {
     // FROZEN_UOCC takes precedence, FREEZE_UOCC directive has second priority
     if (options_["FROZEN_UOCC"].has_changed()) {
         if (options_["FROZEN_UOCC"].size() != epsilon_a_->nirrep()) {
@@ -1214,58 +1132,48 @@ void HF::compute_fvpi()
         int nfzv = options_.get_int("NUM_FROZEN_UOCC");
         // Print out orbital energies.
         std::vector<std::pair<double, int> > pairs;
-        for (int h=0; h<epsilon_a_->nirrep(); ++h) {
-            for (int i=0; i<epsilon_a_->dimpi()[h]; ++i)
-                pairs.push_back(std::make_pair(epsilon_a_->get(h, i), h));
+        for (int h = 0; h < epsilon_a_->nirrep(); ++h) {
+            for (int i = 0; i < epsilon_a_->dimpi()[h]; ++i) pairs.push_back(std::make_pair(epsilon_a_->get(h, i), h));
             frzvpi_[h] = 0;
         }
-        sort(pairs.begin(),pairs.end(), std::greater<std::pair<double, int> >());
+        sort(pairs.begin(), pairs.end(), std::greater<std::pair<double, int> >());
 
-        for (int i=0; i<nfzv; ++i)
-            frzvpi_[pairs[i].second]++;
+        for (int i = 0; i < nfzv; ++i) frzvpi_[pairs[i].second]++;
     }
 }
 
-void HF::print_orbitals(const char* header, std::vector<std::pair<double, std::pair<std::string, int> > > orbs)
-{
-        outfile->Printf( "    %-70s\n\n    ", header);
-        int count = 0;
-        for (int i = 0; i < orbs.size(); i++) {
-            outfile->Printf( "%4d%-4s%11.6f  ", orbs[i].second.second, orbs[i].second.first.c_str(), orbs[i].first);
-            if (count++ % 3 == 2 && count != orbs.size())
-                outfile->Printf( "\n    ");
-        }
-        outfile->Printf( "\n\n");
+void HF::print_orbitals(const char* header, std::vector<std::pair<double, std::pair<std::string, int> > > orbs) {
+    outfile->Printf("    %-70s\n\n    ", header);
+    int count = 0;
+    for (int i = 0; i < orbs.size(); i++) {
+        outfile->Printf("%4d%-4s%11.6f  ", orbs[i].second.second, orbs[i].second.first.c_str(), orbs[i].first);
+        if (count++ % 3 == 2 && count != orbs.size()) outfile->Printf("\n    ");
+    }
+    outfile->Printf("\n\n");
 }
 
-void HF::print_orbitals()
-{
+void HF::print_orbitals() {
     std::vector<std::string> labels = molecule_->irrep_labels();
 
-    outfile->Printf( "    Orbital Energies (a.u.)\n    -----------------------\n\n");
+    outfile->Printf("    Orbital Energies (a.u.)\n    -----------------------\n\n");
 
     std::string reference = options_.get_str("REFERENCE");
-    if((reference == "RHF") || (reference == "RKS")){
-
+    if ((reference == "RHF") || (reference == "RKS")) {
         std::vector<std::pair<double, std::pair<std::string, int> > > occ;
         std::vector<std::pair<double, std::pair<std::string, int> > > vir;
 
         for (int h = 0; h < nirrep_; h++) {
-
             std::vector<std::pair<double, int> > orb_e;
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_e.push_back(std::make_pair(epsilon_a_->get(h,a), a));
+            for (int a = 0; a < nmopi_[h]; a++) orb_e.push_back(std::make_pair(epsilon_a_->get(h, a), a));
             std::sort(orb_e.begin(), orb_e.end());
 
             std::vector<int> orb_order(nmopi_[h]);
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_order[orb_e[a].second] = a;
+            for (int a = 0; a < nmopi_[h]; a++) orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occ.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
+                occ.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_order[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
-
+                vir.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_order[a] + 1)));
         }
         std::sort(occ.begin(), occ.end());
         std::sort(vir.begin(), vir.end());
@@ -1273,44 +1181,36 @@ void HF::print_orbitals()
         print_orbitals("Doubly Occupied:", occ);
         print_orbitals("Virtual:", vir);
 
-    }else if((reference == "UHF") || (reference == "UKS") ||
-        (reference == "CUHF")){
-
+    } else if ((reference == "UHF") || (reference == "UKS") || (reference == "CUHF")) {
         std::vector<std::pair<double, std::pair<std::string, int> > > occA;
         std::vector<std::pair<double, std::pair<std::string, int> > > virA;
         std::vector<std::pair<double, std::pair<std::string, int> > > occB;
         std::vector<std::pair<double, std::pair<std::string, int> > > virB;
 
         for (int h = 0; h < nirrep_; h++) {
-
             std::vector<std::pair<double, int> > orb_eA;
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_eA.push_back(std::make_pair(epsilon_a_->get(h,a), a));
+            for (int a = 0; a < nmopi_[h]; a++) orb_eA.push_back(std::make_pair(epsilon_a_->get(h, a), a));
             std::sort(orb_eA.begin(), orb_eA.end());
 
             std::vector<int> orb_orderA(nmopi_[h]);
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_orderA[orb_eA[a].second] = a;
+            for (int a = 0; a < nmopi_[h]; a++) orb_orderA[orb_eA[a].second] = a;
 
             for (int a = 0; a < nalphapi_[h]; a++)
-                occA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
+                occA.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_orderA[a] + 1)));
             for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
-                virA.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_orderA[a] + 1)));
+                virA.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_orderA[a] + 1)));
 
             std::vector<std::pair<double, int> > orb_eB;
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_eB.push_back(std::make_pair(epsilon_b_->get(h,a), a));
+            for (int a = 0; a < nmopi_[h]; a++) orb_eB.push_back(std::make_pair(epsilon_b_->get(h, a), a));
             std::sort(orb_eB.begin(), orb_eB.end());
 
             std::vector<int> orb_orderB(nmopi_[h]);
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_orderB[orb_eB[a].second] = a;
+            for (int a = 0; a < nmopi_[h]; a++) orb_orderB[orb_eB[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                occB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
+                occB.push_back(std::make_pair(epsilon_b_->get(h, a), std::make_pair(labels[h], orb_orderB[a] + 1)));
             for (int a = nbetapi_[h]; a < nmopi_[h]; a++)
-                virB.push_back(std::make_pair(epsilon_b_->get(h,a), std::make_pair(labels[h],orb_orderB[a] + 1)));
-
+                virB.push_back(std::make_pair(epsilon_b_->get(h, a), std::make_pair(labels[h], orb_orderB[a] + 1)));
         }
         std::sort(occA.begin(), occA.end());
         std::sort(virA.begin(), virA.end());
@@ -1322,30 +1222,25 @@ void HF::print_orbitals()
         print_orbitals("Beta Occupied:", occB);
         print_orbitals("Beta Virtual:", virB);
 
-    }else if(reference == "ROHF"){
-
+    } else if (reference == "ROHF") {
         std::vector<std::pair<double, std::pair<std::string, int> > > docc;
         std::vector<std::pair<double, std::pair<std::string, int> > > socc;
         std::vector<std::pair<double, std::pair<std::string, int> > > vir;
 
         for (int h = 0; h < nirrep_; h++) {
-
             std::vector<std::pair<double, int> > orb_e;
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_e.push_back(std::make_pair(epsilon_a_->get(h,a), a));
+            for (int a = 0; a < nmopi_[h]; a++) orb_e.push_back(std::make_pair(epsilon_a_->get(h, a), a));
             std::sort(orb_e.begin(), orb_e.end());
 
             std::vector<int> orb_order(nmopi_[h]);
-            for (int a = 0; a < nmopi_[h]; a++)
-                orb_order[orb_e[a].second] = a;
+            for (int a = 0; a < nmopi_[h]; a++) orb_order[orb_e[a].second] = a;
 
             for (int a = 0; a < nbetapi_[h]; a++)
-                docc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
-            for (int a = nbetapi_[h] ; a < nalphapi_[h]; a++)
-                socc.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
-            for (int a = nalphapi_[h] ; a < nmopi_[h]; a++)
-                vir.push_back(std::make_pair(epsilon_a_->get(h,a), std::make_pair(labels[h],orb_order[a] + 1)));
-
+                docc.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_order[a] + 1)));
+            for (int a = nbetapi_[h]; a < nalphapi_[h]; a++)
+                socc.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_order[a] + 1)));
+            for (int a = nalphapi_[h]; a < nmopi_[h]; a++)
+                vir.push_back(std::make_pair(epsilon_a_->get(h, a), std::make_pair(labels[h], orb_order[a] + 1)));
         }
         std::sort(docc.begin(), docc.end());
         std::sort(socc.begin(), socc.end());
@@ -1355,26 +1250,23 @@ void HF::print_orbitals()
         print_orbitals("Singly Occupied:", socc);
         print_orbitals("Virtual:", vir);
 
-    }else{
+    } else {
         throw PSIEXCEPTION("Unknown reference in HF::print_orbitals");
     }
 
-    outfile->Printf( "    Final Occupation by Irrep:\n");
+    outfile->Printf("    Final Occupation by Irrep:\n");
     print_occupation();
-
 }
 
-
-void HF::guess()
-{
+void HF::guess() {
     // don't save guess energy as "the" energy because we need to avoid
     // a false positive test for convergence on the first iteration (that
     // was happening before in tests/scf-guess-read before I removed
     // the statements putting this into E_).  -CDS 3/25/13
     double guess_E;
 
-    //What does the user want?
-    //Options will be:
+    // What does the user want?
+    // Options will be:
     // ref_C_-C matrices were detected in the incoming wavefunction
     // "CORE"-CORE Hamiltonain
     // "GWH"-Generalized Wolfsberg-Helmholtz
@@ -1387,53 +1279,52 @@ void HF::guess()
     //     guess_type = "CORE";
     // }
     // Take care of options that should be overridden
-    if (guess_type == "AUTO"){
+    if (guess_type == "AUTO") {
         outfile->Printf("\nWarning! Guess was AUTO, switching to CORE!\n\n");
         outfile->Printf("           This option should have been configured at the driver level.\n\n");
         guess_type = "CORE";
     }
 
-    if ((guess_type == "READ") && !guess_Ca_){
+    if ((guess_type == "READ") && !guess_Ca_) {
         outfile->Printf("\nWarning! Guess was READ without Ca set, switching to CORE!\n");
         outfile->Printf("           This option should have been configured at the driver level.\n\n");
         guess_type = "CORE";
     }
 
-    if (guess_Ca_){
-        if (print_)
-            outfile->Printf( "  SCF Guess: Orbitals guess was supplied from a previous computation.\n\n");
+    if (guess_Ca_) {
+        if (print_) outfile->Printf("  SCF Guess: Orbitals guess was supplied from a previous computation.\n\n");
 
         std::string reference = options_.get_str("REFERENCE");
         bool single_orb = (reference == "RHF");
 
-        if (single_orb){
+        if (single_orb) {
             guess_Cb_ = guess_Ca_;
         } else {
-            if (!guess_Cb_){
+            if (!guess_Cb_) {
                 throw PSIEXCEPTION("Guess Ca was set, but did not find a matching Cb!\n");
             }
         }
 
-
         if ((guess_Ca_->nirrep() != nirrep_) or (guess_Cb_->nirrep() != nirrep_)) {
-            throw PSIEXCEPTION("Number of guess of the input orbitals do not match number of irreps of the wavefunction.");
+            throw PSIEXCEPTION(
+                "Number of guess of the input orbitals do not match number of irreps of the wavefunction.");
         }
         if ((guess_Ca_->rowspi() != nsopi_) or (guess_Cb_->rowspi() != nsopi_)) {
             throw PSIEXCEPTION("Nso of the guess orbitals do not match Nso of the wavefunction.");
         }
 
-       for (int h = 0; h < nirrep_; h++) {
+        for (int h = 0; h < nirrep_; h++) {
             for (int i = 0; i < guess_Ca_->colspi()[h]; i++) {
-                C_DCOPY(nsopi_[h], &guess_Ca_->pointer(h)[0][i], guess_Ca_->colspi()[h],
-                        &Ca_->pointer(h)[0][i], nmopi_[h]);
+                C_DCOPY(nsopi_[h], &guess_Ca_->pointer(h)[0][i], guess_Ca_->colspi()[h], &Ca_->pointer(h)[0][i],
+                        nmopi_[h]);
             }
         }
 
-        if (!single_orb){
-           for (int h = 0; h < nirrep_; h++) {
+        if (!single_orb) {
+            for (int h = 0; h < nirrep_; h++) {
                 for (int i = 0; i < guess_Cb_->colspi()[h]; i++) {
-                    C_DCOPY(nsopi_[h], &guess_Cb_->pointer(h)[0][i], guess_Cb_->colspi()[h],
-                            &Cb_->pointer(h)[0][i], nmopi_[h]);
+                    C_DCOPY(nsopi_[h], &guess_Cb_->pointer(h)[0][i], guess_Cb_->colspi()[h], &Cb_->pointer(h)[0][i],
+                            nmopi_[h]);
                 }
             }
         } else {
@@ -1458,31 +1349,28 @@ void HF::guess()
         guess_E = compute_initial_E();
 
     } else if (guess_type == "SAD") {
+        if (print_) outfile->Printf("  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.\n\n");
 
-        if (print_)
-            outfile->Printf( "  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.\n\n");
-
-        //Superposition of Atomic Density
+        // Superposition of Atomic Density
         iteration_ = -1;
         reset_occ_ = true;
         compute_SAD_guess();
         guess_E = compute_initial_E();
 
     } else if (guess_type == "GWH") {
-        //Generalized Wolfsberg Helmholtz (Sounds cool, easy to code)
-        if (print_)
-            outfile->Printf( "  SCF Guess: Generalized Wolfsberg-Helmholtz.\n\n");
+        // Generalized Wolfsberg Helmholtz (Sounds cool, easy to code)
+        if (print_) outfile->Printf("  SCF Guess: Generalized Wolfsberg-Helmholtz.\n\n");
 
-        Fa_->zero(); //Try Fa_{mn} = S_{mn} (H_{mm} + H_{nn})/2
+        Fa_->zero();  // Try Fa_{mn} = S_{mn} (H_{mm} + H_{nn})/2
         int h, i, j;
-        const int *opi = S_->rowspi();
+        const int* opi = S_->rowspi();
         int nirreps = S_->nirrep();
-        for (h=0; h<nirreps; ++h) {
-            for (i=0; i<opi[h]; ++i) {
-                Fa_->set(h,i,i,H_->get(h,i,i));
-                for (j=0; j<i; ++j) {
-                    Fa_->set(h,i,j,0.875*S_->get(h,i,j)*(H_->get(h,i,i)+H_->get(h,j,j)));
-                    Fa_->set(h,j,i,Fa_->get(h,i,j));
+        for (h = 0; h < nirreps; ++h) {
+            for (i = 0; i < opi[h]; ++i) {
+                Fa_->set(h, i, i, H_->get(h, i, i));
+                for (j = 0; j < i; ++j) {
+                    Fa_->set(h, i, j, 0.875 * S_->get(h, i, j) * (H_->get(h, i, i) + H_->get(h, j, j)));
+                    Fa_->set(h, j, i, Fa_->get(h, i, j));
                 }
             }
         }
@@ -1493,11 +1381,9 @@ void HF::guess()
         guess_E = compute_initial_E();
 
     } else if (guess_type == "CORE") {
+        if (print_) outfile->Printf("  SCF Guess: Core (One-Electron) Hamiltonian.\n\n");
 
-        if (print_)
-            outfile->Printf( "  SCF Guess: Core (One-Electron) Hamiltonian.\n\n");
-
-        Fa_->copy(H_); //Try the core Hamiltonian as the Fock Matrix
+        Fa_->copy(H_);  // Try the core Hamiltonian as the Fock Matrix
         Fb_->copy(H_);
 
         form_initial_C();
@@ -1506,7 +1392,6 @@ void HF::guess()
         guess_E = compute_initial_E();
     } else {
         throw PSIEXCEPTION("  SCF Guess: No guess was found!");
-
     }
 
     if (print_ > 3) {
@@ -1518,19 +1403,15 @@ void HF::guess()
         Fb_->print();
     }
 
-
-    E_ = 0.0; // don't use this guess in our convergence checks
+    E_ = 0.0;  // don't use this guess in our convergence checks
 }
 
-void HF::format_guess()
-{
+void HF::format_guess() {
     // Nothing to do, only for special cases
 }
 
-
-void HF::check_phases()
-{
-    for (int h=0; h<nirrep_; ++h) {
+void HF::check_phases() {
+    for (int h = 0; h < nirrep_; ++h) {
         for (int p = 0; p < Ca_->colspi(h); ++p) {
             for (int mu = 0; mu < Ca_->rowspi(h); ++mu) {
                 if (std::fabs(Ca_->get(h, mu, p)) > 1.0E-3) {
@@ -1544,7 +1425,7 @@ void HF::check_phases()
     }
 
     if (Ca_ != Cb_) {
-        for (int h=0; h<nirrep_; ++h) {
+        for (int h = 0; h < nirrep_; ++h) {
             for (int p = 0; p < Cb_->colspi(h); ++p) {
                 for (int mu = 0; mu < Cb_->rowspi(h); ++mu) {
                     if (std::fabs(Cb_->get(h, mu, p)) > 1.0E-3) {
@@ -1559,35 +1440,30 @@ void HF::check_phases()
     }
 }
 
-
-void HF::initialize()
-{
+void HF::initialize() {
     converged_ = false;
 
     iteration_ = 0;
 
-    if (print_)
-        outfile->Printf( "  ==> Pre-Iterations <==\n\n");
+    if (print_) outfile->Printf("  ==> Pre-Iterations <==\n\n");
 
-    if (print_)
-        print_preiterations();
+    if (print_) print_preiterations();
 
     // Andy trick 2.0
     old_scf_type_ = options_.get_str("SCF_TYPE");
-    if (options_.get_bool("DF_SCF_GUESS") && (old_scf_type_ == "DIRECT") ) {
-         outfile->Printf( "  Starting with a DF guess...\n\n");
-         if(!options_["DF_BASIS_SCF"].has_changed()) {
-             // TODO: Match Dunning basis sets
-             molecule_->set_basis_all_atoms("CC-PVDZ-JKFIT", "DF_BASIS_SCF");
-         }
-         scf_type_ = "DF";
-         options_.set_str("SCF","SCF_TYPE","DF"); // Scope is reset in proc.py. This is not pretty, but it works
+    if (options_.get_bool("DF_SCF_GUESS") && (old_scf_type_ == "DIRECT")) {
+        outfile->Printf("  Starting with a DF guess...\n\n");
+        if (!options_["DF_BASIS_SCF"].has_changed()) {
+            // TODO: Match Dunning basis sets
+            molecule_->set_basis_all_atoms("CC-PVDZ-JKFIT", "DF_BASIS_SCF");
+        }
+        scf_type_ = "DF";
+        options_.set_str("SCF", "SCF_TYPE", "DF");  // Scope is reset in proc.py. This is not pretty, but it works
     }
 
-    if(attempt_number_ == 1){
+    if (attempt_number_ == 1) {
         auto mints = std::make_shared<MintsHelper>(basisset_, options_, 0);
-        if ((options_.get_str("RELATIVISTIC") == "X2C") ||
-            (options_.get_str("RELATIVISTIC") == "DKH")) {
+        if ((options_.get_str("RELATIVISTIC") == "X2C") || (options_.get_str("RELATIVISTIC") == "DKH")) {
             mints->set_rel_basisset(get_basisset("BASIS_RELATIVISTIC"));
         }
 
@@ -1596,43 +1472,42 @@ void HF::initialize()
         integrals();
 
         timer_on("HF: Form H");
-        form_H(); //Core Hamiltonian
+        form_H();  // Core Hamiltonian
         timer_off("HF: Form H");
 
 #ifdef USING_libefp
         // EFP: Add in permanent moment contribution and cache
-        if ( Process::environment.get_efp()->get_frag_count() > 0 ) {
+        if (Process::environment.get_efp()->get_frag_count() > 0) {
             std::shared_ptr<Matrix> Vefp = Process::environment.get_efp()->modify_Fock_permanent();
             H_->add(Vefp);
             Horig_ = std::make_shared<Matrix>("H orig Matrix", basisset_->nbf(), basisset_->nbf());
             Horig_->copy(H_);
-            outfile->Printf( "  QM/EFP: iterating Total Energy including QM/EFP Induction\n");
+            outfile->Printf("  QM/EFP: iterating Total Energy including QM/EFP Induction\n");
         }
 #endif
 
         timer_on("HF: Form S/X");
-        form_Shalf(); //S and X Matrix
+        form_Shalf();  // S and X Matrix
         timer_off("HF: Form S/X");
 
         timer_on("HF: Guess");
-        guess(); // Guess
+        guess();  // Guess
         timer_off("HF: Guess");
 
-    }else{
+    } else {
         // We're reading the orbitals from the previous set of iterations.
         form_D();
         E_ = compute_initial_E();
     }
 
 #ifdef USING_libefp
-    if ( Process::environment.get_efp()->get_frag_count() > 0 ) {
+    if (Process::environment.get_efp()->get_frag_count() > 0) {
         Process::environment.get_efp()->set_qm_atoms();
     }
 #endif
 }
 
-void HF::iterations()
-{
+void HF::iterations() {
     std::string reference = options_.get_str("REFERENCE");
 
     MOM_performed_ = false;
@@ -1640,9 +1515,8 @@ void HF::iterations()
 
     bool df = (options_.get_str("SCF_TYPE") == "DF");
 
-    outfile->Printf( "  ==> Iterations <==\n\n");
-    outfile->Printf( "%s                        Total Energy        Delta E     RMS |[F,P]|\n\n", df ? "   " : "");
-
+    outfile->Printf("  ==> Iterations <==\n\n");
+    outfile->Printf("%s                        Total Energy        Delta E     RMS |[F,P]|\n\n", df ? "   " : "");
 
     // SCF iterations
     do {
@@ -1650,12 +1524,12 @@ void HF::iterations()
 
         save_density_and_energy();
 
-        // Call any preiteration callbacks
+// Call any preiteration callbacks
 //        call_preiteration_callbacks();
 
 #ifdef USING_libefp
         // add efp contribution to Fock matrix
-        if ( Process::environment.get_efp()->get_frag_count() > 0 ) {
+        if (Process::environment.get_efp()->get_frag_count() > 0) {
             H_->copy(Horig_);
             std::shared_ptr<Matrix> Vefp = Process::environment.get_efp()->modify_Fock_induced();
             H_->add(Vefp);
@@ -1669,7 +1543,7 @@ void HF::iterations()
         timer_off("HF: Form G");
 
         // Reset fractional SAD occupation
-        if ((iteration_ == 0) && reset_occ_){
+        if ((iteration_ == 0) && reset_occ_) {
             reset_occupation();
         }
 
@@ -1677,7 +1551,7 @@ void HF::iterations()
         form_F();
         timer_off("HF: Form F");
 
-        if (print_>3) {
+        if (print_ > 3) {
             Fa_->print("outfile");
             Fb_->print("outfile");
         }
@@ -1686,7 +1560,7 @@ void HF::iterations()
 
 #ifdef USING_libefp
         // add efp contribution to energy
-        if ( Process::environment.get_efp()->get_frag_count() > 0 ) {
+        if (Process::environment.get_efp()->get_frag_count() > 0) {
             double efp_wfn_dependent_energy = Process::environment.get_efp()->scf_energy_update();
             E_ += efp_wfn_dependent_energy;
         }
@@ -1695,40 +1569,40 @@ void HF::iterations()
 #ifdef USING_PCMSolver
         // The PCM potential must be added to the Fock operator *after* the
         // energy computation, not in form_F()
-        if(pcm_enabled_) {
-          // Prepare the density
-          SharedMatrix D_pcm(Da_->clone());
-          if(same_a_b_orbs()) {
-            D_pcm->scale(2.0); // PSI4's density doesn't include the occupation
-          } else {
-            D_pcm->add(Db_);
-          }
+        if (pcm_enabled_) {
+            // Prepare the density
+            SharedMatrix D_pcm(Da_->clone());
+            if (same_a_b_orbs()) {
+                D_pcm->scale(2.0);  // PSI4's density doesn't include the occupation
+            } else {
+                D_pcm->add(Db_);
+            }
 
-          // Compute the PCM charges and polarization energy
-          double epcm = 0.0;
-          if (options_.get_str("PCM_SCF_TYPE") == "TOTAL") {
-            epcm = hf_pcm_->compute_E(D_pcm, PCM::Total);
-          } else {
-            epcm = hf_pcm_->compute_E(D_pcm, PCM::NucAndEle);
-          }
-          energies_["PCM Polarization"] = epcm;
-          variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
-          Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
-          E_ += epcm;
+            // Compute the PCM charges and polarization energy
+            double epcm = 0.0;
+            if (options_.get_str("PCM_SCF_TYPE") == "TOTAL") {
+                epcm = hf_pcm_->compute_E(D_pcm, PCM::CalcType::Total);
+            } else {
+                epcm = hf_pcm_->compute_E(D_pcm, PCM::CalcType::NucAndEle);
+            }
+            energies_["PCM Polarization"] = epcm;
+            variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+            Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+            E_ += epcm;
 
-          // Add the PCM potential to the Fock matrix
-          SharedMatrix V_pcm;
-          V_pcm = hf_pcm_->compute_V();
-          if (same_a_b_orbs()) {
-            Fa_->add(V_pcm);
-          } else {
-            Fa_->add(V_pcm);
-            Fb_->add(V_pcm);
-          }
+            // Add the PCM potential to the Fock matrix
+            SharedMatrix V_pcm;
+            V_pcm = hf_pcm_->compute_V();
+            if (same_a_b_orbs()) {
+                Fa_->add(V_pcm);
+            } else {
+                Fa_->add(V_pcm);
+                Fb_->add(V_pcm);
+            }
         } else {
-          energies_["PCM Polarization"] = 0.0;
-          variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
-          Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+            energies_["PCM Polarization"] = 0.0;
+            variables_["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
+            Process::environment.globals["PCM POLARIZATION ENERGY"] = energies_["PCM Polarization"];
         }
 #endif
         std::string status = "";
@@ -1753,8 +1627,7 @@ void HF::iterations()
                     did_soscf = true;  // Stops DIIS
                 } else {
                     if (print_) {
-                        outfile->Printf(
-                            "Did not take a SOSCF step, using normal convergence methods\n");
+                        outfile->Printf("Did not take a SOSCF step, using normal convergence methods\n");
                     }
                     did_soscf = false;  // Back to DIIS
                 }
@@ -1768,12 +1641,11 @@ void HF::iterations()
             }
         }  // End SOSCF block
 
-        if (!did_soscf){ // Normal convergence procedures if we do not do SOSCF
+        if (!did_soscf) {  // Normal convergence procedures if we do not do SOSCF
 
             timer_on("HF: DIIS");
             bool add_to_diis_subspace = false;
-            if (diis_enabled_ && iteration_ > 0 && iteration_ >= diis_start_ )
-                add_to_diis_subspace = true;
+            if (diis_enabled_ && iteration_ > 0 && iteration_ >= diis_start_) add_to_diis_subspace = true;
 
             compute_orbital_gradient(add_to_diis_subspace);
 
@@ -1784,7 +1656,7 @@ void HF::iterations()
             }
             timer_off("HF: DIIS");
 
-            if (print_>4 && diis_performed_) {
+            if (print_ > 4 && diis_performed_) {
                 outfile->Printf("  After DIIS:\n");
                 Fa_->print("outfile");
                 Fb_->print("outfile");
@@ -1798,20 +1670,20 @@ void HF::iterations()
         // If we're too well converged, or damping wasn't enabled, do DIIS
         damping_performed_ = (damping_enabled_ && iteration_ > 1 && Drms_ > damping_convergence_);
 
-        if(diis_performed_){
-            if(status != "") status += "/";
+        if (diis_performed_) {
+            if (status != "") status += "/";
             status += "DIIS";
         }
-        if(MOM_performed_){
-            if(status != "") status += "/";
+        if (MOM_performed_) {
+            if (status != "") status += "/";
             status += "MOM";
         }
-        if(damping_performed_){
-            if(status != "") status += "/";
+        if (damping_performed_) {
+            if (status != "") status += "/";
             status += "DAMP";
         }
-        if(frac_performed_){
-            if(status != "") status += "/";
+        if (frac_performed_) {
+            if (status != "") status += "/";
             status += "FRAC";
         }
 
@@ -1822,9 +1694,9 @@ void HF::iterations()
         Process::environment.globals["SCF ITERATION ENERGY"] = E_;
 
         // After we've built the new D, damp the update if
-        if(damping_performed_) damp_update();
+        if (damping_performed_) damp_update();
 
-        if (print_ > 3){
+        if (print_ > 3) {
             Ca_->print("outfile");
             Cb_->print("outfile");
             Da_->print("outfile");
@@ -1835,10 +1707,8 @@ void HF::iterations()
 
         df = (options_.get_str("SCF_TYPE") == "DF");
 
-
-        outfile->Printf( "   @%s%s iter %3d: %20.14f   %12.5e   %-11.5e %s\n", df ? "DF-" : "",
-                          reference.c_str(), iteration_, E_, E_ - Eold_, Drms_, status.c_str());
-
+        outfile->Printf("   @%s%s iter %3d: %20.14f   %12.5e   %-11.5e %s\n", df ? "DF-" : "", reference.c_str(),
+                        iteration_, E_, E_ - Eold_, Drms_, status.c_str());
 
         // If a an excited MOM is requested but not started, don't stop yet
         if (MOM_excited_ && !MOM_started_) converged_ = false;
@@ -1848,50 +1718,47 @@ void HF::iterations()
 
         // If a DF Guess environment, reset the JK object, and keep running
         if (converged_ && options_.get_bool("DF_SCF_GUESS") && (old_scf_type_ == "DIRECT")) {
-            outfile->Printf( "\n  DF guess converged.\n\n"); // Be cool dude.
+            outfile->Printf("\n  DF guess converged.\n\n");  // Be cool dude.
             converged_ = false;
-            if(initialized_diis_manager_)
-                diis_manager_->reset_subspace();
+            if (initialized_diis_manager_) diis_manager_->reset_subspace();
             scf_type_ = old_scf_type_;
-            options_.set_str("SCF","SCF_TYPE",old_scf_type_);
+            options_.set_str("SCF", "SCF_TYPE", old_scf_type_);
             old_scf_type_ = "DF";
             integrals();
         }
 
         // Call any postiteration callbacks
-//        call_postiteration_callbacks();
+        //        call_postiteration_callbacks();
 
-    } while (!converged_ && iteration_ < maxiter_ );
-
+    } while (!converged_ && iteration_ < maxiter_);
 }
 
-void HF::print_energies()
-{
-    if (!pcm_enabled_){
+void HF::print_energies() {
+    if (!pcm_enabled_) {
         energies_["PCM Polarization"] = 0.0;
     }
 
     double hf_energy = energies_["Nuclear"] + energies_["One-Electron"] + energies_["Two-Electron"];
     double dft_energy = hf_energy + energies_["XC"] + energies_["-D"] + energies_["VV10"];
-    double total_energy = dft_energy  + energies_["EFP"] + energies_["PCM Polarization"];
+    double total_energy = dft_energy + energies_["EFP"] + energies_["PCM Polarization"];
 
     outfile->Printf("   => Energetics <=\n\n");
     outfile->Printf("    Nuclear Repulsion Energy =        %24.16f\n", energies_["Nuclear"]);
     outfile->Printf("    One-Electron Energy =             %24.16f\n", energies_["One-Electron"]);
     outfile->Printf("    Two-Electron Energy =             %24.16f\n", energies_["Two-Electron"]);
-    if(functional_->needs_xc()){
+    if (functional_->needs_xc()) {
         outfile->Printf("    DFT Exchange-Correlation Energy = %24.16f\n", energies_["XC"]);
         outfile->Printf("    Empirical Dispersion Energy =     %24.16f\n", energies_["-D"]);
         outfile->Printf("    VV10 Nonlocal Energy =            %24.16f\n", energies_["VV10"]);
     }
-    if (pcm_enabled_){
+    if (pcm_enabled_) {
         outfile->Printf("    PCM Polarization Energy =         %24.16f\n", energies_["PCM Polarization"]);
     }
-    if (Process::environment.get_efp()->get_frag_count() > 0){
+    if (Process::environment.get_efp()->get_frag_count() > 0) {
         outfile->Printf("    EFP Energy =                      %24.16f\n", energies_["EFP"]);
     }
     outfile->Printf("    Total Energy =                    %24.16f\n", total_energy);
-    outfile->Printf( "\n");
+    outfile->Printf("\n");
 
     Process::environment.globals["NUCLEAR REPULSION ENERGY"] = energies_["Nuclear"];
     Process::environment.globals["ONE-ELECTRON ENERGY"] = energies_["One-Electron"];
@@ -1899,8 +1766,7 @@ void HF::print_energies()
     if (std::fabs(energies_["XC"]) > 1.0e-14) {
         Process::environment.globals["DFT XC ENERGY"] = energies_["XC"];
         Process::environment.globals["DFT VV10 ENERGY"] = energies_["VV10"];
-        Process::environment.globals["DFT FUNCTIONAL TOTAL ENERGY"] = hf_energy +
-            energies_["XC"] + energies_["VV10"];
+        Process::environment.globals["DFT FUNCTIONAL TOTAL ENERGY"] = hf_energy + energies_["XC"] + energies_["VV10"];
         Process::environment.globals["DFT TOTAL ENERGY"] = dft_energy;
     } else {
         Process::environment.globals["HF TOTAL ENERGY"] = hf_energy;
@@ -1912,81 +1778,73 @@ void HF::print_energies()
     Process::environment.globals["SCF ITERATIONS"] = iteration_;
 
     // Only print this alert if we are actually doing EFP or PCM
-    if(pcm_enabled_ || ( Process::environment.get_efp()->get_frag_count() > 0 ) ) {
+    if (pcm_enabled_ || (Process::environment.get_efp()->get_frag_count() > 0)) {
         outfile->Printf("    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.");
     }
     Process::environment.globals["SCF N ITERS"] = iteration_;
-//  Comment so that autodoc utility will find this PSI variable
-//     It doesn't really belong here but needs to be linked somewhere
-//  Process::environment.globals["DOUBLE-HYBRID CORRECTION ENERGY"]
+    //  Comment so that autodoc utility will find this PSI variable
+    //     It doesn't really belong here but needs to be linked somewhere
+    //  Process::environment.globals["DOUBLE-HYBRID CORRECTION ENERGY"]
 }
 
-void HF::print_occupation()
-{
+void HF::print_occupation() {
+    std::vector<std::string> labels = molecule_->irrep_labels();
+    std::string reference = options_.get_str("REFERENCE");
+    outfile->Printf("          ");
+    for (int h = 0; h < nirrep_; ++h) outfile->Printf(" %4s ", labels[h].c_str());
+    outfile->Printf("\n");
+    outfile->Printf("    DOCC [ ");
+    for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", doccpi_[h]);
+    outfile->Printf(" %4d ]\n", doccpi_[nirrep_ - 1]);
+    if (reference != "RHF" && reference != "RKS") {
+        outfile->Printf("    SOCC [ ");
+        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", soccpi_[h]);
+        outfile->Printf(" %4d ]\n", soccpi_[nirrep_ - 1]);
+    }
+    if (MOM_excited_) {
+        // Also print nalpha and nbeta per irrep, which are more physically meaningful
+        outfile->Printf("    NA   [ ");
+        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nalphapi_[h]);
+        outfile->Printf(" %4d ]\n", nalphapi_[nirrep_ - 1]);
+        outfile->Printf("    NB   [ ");
+        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nbetapi_[h]);
+        outfile->Printf(" %4d ]\n", nbetapi_[nirrep_ - 1]);
+    }
 
-        std::vector<std::string> labels = molecule_->irrep_labels();
-        std::string reference = options_.get_str("REFERENCE");
-        outfile->Printf( "          ");
-        for(int h = 0; h < nirrep_; ++h) outfile->Printf( " %4s ", labels[h].c_str()); outfile->Printf( "\n");
-        outfile->Printf( "    DOCC [ ");
-        for(int h = 0; h < nirrep_-1; ++h) outfile->Printf( " %4d,", doccpi_[h]);
-        outfile->Printf( " %4d ]\n", doccpi_[nirrep_-1]);
-        if(reference != "RHF" && reference != "RKS"){
-            outfile->Printf( "    SOCC [ ");
-            for(int h = 0; h < nirrep_-1; ++h) outfile->Printf( " %4d,", soccpi_[h]);
-            outfile->Printf( " %4d ]\n", soccpi_[nirrep_-1]);
-        }
-        if (MOM_excited_) {
-            // Also print nalpha and nbeta per irrep, which are more physically meaningful
-            outfile->Printf( "    NA   [ ");
-            for(int h = 0; h < nirrep_-1; ++h) outfile->Printf( " %4d,", nalphapi_[h]);
-            outfile->Printf( " %4d ]\n", nalphapi_[nirrep_-1]);
-            outfile->Printf( "    NB   [ ");
-            for(int h = 0; h < nirrep_-1; ++h) outfile->Printf( " %4d,", nbetapi_[h]);
-            outfile->Printf( " %4d ]\n", nbetapi_[nirrep_-1]);
-        }
-
-        outfile->Printf("\n");
-
+    outfile->Printf("\n");
 }
 
 //  Returns a vector of the occupation of the a orbitals
-std::shared_ptr<Vector> HF::occupation_a() const
-{
-  auto occA = std::make_shared<Vector>(nmopi_);
-  for(int h=0; h < nirrep_;++h)
-    for(int n=0; n < nalphapi()[h]; n++)
-      occA->set(h, n, 1.0);
+std::shared_ptr<Vector> HF::occupation_a() const {
+    auto occA = std::make_shared<Vector>(nmopi_);
+    for (int h = 0; h < nirrep_; ++h)
+        for (int n = 0; n < nalphapi()[h]; n++) occA->set(h, n, 1.0);
 
-  return occA;
+    return occA;
 }
 
 //  Returns a vector of the occupation of the b orbitals
-std::shared_ptr<Vector> HF::occupation_b() const
-{
-  auto occB = std::make_shared<Vector>(nmopi_);
-  for(int h=0; h < nirrep_;++h)
-    for(int n=0; n < nbetapi()[h]; n++)
-      occB->set(h, n, 1.0);
+std::shared_ptr<Vector> HF::occupation_b() const {
+    auto occB = std::make_shared<Vector>(nmopi_);
+    for (int h = 0; h < nirrep_; ++h)
+        for (int n = 0; n < nbetapi()[h]; n++) occB->set(h, n, 1.0);
 
-  return occB;
+    return occB;
 }
 
-void HF::diagonalize_F(const SharedMatrix& Fm, SharedMatrix& Cm, std::shared_ptr<Vector>& epsm)
-{
-    //Form F' = X'FX for canonical orthogonalization
+void HF::diagonalize_F(const SharedMatrix& Fm, SharedMatrix& Cm, std::shared_ptr<Vector>& epsm) {
+    // Form F' = X'FX for canonical orthogonalization
     diag_temp_->gemm(true, false, 1.0, X_, Fm, 0.0);
     diag_F_temp_->gemm(false, false, 1.0, diag_temp_, X_, 0.0);
 
-    //Form C' = eig(F')
+    // Form C' = eig(F')
     diag_F_temp_->diagonalize(diag_C_temp_, epsm);
 
-    //Form C = XC'
+    // Form C = XC'
     Cm->gemm(false, false, 1.0, X_, diag_C_temp_, 0.0);
 }
 
-void HF::reset_occupation()
-{
+void HF::reset_occupation() {
     // RHF style for now
     doccpi_ = original_doccpi_;
     soccpi_ = original_soccpi_;
@@ -1996,16 +1854,13 @@ void HF::reset_occupation()
     // These may not match the per irrep. Will remap correctly next find_occupation call
     nalpha_ = original_nalpha_;
     nbeta_ = original_nbeta_;
-
 }
-SharedMatrix HF::form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi)
-{
+SharedMatrix HF::form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi) {
     const int* nsopi = Cso->rowspi();
     const int* nmopi = Cso->colspi();
     int* nvirpi = new int[nirrep_];
 
-    for (int h = 0; h < nirrep_; h++)
-        nvirpi[h] = nmopi[h] - noccpi[h];
+    for (int h = 0; h < nirrep_; h++) nvirpi[h] = nmopi[h] - noccpi[h];
 
     auto Fia = std::make_shared<Matrix>("Fia (Some Basis)", nirrep_, noccpi, nvirpi);
 
@@ -2022,38 +1877,36 @@ SharedMatrix HF::form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi)
 
         if (nmo == 0 || nso == 0 || nvir == 0 || nocc == 0) continue;
 
-        //double** C = Cso->pointer(h);
+        // double** C = Cso->pointer(h);
         double** C = C2->pointer(h);
         double** F = Fso->pointer(h);
         double** Fiap = Fia->pointer(h);
 
         double** Temp = block_matrix(nocc, nso);
 
-        C_DGEMM('T','N',nocc,nso,nso,1.0,C[0],nmo,F[0],nso,0.0,Temp[0],nso);
-        C_DGEMM('N','N',nocc,nvir,nso,1.0,Temp[0],nso,&C[0][nocc],nmo,0.0,Fiap[0],nvir);
+        C_DGEMM('T', 'N', nocc, nso, nso, 1.0, C[0], nmo, F[0], nso, 0.0, Temp[0], nso);
+        C_DGEMM('N', 'N', nocc, nvir, nso, 1.0, Temp[0], nso, &C[0][nocc], nmo, 0.0, Fiap[0], nvir);
 
         free_block(Temp);
 
-        //double* eps = E2->pointer(h);
-        //for (int i = 0; i < nocc; i++)
+        // double* eps = E2->pointer(h);
+        // for (int i = 0; i < nocc; i++)
         //    for (int a = 0; a < nvir; a++)
         //        Fiap[i][a] /= eps[a + nocc] - eps[i];
-
     }
 
-    //Fia->print();
+    // Fia->print();
 
     delete[] nvirpi;
 
     return Fia;
 }
-SharedMatrix HF::form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso)
-{
+SharedMatrix HF::form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso) {
     auto FDSmSDF = std::make_shared<Matrix>("FDS-SDF", nirrep_, nsopi_, nsopi_);
     auto DS = std::make_shared<Matrix>("DS", nirrep_, nsopi_, nsopi_);
 
-    DS->gemm(false,false,1.0,Dso,S_,0.0);
-    FDSmSDF->gemm(false,false,1.0,Fso,DS,0.0);
+    DS->gemm(false, false, 1.0, Dso, S_, 0.0);
+    FDSmSDF->gemm(false, false, 1.0, Fso, DS, 0.0);
 
     SharedMatrix SDF(FDSmSDF->transpose());
     FDSmSDF->subtract(SDF);
@@ -2063,40 +1916,38 @@ SharedMatrix HF::form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso)
 
     auto XP = std::make_shared<Matrix>("X'(FDS - SDF)", nirrep_, nmopi_, nsopi_);
     auto XPX = std::make_shared<Matrix>("X'(FDS - SDF)X", nirrep_, nmopi_, nmopi_);
-    XP->gemm(true,false,1.0,X_,FDSmSDF,0.0);
-    XPX->gemm(false,false,1.0,XP,X_,0.0);
+    XP->gemm(true, false, 1.0, X_, FDSmSDF, 0.0);
+    XPX->gemm(false, false, 1.0, XP, X_, 0.0);
 
-    //XPX->print();
+    // XPX->print();
 
     return XPX;
 }
 
-void HF::print_stability_analysis(std::vector<std::pair<double, int> > &vec)
-{
+void HF::print_stability_analysis(std::vector<std::pair<double, int> >& vec) {
     std::sort(vec.begin(), vec.end());
     std::vector<std::pair<double, int> >::const_iterator iter = vec.begin();
-    outfile->Printf( "    ");
+    outfile->Printf("    ");
     std::vector<std::string> irrep_labels = molecule_->irrep_labels();
     int count = 0;
-    for(; iter != vec.end(); ++iter){
+    for (; iter != vec.end(); ++iter) {
         ++count;
-        outfile->Printf( "%4s %-10.6f", irrep_labels[iter->second].c_str(), iter->first);
-        if(count == 4){
-            outfile->Printf( "\n    ");
+        outfile->Printf("%4s %-10.6f", irrep_labels[iter->second].c_str(), iter->first);
+        if (count == 4) {
+            outfile->Printf("\n    ");
             count = 0;
-        }else{
-            outfile->Printf( "    ");
+        } else {
+            outfile->Printf("    ");
         }
     }
-    if(count)
-        outfile->Printf( "\n\n");
+    if (count)
+        outfile->Printf("\n\n");
     else
-        outfile->Printf( "\n");
-
+        outfile->Printf("\n");
 }
-bool HF::stability_analysis()
-{
+bool HF::stability_analysis() {
     throw PSIEXCEPTION("Stability analysis hasn't been implemented yet for this wfn type.");
     return false;
 }
-}}
+}
+}


### PR DESCRIPTION
## Description
This PR will expose the `PCM` object in Psi4 out to Python. The `PCM` object wraps the PCMSolver library and offers three methods:
1. `compute_E` to calculate the polarization energy due to the continuum;
2. `compute_E_electronic` to calculate the polarization energy due to the continuum, but only using the electron density;
3. `compute_V` to calculate the PCM potential, which is added on top of the Fock matrix.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Clean-up the `PCM` object and corresponding sources:
    * Forward-declare as much stuff as possible instaed on `include`-ing
    * Remove raw pointers in favor of `std::vector`, `Vector` or `std::shared_ptr`
    * Use a [scoped `enum`](http://en.cppreference.com/w/cpp/language/enum) instead of an [unscoped `enum`](http://en.cppreference.com/w/cpp/language/enum)
* **User-Facing for Release Notes**
  - [ ] Exposing the `PCM` object to Python.

## Questions
- The initialization of the `PCM` object requires a `BasisSet`. I am unsure what is the best way to grab that Python-side.
- Still regarding initialization, I think it can be done better. Meaning that after reading the user input, the `PCM` object can be initialized by passing the printlevel and the `BasisSet` _under the hood_. @loriab @dgasmith can you point me to existing examples in the codebase? I've looked around in `core.cc` but it's a bit daunting.
- I think this will be useful for the ongoing work on #847 
- @andysim and/or @lothian, the file [psi4/libmints/integral.h](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libmints/integral.h#L487) has a comment `/// Want to change the name of this after the PCM dust settles`. Do you remember what was the intention there?

## Status
- [ ] Ready to go
