### PR TITLE
Fix PCM kerfuffle with directories

### DIFF
--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -1,5 +1,5 @@
     if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.10 CONFIG QUIET)
+    find_package(PCMSolver 1.1.12 CONFIG QUIET)
 
     if(${PCMSolver_FOUND})
         get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
@@ -23,7 +23,7 @@
 
         ExternalProject_Add(pcmsolver_external
             GIT_REPOSITORY https://github.com/PCMSolver/pcmsolver
-            GIT_TAG v1.1.11
+            GIT_TAG v1.1.12
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -42,12 +42,11 @@
                        #-DENABLE_XHOST=${ENABLE_XHOST}  # option missing
                        # always fpic'd
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
-                       -DENABLE_DOCS=OFF
                        -DENABLE_TESTS=OFF
                        -DENABLE_TIMER=OFF
                        -DENABLE_LOGGER=OFF
                        -DBUILD_STANDALONE=OFF
-                       -DENABLE_FORTRAN_API=OFF
+                       -DENABLE_Fortran_API=OFF
                        -DENABLE_CXX11_SUPPORT=ON
                        -DENABLE_64BIT_INTEGERS=OFF
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -119,7 +119,7 @@ list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
 if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.1.10 CONFIG REQUIRED)
+    find_package(PCMSolver 1.1.12 CONFIG REQUIRED)
     get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using PCMSolver${ColourReset}: ${_loc} (version ${PCMSolver_VERSION})")

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -371,8 +371,7 @@ def process_basis_block(matchobj):
             result += """%s    basstrings['%s'] = \"\"\"\n%s\n\"\"\"\n""" % \
                 (spaces, basname(name), basblock[0])
         else:
-            message = ("Conflicting basis set specification: assign lines present but shells have no [basname] label."
-                       "")
+            message = ("Conflicting basis set specification: assign lines present but shells have no [basname] label.""")
             raise TestComparisonError(message)
     else:
         # case with specs separated by [basname] markers

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -25,7 +25,6 @@
 #
 # @END LICENSE
 #
-
 """Module with functions to parse the input file and convert
 Psithon into standard Python. Particularly, forms psi4
 module calls that access the C++ side of Psi4.
@@ -99,6 +98,7 @@ def quotify(string, isbasis=False):
         wordre = re.compile(r'(([$]?)([-+()*.\w\"\'/\\]+))')
     string = wordre.sub(process_word_quotes, string)
     return string
+
 
 def dequotify(string):
     if string[0] == '"' and string[-1] == '"':
@@ -180,13 +180,13 @@ def process_set_commands(matchobj):
 def process_from_file_command(matchobj):
     """Function that process a match of ``from_file`` in molecule block."""
     string = matchobj.group(2)
-    mol=core.mol_from_file(string,1)
-    tempmol=[line for line in mol.split('\n') if line.strip() != '']
-    mol2=set(tempmol)
-    mol=""
+    mol = core.mol_from_file(string, 1)
+    tempmol = [line for line in mol.split('\n') if line.strip() != '']
+    mol2 = set(tempmol)
+    mol = ""
     for i in mol2:
-           mol+=i
-           mol+="\n"
+        mol += i
+        mol += "\n"
     return mol
 
 
@@ -236,7 +236,7 @@ def process_molecule_command(matchobj):
     geometry = matchobj.group(3)
     geometry = pubchemre.sub(process_pubchem_command, geometry)
     from_filere = re.compile(r'^(\s*from_file\s*:\s*(.*)\n)$', re.MULTILINE | re.IGNORECASE)
-    geometry = from_filere.sub(process_from_file_command,geometry)
+    geometry = from_filere.sub(process_from_file_command, geometry)
     molecule = spaces
 
     if name != "":
@@ -329,7 +329,9 @@ def process_basis_block(matchobj):
     command_lines = re.split('\n', matchobj.group(4))
 
     symbol_re = re.compile(r'^\s*assign\s+(?P<symbol>[A-Z]{1,3})\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
-    label_re = re.compile(r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
+    label_re = re.compile(
+        r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+*\(\)\w]+)\s*$',
+        re.IGNORECASE)
     all_re = re.compile(r'^\s*assign\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
     basislabel = re.compile(r'\s*\[\s*([-*\(\)\w]+)\s*\]\s*')
 
@@ -369,7 +371,8 @@ def process_basis_block(matchobj):
             result += """%s    basstrings['%s'] = \"\"\"\n%s\n\"\"\"\n""" % \
                 (spaces, basname(name), basblock[0])
         else:
