### PR TITLE
Corrected printing for uncoupled induction

### DIFF
--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -412,7 +412,7 @@ Advanced SAPT0 Keywords
 
 .. include:: autodir_options_c/sapt__aio_cphf.rst
 .. include:: autodir_options_c/sapt__aio_df_ints.rst
-.. include:: autodir_options_c/sapt__no_response.rst
+.. include:: autodir_options_c/sapt__coupled_induction.rst
 .. include:: autodir_options_c/sapt__exch_scale_alpha.rst
 .. include:: autodir_options_c/sapt__ints_tolerance.rst
 .. include:: autodir_options_c/sapt__denominator_delta.rst

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3425,9 +3425,19 @@ def run_sapt(name, **kwargs):
     from psi4.driver.qcdb.psivardefs import sapt_psivars
     p4util.expand_psivars(sapt_psivars())
     optstash.restore()
-    for term in ['ELST', 'EXCH', 'IND', 'DISP', 'TOTAL']:
+
+    # Make sure we got induction, otherwise replace it with uncoupled induction
+    which_ind = 'IND'
+    target_ind = 'IND'
+    if not core.has_variable(' '.join([name.upper(), which_ind, 'ENERGY'])):
+      which_ind='IND,U'
+    
+    for term in ['ELST', 'EXCH', 'DISP', 'TOTAL']:
         core.set_variable(' '.join(['SAPT', term, 'ENERGY']),
             core.get_variable(' '.join([name.upper(), term, 'ENERGY'])))
+    # Special induction case
+    core.set_variable(' '.join(['SAPT', target_ind, 'ENERGY']),
+        core.get_variable(' '.join([name.upper(), which_ind, 'ENERGY'])))
     core.set_variable('CURRENT ENERGY', core.get_variable('SAPT TOTAL ENERGY'))
 
     return dimer_wfn

--- a/psi4/driver/qcdb/psivardefs.py
+++ b/psi4/driver/qcdb/psivardefs.py
@@ -42,9 +42,14 @@ def sapt_psivars():
     pv1['SAPT HF(2) ALPHA=0.0 ENERGY'] = {'func': lambda x: x[0] - (x[1] + x[2] + x[3] + x[4]),
                                           'args': ['SAPT HF TOTAL ENERGY', 'SAPT ELST10,R ENERGY', 'SAPT EXCH10 ENERGY',
                                                    'SAPT IND20,R ENERGY', 'SAPT EXCH-IND20,R ENERGY']}
+    pv1['SAPT HF(2),U ALPHA=0.0 ENERGY'] = {'func': lambda x: x[0] - (x[1] + x[2] + x[3] + x[4]),
+                                          'args': ['SAPT HF TOTAL ENERGY', 'SAPT ELST10,R ENERGY', 'SAPT EXCH10 ENERGY',
+                                                   'SAPT IND20,U ENERGY', 'SAPT EXCH-IND20,U ENERGY']}
 
     pv1['SAPT HF(2) ENERGY'] = {'func': lambda x: x[1] + (1.0 - x[0]) * x[2],
                                 'args': ['SAPT EXCHSCAL', 'SAPT HF(2) ALPHA=0.0 ENERGY', 'SAPT EXCH-IND20,R ENERGY']}
