### PR TITLE
CdSalcList Pybinding, Cleanup

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -509,7 +509,11 @@ void export_mints(py::module& m)
              "Returns a new Matrix object named name with default dimensions");
 //              py::arg("name"), py::arg("symmetry"));
 
-    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations")
+    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations of Cartesian displacements")
+        .def(py::init<std::shared_ptr<Molecule>, int, bool, bool>())
+        .def("ncd", &CdSalcList::ncd, "Return the number of cartesian displacements SALCs")
+        .def("create_matrices", &CdSalcList::create_matrices, "Return a vector of matrices with the SALC symmetries. Dimensions determined by factory.", py::arg("basename"), py::arg("factory"))
+        .def("salc_name", &CdSalcList::salc_name, "Return the name of SALC #i.", py::arg("i"))
         .def("print_out", &CdSalcList::print, "Print the SALC to the output file")
         .def("matrix", &CdSalcList::matrix, "Return the SALCs")
         .def("matrix_irrep", &CdSalcList::matrix_irrep, "Return only the SALCS in irrep h", py::arg("h"));

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -509,10 +509,13 @@ void export_mints(py::module& m)
              "Returns a new Matrix object named name with default dimensions");
 //              py::arg("name"), py::arg("symmetry"));
 
-    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations of Cartesian displacements")
+    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(
+        m, "CdSalcList", "Class for generating symmetry adapted linear combinations of Cartesian displacements")
         .def(py::init<std::shared_ptr<Molecule>, int, bool, bool>())
         .def("ncd", &CdSalcList::ncd, "Return the number of cartesian displacements SALCs")
-        .def("create_matrices", &CdSalcList::create_matrices, "Return a vector of matrices with the SALC symmetries. Dimensions determined by factory.", py::arg("basename"), py::arg("factory"))
+        .def("create_matrices", &CdSalcList::create_matrices,
+             "Return a vector of matrices with the SALC symmetries. Dimensions determined by factory.",
+             py::arg("basename"), py::arg("factory"))
         .def("salc_name", &CdSalcList::salc_name, "Return the name of SALC #i.", py::arg("i"))
         .def("print_out", &CdSalcList::print, "Print the SALC to the output file")
         .def("matrix", &CdSalcList::matrix, "Return the SALCs")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -498,8 +498,8 @@ void export_mints(py::module& m)
              "Is the deriv_density already backtransformed? Default is False", py::arg("val") = false)
         .def("compute", &Deriv::compute, "Compute the gradient");
 
-    typedef SharedMatrix (MatrixFactory::*create_shared_matrix)();
-    typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&);
+    typedef SharedMatrix (MatrixFactory::*create_shared_matrix)() const;
+    typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&) const;
 //Something here is wrong. These will not work with py::args defined, not sure why
     py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
         .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),

