### PR TITLE
DFT: Fix VV10 timer error and quickens test

### DIFF
--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -202,7 +202,7 @@ size_t VBase::nblocks() { return grid_->blocks().size(); }
 void VBase::finalize() { grid_.reset(); }
 
 double VBase::vv10_nlc(SharedMatrix ret) {
-    timer_on("V: V10");
+    timer_on("V: VV10");
     timer_on("Setup");
 
     // Densities should be set by the calling functional
@@ -347,7 +347,7 @@ double VBase::vv10_nlc(SharedMatrix ret) {
         double* zk = vals["V"]->pointer();
         double* v_rho_a = vals["V_RHO_A"]->pointer();
 
-        parallel_timer_on("Fock", rank);
+        parallel_timer_on("VV10 Fock", rank);
         // => LSDA contribution (symmetrized) <= //
         for (int P = 0; P < npoints; P++) {
             std::fill(Tp[P], Tp[P] + nlocal, 0.0);
@@ -397,7 +397,7 @@ double VBase::vv10_nlc(SharedMatrix ret) {
     }
 
     double vv10_e = std::accumulate(vv10_exc.begin(), vv10_exc.end(), 0.0);
-    timer_off("V: V10");
+    timer_off("V: VV10");
     return vv10_e;
 }
 

--- a/tests/dft-vv10/CMakeLists.txt
+++ b/tests/dft-vv10/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-vv10 "psi;dft;scf")
+add_regression_test(dft-vv10 "psi;quicktests;dft;scf")

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -1,8 +1,8 @@
 #! He Dimer VV10 functional test.
 
-bench = {"DFT VV10 ENERGY": 0.0187972621212943, # TEST
-         "DFT XC ENERGY": -2.1610011925928672,  # TEST
-         "CURRENT ENERGY": -5.8199576848715910} # TEST
+bench = {"DFT VV10 ENERGY": 0.0187968521125124, # TEST
+         "DFT XC ENERGY":  -2.1610005673059192, # TEST
+         "CURRENT ENERGY": -5.8199580945288414} # TEST
 
 molecule ne {
   0 1
@@ -11,7 +11,9 @@ molecule ne {
 }
 
 
-set basis aug-cc-pVDZ
+set BASIS aug-cc-pVDZ
+set DFT_VV10_SPHERICAL_POINTS 50
+set DFT_VV10_RADIAL_POINTS 20
 
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -1,8 +1,8 @@
 #! He Dimer VV10 functional test.
 
-bench = {"DFT VV10 ENERGY": 0.0187968521125124, # TEST
-         "DFT XC ENERGY":  -2.1610005673059192, # TEST
-         "CURRENT ENERGY": -5.8199580945288414} # TEST
+bench = {"DFT VV10 ENERGY": 0.0187968521080026, # TEST
+         "DFT XC ENERGY":  -2.1610005616974943, # TEST
+         "CURRENT ENERGY": -5.8199580945288449} # TEST
 
 molecule ne {
   0 1
@@ -14,8 +14,10 @@ molecule ne {
 set BASIS aug-cc-pVDZ
 set DFT_VV10_SPHERICAL_POINTS 50
 set DFT_VV10_RADIAL_POINTS 20
+set E_CONVERGENCE 1.e-12
+set D_CONVERGENCE 1.e-10
 
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
-    compare_values(v, psi4.get_variable(k), 6, k) # TEST
+    compare_values(v, psi4.get_variable(k), 9, k) # TEST


### PR DESCRIPTION
## Description
Small timer mistype in VV10 NL correlation. I patched this up and added a (faster) test to the quicktests suite so that we also check VV10 in CI.

## Status
- [x] Ready to go