### PR TITLE
External Field Cleanup in DMRG, #844 Continued

### DIFF
--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -265,7 +265,7 @@ void buildHamDMRG( std::shared_ptr<IntegralTransform> ints, std::shared_ptr<MOSp
     const int nirrep = wfn->nirrep();
 
     // Econstant and one-electron integrals
-    double Econstant = wfn->molecule()->nuclear_repulsion_energy();
+    double Econstant = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     for (int h = 0; h < iHandler->getNirreps(); h++){
         const int NOCC = iHandler->getNOCC(h);
         for (int froz = 0; froz < NOCC; froz++){


### PR DESCRIPTION
## Description
PR #844 made the dipole field a required argument almost everywhere but missed DMRG. The DMRG code now supplies this argument, so the code can be built again!

## Questions
- [x] ~I couldn't find a dmrg test suite. I assume that DMRG doesn't need any wacky external field handling.~ Tested and passing!

## Status
- [x] Ready to go