-            message = ("Conflicting basis set specification: assign lines present but shells have no [basname] label.""")
+            message = ("Conflicting basis set specification: assign lines present but shells have no [basname] label."
+                       "")
             raise TestComparisonError(message)
     else:
         # case with specs separated by [basname] markers
@@ -386,18 +389,22 @@ def process_basis_block(matchobj):
 
 def process_pcm_command(matchobj):
     """Function to process match of ``pcm name? { ... }``."""
-    spacing = str(matchobj.group(1)) # Ignore..
-    name = str(matchobj.group(2)) # Ignore..
-    block = str(matchobj.group(3)) # Get input to PCMSolver
-    with open('pcmsolver.inp', 'w') as handle:
+    spacing = str(matchobj.group(1))  # Ignore..
+    name = str(matchobj.group(2))  # Ignore..
+    block = str(matchobj.group(3))  # Get input to PCMSolver
+    suffix = str(os.getpid()) + '.' + str(uuid.uuid4())[:8]
+    pcmsolver_fname = 'pcmsolver.' + suffix + '.inp'
+    with open(pcmsolver_fname, 'w') as handle:
         handle.write(block)
     import pcmsolver
-    parsed_pcm = pcmsolver.parse_pcm_input('pcmsolver.inp').splitlines()
-    pcmsolver_parsed_fname = '@pcmsolver.' + str(os.getpid()) + '.' + str(uuid.uuid4())[:8]
-    write_input_for_pcm  = "parsedFile = os.path.join(os.getcwd(), '{}')\n".format(pcmsolver_parsed_fname)
+    parsed_pcm = pcmsolver.parse_pcm_input(pcmsolver_fname).splitlines()
+    os.remove(pcmsolver_fname)
+    pcmsolver_parsed_fname = '@pcmsolver.' + suffix
+    write_input_for_pcm = "parsedFile = os.path.join(os.getcwd(), '{}')\n".format(pcmsolver_parsed_fname)
     write_input_for_pcm += "with open(parsedFile, 'w') as tmp:\n"
     write_input_for_pcm += "    tmp.write('\\n'.join({}))\n\n".format(parsed_pcm)
-    write_input_for_pcm += "core.set_global_option(\'PCMSOLVER_PARSED_FNAME\', \'{}\')\n\n".format(pcmsolver_parsed_fname)
+    write_input_for_pcm += "core.set_global_option(\'PCMSOLVER_PARSED_FNAME\', \'{}\')\n\n".format(
+        pcmsolver_parsed_fname)
     return write_input_for_pcm
 
 
@@ -468,9 +475,11 @@ def process_external_command(matchobj):
         mobj = charge_re.match(line)
         if mobj:
             if units == 'ang':
-                extern += '%sqmmm.addChargeAngstrom(%s,%s,%s,%s)\n' % (spaces, mobj.group(1), mobj.group(2), mobj.group(3), mobj.group(4))
+                extern += '%sqmmm.addChargeAngstrom(%s,%s,%s,%s)\n' % (spaces, mobj.group(1), mobj.group(2),
+                                                                       mobj.group(3), mobj.group(4))
             if units == 'bohr':
-                extern += '%sqmmm.addChargeBohr(%s,%s,%s,%s)\n' % (spaces, mobj.group(1), mobj.group(2), mobj.group(3), mobj.group(4))
+                extern += '%sqmmm.addChargeBohr(%s,%s,%s,%s)\n' % (spaces, mobj.group(1), mobj.group(2), mobj.group(3),
+                                                                   mobj.group(4))
         else:
             lines2.append(line)
     lines = lines2
@@ -672,8 +681,7 @@ def process_input(raw_input, print_level=1):
     #   Must be stored then subbed in the end to escape the normal processing
 
     # Process "cfour name? { ... }"
