### PR TITLE
Fix Hessian bug

### DIFF
--- a/psi4/src/psi4/libmints/overlap.cc
+++ b/psi4/src/psi4/libmints/overlap.cc
@@ -336,7 +336,7 @@ void OverlapInt::compute_pair_deriv2(const GaussianShell& s1, const GaussianShel
                             buffer_[(0*size)+ao12] += (4.0*a1*a1*x[l1+2][l2]*y[m1][m2]*z[n1][n2] -
                                                       2.0*a1*(2*l1+1)*x[l1][l2]*y[m1][m2]*z[n1][n2]) * over_pf;
                             if (l1 > 1)
-                                buffer_[(0*size)+ao12] += over_pf*l1*(l1-1)*x[l1-2][l2]*y[m1][m1]*z[n1][n2];
+                                buffer_[(0*size)+ao12] += over_pf*l1*(l1-1)*x[l1-2][l2]*y[m1][m2]*z[n1][n2];
 
                             // S_{\mu\nu}^{a_x a_y}
                             buffer_[(1*size)+ao12] += over_pf*4.0*a1*a1*x[l1+1][l2]*y[m1+1][m2]*z[n1][n2];
@@ -360,7 +360,7 @@ void OverlapInt::compute_pair_deriv2(const GaussianShell& s1, const GaussianShel
                             buffer_[(3*size)+ao12] += (4.0*a1*a1*x[l1][l2]*y[m1+2][m2]*z[n1][n2] -
                                                       2.0*a1*(2*m1+1)*x[l1][l2]*y[m1][m2]*z[n1][n2]) * over_pf;
                             if (m1 > 1)
-                                buffer_[(3*size)+ao12] += over_pf*m1*(m1-1)*x[l1][l2]*y[m1-2][m1]*z[n1][n2];
+                                buffer_[(3*size)+ao12] += over_pf*m1*(m1-1)*x[l1][l2]*y[m1-2][m2]*z[n1][n2];
 
                             // S_{\mu\nu}^{a_y a_z}
                             buffer_[(4*size)+ao12] += over_pf*4.0*a1*a1*x[l1][l2]*y[m1+1][m2]*z[n1+1][n2];
@@ -375,7 +375,7 @@ void OverlapInt::compute_pair_deriv2(const GaussianShell& s1, const GaussianShel
                             buffer_[(5*size)+ao12] += (4.0*a1*a1*x[l1][l2]*y[m1][m2]*z[n1+2][n2] -
                                                       2.0*a1*(2*n1+1)*x[l1][l2]*y[m1][m2]*z[n1][n2]) * over_pf;
                             if (n1 > 1)
-                                buffer_[(5*size)+ao12] += over_pf*n1*(n1-1)*x[l1][l2]*y[m1][m1]*z[n1-2][n2];
+                                buffer_[(5*size)+ao12] += over_pf*n1*(n1-1)*x[l1][l2]*y[m1][m2]*z[n1-2][n2];
 
                             ao12++;
                         }

--- a/tests/scf-hess1/input.dat
+++ b/tests/scf-hess1/input.dat
@@ -57,3 +57,20 @@ set {
 psi4_hess = hessian('scf')
 
 compare_arrays(psi3_hess, psi4_hess, 1E-7, "cc-pVDZ Hessian") #TEST
+
+# Now repeat the test, permuting the first two atoms' coordinates;
+# this exposes a (now-fixed) bug in the overlap hessian.
+molecule {
+units bohr
+nocom
+noreorient
+  H           -1.069804624577     1.430455315728    -0.000000000000
+  O            0.134467872279     0.000255539126     0.000000000000
+  H           -1.064298089419    -1.434510907104    -0.000000000000
+}
+
+psi4_hess = hessian('scf')
+
+permuted_indices = [ 3, 4, 5, 0, 1, 2, 6, 7, 8 ]                       #TEST
+psi3_hess = psi3_hess[:,permuted_indices][permuted_indices,:]          #TEST
+compare_arrays(psi3_hess, psi4_hess, 1E-7, "Permuted cc-pVDZ Hessian") #TEST


### PR DESCRIPTION
## Description
A typo in the overlap integral second derivatives caused errors in the analytic hessians.  The error seems to be confined to one of the three contributions to matrix elements where the angular momentum in the bra and ket differ, and only when the derivatives both refer to the same perturbation; which is why the code made it through the initial tests.  I'm still trying to wrap my head around exactly why those tests work, so I'd like a day or two before this is ready to merge.  My sincere apologies to all whom this bug inconvenienced.  Fixes #791 and #901.

## Todos
Notable points that this PR has either accomplished or will accomplish.

* **User-Facing for Release Notes**
  - [ ] Fixed a bug in the analytic Hessian code.

## Questions
- [x] Which extra tests do you have in mind, @loriab?

## Status
- [x] Ready to go
