### PR TITLE
CUBEPROP: Compute adaptive isocontour range for cube files

### DIFF
--- a/doc/sphinxman/source/cubeprop.rst
+++ b/doc/sphinxman/source/cubeprop.rst
@@ -80,8 +80,19 @@ should be generated only for alpha orbitals 5 (HOMO) and 6 (LUMO) and
 beta orbitals 5 (indicated as -5) and 6.
 If the option |globals__cubeprop_orbitals| is not provided, then cube files are
 generated for all orbitals.
-After running, the above input will generate four files: ``Psi_a_5.cube``,
-``Psi_a_6.cube``, ``Psi_b_5.cube``, and ``Psi_b_6.cube``.
+After running, the above input will generate four files: ``Psi_a_5_1-B1.cube``,
+``Psi_a_6_4-A1.cube``, ``Psi_a_5_1-B1.cube``, and ``Psi_a_6_4-A1.cube``. The subscript ``a`` in
+``Psi_a_5_1-B1.cube`` indicates an alpha orbital. The first number (``5``) is the index of the
+orbital while ``1-B1`` indicates that this is the first orbital that belongs to the B1 irrep.
+The file ``Psi_a_5_1-B1.cube`` begins with two comment lines::
+
+   Psi4 Gaussian Cube File.
+   Property: Psi_a_5_1-B1. Isocontour range for 85% of the density: (0.0787495,-0.0787495)
+
+The second line reports the isocontour values that capture 85% of the probability density using
+the least amount of grid points. This quantity is determined for orbitals and densities. The
+fraction of the density captured by the isocontour values is by default 0.85, but can
+be changed via the option |globals__cubeprop_isocontour_threshold|.
 
 .. note:: If your cube plots are too coarse, try to decrease the grid spacing via
     the option |globals__cubic_grid_spacing|.  If the edges of your plot are cut then

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -367,9 +367,14 @@ def compare_cubes(expected, computed, label):
     Performs a system exit on failure. Used in input files in the test suite.
 
     """
-    # Skip the first six elemets which are just labels
-    evec = [float(k) for k in expected.split()[6:]]
-    cvec = [float(k) for k in computed.split()[6:]]
+    # Grab grid points and skip the first two lines which are just labels
+    evec = []
+    for line in expected.split("\n")[2:]:
+        evec.extend([float(k) for k in line.split()])
+    cvec = []
+    for line in computed.split("\n")[2:]:
+        cvec.extend([float(k) for k in line.split()])
+
     if len(evec) == len(cvec):
         for n in range(len(evec)):
             if (math.fabs(evec[n]-cvec[n]) > 1.0e-4):

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -367,21 +367,15 @@ def compare_cubes(expected, computed, label):
     Performs a system exit on failure. Used in input files in the test suite.
 
     """
-    # Grab grid points and skip the first two lines which are just labels
-    evec = []
-    for line in expected.split("\n")[2:]:
-        evec.extend([float(k) for k in line.split()])
-    cvec = []
-    for line in computed.split("\n")[2:]:
-        cvec.extend([float(k) for k in line.split()])
-
-    if len(evec) == len(cvec):
-        for n in range(len(evec)):
-            if (math.fabs(evec[n]-cvec[n]) > 1.0e-4):
-                message = ("\t%s: computed cube file does not match expected cube file." % label)
-                raise TestComparisonError(message)
+    # Grab grid points. Skip the first nine lines and the last one
+    evec = np.genfromtxt(expected,skip_header=9,skip_footer=1)
+    cvec = np.genfromtxt(computed,skip_header=9,skip_footer=1)
+    if evec.size == cvec.size:
+        if not np.allclose(cvec, evec, rtol=5e-02, atol=1e-10):
+            message = ("\t%s: computed cube file does not match expected cube file." % label)
+            raise TestComparisonError(message)
     else:
-        message = ("\t%s: computed cube file does not match expected cube file." % (label, computed, expected))
+        message = ("\t%s: computed cube file does not match size of expected cube file." % label)
         raise TestComparisonError(message)
     success(label)
     return True

