### PR TITLE
#859, #860 Fix: Tightly Converged IRCs Now Run

### DIFF
--- a/doc/sphinxman/CMakeLists.txt
+++ b/doc/sphinxman/CMakeLists.txt
@@ -51,7 +51,7 @@ if(PERL_FOUND AND SPHINX_FOUND AND SPHINX_STUFF_FOUND)
     manage_addon.rst numpy.rst build_planning.rst build_faq.rst
     build_obtaining.rst libint.rst erd.rst simint.rst gcp.rst
     index_tutorials.rst prog_faq.rst manage_index.rst manage_git.rst
-    style_c.rst prog_blas.rst
+    style_c.rst prog_blas.rst add_tests.rst
     )
 
     # * compute relative path btwn top_srcdir and objdir/doc/sphinxman

--- a/doc/sphinxman/source/add_tests.rst
+++ b/doc/sphinxman/source/add_tests.rst
@@ -28,12 +28,12 @@
 
 .. include:: autodoc_abbr_options_c.rst
 
-.. _`sec:add_tests`:
+.. _`faq:add_tests`:
 
 Adding Test Cases
-=========
+=================
 
-To create a new test case, first make a folder in :source:`tests`. This directory will need two files. The first is ``CMakeLists.txt``, which is necessary to add the test case to the suite. This file should have the following lines::
+To create a new test case, first make a folder in :source:`tests`. The directory name may not contain an underscore; to indicate spaces, use a hyphen instead. This directory will need two files. The first is ``CMakeLists.txt``, which is necessary to add the test case to the suite. This file should have the following lines::
 
     include(TestingMacros)
     

--- a/doc/sphinxman/source/add_tests.rst
+++ b/doc/sphinxman/source/add_tests.rst
@@ -1,0 +1,79 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. _`sec:add_tests`:
+
+Adding Test Cases
+=========
+
+To create a new test case, first make a folder in :source:`tests`. This directory will need two files. The first is ``CMakeLists.txt``, which is necessary to add the test case to the suite. This file should have the following lines::
+
+    include(TestingMacros)
+    
+    add_regression_test(directory_name "psi;semicolon_separated-list-of-applicable-test-labels")
+    
+
+The labels specify which groups of tests include the test case. The ``psi`` label should always be added, but the other labels are test-specific. The method tested should always be included, and this is often sufficient. If adding a test for an already existing module, the labels for other tests of the module will suggest other labels to add.
+
+A test requiring over 15 minutes should be labeled ``longtests``. A short test used for general bug checking should be labeled ``quicktests``. A test that confirms |PSIfour| is operational should be labeled ``smoketests``.
+
+The other necessary file is the input file itself, ``input.dat``. The input file should be just a simple input file to run the test, with small modifications. ::
+
+    #! RI-SCF cc-pVTZ energy of water, with Z-matrix input and cc-pVTZ-RI auxilliary basis.
+    #! Also a bit more to force a second line.
+    
+    nucenergy = 8.801466202085710  #TEST
+    refenergy = -76.05098402733282 #TEST
+    
+    molecule h2o {
+       symmetry c1
+       O
+       H 1 1.0
+       H 1 1.0 2 104.5
+    }
+    
+    set {
+       basis cc-pVTZ
+       scf_type df
+       df_basis_scf cc-pVTZ-RI
+       e_convergence 10
+    }
+    
+    thisenergy = energy('rhf')
+    
+    compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+    compare_values(refenergy, thisenergy, 9, "Reference energy") #TEST
+    compare_values(refenergy, get_variable('scf total energy'), 9, "Reference energy") #TEST
+
+Of those small modifications, first, note the special comment at the top (starting with the #! comment marker). This should be very descriptive since it is inlined into the manual (unless !nosample is present in this comment) as a sample input.
+
+The reference values are assigned to variables for later use. The compare_values function (along with several relatives in :source:`psi4/driver/p4util/util.py` for comparing strings, matrices, etc.) checks that the computed values match these reference values to suitable precision. This function prints an error message and signals that the test failed to the make system, if the values don't match. Any lines of the input associated with the validation process should be flagged with #TEST at the end of each line, so that they can be removed when copying from the tests to the samples directory.
+
+Finally, add the directory name to the list of tests in :source:`tests/CMakeLists.txt`.

--- a/doc/sphinxman/source/prog_faq.rst
+++ b/doc/sphinxman/source/prog_faq.rst
@@ -67,3 +67,4 @@ Versioning |PSIfour|
 Miscellaneous
 -------------
 
+#. :ref:`faq:add_tests`

--- a/doc/sphinxman/source/programming.rst
+++ b/doc/sphinxman/source/programming.rst
@@ -36,6 +36,7 @@ Programming: Using the Core Libraries
    optionshandling
    proc_py
    prog_blas
+   add_tests
 
 ..   prog_basissets
 

--- a/psi4/src/psi4/optking/molecule_irc_step.cc
+++ b/psi4/src/psi4/optking/molecule_irc_step.cc
@@ -205,7 +205,7 @@ void MOLECULE::irc_step(void)
     }
   }
 