--- a/psi4/src/psi4/findif/fd_1_0.cc
+++ b/psi4/src/psi4/findif/fd_1_0.cc
@@ -52,10 +52,9 @@ SharedMatrix fd_1_0(std::shared_ptr<Molecule> mol, Options &options, const py::l
     int print_lvl = options.get_int("PRINT");
 
     int Natom = mol->natom();
-    std::shared_ptr<MatrixFactory> fact;
 
     bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
-    CdSalcList cdsalc(mol, fact, 0x1, project, project);
+    CdSalcList cdsalc(mol, 0x1, project, project);
     int Nsalc = cdsalc.ncd();
 
     // Compute number of displacements - check with number of energies passed in

--- a/psi4/src/psi4/findif/fd_freq_0.cc
+++ b/psi4/src/psi4/findif/fd_freq_0.cc
@@ -68,9 +68,8 @@ SharedMatrix fd_freq_0(std::shared_ptr<Molecule> mol, Options &options,
     int print_lvl = options.get_int("PRINT");
 
     int Natom = mol->natom();
-    std::shared_ptr<MatrixFactory> fact;
     bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
-    CdSalcList salc_list(mol, fact, 0xFF, project, project);
+    CdSalcList salc_list(mol, 0xFF, project, project);
     int Nirrep = salc_list.nirrep();
 
     // build vectors that list indices of salcs for each irrep

--- a/psi4/src/psi4/findif/fd_freq_1.cc
+++ b/psi4/src/psi4/findif/fd_freq_1.cc
@@ -55,10 +55,9 @@ SharedMatrix fd_freq_1(std::shared_ptr<Molecule> mol, Options &options,
     int print_lvl = options.get_int("PRINT");
 
     int Natom = mol->natom();
-    std::shared_ptr<MatrixFactory> fact;
     bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
 
-    CdSalcList salc_list(mol, fact, 0xFF, project, project);
+    CdSalcList salc_list(mol, 0xFF, project, project);
     int Nirrep = salc_list.nirrep();
 
     // *** Build vectors that list indices of salcs for each irrep

--- a/psi4/src/psi4/findif/fd_geoms_1_0.cc
+++ b/psi4/src/psi4/findif/fd_geoms_1_0.cc
@@ -63,9 +63,8 @@ std::vector<SharedMatrix> fd_geoms_1_0(std::shared_ptr<Molecule> mol, Options &o
     int Natom = mol->natom();
 
     // Get SALCS from libmints
-    std::shared_ptr<MatrixFactory> fact;
     bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
-    CdSalcList cdsalc(mol, fact, 0x1, project, project);
+    CdSalcList cdsalc(mol, 0x1, project, project);
 
     int Nsalc = cdsalc.ncd();
 

--- a/psi4/src/psi4/findif/fd_geoms_freq_0.cc
+++ b/psi4/src/psi4/findif/fd_geoms_freq_0.cc
@@ -80,9 +80,8 @@ std::vector< SharedMatrix > fd_geoms_freq_0(std::shared_ptr<Molecule> mol, Optio
 
 
   // Get SALCS from libmints: all modes with rotations and translations projected out
-  std::shared_ptr<MatrixFactory> fact;
   bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
-  CdSalcList salc_list(mol, fact, 0xFF, project, project);
+  CdSalcList salc_list(mol, 0xFF, project, project);
 
   int Natom = mol->natom();
   int Nirrep = salc_list.nirrep();

--- a/psi4/src/psi4/findif/fd_geoms_freq_1.cc
+++ b/psi4/src/psi4/findif/fd_geoms_freq_1.cc
@@ -63,9 +63,8 @@ std::vector<SharedMatrix> fd_geoms_freq_1(std::shared_ptr<Molecule> mol, Options
         throw PsiException("FINDIF: Invalid number of points!", __FILE__, __LINE__);
 
     // Get SALCS from libmints: all modes with rotations and translations projected out
-    std::shared_ptr<MatrixFactory> fact;
     bool project = !options.get_bool("EXTERN") && !options.get_bool("PERTURB_H");
-    CdSalcList salc_list(mol, fact, 0xFF, project, project);
+    CdSalcList salc_list(mol, 0xFF, project, project);
 
     int Natom = mol->natom();
     int Nirrep = salc_list.nirrep();

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -360,12 +360,14 @@ SharedMatrix CdSalcList::matrix_irrep(int h) const {
 }
 
 void CdSalcList::print() const {
+    const PointGroup &pg = *molecule_->point_group().get();
+    const std::string irreps = pg.irrep_bits_to_string(needed_irreps_);
     outfile->Printf("  Cartesian Displacement SALCs\n  By SALC:\n");
     outfile->Printf(
-        "  Number of SALCs: %ld, nirreps: %d\n"
+        "  Number of SALCs: %ld, nirreps: %s\n"
         "  Project out translations: %s\n"
         "  Project out rotations: %s\n",
-        salcs_.size(), needed_irreps_, project_out_translations_ ? "True" : "False",
+        salcs_.size(), irreps.c_str(), project_out_translations_ ? "True" : "False",
         project_out_rotations_ ? "True" : "False");
 
     for (size_t i = 0; i < salcs_.size(); ++i) salcs_[i].print();

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -84,10 +84,8 @@ void CdSalcWRTAtom::print() const {
     }
 }
 
-CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFactory> fact, int needed_irreps,
-                       bool project_out_translations, bool project_out_rotations)
+CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, int needed_irreps, bool project_out_translations, bool project_out_rotations)
     : molecule_(mol),
-      factory_(fact),
       needed_irreps_(needed_irreps),
       project_out_translations_(project_out_translations),
       project_out_rotations_(project_out_rotations) {
@@ -291,21 +289,21 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFact
 
 CdSalcList::~CdSalcList() {}
 
-std::vector<SharedMatrix> CdSalcList::create_matrices(const std::string &basename) {
+std::vector<SharedMatrix> CdSalcList::create_matrices(const std::string &basename, const MatrixFactory &factory) const {
     std::vector<SharedMatrix> matrices;
     std::string name;
 
     for (size_t i = 0; i < salcs_.size(); ++i) {
-        name = basename + " " + name_of_component(i);
-        matrices.push_back(factory_->create_shared_matrix(name, salcs_[i].irrep()));
+        name = basename + " " + salc_name(i);
+        matrices.push_back(factory.create_shared_matrix(name, salcs_[i].irrep()));
     }
 
     return matrices;
 }
 
-std::string CdSalcList::name_of_component(int component) {
+std::string CdSalcList::salc_name(int index) const {
     std::string name;
-    CdSalc &salc = salcs_[component];
+    const CdSalc &salc = salcs_[index];
 
     for (size_t i = 0; i < salc.ncomponent(); ++i) {
         const CdSalc::Component &com = salc.component(i);

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -96,7 +96,7 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFact
         throw PSIEXCEPTION("CdSalcList::CdSalcList: Molecule point group has not been set.");
     }
 
-    int natom = molecule_->natom();
+    const int natom = molecule_->natom();
     ncd_ = 3 * natom;
 
     // Immediately create the rotation and translation vectors to be projected out.
@@ -112,9 +112,9 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFact
     //    X.eivprint(ev);
 
     // Pull out data to local variables to reduce memory lookup
-    double X00 = X(0, 0), X01 = X(0, 1), X02 = X(0, 2);
-    double X10 = X(1, 0), X11 = X(1, 1), X12 = X(1, 2);
-    double X20 = X(2, 0), X21 = X(2, 1), X22 = X(2, 2);
+    const double X00 = X(0, 0), X01 = X(0, 1), X02 = X(0, 2);
+    const double X10 = X(1, 0), X11 = X(1, 1), X12 = X(1, 2);
+    const double X20 = X(2, 0), X21 = X(2, 1), X22 = X(2, 2);
 
     //    Matrix constraints("COM & Rotational Constraints", 6, 3*natom);
     double tval0, tval1, tval2;
@@ -175,8 +175,8 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFact
     double *salc = new double[ncd_];
 
     // Obtain handy reference to point group.
-    PointGroup &pg = *molecule_->point_group().get();
-    CharacterTable char_table = pg.char_table();
+    const PointGroup &pg = *molecule_->point_group().get();
+    const CharacterTable char_table = pg.char_table();
     nirrep_ = char_table.nirrep();
 
     // I don't know up front how many I have per irrep
@@ -230,18 +230,17 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, std::shared_ptr<MatrixFact
                 if (stab_order == 0)
                     throw PSIEXCEPTION("CdSalcList::CdSalcList: Stabilizer order is 0 this is not possible.");
 
-                int nonzero = 0;
+                bool nonzero = false;
                 for (int cd = 0; cd < ncd_; ++cd) {
                     // Normalize the salc
                     salc[cd] /= sqrt((double)nirrep_ * stab_order);
 
                     // Count number of nonzeros
-                    if (std::fabs(salc[cd]) > 1e-10) ++nonzero;
+                    if (std::fabs(salc[cd]) > 1e-10) nonzero = true;
                 }
 
                 // We're only interested in doing the following if there are nonzeros
                 // AND the irrep that we're on is what the user wants.
-                // if (nonzero && (1 << irrep) & needed_irreps) {
                 if (nonzero && (1 << irrep) & needed_irreps) {
                     // Store the salc so we can project out constraints below
                     salcs.copy_to_row(irrep, cdsalcpi_[irrep], salc);
@@ -326,7 +325,7 @@ std::string CdSalcList::name_of_component(int component) {
     return name;
 }
 
-SharedMatrix CdSalcList::matrix() {
+SharedMatrix CdSalcList::matrix() const {
     auto temp = std::make_shared<Matrix>("Cartesian/SALC transformation", ncd(), 3 * molecule_->natom());
 
     for (size_t i = 0; i < ncd(); ++i) {
@@ -342,19 +341,10 @@ SharedMatrix CdSalcList::matrix() {
     return temp;
 }
 
-SharedMatrix CdSalcList::matrix_irrep(int h) {
-    // cdsalcpi_ does not get updated after projected out translation and rotations
-    // why?  if it ever is, I can use it.
-    // SharedMatrix temp = std::make_shared<Matrix>("Cartesian/SALC transformation", cdsalcpi_[h],
-    // 3*molecule_->natom());
+SharedMatrix CdSalcList::matrix_irrep(int h) const {
+    auto temp = std::make_shared<Matrix>("Cartesian/SALC transformation", cdsalcpi_[h], 3 * molecule_->natom());
 
     int cnt = 0;
-    for (size_t i = 0; i < ncd(); ++i)
-        if (salcs_[i].irrep() == h) ++cnt;
-
-    auto temp = std::make_shared<Matrix>("Cartesian/SALC transformation", cnt, 3 * molecule_->natom());
-
-    cnt = 0;
     for (size_t i = 0; i < ncd(); ++i) {
         if (salcs_[i].irrep() == h) {
             int nc = salcs_[i].ncomponent();

--- a/psi4/src/psi4/libmints/cdsalclist.h
+++ b/psi4/src/psi4/libmints/cdsalclist.h
@@ -124,7 +124,6 @@ public:
 class CdSalcList
 {
     SharedMolecule molecule_;
-    std::shared_ptr<MatrixFactory> factory_;
 
     char needed_irreps_;
     bool project_out_translations_;
@@ -155,7 +154,6 @@ public:
      *  \param project_out_rotations Project out rotational SALCs
      */
     CdSalcList(SharedMolecule mol,
-               std::shared_ptr<MatrixFactory> fact,
                int needed_irreps=0xFF,
                bool project_out_translations=true,
                bool project_out_rotations=true);
@@ -166,8 +164,8 @@ public:
      */
     size_t ncd() const { return salcs_.size(); }
 
-    std::vector<SharedMatrix > create_matrices(const std::string& basename);
-    std::string name_of_component(int component);
+    std::vector<SharedMatrix > create_matrices(const std::string &basename, const MatrixFactory &factory) const;
+    std::string salc_name(int index) const;
 
     char needed_irreps() const { return needed_irreps_; }
     int nirrep(void) const { return nirrep_; }

--- a/psi4/src/psi4/libmints/cdsalclist.h
+++ b/psi4/src/psi4/libmints/cdsalclist.h
@@ -159,11 +159,10 @@ public:
                int needed_irreps=0xFF,
                bool project_out_translations=true,
                bool project_out_rotations=true);
-    virtual ~CdSalcList();
+    ~CdSalcList();
 
-    /*! Returns the number of combintations. It may not be 3n-5 or 3n-6.
-     *  The value returned depends on needed_irreps and the project_out*
-     *  settings.
+    /*! Returns the number of SALCs. It may not be 3n-5 or 3n-6. The value
+     *  returned depends on needed_irreps and the project_out* settings.
      */
     size_t ncd() const { return salcs_.size(); }
 
@@ -180,8 +179,8 @@ public:
 
     const CdSalcWRTAtom& atom_salc(int i) const { return atom_salcs_[i]; }
 
-    SharedMatrix matrix();
-    SharedMatrix matrix_irrep(int h); // return only salcs of a given irrep
+    SharedMatrix matrix() const;
+    SharedMatrix matrix_irrep(int h) const; // return only salcs of a given irrep
     //SharedMatrix matrix_projected_out() const;
 
     void print() const;

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -431,7 +431,6 @@ Deriv::Deriv(const std::shared_ptr<Wavefunction>& wave,
              bool project_out_rotations)
     : wfn_(wave),
       cdsalcs_(wave->molecule(),
-          wave->matrix_factory(),
           needed_irreps,
           project_out_translations,
           project_out_rotations)
@@ -478,8 +477,7 @@ SharedMatrix Deriv::compute()
     so_eri.set_only_totally_symmetric(true);
 
     // Compute one-electron derivatives.
-    std::vector<SharedMatrix> s_deriv = cdsalcs_.create_matrices("S'");
-
+    std::vector<SharedMatrix> s_deriv = cdsalcs_.create_matrices("S'", *factory_);
     std::shared_ptr<OneBodySOInt> s_int(integral_->so_overlap(1));
 
     s_int->compute_deriv1(s_deriv, cdsalcs_);

--- a/psi4/src/psi4/libmints/factory.cc
+++ b/psi4/src/psi4/libmints/factory.cc
@@ -109,7 +109,7 @@ int MatrixFactory::norb() const { return nso_; }
 Matrix* MatrixFactory::create_matrix(int symmetry) { return new Matrix(nirrep_, rowspi_, colspi_, symmetry); }
 
 /// Returns a new Matrix object with default dimensions
-SharedMatrix MatrixFactory::create_shared_matrix() { return std::make_shared<Matrix>(nirrep_, rowspi_, colspi_); }
+SharedMatrix MatrixFactory::create_shared_matrix() const { return std::make_shared<Matrix>(nirrep_, rowspi_, colspi_); }
 
 void MatrixFactory::create_matrix(Matrix& mat, int symmetry) { mat.init(nirrep_, rowspi_, colspi_, "", symmetry); }
 
@@ -118,15 +118,15 @@ Matrix* MatrixFactory::create_matrix(std::string name, int symmetry) {
     return new Matrix(name, nirrep_, rowspi_, colspi_, symmetry);
 }
 
-SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name) {
+SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name) const {
     return std::make_shared<Matrix>(name, nirrep_, rowspi_, colspi_);
 }
 
-SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int symmetry) {
+SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int symmetry) const {
     return std::make_shared<Matrix>(name, nirrep_, rowspi_, colspi_, symmetry);
 }
 
-SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int rows, int cols) {
+SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int rows, int cols) const {
     return std::make_shared<Matrix>(name, rows, cols);
 }
 

--- a/psi4/src/psi4/libmints/factory.h
+++ b/psi4/src/psi4/libmints/factory.h
@@ -93,18 +93,18 @@ public:
     Matrix * create_matrix(int symmetry=0);
 
     /// Returns a new Matrix object with default dimensions
-    SharedMatrix create_shared_matrix();
+    SharedMatrix create_shared_matrix() const;
 
     void create_matrix(Matrix& mat, int symmetry=0);
 
     /// Returns a new Matrix object named name with default dimensions
     Matrix * create_matrix(std::string name, int symmetry=0);
 
-    SharedMatrix create_shared_matrix(const std::string& name);
+    SharedMatrix create_shared_matrix(const std::string& name) const;
 
-    SharedMatrix create_shared_matrix(const std::string& name, int symmetry);
+    SharedMatrix create_shared_matrix(const std::string& name, int symmetry) const;
 
-    SharedMatrix create_shared_matrix(const std::string& name, int rows, int cols);
+    SharedMatrix create_shared_matrix(const std::string& name, int rows, int cols) const;
 
     void create_matrix(Matrix& mat, std::string name, int symmetry=0);
 

--- a/psi4/src/psi4/libmints/factory.h
+++ b/psi4/src/psi4/libmints/factory.h
@@ -40,7 +40,7 @@ class SOBasisSet;
 
 /*! \ingroup MINTS
  *  \class MatrixFactory
- *  \brief A class for creating Matrix, SimpleMatrix, Vector, and SimpleVector objects.
+ *  \brief A class for creating Matrix and Vector objects.
  *
  * The objects this factory creates can automatically be sized based on information
  * from checkpoint.

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -44,7 +44,6 @@ struct dpdfile2;
 
 class PSIO;
 class Vector;
-class SimpleMatrix;
 class Dimension;
 class Molecule;
 class Vector3;
@@ -148,7 +147,6 @@ public:
     /**
      * Constructor, sets up the matrix
      * Convenience case for 1 irrep
-     * Note: You should be using SimpleMatrix
      *
      * @param rows Row dimensionality.
      * @param cols Column dimensionality.
@@ -157,7 +155,6 @@ public:
     /**
      * Constructor, sets up the matrix
      * Convenience case for 1 irrep
-     * Note: You should be using SimpleMatrix
      *
      * @param name Name of the matrix.
      * @param rows Row dimensionality.
@@ -360,16 +357,6 @@ public:
     /** @} */
 
     /**
-     * @{
-     * Copies sq to matrix_
-     *
-     * @param sq SimpleMatrix object to set this matrix to.
-     */
-    void set(const SimpleMatrix * const sq);
-    void set(const std::shared_ptr<SimpleMatrix>& sq);
-    /** @} */
-
-    /**
      * Set a single element of matrix_
      *
      * @param h Subblock to address
@@ -537,13 +524,6 @@ public:
      * @returns the matrix
      */
     double *to_lower_triangle() const;
-
-    /**
-     * Converts this to a full non-symmetry-block matrix
-     *
-     * @returns The SimpleMatrix copy of the current matrix.
-     */
-    SimpleMatrix *to_simple_matrix() const;
 
     /**
      * Sets the name of the matrix, used in print(...) and save(...)
@@ -747,16 +727,14 @@ public:
     /// Scale column n of irrep h by a
     void scale_column(int h, int n, double a);
 
-    /** Special function to transform a SimpleMatrix (no symmetry) into
-     *  a symmetry matrix.
+    /** Special function to add symmetry to a Matrix .
      *
-     *  \param a SimpleMatrix to transform
+     *  \param a Matrix to transform
      *  \param transformer The matrix returned by PetiteList::aotoso() that acts as the transformer
      */
     void apply_symmetry(const SharedMatrix& a, const SharedMatrix& transformer);
 
-    /** Special function to transform a symmetry matrix into
-     *  a SimpleMatrix (no symmetry).
+    /** Special function to remove symmetry from a matrix.
      *
      *  \param a symmetry matrix to transform
      *  \param transformer The matrix returned by PetiteList::sotoao() that acts as the transformer

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1517,8 +1517,7 @@ std::vector<SharedMatrix> MintsHelper::ao_nabla() {
 
 std::shared_ptr<CdSalcList> MintsHelper::cdsalcs(int needed_irreps, bool project_out_translations,
                                                  bool project_out_rotations) {
-    return std::make_shared<CdSalcList>(molecule_, factory_, needed_irreps, project_out_translations,
-                                        project_out_rotations);
+    return std::make_shared<CdSalcList>(molecule_, needed_irreps, project_out_translations, project_out_rotations);
 }
 
 SharedMatrix MintsHelper::mo_transform(SharedMatrix Iso, SharedMatrix C1, SharedMatrix C2, SharedMatrix C3,

--- a/psi4/src/psi4/libmints/pointgrp.cc
+++ b/psi4/src/psi4/libmints/pointgrp.cc
@@ -83,6 +83,7 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 
+#include <bitset>
 #include <cstdlib>
 #include <cstring>
 #include <ctype.h>
@@ -370,6 +371,19 @@ PointGroup::print(std::string out) const
     printer->Printf("PointGroup: %s\n", symb.c_str());
 }
 
+std::string PointGroup::irrep_bits_to_string(int irrep_bits) const {
+    std::string irrep_str;
+    const CharacterTable c_table = char_table();
+    for (int irrep = 0; irrep < c_table.nirrep(); ++irrep) {
+        if ((1 << irrep) & irrep_bits) {
+            if (!irrep_str.empty()) {
+                irrep_str += ", ";
+            }
+            irrep_str += c_table.gamma(irrep).symbol();
+        }
+    }
+    return irrep_str;
+}
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/psi4/src/psi4/libmints/pointgrp.cc
+++ b/psi4/src/psi4/libmints/pointgrp.cc
@@ -83,7 +83,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 
-#include <bitset>
 #include <cstdlib>
 #include <cstring>
 #include <ctype.h>

--- a/psi4/src/psi4/libmints/pointgrp.h
+++ b/psi4/src/psi4/libmints/pointgrp.h
@@ -524,10 +524,10 @@ public:
     const std::string& symbol() const
     { return symb; }
     /// Returns the i'th irrep.
-    IrreducibleRepresentation& gamma(int i)
+    IrreducibleRepresentation& gamma(int i) const
     { return gamma_[i]; }
     /// Returns the i'th symmetry operation.
-    SymmetryOperation& symm_operation(int i)
+    SymmetryOperation& symm_operation(int i) const
     { return symop[i]; }
 
     /** Cn, Cnh, Sn, T, and Th point groups have complex representations.

--- a/psi4/src/psi4/libmints/pointgrp.h
+++ b/psi4/src/psi4/libmints/pointgrp.h
@@ -684,6 +684,9 @@ public:
     static bool full_name_to_bits(const std::string& pg, unsigned char& bits);
 
     void print(std::string out_fname = "outfile") const;
+
+    /// Convert an irrep bit string to a human readable irrep list
+    std::string irrep_bits_to_string(int irrep_bits) const;
 };
 
 }

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -1073,7 +1073,7 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
     bool ignore_symmetry = nirrep_ == 1 || jk->C1();
 
     Dimension nvirpi = nmopi_ - doccpi_;
-    CdSalcList SALCList(molecule_, factory_, 0xFF, false, false);
+    CdSalcList SALCList(molecule_, 0xFF, false, false);
 
 
     /*


### PR DESCRIPTION
## Description
The CdSalcList code is made fully accessible to the Python layer, per #884. This code does that and makes a few other changes to clean up code I found while trying to write the documentation for Pybind.

Pinging @loriab and @dgasmith by request.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Moves the factory argument from the CdSalcList constructor to an argument of the method that uses it, getting rid of several null pointers and also meaning that a list of displacements no longer needs to care about orbital irreps.
  - [x] Adds missing `const` declarations
  - [x] The documentation no longer tells developers to use the non-existent SimpleMatrix class
  - [x] Other misc. cleanup, from removing an overloaded term to simplification
* **User-Facing for Release Notes**
  - [x] Exposed `CdSalcList` to Python
  - [x] Made the needed irreps for Cartesian displacements more readable

## Questions
- [x] ~~I am playing with reworking the print function. needed_irreps displays as an integer, so that part of the output is unintelligible to people who do not know that it is internally a bitstring. Would this be worth changing?~~ Changed!

## Status
- [x] Ready to go!