+    pv1['SAPT HF(2),U ENERGY'] = {'func': lambda x: x[1] + (1.0 - x[0]) * x[2],
+                                'args': ['SAPT EXCHSCAL', 'SAPT HF(2),U ALPHA=0.0 ENERGY', 'SAPT EXCH-IND20,U ENERGY']}
     pv1['SAPT HF(3) ENERGY'] = {'func': lambda x: x[1] - (x[2] + x[0] * x[3]),
                                 'args': ['SAPT EXCHSCAL', 'SAPT HF(2) ENERGY', 'SAPT IND30,R ENERGY', 'SAPT EXCH-IND30,R ENERGY']}
     pv1['SAPT MP2(2) ENERGY'] = {'func': lambda x: x[1] - (x[2] + x[3] + x[4] + x[0] * (x[5] + x[6] + x[7] + x[8])),
@@ -63,6 +68,8 @@ def sapt_psivars():
     pv1['SAPT0 EXCH ENERGY'] = {'func': sum, 'args': ['SAPT EXCH10 ENERGY']}
     pv1['SAPT0 IND ENERGY'] = {'func': lambda x: x[1] + x[2] + x[0] * x[3],
                                 'args': ['SAPT EXCHSCAL', 'SAPT HF(2) ENERGY', 'SAPT IND20,R ENERGY', 'SAPT EXCH-IND20,R ENERGY']}
+    pv1['SAPT0 IND,U ENERGY'] = {'func': lambda x: x[1] + x[2] + x[0] * x[3],
+                                'args': ['SAPT EXCHSCAL', 'SAPT HF(2),U ENERGY', 'SAPT IND20,U ENERGY', 'SAPT EXCH-IND20,U ENERGY']}
     pv1['SAPT0 DISP ENERGY'] = {'func': lambda x: x[0] * x[1] + x[2],
                                 'args': ['SAPT EXCHSCAL', 'SAPT EXCH-DISP20 ENERGY', 'SAPT DISP20 ENERGY']}
     pv1['SAPT0 TOTAL ENERGY'] = {'func': sum, 'args': ['SAPT0 ELST ENERGY', 'SAPT0 EXCH ENERGY', 'SAPT0 IND ENERGY', 'SAPT0 DISP ENERGY']}
@@ -70,12 +77,15 @@ def sapt_psivars():
     pv1['SSAPT0 EXCH ENERGY'] = {'func': sum, 'args': ['SAPT0 EXCH ENERGY']}
     pv1['SSAPT0 IND ENERGY'] = {'func': lambda x: x[1] + (x[0] - 1.0) * x[2],
                                  'args': ['SAPT EXCHSCAL3', 'SAPT0 IND ENERGY', 'SAPT EXCH-IND20,R ENERGY']}
+    pv1['SSAPT0 IND,U ENERGY'] = {'func': lambda x: x[1] + (x[0] - 1.0) * x[2],
+                                 'args': ['SAPT EXCHSCAL3', 'SAPT0 IND,U ENERGY', 'SAPT EXCH-IND20,U ENERGY']}
     pv1['SSAPT0 DISP ENERGY'] = {'func': lambda x: x[0] * x[1] + x[2],
                                  'args': ['SAPT EXCHSCAL3', 'SAPT EXCH-DISP20 ENERGY', 'SAPT DISP20 ENERGY']}
     pv1['SSAPT0 TOTAL ENERGY'] = {'func': sum, 'args': ['SSAPT0 ELST ENERGY', 'SSAPT0 EXCH ENERGY', 'SSAPT0 IND ENERGY', 'SSAPT0 DISP ENERGY']}
     pv1['SCS-SAPT0 ELST ENERGY'] = {'func': sum, 'args': ['SAPT0 ELST ENERGY']}
     pv1['SCS-SAPT0 EXCH ENERGY'] = {'func': sum, 'args': ['SAPT0 EXCH ENERGY']}
     pv1['SCS-SAPT0 IND ENERGY'] = {'func': sum, 'args': ['SAPT0 IND ENERGY']}
+    pv1['SCS-SAPT0 IND,U ENERGY'] = {'func': sum, 'args': ['SAPT0 IND,U ENERGY']}
     pv1['SCS-SAPT0 DISP ENERGY'] = {'func': lambda x: (x[0] - x[3]) * (x[1] + x[2]) + x[3] * (x[4] + x[5]),
                                     'args': [0.66, 'SAPT SAME-SPIN EXCH-DISP20 ENERGY', 'SAPT SAME-SPIN DISP20 ENERGY',
                                              1.2, 'SAPT EXCH-DISP20 ENERGY', 'SAPT DISP20 ENERGY']}  # note no xs for SCS disp

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -2360,9 +2360,22 @@ void FISAPT::print_trailer() {
     outfile->Printf("    Han Solo: I *did* say so before.\n");
 
     Process::environment.globals["SAPT ELST ENERGY"] = scalars_["Electrostatics"];
+    Process::environment.globals["SAPT ELST10,R ENERGY"] = scalars_["Elst10,r"];
+
     Process::environment.globals["SAPT EXCH ENERGY"] = scalars_["Exchange"];
+    Process::environment.globals["SAPT EXCH10 ENERGY"] = scalars_["Exch10"];
+    Process::environment.globals["SAPT EXCH10(S^2) ENERGY"] = scalars_["Exch10(S^2)"];
+
     Process::environment.globals["SAPT IND ENERGY"] = scalars_["Induction"];
+    Process::environment.globals["SAPT IND20,R ENERGY"] = scalars_["Ind20,r"];
+    Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = scalars_["Exch-Ind20,r"];
+    Process::environment.globals["SAPT IND20,U ENERGY"] = scalars_["Ind20,u"];
+    Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = scalars_["Exch-Ind20,u"];
+
     Process::environment.globals["SAPT DISP ENERGY"] = scalars_["Dispersion"];
+    Process::environment.globals["SAPT DISP20 ENERGY"] = scalars_["Disp20"];
+    Process::environment.globals["SAPT EXCH-DISP20 ENERGY"] = scalars_["Exch-Disp20"];
+
     Process::environment.globals["SAPT0 TOTAL ENERGY"] = scalars_["SAPT"];
     Process::environment.globals["SAPT TOTAL ENERGY"] = scalars_["SAPT"];
     Process::environment.globals["CURRENT ENERGY"] = Process::environment.globals["SAPT TOTAL ENERGY"];

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -249,6 +249,7 @@ void SAPT0::print_results() {
             outfile->Printf("    with Alpha = %12.6f \n", exch_scale_alpha_);
         }
         std::string scaled = (scal_it != Xscal.begin() ? "sc." : "   ");
+        std::string coupled = (no_response_ ? "u" : "r")
         outfile->Printf(
             "  "
             "--------------------------------------------------------------------------------------------------------"
@@ -265,23 +266,13 @@ void SAPT0::print_results() {
                         e_exch10_s2_ * 1000.0, e_exch10_s2_ * pc_hartree2kcalmol, e_exch10_s2_ * pc_hartree2kJmol);
         outfile->Printf("\n    Induction %3s             %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
                         scaled.c_str(), tot_ind * 1000.0, tot_ind * pc_hartree2kcalmol, tot_ind * pc_hartree2kJmol);
-        if(no_response_) {
-            outfile->Printf("      Ind20,u                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
-            outfile->Printf("      Exch-Ind20,u %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
-                            *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
-            outfile->Printf("      delta HF,u (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
-        } else {
-            outfile->Printf("      Ind20,r                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
-            outfile->Printf("      Exch-Ind20,r %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
-                            *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
-            outfile->Printf("      delta HF,r (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                            scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
-        }
+        outfile->Printf("      Ind20,%1s                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                        coupled.c_str(), e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
+        outfile->Printf("      Exch-Ind20,%1s %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                        coupled.c_str(), scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
+                        *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
+        outfile->Printf("      delta HF,%1s (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                        coupled.c_str(), scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
         outfile->Printf("\n    Dispersion %3s            %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
                         scaled.c_str(), tot_disp * 1000.0, tot_disp * pc_hartree2kcalmol, tot_disp * pc_hartree2kJmol);
         outfile->Printf("      Disp20                  %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
@@ -332,11 +323,6 @@ void SAPT0::print_results() {
             Process::environment.globals["SAPT EXCH10(S^2) ENERGY"] = e_exch10_s2_;
 
             if(no_response_) {
-                // We still store in the R variants so the PsiVars machinery works.
-                outfile->Printf("    WARNING: **Uncoupled** SAPT induction stored in SAPT IND20,R ENERGY \n");
-                outfile->Printf("             and in SAPT EXCH-IND20,R ENERGY \n");
-                Process::environment.globals["SAPT IND20,R ENERGY"] = e_ind20_;
-                Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = e_exch_ind20_;
                 Process::environment.globals["SAPT IND20,U ENERGY"] = e_ind20_;
                 Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = e_exch_ind20_;
             } else {

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -249,7 +249,7 @@ void SAPT0::print_results() {
             outfile->Printf("    with Alpha = %12.6f \n", exch_scale_alpha_);
         }
         std::string scaled = (scal_it != Xscal.begin() ? "sc." : "   ");
-        std::string coupled = (no_response_ ? "u" : "r")
+        std::string coupled = (no_response_ ? "u" : "r");
         outfile->Printf(
             "  "
             "--------------------------------------------------------------------------------------------------------"

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -265,13 +265,23 @@ void SAPT0::print_results() {
                         e_exch10_s2_ * 1000.0, e_exch10_s2_ * pc_hartree2kcalmol, e_exch10_s2_ * pc_hartree2kJmol);
         outfile->Printf("\n    Induction %3s             %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
                         scaled.c_str(), tot_ind * 1000.0, tot_ind * pc_hartree2kcalmol, tot_ind * pc_hartree2kJmol);
-        outfile->Printf("      Ind20,r                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                        e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
-        outfile->Printf("      Exch-Ind20,r %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                        scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
-                        *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
-        outfile->Printf("      delta HF,r (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
-                        scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
+        if(no_response_) {
+            outfile->Printf("      Ind20,u                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
+            outfile->Printf("      Exch-Ind20,u %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
+                            *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
+            outfile->Printf("      delta HF,u (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
+        } else {
+            outfile->Printf("      Ind20,r                 %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            e_ind20_ * 1000.0, e_ind20_ * pc_hartree2kcalmol, e_ind20_ * pc_hartree2kJmol);
+            outfile->Printf("      Exch-Ind20,r %3s        %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            scaled.c_str(), *scal_it * e_exch_ind20_ * 1000.0,
+                            *scal_it * e_exch_ind20_ * pc_hartree2kcalmol, *scal_it * e_exch_ind20_ * pc_hartree2kJmol);
+            outfile->Printf("      delta HF,r (2) %3s      %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
+                            scaled.c_str(), dHF2 * 1000.0, dHF2 * pc_hartree2kcalmol, dHF2 * pc_hartree2kJmol);
+        }
         outfile->Printf("\n    Dispersion %3s            %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
                         scaled.c_str(), tot_disp * 1000.0, tot_disp * pc_hartree2kcalmol, tot_disp * pc_hartree2kJmol);
         outfile->Printf("      Disp20                  %16.8lf [mEh] %16.8lf [kcal/mol] %16.8lf [kJ/mol]\n",
@@ -321,8 +331,18 @@ void SAPT0::print_results() {
             Process::environment.globals["SAPT EXCH10 ENERGY"] = e_exch10_;
             Process::environment.globals["SAPT EXCH10(S^2) ENERGY"] = e_exch10_s2_;
 
-            Process::environment.globals["SAPT IND20,R ENERGY"] = e_ind20_;
-            Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = e_exch_ind20_;
+            if(no_response_) {
+                // We still store in the R variants so the PsiVars machinery works.
+                outfile->Printf("    WARNING: **Uncoupled** SAPT induction stored in SAPT IND20,R ENERGY \n");
+                outfile->Printf("             and in SAPT EXCH-IND20,R ENERGY \n");
+                Process::environment.globals["SAPT IND20,R ENERGY"] = e_ind20_;
+                Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = e_exch_ind20_;
+                Process::environment.globals["SAPT IND20,U ENERGY"] = e_ind20_;
+                Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = e_exch_ind20_;
+            } else {
+                Process::environment.globals["SAPT IND20,R ENERGY"] = e_ind20_;
+                Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = e_exch_ind20_;
+            }
             Process::environment.globals["SAPT HF TOTAL ENERGY"] = eHF_;
             Process::environment.globals["SAPT CT ENERGY"] = e_ind20_ + e_exch_ind20_;
 

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -61,7 +61,7 @@ SAPT0::SAPT0(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefu
     maxiter_ = options_.get_int("MAXITER");
     e_conv_ = options_.get_double("E_CONVERGENCE");
     d_conv_ = options_.get_double("D_CONVERGENCE");
-    no_response_ = options_.get_bool("NO_RESPONSE");
+    no_response_ = !options_.get_bool("COUPLED_INDUCTION");
     aio_cphf_ = options_.get_bool("AIO_CPHF");
     aio_dfints_ = options_.get_bool("AIO_DF_INTS");
     do_e10_ = options_.get_bool("SAPT0_E10");

--- a/psi4/src/psi4/libsapt_solver/usapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/usapt0.cc
@@ -381,10 +381,10 @@ void USAPT0::print_trailer() {
             if (coupled_ind_) {
                 Process::environment.globals["SAPT IND20,R ENERGY"] = energies_["Ind20,r"];
                 Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = energies_["Exch-Ind20,r"];
-            } else {
-                Process::environment.globals["SAPT IND20,U ENERGY"] = energies_["Ind20,u"];
-                Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = energies_["Exch-Ind20,u"];
-            }
+            } // We always compute uncoupled induction in this routine
+            Process::environment.globals["SAPT IND20,U ENERGY"] = energies_["Ind20,u"];
+            Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = energies_["Exch-Ind20,u"];
+            
             Process::environment.globals["SAPT HF TOTAL ENERGY"] = energies_["HF"];
             // Process::environment.globals["SAPT CT ENERGY"] = e_ind20_ + e_exch_ind20_;
 

--- a/psi4/src/psi4/libsapt_solver/usapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/usapt0.cc
@@ -382,11 +382,6 @@ void USAPT0::print_trailer() {
                 Process::environment.globals["SAPT IND20,R ENERGY"] = energies_["Ind20,r"];
                 Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = energies_["Exch-Ind20,r"];
             } else {
-                // We still store in the R variants so the PsiVars machinery works.
-                outfile->Printf("    WARNING: **Uncoupled** SAPT induction stored in SAPT IND20,R ENERGY \n");
-                outfile->Printf("             and in SAPT EXCH-IND20,R ENERGY \n");
-                Process::environment.globals["SAPT IND20,R ENERGY"] = energies_["Ind20,u"];
-                Process::environment.globals["SAPT EXCH-IND20,R ENERGY"] = energies_["Exch-Ind20,u"];
                 Process::environment.globals["SAPT IND20,U ENERGY"] = energies_["Ind20,u"];
                 Process::environment.globals["SAPT EXCH-IND20,U ENERGY"] = energies_["Exch-Ind20,u"];
             }

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -830,11 +830,13 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     $E@@{ind,resp}^{(20)}$ term. -*/
     options.add_double("D_CONVERGENCE",1e-8);
 
-    /*- Don't solve the CPHF equations? Evaluate $E@@{ind}^{(20)}$ and
-    $E@@{exch-ind}^{(20)}$ instead of their response-including counterparts.
-    Only turn on this option if the induction energy is not going to be
-    used. -*/
-    options.add_bool("NO_RESPONSE",false);
+    /*- Solve the CPHF equations to compute coupled induction and 
+        exchange-induction. These are not available for ROHF, and 
+        the option is automatically false in this case. In all other cases,
+        coupled induction is strongly recommended. Only turn it off if the 
+        induction energy is not going to be used.
+        !expert -*/
+    options.add_bool("COUPLED_INDUCTION",true);
 
     /*- Do use asynchronous disk I/O in the solution of the CPHF equations?
     Use may speed up the computation slightly at the cost of spawning an
@@ -916,14 +918,6 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     (recommended for large calculations) some intermediate quantities are also
     printed. -*/
     options.add_int("PRINT", 1);
-    /*- Whether or not to compute coupled induction, applies only to
-        the open-shell SAPT0 code. Coupled induction is not available for
-        ROHF, and the option is automatically false in this case.
-        Note that when coupled induction is turned off, the Psi variables
-        SAPT IND20,R ENERGY and SAPT EXCH-IND20,R ENERGY actually contain
-        the **uncoupled** induction! A corresponding warning is issued in the
-        output file. !expert -*/
-    options.add_bool("COUPLED_INDUCTION",true);
     /*- Proportion of memory available for the DF-MP2 three-index integral
         buffers used to evaluate dispersion. !expert -*/
     options.add_double("SAPT_MEM_FACTOR", 0.9);


### PR DESCRIPTION
## Description
When requesting uncoupled induction in RHF-based SAPT0, the final summary still printed Ind20,r instead of Ind20,u as the line title, and no warning was issued about the uncoupled induction stored in the Psi4 variable for coupled induction, contrary to what is happening for open-shell SAPT0.
Solves #907.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [x] Correct printing of titles and warning for uncoupled induction in RHF-based SAPT0

## Status
- [x] Ready to go