--- a/psi4/src/psi4/libcubeprop/csg.cc
+++ b/psi4/src/psi4/libcubeprop/csg.cc
@@ -598,10 +598,10 @@ void CubicScalarGrid::compute_density(std::shared_ptr<Matrix> D, const std::stri
     std::pair<double, double> isocontour_range = compute_isocontour_range(v, 1.0);
     double density_percent = 100.0 * options_.get_double("CUBEPROP_ISOCONTOUR_THRESHOLD");
     std::stringstream comment;
-    comment << ". Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first << ","
-            << isocontour_range.second << ")";
+    comment << " [e/a0^3]. Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first
+            << "," << isocontour_range.second << ")";
     // Write to disk
-    write_gen_file(v, name, type,comment.str());
+    write_gen_file(v, name, type, comment.str());
     delete[] v;
 }
 void CubicScalarGrid::compute_esp(std::shared_ptr<Matrix> D, const std::vector<double>& w, const std::string& name,
@@ -609,7 +609,7 @@ void CubicScalarGrid::compute_esp(std::shared_ptr<Matrix> D, const std::vector<d
     double* v = new double[npoints_];
     memset(v, '\0', npoints_ * sizeof(double));
     add_esp(v, D, w);
-    write_gen_file(v, name, type);
+    write_gen_file(v, name, type, " [Eh/e]");
     delete[] v;
 }
 void CubicScalarGrid::compute_basis_functions(const std::vector<int>& indices, const std::string& name,
@@ -641,8 +641,8 @@ void CubicScalarGrid::compute_orbitals(std::shared_ptr<Matrix> C, const std::vec
         std::pair<double, double> isocontour_range = compute_isocontour_range(v[k], 2.0);
         double density_percent = 100.0 * options_.get_double("CUBEPROP_ISOCONTOUR_THRESHOLD");
         std::stringstream comment;
-        comment << ". Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first << ","
-                << isocontour_range.second << ")";
+        comment << ". Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first
+                << "," << isocontour_range.second << ")";
         // Write to disk
         std::stringstream ss;
         ss << name << "_" << (indices[k] + 1) << "_" << labels[k];

--- a/psi4/src/psi4/libcubeprop/csg.h
+++ b/psi4/src/psi4/libcubeprop/csg.h
@@ -148,9 +148,9 @@ class CubicScalarGrid {
     // => Low-Level Write Routines (Use only if you know what you are doing) <= //
 
     /// Write a general file of the scalar field v (in fast ordering) to filepath/name.ext
-    void write_gen_file(double* v, const std::string& name, const std::string& type);
+    void write_gen_file(double* v, const std::string& name, const std::string& type, const std::string& comment = "");
     /// Write a Gaussian cube file of the scalar field v (in fast ordering) to filepath/name.cube
-    void write_cube_file(double* v, const std::string& name);
+    void write_cube_file(double* v, const std::string& name, const std::string& comment = "");
 
     // => Low-Level Scalar Field Computation (Use only if you know what you are doing) <= //
 
@@ -186,8 +186,9 @@ class CubicScalarGrid {
     /// Compute an ELF-type property and drop a file corresponding to name and type (TODO: this seems very unstable)
     void compute_ELF(std::shared_ptr<Matrix> D, const std::string& name, const std::string& type = "CUBE");
 
-    /// Compute the isocountour range that capture a given fraction of the MO density
-    std::pair<double, double> compute_isocontour_range(double* v2);
+    /// Compute the isocountour range that capture a given fraction of a property. Exponent is used
+    /// to properly compute the density. E.g. for orbitals exponent = 2, for densities exponent = 1
+    std::pair<double, double> compute_isocontour_range(double* v2, double exponent);
 };
 
 }  // End namespace

--- a/psi4/src/psi4/libcubeprop/csg.h
+++ b/psi4/src/psi4/libcubeprop/csg.h
@@ -42,9 +42,7 @@ class RKSFunctions;
 class BlockOPoints;
 
 class CubicScalarGrid {
-
-protected:
-
+   protected:
     // => Input Specification <= //
 
     /// Options object for overages and voxel spacing
@@ -95,7 +93,7 @@ protected:
     /// Setup grid from info in N_, D_, O_
     void populate_grid();
 
-public:
+   public:
     // => Constructors <= //
 
     CubicScalarGrid(std::shared_ptr<BasisSet> primary, Options& options);
@@ -174,18 +172,24 @@ public:
     /// Compute a density-type property and drop a file corresponding to name and type
     void compute_density(std::shared_ptr<Matrix> D, const std::string& name, const std::string& type = "CUBE");
     /// Compute an ESP-type property and drop a file corresponding to name and type
-    void compute_esp(std::shared_ptr<Matrix> D, const std::vector<double>& nuc_weights, const std::string& name, const std::string& type = "CUBE");
+    void compute_esp(std::shared_ptr<Matrix> D, const std::vector<double>& nuc_weights, const std::string& name,
+                     const std::string& type = "CUBE");
     /// Compute a set of basis function-type properties and drop files corresponding to name, index, and type
-    void compute_basis_functions(const std::vector<int>& indices, const std::string& name, const std::string& type = "CUBE");
+    void compute_basis_functions(const std::vector<int>& indices, const std::string& name,
+                                 const std::string& type = "CUBE");
     /// Compute a set of orbital-type properties and drop files corresponding to name, index, symmetry label, and type
-    void compute_orbitals(std::shared_ptr<Matrix> C, const std::vector<int>& indices, const std::vector<std::string>& labels, const std::string& name, const std::string& type = "CUBE");
+    void compute_orbitals(std::shared_ptr<Matrix> C, const std::vector<int>& indices,
+                          const std::vector<std::string>& labels, const std::string& name,
+                          const std::string& type = "CUBE");
     /// Compute a LOL-type property and drop a file corresponding to name and type
     void compute_LOL(std::shared_ptr<Matrix> D, const std::string& name, const std::string& type = "CUBE");
     /// Compute an ELF-type property and drop a file corresponding to name and type (TODO: this seems very unstable)
     void compute_ELF(std::shared_ptr<Matrix> D, const std::string& name, const std::string& type = "CUBE");
 
+    /// Compute the isocountour range that capture a given fraction of the MO density
+    std::pair<double, double> compute_isocontour_range(double* v2);
 };
 
-} // End namespace
+}  // End namespace
 
 #endif

--- a/psi4/src/psi4/libcubeprop/cubeprop.h
+++ b/psi4/src/psi4/libcubeprop/cubeprop.h
@@ -39,9 +39,7 @@ namespace psi {
 class CubicScalarGrid;
 
 class CubeProperties {
-
-protected:
-
+   protected:
     // => Task specification <= //
 
     /// Global options object
@@ -76,7 +74,7 @@ protected:
     /// Common setup across all constructors
     void common_init();
 
-public:
+   public:
     // => Constructors <= //
 
     /// Construct a CubeProperties object from a Wavefunction (possibly with symmetry in wfn)
@@ -99,7 +97,8 @@ public:
     /// Compute an ESP grid task (Dt.cube and ESP.cube)
     void compute_esp(std::shared_ptr<Matrix> Dt, const std::vector<double>& nuc_weights = std::vector<double>());
     /// Compute an orbital task (key_N.cube, for 0-based indices of C)
-    void compute_orbitals(std::shared_ptr<Matrix> C, const std::vector<int>& indices, const std::vector<std::string>& labels, const std::string& key);
+    void compute_orbitals(std::shared_ptr<Matrix> C, const std::vector<int>& indices,
+                          const std::vector<std::string>& labels, const std::string& key);
     /// Compute a basis function task (key_N.cube, for 0-based indices of basisset_)
     void compute_basis_functions(const std::vector<int>& indices, const std::string& key);
     /// Compute a LOL grid task (key.cube)
@@ -107,7 +106,6 @@ public:
     /// Compute an ELF grid task (key.cube)
     void compute_ELF(std::shared_ptr<Matrix> D, const std::string& key);
 };
-
 }
 
 #endif

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -226,6 +226,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
   /*- List of basis function indices for which cube files are generated
   (1-based). All basis functions computed if empty.-*/
   options.add("CUBEPROP_BASIS_FUNCTIONS", new ArrayType());
+  /* Fraction of density captured by adaptive isocontour values */
+  options.add_double("CUBEPROP_ISOCONTOUR_THRESHOLD",0.85);
   /*- CubicScalarGrid basis cutoff. !expert -*/
   options.add_double("CUBIC_BASIS_TOLERANCE", 1.0E-12);
   /*- CubicScalarGrid maximum number of grid points per evaluation block. !expert -*/

--- a/tests/cubeprop-esp/input.dat
+++ b/tests/cubeprop-esp/input.dat
@@ -13,13 +13,8 @@ set cubeprop_tasks ['esp']
 e, wfn = energy('scf', return_wfn=True)
 cubeprop(wfn)
 
-#for n in ['1_1-A1','2_2-A1','3_1-B2','4_3-A1','5_1-B1']:
-#    ref_cube = open('Psi_a_%s.cube.ref' % n,'r').read()
-#    this_cube = open('Psi_a_%s.cube' % n,'r').read()
-#    compare_cubes(ref_cube,this_cube,"Comparing MO %s" % n) #TEST
-#
 for s in ['Dt', 'ESP']:
-    ref_cube = open('%s.cube.ref' % s,'r').read()
-    this_cube = open('%s.cube' % s,'r').read()
+    ref_cube = '%s.cube.ref' % s
+    this_cube = '%s.cube' % s
     compare_cubes(ref_cube,this_cube,"Comparing %s" % s) #TEST
 

--- a/tests/cubeprop/input.dat
+++ b/tests/cubeprop/input.dat
@@ -18,11 +18,11 @@ scf_e, scf_wfn = energy('scf', return_wfn=True)
 cubeprop(scf_wfn)
 
 for n in ['1_1-A1','2_2-A1','3_1-B2','4_3-A1','5_1-B1']:
-    ref_cube = open('Psi_a_%s.cube.ref' % n,'r').read()
-    this_cube = open('Psi_a_%s.cube' % n,'r').read()
+    ref_cube = 'Psi_a_%s.cube.ref' % n
+    this_cube ='Psi_a_%s.cube' % n
     compare_cubes(ref_cube,this_cube,"Comparing MO %s" % n) #TEST
 
 for s in ['Da','Db','Dt','Ds']:
-    ref_cube = open('%s.cube.ref' % s,'r').read()
-    this_cube = open('%s.cube' % s,'r').read()
+    ref_cube = '%s.cube.ref' % s
+    this_cube = '%s.cube' % s
     compare_cubes(ref_cube,this_cube,"Comparing %s" % s) #TEST


### PR DESCRIPTION
## Description
This is an enhancement to Psi4 cubeprop library. Cube files are usually plotted using isocontour surfaces with a common iso value. This PR implements the computation of adaptive isocontour values that capture a certain fraction of a MO density (orbital squared) using the least amount of points. This is similar to the approach of Lehtola and Jónsson [J. Chem. Theory Comput. 10, 642–649 (2014)], but appears to be different in the fact that the implementation in this PR uses two isocontour values.

The added code just sorts a cube file's grid points and finds a pair of positive and negative isocontour values the satisfy the above definition. The default is to capture 85% of the density, but the user can specify a different value with the new option `CUBEPROP_ISOCONTOUR_THRESHOLD`.  The adaptive isocontour range is included in the second comment line of the MO cube files and looks like this
```
Psi4 Gaussian Cube File.
Property: Psi_a_1_1-Ag. Isocontour range for 85% of the density: (  0.053504,  0.000000)
```
The user can then inspect the cube file to find the value of the range. However, the recommended way to use this feature is to use an updated version of `vmd_cube` that will be posted shortly and that will automatically plot all cube files using the adaptive ranges saved in the cube files.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Add ability to compute range for densities
  - [x] Add documentation of feature
  - [x] Add documentation of new options

## Questions
- [x] Merge the changes done in #822 with this PR?
## Status
- [x] Ready to go
- [x] Closes #822 