-    if (p_irc_data->sphere_step == 1) {
+    if (p_irc_data->sphere_step == 1 && p_irc_data->size() > 3) {
 
       double *u_f_q = init_array(Nintco);
       double *u_f_q_0 = init_array(Nintco);
@@ -219,21 +219,19 @@ void MOLECULE::irc_step(void)
         p_irc_data->in_min_range = 1;
       }
 
-      if(p_irc_data->size() > 3) {
-        if (u_f_q_dot < -0.7 ||
-            (
-              std::fabs(p_irc_data->g_line_dist(p_irc_data->size()-1) - p_irc_data->g_line_dist(p_irc_data->size()-2)) < s*10e-03
-            )
-           ) {
-          oprintf_out("\n@IRC\n@IRC Houston, we've found a minimum!\n@IRC\n");
+      if (u_f_q_dot < -0.7 ||
+          (
+            std::fabs(p_irc_data->g_line_dist(p_irc_data->size()-1) - p_irc_data->g_line_dist(p_irc_data->size()-2)) < s*10e-03
+          )
+         ) {
+        oprintf_out("\n@IRC\n@IRC Houston, we've found a minimum!\n@IRC\n");
 
-          if(Opt_params.IRC_stop == OPT_PARAMS::ASK) {
-            std::cout << "Would you like to proceed? (1=yes, 0=no):";
-            std::cin >> answer;
-          }
-          if(Opt_params.IRC_stop == OPT_PARAMS::STOP || !answer) {
-            p_irc_data->go = 0;
-          }
+        if(Opt_params.IRC_stop == OPT_PARAMS::ASK) {
+          std::cout << "Would you like to proceed? (1=yes, 0=no):";
+          std::cin >> answer;
+        }
+        if(Opt_params.IRC_stop == OPT_PARAMS::STOP || !answer) {
+          p_irc_data->go = 0;
         }
       }
 

--- a/psi4/src/psi4/optking/opt_data.cc
+++ b/psi4/src/psi4/optking/opt_data.cc
@@ -219,6 +219,12 @@ bool OPT_DATA::conv_check(opt::MOLECULE &mol) const {
   }
 
 // Test for convergence
+
+  // The initial TS of an IRC doesn't count
+  if (Opt_params.opt_type == OPT_PARAMS::IRC && g_iteration() == 1) {
+    return false;
+  }
+
 #if defined(OPTKING_PACKAGE_PSI)
 
   // Q-Chem and Gaussian have convergence tests involving interplay among criteria.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   omp2p5-1 omp2p5-2 omp2p5-grad1 omp2p5-grad2 omp3-1 omp3-2 
                   omp3-3 omp3-4 omp3-5 omp3-grad1 omp3-grad2 opt-lindep-change 
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9 
-                  opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-freeze-coords 
+                  opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-irc-3 opt-freeze-coords 
                   props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2 
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1 
                   psimrcc-fd-freq2 psimrcc-pt2 psimrcc-sp1 psithon1 psithon2 

--- a/tests/opt-irc-3/CMakeLists.txt
+++ b/tests/opt-irc-3/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(opt-irc-3 "psi;opt")

--- a/tests/opt-irc-3/input.dat
+++ b/tests/opt-irc-3/input.dat
@@ -24,7 +24,6 @@ set {
   basis                      sto-3g
   opt_type                   irc
   geom_maxiter               10
-  g_convergence              gau_verytight
   irc_step_size              0.5
 }
 

--- a/tests/opt-irc-3/input.dat
+++ b/tests/opt-irc-3/input.dat
@@ -1,0 +1,44 @@
+#! Compute the IRC for HOOH torsional rotation at the RHF/STO-3G level of theory, with a tightly converged TS and ZMAT input. This isn't working perfectly, so we need a hack that renders this a poor sample !nosample
+# Print
+# the path to a trajectory file for visualization
+# in Jmol.
+# grep '@IRC' on the output to see a nice printout
+# of the progress of your IRC computation.
+
+molecule h2o2 {
+   H   
+   O 1 OH
+   O 2 OO 1 A 
+   H 3 OH 2 A 1 D 
+ 
+    A         =  104.9380499376
+    D         =   -0.0000000000
+    OH        =    1.0008060649
+    OO        =    1.4057357716
+}
+
+# g_convergence needs to be tight for IRCs:
+set g_convergence gau_verytight
+
+set {
+  basis                      sto-3g
+  opt_type                   irc
+  geom_maxiter               10
+  g_convergence              gau_verytight
+  irc_step_size              0.5
+}
+
+frequencies('scf', dertype=1)
+
+# Lower point group from C2v to C2
+h2o2.reset_point_group('c2')
+
+# An ideal test would check the energy at the minima, but there's
+# an unpredictable last step; see #860. Instead, check after 10 steps.
+# We just need to make sure this makes it past the second point.
+try:
+    energy = optimize('scf')
+except psi4.OptimizationConvergenceError as ex:
+    wfn = ex.wfn
+
+compare_values(-148.752629, wfn.energy(), 5, "Energy of IRC point after 10 iterations")  #TEST


### PR DESCRIPTION
## Description
As documented in #859, an IRC performed on a tightly converged transition state would converge to the initial transition state. The obvious workaround showed non-deterministic optking steps, as documented in #860. Both bugs originate from neglecting the possibility of near-zero gradients and have been fixed. Also as documented in #860, there is still some non-deterministic behavior after the minimum has been found. As optking is going to be moved Python-side soon and this behavior is irrelevant for most users, I'll hold off from investigating that until we see if the Python-version has the problem.

I have added a test case for tightly converged transition states, thanks to the oddly prescient #881. For the sake of other developers, I added a page on how to add test cases.

## Todos
Notable points that this PR has either accomplished or will accomplish.

* **User-Facing for Release Notes**
  - [x] Fixes a bug disabling IRCs for tightly converged transition states.

## Status
- [x] Ready to go
