### PR TITLE
Adding force_soccpi and force_doccpi functions

### DIFF
--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -140,8 +140,10 @@ void export_wavefunction(py::module& m) {
         .def("molecule", &Wavefunction::molecule, "Returns the Wavefunctions molecule.")
         .def("doccpi", &Wavefunction::doccpi, py::return_value_policy::copy,
              "Returns the number of doubly occupied orbitals per irrep.")
+        .def("force_doccpi", &Wavefunction::force_doccpi, "Specialized expert use only. Sets the number of doubly occupied oribtals per irrep. Note that this results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy,
              "Returns the number of singly occupied orbitals per irrep.")
+        .def("force_soccpi", &Wavefunction::force_soccpi, "Specialized expert use only. Sets the number of singly occupied oribtals per irrep. Note that this results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("nsopi", &Wavefunction::nsopi, py::return_value_policy::copy,
              "Returns the number of symmetry orbitals per irrep.")
         .def("nmopi", &Wavefunction::nmopi, py::return_value_policy::copy,

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -609,8 +609,8 @@ void Wavefunction::set_reference_wavefunction(const std::shared_ptr<Wavefunction
 
 void Wavefunction::force_doccpi(const Dimension &doccpi) {
     for (int h = 0; h < nirrep_; h++) {
-        if(doccpi[h] > nmopi_[h]) {
-            throw PSIEXCEPTION("Wavefunction::force_doccpi: Number of doubly occupied orbitals in an irrep cannot exceed the number of molecular orbitals.");
+        if((soccpi_[h] + doccpi[h]) > nmopi_[h]) {
+            throw PSIEXCEPTION("Wavefunction::force_doccpi: Number of doubly and singly occupied orbitals in an irrep cannot exceed the total number of molecular orbitals.");
         }
         doccpi_[h] = doccpi[h];
         nalphapi_[h] = doccpi_[h] + soccpi_[h];
@@ -625,8 +625,8 @@ void Wavefunction::force_soccpi(const Dimension &soccpi) {
        throw PSIEXCEPTION("Wavefunction::force_soccpi: Cannot set soccpi since alpha and beta densities must be the same for this Wavefunction."); 
     }
     for (int h = 0; h < nirrep_; h++) {
-        if(soccpi[h] > nmopi_[h]) {
-            throw PSIEXCEPTION("Wavefunction::force_soccpi: Number of singly occupied orbitals in an irrep cannot exceed the number of molecular orbitals.");
+        if((soccpi[h] + doccpi_[h]) > nmopi_[h]) {
+            throw PSIEXCEPTION("Wavefunction::force_soccpi: Number of doubly and singly occupied orbitals in an irrep cannot exceed the total number of molecular orbitals.");
         }
         soccpi_[h] = soccpi[h];
         nalphapi_[h] = doccpi_[h] + soccpi_[h];

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -609,6 +609,9 @@ void Wavefunction::set_reference_wavefunction(const std::shared_ptr<Wavefunction
 
 void Wavefunction::force_doccpi(const Dimension &doccpi) {
     for (int h = 0; h < nirrep_; h++) {
+        if(doccpi[h] > nmopi_[h]) {
+            throw PSIEXCEPTION("Wavefunction::force_doccpi: Number of doubly occupied orbitals in an irrep cannot exceed the number of molecular orbitals.");
+        }
         doccpi_[h] = doccpi[h];
         nalphapi_[h] = doccpi_[h] + soccpi_[h];
         nbetapi_[h] = doccpi_[h];
@@ -618,13 +621,17 @@ void Wavefunction::force_doccpi(const Dimension &doccpi) {
 }
 
 void Wavefunction::force_soccpi(const Dimension &soccpi) {
+    if(same_a_b_dens_) {
+       throw PSIEXCEPTION("Wavefunction::force_soccpi: Cannot set soccpi since alpha and beta densities must be the same for this Wavefunction."); 
+    }
     for (int h = 0; h < nirrep_; h++) {
+        if(soccpi[h] > nmopi_[h]) {
+            throw PSIEXCEPTION("Wavefunction::force_soccpi: Number of singly occupied orbitals in an irrep cannot exceed the number of molecular orbitals.");
+        }
         soccpi_[h] = soccpi[h];
         nalphapi_[h] = doccpi_[h] + soccpi_[h];
-        nbetapi_[h] = doccpi_[h];
     }
     nalpha_ = doccpi_.sum() + soccpi_.sum();
-    nbeta_ = doccpi_.sum();
 }
 
 void Wavefunction::set_frzvpi(const Dimension &frzvpi) {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -613,8 +613,8 @@ void Wavefunction::force_doccpi(const Dimension &doccpi) {
         nalphapi_[h] = doccpi_[h] + soccpi_[h];
         nbetapi_[h] = doccpi_[h];
     }
-    nalphapi_ = doccpi_.sum() + soccpi_.sum();
-    nbetapi_ = doccpi_.sum();
+    nalpha_ = doccpi_.sum() + soccpi_.sum();
+    nbeta_ = doccpi_.sum();
 }
 
 void Wavefunction::force_soccpi(const Dimension &soccpi) {
@@ -623,8 +623,8 @@ void Wavefunction::force_soccpi(const Dimension &soccpi) {
         nalphapi_[h] = doccpi_[h] + soccpi_[h];
         nbetapi_[h] = doccpi_[h];
     }
-    nalphapi_ = doccpi_.sum() + soccpi_.sum();
-    nbetapi_ = doccpi_.sum();
+    nalpha_ = doccpi_.sum() + soccpi_.sum();
+    nbeta_ = doccpi_.sum();
 }
 
 void Wavefunction::set_frzvpi(const Dimension &frzvpi) {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -607,6 +607,26 @@ void Wavefunction::set_reference_wavefunction(const std::shared_ptr<Wavefunction
     reference_wavefunction_ = wfn;
 }
 
+void Wavefunction::force_doccpi(const Dimension &doccpi) {
+    for (int h = 0; h < nirrep_; h++) {
+        doccpi_[h] = doccpi[h];
+        nalphapi_[h] = doccpi_[h] + soccpi_[h];
+        nbetapi_[h] = doccpi_[h];
+    }
+    nalphapi_ = doccpi_.sum() + soccpi_.sum();
+    nbetapi_ = doccpi_.sum();
+}
+
+void Wavefunction::force_soccpi(const Dimension &soccpi) {
+    for (int h = 0; h < nirrep_; h++) {
+        soccpi_[h] = soccpi[h];
+        nalphapi_[h] = doccpi_[h] + soccpi_[h];
+        nbetapi_[h] = doccpi_[h];
+    }
+    nalphapi_ = doccpi_.sum() + soccpi_.sum();
+    nbetapi_ = doccpi_.sum();
+}
+
 void Wavefunction::set_frzvpi(const Dimension &frzvpi) {
     for (int h = 0; h < nirrep_; h++) {
         frzvpi_[h] = frzvpi[h];

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -358,8 +358,6 @@ public:
     std::array<double,3> get_dipole_field_strength() const;
     FieldType get_dipole_perturbation_type() const;
 
-    void set_doccpi(const Dimension& doccpi);
-    void set_soccpi(const Dimension& soccpi);
     /**
      * @brief Expert specialized use only. Sets the number of doubly occupied orbitals per irrep. Results in an inconsistent Wavefunction object for SCF purposes, so caution is advised.
      * @param doccpi the new list of doubly occupied orbitals per irrep

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -361,12 +361,12 @@ public:
     void set_doccpi(const Dimension& doccpi);
     void set_soccpi(const Dimension& soccpi);
     /**
-     * @brief Expert specialized use only. Sets the number of doubly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
+     * @brief Expert specialized use only. Sets the number of doubly occupied orbitals per irrep. Results in an inconsistent Wavefunction object for SCF purposes, so caution is advised.
      * @param doccpi the new list of doubly occupied orbitals per irrep
      */
     void force_doccpi(const Dimension& doccpi);
     /**
-     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
+     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in an inconsistent Wavefunction object for SCF purposes, so caution is advised.
      * @param soccpi the new list of singly occupied orbitals per irrep
      */
     void force_soccpi(const Dimension& soccpi);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -360,6 +360,15 @@ public:
 
     void set_doccpi(const Dimension& doccpi);
     void set_soccpi(const Dimension& soccpi);
+    /**
+     * @brief Expert specialized use only. Sets the number of doubly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
+     * @param doccpi the new list of doubly occupied orbitals per irrep
+     */
+    void force_doccpi(const Dimension& doccpi);
+   /**     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
+     * @param doccpi the new list of singly occupied orbitals per irrep
+     */
+    void force_soccpi(const Dimension& soccpi);
 
     /// Sets the frozen virtual orbitals per irrep array.
     void set_frzvpi(const Dimension& frzvpi);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -365,8 +365,9 @@ public:
      * @param doccpi the new list of doubly occupied orbitals per irrep
      */
     void force_doccpi(const Dimension& doccpi);
-   /**     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
-     * @param doccpi the new list of singly occupied orbitals per irrep
+    /**
+     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in inconsistent Wavefunction object for SCF, so caution is advised.
+     * @param soccpi the new list of singly occupied orbitals per irrep
      */
     void force_soccpi(const Dimension& soccpi);
 


### PR DESCRIPTION
## Description
This PR adds implementation of `force_soccpi` and `force_doccpi`, allowing the user to change the singly and doubly occupied orbitals per irrep in the Wavefunction object. The alpha and beta electron counts are also updated accordingly. This functionality should only be used by expert users in special circumstances, since it causes inconsistency in the Wavefunction object for SCF purposes. (Let me know if I should add some sort of "expert" flag in the documentation to reflect this, or if I need to add any other documentation besides what I've put in already!)

## Todos
  - [x] Add implementation of `force_soccpi` and `force_doccpi` C++-side
  - [x] Add Python-side accessibility to `force_soccpi` and `force_doccpi`

## Status
- [ ] Ready to go