### PR TITLE
Get useful info back after optimizer errors

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -843,7 +843,7 @@ def optimize(name, **kwargs):
 
     :returns: (*float*, :py:class:`~psi4.core.Wavefunction`) |w--w| energy and wavefunction when **return_wfn** specified.
 
-    :raises: psi4.ConvergenceError if |optking__geom_maxiter| exceeded without reaching geometry convergence.
+    :raises: psi4.OptimizationConvergenceError if |optking__geom_maxiter| exceeded without reaching geometry convergence.
 
     :PSI variables:
 
@@ -983,7 +983,7 @@ def optimize(name, **kwargs):
     >>> #     geometry (by default) is the anticipated *next* optimization step.
     >>> try:
     >>>     optimize('hf/cc-pvtz')
-    >>> except psi4.ConvergenceError as ex:
+    >>> except psi4.OptimizationConvergenceError as ex:
     >>>     next_geom_coords_as_numpy_array = np.asarray(ex.wfn.molecule().geometry())
 
     """
@@ -1153,7 +1153,7 @@ def optimize(name, **kwargs):
             molecule.set_geometry(moleculeclone.geometry())
             core.clean()
             optstash.restore()
-            raise ConvergenceError("""geometry optimization""", n - 1, wfn)
+            raise OptimizationConvergenceError("""geometry optimization""", n - 1, wfn)
             return thisenergy
 
         core.print_out('\n    Structure for next step:\n')
@@ -1171,7 +1171,7 @@ def optimize(name, **kwargs):
             core.opt_clean()
 
     optstash.restore()
-    raise ConvergenceError("""geometry optimization""", n - 1, wfn)
+    raise OptimizationConvergenceError("""geometry optimization""", n - 1, wfn)
 
 
 def hessian(name, **kwargs):

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -977,6 +977,15 @@ def optimize(name, **kwargs):
     >>> # cbs-xtpl* for more examples of this input style
     >>> optimize("MP2/aug-cc-pv([d,t]+d)z + d:ccsd(t)/cc-pvdz", corl_scheme=myxtplfn_2)
 
+    >>> # [6] Get info like geometry, gradient, energy back after an
+    >>> #     optimization fails. Note that the energy and gradient
+    >>> #     correspond to the last optimization cycle, whereas the
+    >>> #     geometry (by default) is the anticipated *next* optimization step.
+    >>> try:
+    >>>     optimize('hf/cc-pvtz')
+    >>> except psi4.ConvergenceError as ex:
+    >>>     next_geom_coords_as_numpy_array = np.asarray(ex.wfn.molecule().geometry())
+
     """
     kwargs = p4util.kwargs_lower(kwargs)
 
@@ -1144,7 +1153,7 @@ def optimize(name, **kwargs):
             molecule.set_geometry(moleculeclone.geometry())
             core.clean()
             optstash.restore()
-            raise ConvergenceError("""geometry optimization""", n - 1)
+            raise ConvergenceError("""geometry optimization""", n - 1, wfn)
             return thisenergy
 
         core.print_out('\n    Structure for next step:\n')
@@ -1162,7 +1171,7 @@ def optimize(name, **kwargs):
             core.opt_clean()
 
     optstash.restore()
-    raise ConvergenceError("""geometry optimization""", n - 1)
+    raise ConvergenceError("""geometry optimization""", n - 1, wfn)
 
 
 def hessian(name, **kwargs):

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -81,10 +81,11 @@ class ConvergenceError(PsiException):
     error message *msg* to standard output stream and output file.
 
     """
-    def __init__(self, eqn_description, maxit):
+    def __init__(self, eqn_description, maxit, wfn=None):
         msg = "Could not converge %s in %d iterations." % (eqn_description, maxit)
         PsiException.__init__(self, msg)
         self.message = msg
+        self.wfn = wfn
         core.print_out('\nPsiException: %s\n\n' % (msg))
 
 

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -81,12 +81,19 @@ class ConvergenceError(PsiException):
     error message *msg* to standard output stream and output file.
 
     """
-    def __init__(self, eqn_description, maxit, wfn=None):
+    def __init__(self, eqn_description, maxit):
         msg = "Could not converge %s in %d iterations." % (eqn_description, maxit)
         PsiException.__init__(self, msg)
         self.message = msg
-        self.wfn = wfn
         core.print_out('\nPsiException: %s\n\n' % (msg))
+
+
+class OptimizationConvergenceError(ConvergenceError):
+    """Error called for problems with geometry optimizer."""
+
+    def __init__(self, eqn_description, maxit, wfn):
+        ConvergenceError.__init__(self, eqn_description, maxit)
+        self.wfn = wfn
 
 
 class CSXError(PsiException):

--- a/tests/opt1/input.dat
+++ b/tests/opt1/input.dat
@@ -34,7 +34,7 @@ set geom_maxiter 2
 convergence_error_set = False
 try:
     optimize('scf')
-except psi4.ConvergenceError as ex:
+except psi4.OptimizationConvergenceError as ex:
     convergence_error_set = True
     wfn_from_error = ex.wfn
 

--- a/tests/opt1/input.dat
+++ b/tests/opt1/input.dat
@@ -34,6 +34,16 @@ set geom_maxiter 2
 convergence_error_set = False
 try:
     optimize('scf')
-except psi4.ConvergenceError:
+except psi4.ConvergenceError as ex:
     convergence_error_set = True
+    wfn_from_error = ex.wfn
+
+# grab molecule from the optimization that ended in an error and print
+#   geometry out to the output file. note that geometry is the next step the
+#   optimizer would have taken, not the geometry of the last available SCF and
+#   gradient.
+mol_from_error = wfn_from_error.molecule()
+mol_from_error.print_out()
+
 compare_integers(1, int(convergence_error_set), 'opt() exit gracefully but truthfully')
+compare_values(9.297919, wfn_from_error.molecule().nuclear_repulsion_energy(), 2, 'NRE from error exit')


### PR DESCRIPTION
## Description
Allow access to wfn (incl. geom) after optking errors

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
* **User-Facing for Release Notes**
  - [x] If optking fails internally or through exceeding max cycles and throws a `ConvergenceError`, you can now catch it with:

```
try:
    optimize('hf')
except psi4.ConvergenceError as err:
    gotcha = err.wfn
    print(gotcha.molecule().nuclear_repulsion_energy())
```

## Status
- [x] Ready to go
