### PR TITLE
turning off iwl integrals for df-dcft

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1456,11 +1456,13 @@ def run_dcft(name, **kwargs):
                                             "JKFIT", core.get_global_option('BASIS'),
                                             puream=ref_wfn.basisset().has_puream())
         ref_wfn.set_basisset("DF_BASIS_SCF", scf_aux_basis)
+        dcft_wfn = core.dcft(ref_wfn)
 
-    # Ensure IWL files have been written
-    proc_util.check_iwl_file_from_scf_type(core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
+    else:
+    # Ensure IWL files have been written for non DF-DCFT
+        proc_util.check_iwl_file_from_scf_type(core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
+        dcft_wfn = core.dcft(ref_wfn)
 
-    dcft_wfn = core.dcft(ref_wfn)
     return dcft_wfn
 
 


### PR DESCRIPTION
## Description
The IWL integrals are calculated but apparently not needed for DF-DCFT. Added IF/ELSE clause to avoid this.

## Status
- [x] Ready to go