-    cfour = re.compile(r'^(\s*?)cfour[=\s]*(\w*?)\s*\{(.*?)\}',
-                          re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    cfour = re.compile(r'^(\s*?)cfour[=\s]*(\w*?)\s*\{(.*?)\}', re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(cfour, process_cfour_command, raw_input)
 
     # Return from handling literal blocks to normal processing
@@ -702,31 +710,28 @@ def process_input(raw_input, print_level=1):
     temp = process_multiline_arrays(temp)
 
     # Process all "set name? { ... }"
-    set_commands = re.compile(r'^(\s*?)set\s*([-,\w]*?)[\s=]*\{(.*?)\}',
-                              re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    set_commands = re.compile(r'^(\s*?)set\s*([-,\w]*?)[\s=]*\{(.*?)\}', re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(set_commands, process_set_commands, temp)
 
     # Process all individual "set (module_list) key  {[value_list] or $value or value}"
     # N.B. We have to be careful here, because \s matches \n, leading to potential problems
     # with undesired multiline matches.  Better the double-negative [^\S\n] instead, which
     # will match any space, tab, etc., except a newline
-    set_command = re.compile(r'^(\s*?)set\s+(?:([-,\w]+)[^\S\n]+)?(\w+)(?:[^\S\n]|=)+((\[.*\])|(\$?[-+,*()\.\w]+))\s*$',
-                             re.MULTILINE | re.IGNORECASE)
+    set_command = re.compile(
+        r'^(\s*?)set\s+(?:([-,\w]+)[^\S\n]+)?(\w+)(?:[^\S\n]|=)+((\[.*\])|(\$?[-+,*()\.\w]+))\s*$',
+        re.MULTILINE | re.IGNORECASE)
     temp = re.sub(set_command, process_set_command, temp)
 
     # Process "molecule name? { ... }"
-    molecule = re.compile(r'^(\s*?)molecule[=\s]*(\S*?)\s*\{(.*?)\}',
-                          re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    molecule = re.compile(r'^(\s*?)molecule[=\s]*(\S*?)\s*\{(.*?)\}', re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(molecule, process_molecule_command, temp)
 
     # Process "external name? { ... }"
-    external = re.compile(r'^(\s*?)external[=\s]*(\w*?)\s*\{(.*?)\}',
-                          re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    external = re.compile(r'^(\s*?)external[=\s]*(\w*?)\s*\{(.*?)\}', re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(external, process_external_command, temp)
 
     # Process "pcm name? { ... }"
-    pcm = re.compile(r'^(\s*?)pcm[=\s]*(\w*?)\s*\{(.*?)^\}',
-                          re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    pcm = re.compile(r'^(\s*?)pcm[=\s]*(\w*?)\s*\{(.*?)^\}', re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(pcm, process_pcm_command, temp)
 
     # Then remove repeated newlines
@@ -734,8 +739,7 @@ def process_input(raw_input, print_level=1):
     temp = re.sub(multiplenewlines, '\n', temp)
 
     # Process " extract"
-    extract = re.compile(r'(\s*?)(\w+)\s*=\s*\w+\.extract_subsets.*',
-                         re.IGNORECASE)
+    extract = re.compile(r'(\s*?)(\w+)\s*=\s*\w+\.extract_subsets.*', re.IGNORECASE)
     temp = re.sub(extract, process_extract_command, temp)
 
     # Process "print" and transform it to "core.print_out()"
@@ -743,13 +747,13 @@ def process_input(raw_input, print_level=1):
     #temp = re.sub(print_string, process_print_command, temp)
 
     # Process "memory ... "
-    memory_string = re.compile(r'(\s*?)memory\s+(\d*\.?\d+)\s*([KMGTPBE]i?B)',
-                               re.IGNORECASE)
+    memory_string = re.compile(r'(\s*?)memory\s+(\d*\.?\d+)\s*([KMGTPBE]i?B)', re.IGNORECASE)
     temp = re.sub(memory_string, process_memory_command, temp)
 
     # Process "basis name? { ... }"
-    basis_block = re.compile(r'^(\s*?)(basis|df_basis_scf|df_basis_mp2|df_basis_cc|df_basis_sapt)[=\s]*(\w*?)\s*\{(.*?)\}',
-                             re.MULTILINE | re.DOTALL | re.IGNORECASE)
+    basis_block = re.compile(
+        r'^(\s*?)(basis|df_basis_scf|df_basis_mp2|df_basis_cc|df_basis_sapt)[=\s]*(\w*?)\s*\{(.*?)\}',
+        re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(basis_block, process_basis_block, temp)
 
     # Process literal blocks by substituting back in
@@ -757,6 +761,7 @@ def process_input(raw_input, print_level=1):
     temp = re.sub(lit_block, process_literal_blocks, temp)
 
     future_imports = []
+
     def future_replace(m):
         future_imports.append(m.group(0))
         return ''

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -236,31 +236,16 @@ def pcm_helper(block):
     Parameters
     ----------
     block: multiline string with PCM input in PCMSolver syntax.
-
-    Notes
-    -----
-    !Warning! This function changes directory from launch site to scratch and
-    back. This is needed because PCMSolver does not have a notion of an
-    absolute paths for its input file. If you are looking at this function as
-    an example, remember that changing directories is usually a **bad idea**
-    and **should not be done**.
     """
 
-    # Setup unique scratch directory and move in, as done for other add-ons
-    psioh = core.IOManager.shared_object()
-    psio = core.IO.shared_object()
-    curdir = os.getcwd()
-    os.chdir(psioh.get_default_path())
-    pcm_tmpdir = 'psi.' + str(os.getpid()) + '.' + psio.get_default_namespace() + \
-        'pcmsolver.' + str(uuid.uuid4())[:8]
-    if os.path.exists(pcm_tmpdir) is False:
-        os.mkdir(pcm_tmpdir)
-    os.chdir(pcm_tmpdir)
     with open('pcmsolver.inp', 'w') as handle:
         handle.write(block)
     import pcmsolver
-    pcmsolver.parse_pcm_input('pcmsolver.inp')
-    os.chdir(curdir)
+    parsed_pcm = pcmsolver.parse_pcm_input('pcmsolver.inp')
+    pcmsolver_parsed_fname = '@pcmsolver.' + str(os.getpid()) + '.' + str(uuid.uuid4())[:8]
+    with open(pcmsolver_parsed_fname, 'w') as tmp:
+        tmp.write(parsed_pcm)
+    core.set_global_option('PCMSOLVER_PARSED_FNAME', '{}'.format(pcmsolver_parsed_fname))
 
 
 def filter_comments(string):

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -40,7 +40,14 @@ from psi4 import core
 
 
 @staticmethod
-def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, puream=-1, return_atomlist=False, quiet=False):
+def pybuild_basis(mol,
+                  key=None,
+                  target=None,
+                  fitrole='ORBITAL',
+                  other=None,
+                  puream=-1,
+                  return_atomlist=False,
+                  quiet=False):
     if key == 'ORBITAL':
         key = 'BASIS'
 
@@ -64,8 +71,8 @@ def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, pur
     # if a string, they search for a gbs file with that name.
     # if a function, it needs to apply a basis to each atom.
 
-    basisdict = qcdb.BasisSet.pyconstruct(mol.create_psi4_string_from_molecule(),
-                                          key, resolved_target, fitrole, other, return_atomlist=return_atomlist)
+    basisdict = qcdb.BasisSet.pyconstruct(
+        mol.create_psi4_string_from_molecule(), key, resolved_target, fitrole, other, return_atomlist=return_atomlist)
 
     if return_atomlist:
         atom_basis_list = []
@@ -75,8 +82,8 @@ def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, pur
             atom_basis_list.append(lmbs)
             #lmbs.print_detail_out()
         return atom_basis_list
-    if ((sys.version_info < (3,0) and isinstance(resolved_target, basestring)) or
-        (sys.version_info >= (3,0) and isinstance(resolved_target, str))):
+    if ((sys.version_info < (3, 0) and isinstance(resolved_target, basestring))
+            or (sys.version_info >= (3, 0) and isinstance(resolved_target, str))):
         basisdict['name'] = basisdict['name'].split('/')[-1].replace('.gbs', '')
     if callable(resolved_target):
         basisdict['name'] = resolved_target.__name__.replace('basisspec_psi4_yo__', '').upper()
@@ -89,9 +96,11 @@ def pybuild_basis(mol, key=None, target=None, fitrole='ORBITAL', other=None, pur
     psibasis = core.BasisSet.construct_from_pydict(mol, basisdict, puream)
     return psibasis
 
+
 core.BasisSet.build = pybuild_basis
 
 ## Python wavefunction helps
+
 
 @staticmethod
 def pybuild_wavefunction(mol, basis=None):
@@ -105,9 +114,11 @@ def pybuild_wavefunction(mol, basis=None):
     wfn = core.Wavefunction(mol, basis)
     return wfn
 
+
 core.Wavefunction.build = pybuild_wavefunction
 
 ## Python JK helps
+
 
 @staticmethod
 def pybuild_JK(orbital_basis, aux=None, jk_type=None):
@@ -156,21 +167,21 @@ def pybuild_JK(orbital_basis, aux=None, jk_type=None):
     if aux is None:
         if core.get_option("SCF", "SCF_TYPE") == "DF":
             aux = core.BasisSet.build(orbital_basis.molecule(), "DF_BASIS_SCF",
-                                      core.get_option("SCF", "DF_BASIS_SCF"),
-                                      "JKFIT", core.get_global_option('BASIS'),
-                                      orbital_basis.has_puream())
+                                      core.get_option("SCF", "DF_BASIS_SCF"), "JKFIT",
+                                      core.get_global_option('BASIS'), orbital_basis.has_puream())
         else:
             aux = core.BasisSet.zero_ao_basis_set()
-
 
     jk = core.JK.build_JK(orbital_basis, aux)
 
     optstash.restore()
     return jk
 
+
 core.JK.build = pybuild_JK
 
 ## Grid Helpers
+
 
 def get_np_xyzw(Vpot):
     """
@@ -199,6 +210,7 @@ def get_np_xyzw(Vpot):
     w = np.hstack(w_list)
 
     return (x, y, z, w)
+
 
 core.VBase.get_np_xyzw = get_np_xyzw
 
@@ -238,11 +250,14 @@ def pcm_helper(block):
     block: multiline string with PCM input in PCMSolver syntax.
     """
 
-    with open('pcmsolver.inp', 'w') as handle:
+    suffix = str(os.getpid()) + '.' + str(uuid.uuid4())[:8]
+    pcmsolver_fname = 'pcmsolver.' + suffix + '.inp'
+    with open(pcmsolver_fname, 'w') as handle:
         handle.write(block)
     import pcmsolver
-    parsed_pcm = pcmsolver.parse_pcm_input('pcmsolver.inp')
-    pcmsolver_parsed_fname = '@pcmsolver.' + str(os.getpid()) + '.' + str(uuid.uuid4())[:8]
+    parsed_pcm = pcmsolver.parse_pcm_input(pcmsolver_fname)
+    os.remove(pcmsolver_fname)
+    pcmsolver_parsed_fname = '@pcmsolver.' + suffix
     with open(pcmsolver_parsed_fname, 'w') as tmp:
         tmp.write(parsed_pcm)
     core.set_global_option('PCMSOLVER_PARSED_FNAME', '{}'.format(pcmsolver_parsed_fname))
@@ -279,7 +294,9 @@ def basis_helper(block, name='', key='BASIS', set_option=True):
     command_lines = re.split('\n', block)
 
     symbol_re = re.compile(r'^\s*assign\s+(?P<symbol>[A-Z]{1,3})\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
-    label_re = re.compile(r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
+    label_re = re.compile(
+        r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+*\(\)\w]+)\s*$',
+        re.IGNORECASE)
     all_re = re.compile(r'^\s*assign\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
     basislabel = re.compile(r'\s*\[\s*([-*\(\)\w]+)\s*\]\s*')
 
@@ -318,7 +335,9 @@ def basis_helper(block, name='', key='BASIS', set_option=True):
                 mol.set_basis_all_atoms(name, role=role)
                 basstrings[basname(name)] = basblock[0]
             else:
-                message = ("Conflicting basis set specification: assign lines present but shells have no [basname] label.""")
+                message = (
+                    "Conflicting basis set specification: assign lines present but shells have no [basname] label."
+                    "")
                 raise TestComparisonError(message)
         else:
             # case with specs separated by [basname] markers
@@ -326,18 +345,20 @@ def basis_helper(block, name='', key='BASIS', set_option=True):
                 basstrings[basname(basblock[idx])] = basblock[idx + 1]
 
         return basstrings
+
     anon.__name__ = 'basisspec_psi4_yo__' + cleanbas
     qcdb.libmintsbasisset.basishorde[name.upper()] = anon
     if set_option:
         core.set_global_option(key, name)
 
+
 core.OEProp.valid_methods = [
-    'DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES', 'WIBERG_LOWDIN_INDICES',
-    'MAYER_INDICES', 'MAYER_INDICES', 'MO_EXTENTS', 'GRID_FIELD', 'GRID_ESP', 'ESP_AT_NUCLEI',
-    'NO_OCCUPATIONS'
+    'DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES', 'WIBERG_LOWDIN_INDICES', 'MAYER_INDICES',
+    'MAYER_INDICES', 'MO_EXTENTS', 'GRID_FIELD', 'GRID_ESP', 'ESP_AT_NUCLEI', 'NO_OCCUPATIONS'
 ]
 
 ## Option helpers
+
 
 def py_psi_set_global_option_python(key, EXTERN):
     """
@@ -358,5 +379,3 @@ def py_psi_set_global_option_python(key, EXTERN):
 
 
 core.set_global_option_python = py_psi_set_global_option_python
-
-

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -28,6 +28,7 @@
 # @END LICENSE
 #
 
+import atexit
 import sys
 import os
 import json
@@ -242,7 +243,6 @@ if args["verbose"]:
 
 # Handle Messy
 if args["messy"]:
-    import atexit
 
     if sys.version_info >= (3, 0):
         atexit.unregister(psi4.core.clean)
@@ -252,7 +252,6 @@ if args["messy"]:
                 atexit._exithandlers.remove(handler)
 
 # Register exit printing, failure GOTO coffee ELSE beer
-import atexit
 atexit.register(psi4.extras.exit_printing)
 
 # Run the program!

--- a/psi4/src/psi4/libpsipcm/psipcm.cc
+++ b/psi4/src/psi4/libpsipcm/psipcm.cc
@@ -134,8 +134,8 @@ PCM::PCM(Options &options, std::shared_ptr<PSIO> /* psio */, int nirrep, std::sh
     context_ = pcmsolver_new(PCMSOLVER_READER_HOST, molecule->natom(), charges, coordinates,
                              symmetry_info, &host_input, host_writer);
   } else {
-    context_ = pcmsolver_new(PCMSOLVER_READER_OWN, molecule->natom(), charges, coordinates,
-                             symmetry_info, &host_input, host_writer);
+    context_ = pcmsolver_new_v1112(PCMSOLVER_READER_OWN, molecule->natom(), charges, coordinates,
+                             symmetry_info, options.get_str("PCMSOLVER_PARSED_FNAME").c_str(), &host_input, host_writer);
   }
   pcmsolver_print(context_);
   ntess_ = pcmsolver_get_cavity_size(context_);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -156,6 +156,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
   options.add_bool("PCM", false);
   /*- Use total or separate potentials and charges in the PCM-SCF step. !expert -*/
   options.add_str("PCM_SCF_TYPE", "TOTAL", "TOTAL SEPARATE");
+  /*- Name of the PCMSolver input file as parsed by pcmsolver.py !expert -*/
+  options.add_str_i("PCMSOLVER_PARSED_FNAME", "");
   /*- PCM-CCSD algorithm type. -*/
   options.add_str("PCM_CC_TYPE", "PTE", "PTE");
   /*- The density fitting basis to use in coupled cluster computations. -*/


### PR DESCRIPTION
## Description
This PR brings (hopefully!) to a close the PCM-changes-directory saga noted in issue #817 and partially alleviated in PR #818.  
This change needed an API update PCMSolver-side, hence the minimum required version bump to its 1.1.12 version.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] PCMSolver updated to its v1.1.12
* **User-Facing for Release Notes**
  - [x] Parsing PCM directory _no longer_ changes directory.

## Questions
- As (probably not very clearly) noted in the manual, **analytical gradients including PCM are NOT available**. Should there be a stop in the code when such a request is made or should the code be routed to use a numerical gradient?

## Status
- [x] Ready to go