### PR TITLE
New DF_Helper Technology

### DIFF
--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -154,7 +154,7 @@ void CIWavefunction::setup_dfmcscf_ints() {
     // ==> Init DF object <== /
     dfh_ = std::make_shared<DF_Helper>(get_basisset("ORBITAL"), get_basisset("DF_BASIS_SCF"));
     dfh_->set_memory(Process::environment.get_memory() * 0.8 / sizeof(double));
-    dfh_->set_method("STORE");
+    dfh_->set_method("DIRECT_iaQ");
     dfh_->set_nthreads(num_threads_);
     dfh_->initialize();
 
@@ -276,7 +276,7 @@ void CIWavefunction::transform_dfmcscf_ints(bool approx_only) {
     }
 
     // => Compute DF ints <= //
-    dfh_->clear_all();
+    dfh_->clear_spaces();
 
     dfh_->add_space("R", AO_R);
     dfh_->add_space("a", AO_a);

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -154,7 +154,7 @@ void CIWavefunction::setup_dfmcscf_ints() {
     // ==> Init DF object <== /
     dfh_ = std::make_shared<DF_Helper>(get_basisset("ORBITAL"), get_basisset("DF_BASIS_SCF"));
     dfh_->set_memory(Process::environment.get_memory() * 0.8 / sizeof(double));
-    dfh_->set_method("DIRECT_iaQ");
+    dfh_->set_method("STORE");
     dfh_->set_nthreads(num_threads_);
     dfh_->initialize();
 

--- a/psi4/src/psi4/dfep2/dfep2.cc
+++ b/psi4/src/psi4/dfep2/dfep2.cc
@@ -91,7 +91,7 @@ DFEP2Wavefunction::DFEP2Wavefunction(std::shared_ptr<Wavefunction> ref_wfn)
 
     // ==> Init DF object <== /
     dfh_ = std::make_shared<DF_Helper>(get_basisset("ORBITAL"), get_basisset("DF_BASIS_SCF"));
-    dfh_->set_method("DIRECT");
+    dfh_->set_method("DIRECT_iaQ");
     dfh_->set_memory(memory_doubles_);
     dfh_->set_nthreads(num_threads_);
     dfh_->initialize();
@@ -198,6 +198,9 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
 
     // ==> Transform DF integrals <== /
 
+    // safety check
+    dfh_->clear_spaces();
+    
     // add spaces
     dfh_->add_space("i", AO_Cocc_);
     dfh_->add_space("a", AO_Cvir_);

--- a/psi4/src/psi4/dfep2/dfep2.cc
+++ b/psi4/src/psi4/dfep2/dfep2.cc
@@ -199,7 +199,6 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
     // ==> Transform DF integrals <== /
 
     // add spaces
-    dfh_->clear_all();
     dfh_->add_space("i", AO_Cocc_);
     dfh_->add_space("a", AO_Cvir_);
     dfh_->add_space("E", AO_CE);

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -2049,7 +2049,7 @@ void FISAPT::disp(std::map<std::string, SharedMatrix> matrix_cache, std::map<std
     // => Get integrals from DF_Helper <= //
     auto dfh(std::make_shared<DF_Helper>(primary_, auxiliary));
     dfh->set_memory(doubles_ - Cs[0]->nrow() * ncol);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
     dfh->print_header();
@@ -2067,16 +2067,16 @@ void FISAPT::disp(std::map<std::string, SharedMatrix> matrix_cache, std::map<std
     dfh->add_space("a4", Cs[10]);
     dfh->add_space("b4", Cs[11]);
 
-    dfh->add_transformation("Aar", "a", "r", "pqQ");
-    dfh->add_transformation("Abs", "b", "s", "pqQ");
-    dfh->add_transformation("Bas", "a", "s1", "pqQ");
-    dfh->add_transformation("Bbr", "b", "r1", "pqQ");
-    dfh->add_transformation("Cas", "a2", "s", "pqQ");
-    dfh->add_transformation("Cbr", "b2", "r", "pqQ");
-    dfh->add_transformation("Dar", "a", "r3", "pqQ");
-    dfh->add_transformation("Dbs", "b", "s3", "pqQ");
-    dfh->add_transformation("Ear", "a4", "r", "pqQ");
-    dfh->add_transformation("Ebs", "b4", "s", "pqQ");
+    dfh->add_transformation("Aar", "a" , "r" );
+    dfh->add_transformation("Abs", "b" , "s" );
+    dfh->add_transformation("Bas", "a" , "s1");
+    dfh->add_transformation("Bbr", "b" , "r1");
+    dfh->add_transformation("Cas", "a2", "s" );
+    dfh->add_transformation("Cbr", "b2", "r" );
+    dfh->add_transformation("Dar", "a" , "r3");
+    dfh->add_transformation("Dbs", "b" , "s3");
+    dfh->add_transformation("Ear", "a4", "r" );
+    dfh->add_transformation("Ebs", "b4", "s" );
 
     dfh->transform();
 
@@ -2637,7 +2637,7 @@ void FISAPT::felst() {
     // => Get integrals from DF_Helper <= //
     auto dfh(std::make_shared<DF_Helper>(primary_, reference_->get_basisset("DF_BASIS_SCF")));
     dfh->set_memory(doubles_);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
     dfh->print_header();
@@ -2645,8 +2645,8 @@ void FISAPT::felst() {
     dfh->add_space("a", matrices_["Locc0A"]);
     dfh->add_space("b", matrices_["Locc0B"]);
 
-    dfh->add_transformation("Aaa", "a", "a", "pqQ");
-    dfh->add_transformation("Abb", "b", "b", "pqQ");
+    dfh->add_transformation("Aaa", "a", "a");
+    dfh->add_transformation("Abb", "b", "b");
 
     dfh->transform();
 
@@ -2793,7 +2793,7 @@ void FISAPT::fexch() {
     // => Get integrals from DF_Helper <= //
     auto dfh(std::make_shared<DF_Helper>(primary_, reference_->get_basisset("DF_BASIS_SCF")));
     dfh->set_memory(doubles_);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
     dfh->print_header();
@@ -2803,9 +2803,9 @@ void FISAPT::fexch() {
     dfh->add_space("b", Cs[2]);
     dfh->add_space("s", Cs[3]);
 
-    dfh->add_transformation("Aar", "a", "r", "pqQ");
-    dfh->add_transformation("Abs", "b", "s", "pqQ");
-
+    dfh->add_transformation("Aar", "a", "r");
+    dfh->add_transformation("Abs", "b", "s");
+    
     dfh->transform();
 
     // ==> Electrostatic Potentials <== //
@@ -3789,7 +3789,7 @@ void FISAPT::fdisp() {
 
     auto dfh(std::make_shared<DF_Helper>(primary_, auxiliary));
     dfh->set_memory(doubles_ - Cs[0]->nrow() * ncol);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
     dfh->print_header();
@@ -3807,16 +3807,16 @@ void FISAPT::fdisp() {
     dfh->add_space("a4", Cs[10]);
     dfh->add_space("b4", Cs[11]);
 
-    dfh->add_transformation("Aar", "r", "a", "pqQ");
-    dfh->add_transformation("Abs", "s", "b", "pqQ");
-    dfh->add_transformation("Bas", "s1", "a", "pqQ");
-    dfh->add_transformation("Bbr", "r1", "b", "pqQ");
-    dfh->add_transformation("Cas", "s", "a2", "pqQ");
-    dfh->add_transformation("Cbr", "r", "b2", "pqQ");
-    dfh->add_transformation("Dar", "r3", "a", "pqQ");
-    dfh->add_transformation("Dbs", "s3", "b", "pqQ");
-    dfh->add_transformation("Ear", "r", "a4", "pqQ");
-    dfh->add_transformation("Ebs", "s", "b4", "pqQ");
+    dfh->add_transformation("Aar", "r" , "a" );
+    dfh->add_transformation("Abs", "s" , "b" );
+    dfh->add_transformation("Bas", "s1", "a" );
+    dfh->add_transformation("Bbr", "r1", "b" );
+    dfh->add_transformation("Cas", "s" , "a2");
+    dfh->add_transformation("Cbr", "r" , "b2");
+    dfh->add_transformation("Dar", "r3", "a" );
+    dfh->add_transformation("Dbs", "s3", "b" );
+    dfh->add_transformation("Ear", "r" , "a4");
+    dfh->add_transformation("Ebs", "s" , "b4");
 
     dfh->transform();
 

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -2804,8 +2804,8 @@ void FISAPT::fexch() {
     dfh->add_space("b", Cs[2]);
     dfh->add_space("s", Cs[3]);
 
-    dfh->add_transformation("Aar", "a", "r", "pqQ");
-    dfh->add_transformation("Abs", "b", "s", "pqQ");
+    dfh->add_transformation("Aar", "a", "r");
+    dfh->add_transformation("Abs", "b", "s");
     
     dfh->transform();
 
@@ -2875,21 +2875,16 @@ void FISAPT::fexch() {
 
     dfh->add_disk_tensor("Bab", std::make_tuple(na, nb, nQ));
 
-    SharedMatrix A = dfh->get_tensor("Aar");
-    printf("Aar: %f\n", A->rms());
     for (size_t a = 0; a < na; a++) {
         dfh->fill_tensor("Aar", TrQ, {a, a + 1});
-        printf("----- (%d): %f\n", a, TrQ->rms());
         C_DGEMM('N', 'N', nb, nQ, nr, 1.0, Sbrp[0], nr, TrQp[0], nQ, 0.0, TbQp[0], nQ);
         dfh->write_disk_tensor("Bab", TbQ, {a, a + 1});
     }
 
     dfh->add_disk_tensor("Bba", std::make_tuple(nb, na, nQ));
 
-    printf("Abs: %f\n", dfh->get_tensor("Abs")->rms());
     for (size_t b = 0; b < nb; b++) {
         dfh->fill_tensor("Abs", TsQ, {b, b + 1});
-        printf("----- (%d): %f\n", b, TsQ->rms());
         C_DGEMM('N', 'N', na, nQ, ns, 1.0, Sasp[0], ns, TsQp[0], nQ, 0.0, TaQp[0], nQ);
         dfh->write_disk_tensor("Bba", TaQ, {b, b + 1});
     }
@@ -2897,8 +2892,6 @@ void FISAPT::fexch() {
     auto E_exch3 = std::make_shared<Matrix>("E_exch [a <x-x> b]", na, nb);
     double** E_exch3p = E_exch3->pointer();
 
-    printf("Bab: %f\n", dfh->get_tensor("Bab")->rms());
-    printf("Bba: %f\n", dfh->get_tensor("Bba")->rms());
     for (size_t a = 0; a < na; a++) {
         dfh->fill_tensor("Bab", TbQ, {a, a + 1});
         for (size_t b = 0; b < nb; b++) {
@@ -2990,7 +2983,7 @@ void FISAPT::find() {
 
     auto dfh(std::make_shared<DF_Helper>(primary_, reference_->get_basisset("DF_BASIS_SCF")));
     dfh->set_memory(doubles_);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
     dfh->print_header();
@@ -3050,8 +3043,8 @@ void FISAPT::find() {
     dfh->add_space("b", Cs[2]);
     dfh->add_space("s", Cs[3]);
 
-    dfh->add_transformation("Aar", "a", "r", "pqQ");
-    dfh->add_transformation("Abs", "b", "s", "pqQ");
+    dfh->add_transformation("Aar", "a", "r");
+    dfh->add_transformation("Abs", "b", "s");
 
     dfh->transform();
 

--- a/psi4/src/psi4/lib3index/df_helper.cc
+++ b/psi4/src/psi4/lib3index/df_helper.cc
@@ -1970,11 +1970,8 @@ void DF_Helper::put_transformations_pQq(int naux, int begin, int end, int rblock
             #pragma omp parallel for num_threads(nthreads_)
             for (size_t x = 0; x < rblock_size; x++) {
                 for (size_t z = 0; z < wsize; z++) {
-                    #pragma omp simd
-                    for (size_t y = 0; y < bsize; y++) {
-                        Np[(bcount + x) * wsize * bsize + z * bsize + y] 
-                            = Fp[z * rblock_size * bsize + x * bsize + y];
-                    }
+                    C_DCOPY(bsize, &Fp[z * rblock_size * bsize + x * bsize], 
+                        1, &Np[(bcount + x) * wsize * bsize + z * bsize], 1);
                 }
             }
             timer_off("DFH: (w|Qb)->(bw|Q)");

--- a/psi4/src/psi4/lib3index/df_helper.cc
+++ b/psi4/src/psi4/lib3index/df_helper.cc
@@ -1398,7 +1398,7 @@ void DF_Helper::add_transformation(std::string name, std::string key1, std::stri
     } else if(!order.compare("pqQ")) {
         op = 2;
     } else {
-        throw PSIEXCEPTION("Matt doesnt do exceptions.");
+        throw PSIEXCEPTION("DF_Hepler:add_transformation: incorrect integral format, use 'Qpq', 'pQq', or 'pqQ'");
     }
     transf_[name] = std::make_tuple(key1, key2, op);
     
@@ -1418,10 +1418,10 @@ void DF_Helper::clear_spaces() {
 
     // no ordering
     ordered_ = false;
+    transformed_ = false;
 }
 
 void DF_Helper::clear_all() {
-
 
     // invokes destructors, eliminating all files.
     file_streams_.clear();
@@ -1433,7 +1433,6 @@ void DF_Helper::clear_all() {
     tsizes_.clear();
     transf_.clear();
     transf_core_.clear();
-    transformed_ = false;
 }
 
 std::pair<size_t, size_t> DF_Helper::identify_order() {
@@ -1596,8 +1595,6 @@ void DF_Helper::transform() {
             // print step info
             // outfile->Printf("      Qshell: (%zu, %zu)", start, stop);
             // outfile->Printf(", PHI: (%zu, %zu), size: %zu\n", begin, end, block_size);
-            //printf("      Qshell: (%zu, %zu)", start, stop);
-            //printf(", PHI: (%zu, %zu), size: %zu\n", begin, end, block_size);
 
             // get AO chunk according to directives
             if (AO_core_) {

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -320,6 +320,8 @@ class DF_Helper {
                                                          std::vector<std::pair<size_t, size_t>>& b);
     std::pair<size_t, size_t> Qshell_blocks_for_transform(const size_t mem, size_t wtmp, size_t wfinal,
                                                           std::vector<std::pair<size_t, size_t>>& b);
+    void metric_contraction_blocking(std::vector<std::pair<size_t, size_t>>& steps, 
+        size_t blocking_index, size_t block_sizes, size_t total_mem, size_t memory_factor, size_t memory_bump); 
 
     // => Schwarz Screening <=
     std::vector<size_t> schwarz_fun_mask_;

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -53,9 +53,10 @@ class DF_Helper {
 
     /// 
     /// Specify workflow for transforming and contracting integrals
-    /// @param method (STORE or DIRECT) to indicate workflow
-    /// DIRECT: pre-transform integrals before metric contraction 
+    /// @param method (STORE or DIRECT or DIRECT_iaQ) to indicate workflow
     /// STORE: contract and save AO integrals before transforming 
+    /// DIRECT: pre-transform integrals before metric contraction 
+    /// DIRECT_iaQ: special workflow when using integrals of the iaQ form
     /// (defaults to STORE)
     ///
     void set_method(std::string method) { method_ = method; }
@@ -281,6 +282,8 @@ class DF_Helper {
     // => AO building machinery <=
     void prepare_AO();
     void prepare_AO_core();
+    void compute_Qpq_blocking_Q(const size_t start, const size_t stop, double* Mp,
+                      std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
     void compute_pQq_blocking_Q(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
     void compute_pQq_blocking_p(const size_t start, const size_t stop, double* Mp,
@@ -289,6 +292,11 @@ class DF_Helper {
                            std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
     void contract_metric_AO_core_symm(double* Qpq, double* metp, size_t begin, size_t end);
     void grab_AO(const size_t start, const size_t stop, double* Mp);
+
+    // first integral transforms
+    void first_transform_pQq(int nao, int naux, int bsize, int bcount, int block_size, int rank, 
+        double* Mp, double* Tp, double* Bp, std::vector<std::vector<double>> C_buffers);
+    
 
     // => index vectors for screened AOs <=
     std::vector<size_t> small_skips_;

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -298,6 +298,8 @@ class DF_Helper {
     void grab_AO(const size_t start, const size_t stop, double* Mp);
 
     // first integral transforms
+    void first_transform_Qpq(int nao, int naux, int bsize, int bcount, int block_size, int rank, 
+        double* Mp, double* Tp, double* Bp);
     void first_transform_pQq(int nao, int naux, int bsize, int bcount, int block_size, int rank, 
         double* Mp, double* Tp, double* Bp, std::vector<std::vector<double>> C_buffers);
     
@@ -337,6 +339,7 @@ class DF_Helper {
     std::string compute_metric(double pow);
 
     // => metric operations <=
+    void contract_metric_Qpq(std::string file, double* metp, double* Mp, double* Fp, const size_t tots);
     void contract_metric(std::string file, double* metp, double* Mp, double* Fp, const size_t tots);
     void contract_metric_core(std::string file);
     void contract_metric_AO(double* Mp);
@@ -348,7 +351,9 @@ class DF_Helper {
     std::map<std::string, std::vector<double>> transf_core_;
 
     // => transformation machinery <=
-    void put_transformations(int naux, int begin, int end, int block_size, int bcount, 
+    void put_transformations_Qpq(int naux, int begin, int end,  
+        int wsize, int bsize, double* Fp, int ind, bool bleft);
+    void put_transformations_pQq(int naux, int begin, int end, int block_size, int bcount, 
         int wsize, int bsize, double* Np, double* Fp, int ind, bool bleft);
     std::vector<std::pair<std::string, size_t>> sorted_spaces_;
     std::vector<std::string> order_;

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -388,7 +388,7 @@ class DF_Helper {
     std::map<std::string, std::string> AO_files_;
     std::vector<size_t> AO_file_sizes_;
     std::vector<std::string> AO_names_;
-    void filename_maker(std::string name, size_t a0, size_t a1, size_t a2, size_t op = 0);
+    void filename_maker(std::string name, size_t a0, size_t a1, size_t a2, size_t op=0);
     void AO_filename_maker(size_t i);
     void check_file_key(std::string);
     void check_file_tuple(std::string name, std::pair<size_t, size_t> t0, std::pair<size_t, size_t> t1,

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -361,12 +361,24 @@ class DF_Helper {
     std::vector<size_t> strides_;
 
     // => FILE IO maintenence <=
-    struct stream {
-        FILE* fp;
-        std::string op;
-        bool exists = false;
-    };
-    std::map<std::string, stream> file_streams_;
+    typedef struct StreamStruct {
+        
+        StreamStruct();
+        StreamStruct(std::string filename, std::string op, bool activate=true);
+        ~StreamStruct();
+
+        FILE* get_stream(std::string op);
+        void change_stream(std::string op);
+        void close_stream();
+ 
+        FILE* fp_;
+        std::string op_;
+        bool open_ = false;
+        std::string filename_;   
+         
+    } Stream;
+   
+    std::map<std::string, std::shared_ptr<Stream>> file_streams_;
     FILE* stream_check(std::string filename, std::string op);
 
     // => FILE IO machinery <=

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -245,9 +245,6 @@ class DF_Helper {
     void build_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright, std::vector<SharedMatrix> J,
                   std::vector<SharedMatrix> K);
 
-    // FIXME
-    SharedMatrix check_function();
-
    protected:
     // => basis sets <=
     std::shared_ptr<BasisSet> primary_;
@@ -401,6 +398,7 @@ class DF_Helper {
     std::map<std::string, std::string> AO_files_;
     std::vector<size_t> AO_file_sizes_;
     std::vector<std::string> AO_names_;
+    std::string start_filename(std::string start);
     void filename_maker(std::string name, size_t a0, size_t a1, size_t a2, size_t op=0);
     void AO_filename_maker(size_t i);
     void check_file_key(std::string);

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -288,11 +288,11 @@ class DF_Helper {
     void prepare_AO_core();
     void compute_dense_Qpq_blocking_Q(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
-    void compute_pQq_blocking_Q(const size_t start, const size_t stop, double* Mp,
+    void compute_sparse_pQq_blocking_Q(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
-    void compute_pQq_blocking_p(const size_t start, const size_t stop, double* Mp,
+    void compute_sparse_pQq_blocking_p(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
-    void compute_pQq_blocking_p_symm(const size_t start, const size_t stop, double* Mp,
+    void compute_sparse_pQq_blocking_p_symm(const size_t start, const size_t stop, double* Mp,
                            std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
     void contract_metric_AO_core_symm(double* Qpq, double* metp, size_t begin, size_t end);
     void grab_AO(const size_t start, const size_t stop, double* Mp);
@@ -364,8 +364,9 @@ class DF_Helper {
     struct stream {
         FILE* fp;
         std::string op;
+        bool exists = false;
     };
-    std::map<std::string, stream> file_status_;
+    std::map<std::string, stream> file_streams_;
     FILE* stream_check(std::string filename, std::string op);
 
     // => FILE IO machinery <=

--- a/psi4/src/psi4/lib3index/df_helper.h
+++ b/psi4/src/psi4/lib3index/df_helper.h
@@ -245,6 +245,9 @@ class DF_Helper {
     void build_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright, std::vector<SharedMatrix> J,
                   std::vector<SharedMatrix> K);
 
+    // FIXME
+    SharedMatrix check_function();
+
    protected:
     // => basis sets <=
     std::shared_ptr<BasisSet> primary_;
@@ -259,6 +262,7 @@ class DF_Helper {
     std::string method_ = "STORE";
     bool direct_;
     bool direct_iaQ_;
+    bool symm_compute_;
     bool AO_core_ = 1;
     bool MO_core_ = 0;
     size_t nthreads_ = 1;
@@ -282,7 +286,7 @@ class DF_Helper {
     // => AO building machinery <=
     void prepare_AO();
     void prepare_AO_core();
-    void compute_Qpq_blocking_Q(const size_t start, const size_t stop, double* Mp,
+    void compute_dense_Qpq_blocking_Q(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);
     void compute_pQq_blocking_Q(const size_t start, const size_t stop, double* Mp,
                       std::vector<std::shared_ptr<TwoBodyAOInt>> eri);

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -155,7 +155,7 @@ FDDS_Dispersion::FDDS_Dispersion(std::shared_ptr<BasisSet> primary, std::shared_
     // Build DF_Helper
     dfh_ = std::make_shared<DF_Helper>(primary_, auxiliary_);
     dfh_->set_memory(doubles);
-    dfh_->set_method("STORE");
+    dfh_->set_method("DIRECT_iaQ");
     dfh_->set_nthreads(nthread);
     dfh_->set_metric_pow(0.0);
     dfh_->initialize();

--- a/psi4/src/psi4/libsapt_solver/usapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/usapt0.cc
@@ -1968,7 +1968,7 @@ void USAPT0::mp2_terms() {
 
     auto dfh(std::make_shared<DF_Helper>(primary_, mp2fit_));
     dfh->set_memory(memory_ - Cs[0]->nrow() * ncol);
-    dfh->set_method("DIRECT");
+    dfh->set_method("DIRECT_iaQ");
     dfh->set_nthreads(nT);
     dfh->initialize();
 

--- a/tests/python/3-index-transforms/input.dat
+++ b/tests/python/3-index-transforms/input.dat
@@ -1,18 +1,24 @@
 import psi4
 import numpy as np
 import random
+from collections import OrderedDict
 
 mol = psi4.geometry("""
-H
-H 1 20
+H 0.0  2.0 0.0    
+H 0.0  4.0 0.0
+H 0.0  6.0 0.0
+H 0.0  8.0 0.0
+H 0.0 10.0 0.0
 """)
 
-primary = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pVDZ")
-aux = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pVDZ-jkfit")
+primary = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pVTZ")
+aux = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pVTZ-jkfit")
 
+# setup ~
 nbf = primary.nbf()
 naux = aux.nbf()
-mem = 10000
+mem = 1000000
+ntransforms = 6
 
 # form metric
 mints = psi4.core.MintsHelper(primary)
@@ -29,669 +35,87 @@ Qpq = np.squeeze(mints.ao_eri(aux, zero_bas, primary, primary))
 Qpq = Jmetric_inv.dot(Qpq.reshape(naux, -1))
 Qpq = Qpq.reshape(naux, nbf, -1) 
 
-# space sizes
-c1 = 10
-c2 = 12
-c3 = 14
-c4 = 40 
+# construct spaces
+names = ['C1', 'C2', 'C3', 'C4']
+sizes = [_ * 5 for _ in range(1, 5)]
+spaces = {names[ind]: psi4.core.Matrix(nbf, _) for ind, _ in enumerate(sizes)}
 
-# space initiations
-C1 = psi4.core.Matrix(nbf,c1) 
-C2 = psi4.core.Matrix(nbf,c2) 
-C3 = psi4.core.Matrix(nbf,c3)
-C4 = psi4.core.Matrix(nbf,c4)
-
-# get random numpy arrays
-C1.np[:] = 1 #np.random.random()
-C2.np[:] = 2 #np.random.random()
-C3.np[:] = 3 #np.random.random()
-C4.np[:] = 4 #np.random.random()
+# make fake spaces
+for ind, i in enumerate(spaces):
+    spaces[i].np[:] = ind + 1
 
 # set transformed integrals
 Qmo = []
-Qmo.append(np.zeros((naux, c1, c2)))
-Qmo.append(np.zeros((naux, c3, c2)))
-Qmo.append(np.zeros((naux, c4, c2)))
-Qmo.append(np.zeros((naux, c1, c4)))
-Qmo.append(np.zeros((naux, c3, c1)))
-Qmo.append(np.zeros((naux, c3, c3)))
+space_pairs = [[0, 1], [2, 1], [3, 1], [0, 3], [2, 0], [2, 2]]
+for i in space_pairs:
+    Qmo.append(np.zeros((naux, sizes[i[0]], sizes[i[1]])))
 
 # transform
-for i in range(naux):
-    Qmo[0][i] = np.dot(C1.np.T, Qpq[i]).dot(C2)
-    Qmo[1][i] = np.dot(C3.np.T, Qpq[i]).dot(C2)
-    Qmo[2][i] = np.dot(C4.np.T, Qpq[i]).dot(C2)
-    Qmo[3][i] = np.dot(C1.np.T, Qpq[i]).dot(C4)
-    Qmo[4][i] = np.dot(C3.np.T, Qpq[i]).dot(C1)
-    Qmo[5][i] = np.dot(C3.np.T, Qpq[i]).dot(C3)
+for ind, i in enumerate(space_pairs): 
+    for Q in range(naux):
+        C1 = spaces[names[space_pairs[ind][0]]]
+        C2 = spaces[names[space_pairs[ind][1]]]
+        Qmo[ind][Q] = np.dot(C1.np.T, Qpq[Q]).dot(C2)
+
+# setup ~
+methods = ['STORE', 'DIRECT', 'DIRECT_iaQ']
+transformation_names = ['Qmo1', 'Qmo2', 'Qmo3', 'Qmo4', 'Qmo5', 'Qmo6']
+transformations = OrderedDict({})
+for ind, i in enumerate(transformation_names):
+    transformations[i] = [names[space_pairs[ind][0]], names[space_pairs[ind][1]]] 
+
+# somewhat exhuastive search on all options
+switched = False
+for method in methods:
+    if((not switched) and method == 'DIRECT_iaQ'):
+        for i in range(ntransforms):
+            Qmo[i] = np.swapaxes(np.swapaxes(Qmo[i], 0, 2), 0, 1)    
+        switched = True        
+    for AO_core in [False, True]:
+        for MO_core in [True, False]:
+            for hold_met in [False, True]:
+                        
+                # get object
+                dfh = psi4.core.DF_Helper(primary, aux)
+                
+                # set test options
+                dfh.set_method(method)
+                dfh.set_memory(mem)
+                dfh.set_AO_core(AO_core)
+                dfh.set_MO_core(MO_core)
+                dfh.hold_met(hold_met)
+
+                # build
+                dfh.initialize()
+                
+                # add spaces
+                for i in spaces:
+                    dfh.add_space(i, spaces[i])
+
+                # add transformations
+                for i in transformations:
+                    j = transformations[i]
+                    dfh.add_transformation(i, j[0], j[1]) 
+
+                # invoke transformations
+                dfh.transform()
+
+                # grab transformed integrals
+                dfh_Qmo = []
+                for ind, i in enumerate(transformations):
+                    dfh_Qmo.append(np.asarray(dfh.get_tensor(i)))
+
+                test_string = 'Alg: ' + method + ' in core (AOs, MOs, met): [' 
+                test_string += str(AO_core) + ', ' + str(MO_core) + ', ' + str(hold_met) + ']' 
+
+                # am i right?
+                for i in range(ntransforms):
+                    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, test_string)
+
+                del dfh
+
+# TODO:
+# test tensor slicing grabs
+# test pQq and pqQ builds for store and direct0
 
-# now compare to DF_Helper
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("STORE")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(False)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo = []
-dfh_Qmo.append(dfh.get_tensor("Qmo1"))
-dfh_Qmo.append(dfh.get_tensor("Qmo2"))
-dfh_Qmo.append(dfh.get_tensor("Qmo3"))
-dfh_Qmo.append(dfh.get_tensor("Qmo4"))
-dfh_Qmo.append(dfh.get_tensor("Qmo5"))
-dfh_Qmo.append(dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: STORE, AO_CORE = FALSE, MO_CORE = FALSE" )     #TEST
-
-# Let's use new orbital spaces
-C1.np[:] = 1 #np.random.random()
-C2.np[:] = 2 #np.random.random()
-C3.np[:] = 3 #np.random.random()
-C4.np[:] = 4 #np.random.random()
-
-# adding a new space overwrites the previous one
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# set transformed integrals
-Qmo = []
-Qmo.append(np.zeros((naux, c1, c2)))
-Qmo.append(np.zeros((naux, c3, c2)))
-Qmo.append(np.zeros((naux, c4, c2)))
-Qmo.append(np.zeros((naux, c1, c4)))
-Qmo.append(np.zeros((naux, c3, c1)))
-Qmo.append(np.zeros((naux, c3, c3)))
-
-# recompute python side
-for i in range(naux):
-    Qmo[0][i] = np.dot(C1.np.T, Qpq[i]).dot(C2)
-    Qmo[1][i] = np.dot(C3.np.T, Qpq[i]).dot(C2)
-    Qmo[2][i] = np.dot(C4.np.T, Qpq[i]).dot(C2)
-    Qmo[3][i] = np.dot(C1.np.T, Qpq[i]).dot(C4)
-    Qmo[4][i] = np.dot(C3.np.T, Qpq[i]).dot(C1)
-    Qmo[5][i] = np.dot(C3.np.T, Qpq[i]).dot(C3)
-
-# recompute using df_helper
-dfh.transform()
-
-# grab new transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "SAME as ^ with new orbital spaces" )     #TEST
-# test some tranposes, both in transform and after
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("STORE")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(False)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# test transposes:
-Qmo[2] = np.einsum("Qpq->pQq", Qmo[2])
-Qmo[3] = np.einsum("Qpq->pQq", Qmo[3])
-Qmo[4] = np.einsum("Qpq->pqQ", Qmo[4])
-Qmo[5] = np.einsum("Qpq->pqQ", Qmo[5])
-
-# invoke transformations
-dfh.transform()
-
-# tranpose necessary tensors
-dfh.transpose("Qmo3", (1, 0, 2))
-dfh.transpose("Qmo4", (1, 0, 2))
-dfh.transpose("Qmo5", (1, 2, 0))
-dfh.transpose("Qmo6", (1, 2, 0))
-
-# grab transformed integrals
-dfh_Qmo = []
-dfh_Qmo.append(dfh.get_tensor("Qmo1"))
-dfh_Qmo.append(dfh.get_tensor("Qmo2"))
-dfh_Qmo.append(dfh.get_tensor("Qmo3"))
-dfh_Qmo.append(dfh.get_tensor("Qmo4"))
-dfh_Qmo.append(dfh.get_tensor("Qmo5"))
-dfh_Qmo.append(dfh.get_tensor("Qmo6"))
-
-
-## am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "SAME as ^ with transposes" )     #TEST
-
-# okay, let's try with all other disc/core options ---------------------------------------------------------------------
-# destoy the original instance!
-
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("STORE")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1", "pqQ")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3", "pqQ")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# tranpose necessary tensors
-dfh.transpose("Qmo3", (1, 0, 2))
-dfh.transpose("Qmo4", (1, 0, 2))
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: STORE, AO_CORE = FALSE, MO_CORE = TRUE + tranposes" )     #TEST
-
-# transpose back:
-Qmo[2] = np.einsum("pQq->Qpq", Qmo[2])
-Qmo[3] = np.einsum("pQq->Qpq", Qmo[3])
-Qmo[4] = np.einsum("pqQ->Qpq", Qmo[4])
-Qmo[5] = np.einsum("pqQ->Qpq", Qmo[5])
-
-# again!
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("STORE")
-dfh.set_memory(mem)
-dfh.set_AO_core(True)
-dfh.set_MO_core(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: STORE, AO_CORE = TRUE, MO_CORE = TRUE" )     #TEST
-
-# again!
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("STORE")
-dfh.set_memory(mem)
-dfh.set_AO_core(True)
-dfh.set_MO_core(False)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: STORE, AO_CORE = TRUE, MO_CORE = FALSE" )     #TEST
-
-# let's try clearing everything
-dfh.clear_all()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "SAME as ^ after calling clear()" )     #TEST
-
-# again ~ DIRECT
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(False)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo = []
-dfh_Qmo.append(dfh.get_tensor("Qmo1"))
-dfh_Qmo.append(dfh.get_tensor("Qmo2"))
-dfh_Qmo.append(dfh.get_tensor("Qmo3"))
-dfh_Qmo.append(dfh.get_tensor("Qmo4"))
-dfh_Qmo.append(dfh.get_tensor("Qmo5"))
-dfh_Qmo.append(dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: DIRECT, AO_CORE = FALSE, MO_CORE = FALSE" )     #TEST
-
-# again ~ DIRECT
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(False)
-dfh.hold_met(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "SAME as ^ with hold_met = True" )     #TEST
-
-# again!
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(True)
-dfh.set_MO_core(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: DIRECT, AO_CORE = True, MO_CORE = TRUE" )     #TEST
-
-# again ~ DIRECT
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(True)
-dfh.set_MO_core(True)
-dfh.hold_met(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "SAME as ^ with hold_met = True" )     #TEST
-
-# again!
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(True)
-dfh.set_MO_core(False)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: DIRECT, AO_CORE = TRUE, MO_CORE = FALSE" )     #TEST
-
-# again!
-# destoy the original instance!
-del dfh
-
-# redeclare
-dfh = psi4.core.DF_Helper(primary, aux)
-
-# tweak options
-dfh.set_method("DIRECT")
-dfh.set_memory(mem)
-dfh.set_AO_core(False)
-dfh.set_MO_core(True)
-
-# build
-dfh.initialize()
-
-# set spaces
-dfh.add_space("C1", C1)
-dfh.add_space("C2", C2)
-dfh.add_space("C3", C3)
-dfh.add_space("C4", C4)
-
-# add transformations
-dfh.add_transformation("Qmo1", "C1", "C2")      # best on left  (Q|bw)
-dfh.add_transformation("Qmo2", "C3", "C2")      # best on right (Q|wb)
-dfh.add_transformation("Qmo3", "C4", "C2")      # best on right (w|Qb)
-dfh.add_transformation("Qmo4", "C1", "C4")      # best on left  (b|Qw)
-dfh.add_transformation("Qmo5", "C3", "C1")      # best on right (wb|Q)
-dfh.add_transformation("Qmo6", "C3", "C3")      # best on left  (bw|Q)
-
-# invoke transformations
-dfh.transform()
-
-# grab transformed integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1"))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2"))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3"))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4"))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5"))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6"))
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, "Algorithm: DIRECT, AO_CORE = FALSE, MO_CORE = TRUE" )     #TEST
-
-# test slicing
-c1_index = random.randint(0, c1 - 1)
-c2_index = random.randint(0, c2 - 1)
-c3_index = random.randint(0, c3 - 1)
-c4_index = random.randint(0, c4 - 1)
-
-ni = (0, naux)
-C1_index = (c1_index, random.randint(c1_index + 1, c1))
-C2_index = (c2_index, random.randint(c2_index + 1, c2))
-C3_index = (c3_index, random.randint(c3_index + 1, c3))
-C4_index = (c4_index, random.randint(c4_index + 1, c4))
-
-# grab sliced integrals
-dfh_Qmo[0] = (dfh.get_tensor("Qmo1", ni, C1_index, C2_index))
-dfh_Qmo[1] = (dfh.get_tensor("Qmo2", ni, C3_index, C2_index))
-dfh_Qmo[2] = (dfh.get_tensor("Qmo3", ni, C4_index, C2_index))
-dfh_Qmo[3] = (dfh.get_tensor("Qmo4", ni, C1_index, C4_index))
-dfh_Qmo[4] = (dfh.get_tensor("Qmo5", ni, C3_index, C1_index))
-dfh_Qmo[5] = (dfh.get_tensor("Qmo6", ni, C3_index, C3_index))
-
-# slice python side
-sQmo = []
-sQmo.append(Qmo[0][:, C1_index[0]:C1_index[1], C2_index[0]:C2_index[1]]) 
-sQmo.append(Qmo[1][:, C3_index[0]:C3_index[1], C2_index[0]:C2_index[1]])
-sQmo.append(Qmo[2][:, C4_index[0]:C4_index[1], C2_index[0]:C2_index[1]])
-sQmo.append(Qmo[3][:, C1_index[0]:C1_index[1], C4_index[0]:C4_index[1]])
-sQmo.append(Qmo[4][:, C3_index[0]:C3_index[1], C1_index[0]:C1_index[1]])
-sQmo.append(Qmo[5][:, C3_index[0]:C3_index[1], C3_index[0]:C3_index[1]])
-
-# am i right?
-for i in range(6):
-    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), sQmo[i], 9, "tensor slicing" )     #TEST
-   
 

--- a/tests/python/3-index-transforms/input.dat
+++ b/tests/python/3-index-transforms/input.dat
@@ -122,7 +122,6 @@ for method in methods:
                         if(form == 'pqQ'):    
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pqQ[i], 9, test_string)
                         elif(form == 'pQq'):
-                            #print(np.linalg.norm(np.asarray(dfh_Qmo[i])), np.linalg.norm(Qmo_pqQ[i])) 
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pQq[i], 9, test_string)
                         else:
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, test_string)

--- a/tests/python/3-index-transforms/input.dat
+++ b/tests/python/3-index-transforms/input.dat
@@ -56,63 +56,73 @@ for ind, i in enumerate(space_pairs):
         C1 = spaces[names[space_pairs[ind][0]]]
         C2 = spaces[names[space_pairs[ind][1]]]
         Qmo[ind][Q] = np.dot(C1.np.T, Qpq[Q]).dot(C2)
+    
+# get other forms (pQq and pqQ)
+Qmo_pQq = []    
+Qmo_pqQ = []    
+for i in range(ntransforms):
+    Qmo_pQq.append(np.swapaxes(Qmo[i], 0, 1))    
+    Qmo_pqQ.append(np.swapaxes(np.swapaxes(Qmo[i], 0, 2), 0, 1))    
 
 # setup ~
 methods = ['STORE', 'DIRECT', 'DIRECT_iaQ']
+forms = ['Qpq', 'pQq', 'pqQ']
 transformation_names = ['Qmo1', 'Qmo2', 'Qmo3', 'Qmo4', 'Qmo5', 'Qmo6']
 transformations = OrderedDict({})
 for ind, i in enumerate(transformation_names):
     transformations[i] = [names[space_pairs[ind][0]], names[space_pairs[ind][1]]] 
 
 # somewhat exhuastive search on all options
-switched = False
 for method in methods:
-    if((not switched) and method == 'DIRECT_iaQ'):
-        for i in range(ntransforms):
-            Qmo[i] = np.swapaxes(np.swapaxes(Qmo[i], 0, 2), 0, 1)    
-        switched = True        
-    for AO_core in [False, True]:
-        for MO_core in [True, False]:
-            for hold_met in [False, True]:
-                        
-                # get object
-                dfh = psi4.core.DF_Helper(primary, aux)
-                
-                # set test options
-                dfh.set_method(method)
-                dfh.set_memory(mem)
-                dfh.set_AO_core(AO_core)
-                dfh.set_MO_core(MO_core)
-                dfh.hold_met(hold_met)
+    for form in forms:
+        if(form != 'pqQ' and method == 'DIRECT_iaQ'): continue
+        for AO_core in [False, True]:
+            for MO_core in [True, False]:
+                for hold_met in [False, True]:
+                            
+                    # get object
+                    dfh = psi4.core.DF_Helper(primary, aux)
+                    
+                    # set test options
+                    dfh.set_method(method)
+                    dfh.set_memory(mem)
+                    dfh.set_AO_core(AO_core)
+                    dfh.set_MO_core(MO_core)
+                    dfh.hold_met(hold_met)
 
-                # build
-                dfh.initialize()
-                
-                # add spaces
-                for i in spaces:
-                    dfh.add_space(i, spaces[i])
+                    # build
+                    dfh.initialize()
+                    
+                    # add spaces
+                    for i in spaces:
+                        dfh.add_space(i, spaces[i])
 
-                # add transformations
-                for i in transformations:
-                    j = transformations[i]
-                    dfh.add_transformation(i, j[0], j[1]) 
+                    # add transformations
+                    for i in transformations:
+                        j = transformations[i]
+                        dfh.add_transformation(i, j[0], j[1], form) 
 
-                # invoke transformations
-                dfh.transform()
+                    # invoke transformations
+                    dfh.transform()
 
-                # grab transformed integrals
-                dfh_Qmo = []
-                for ind, i in enumerate(transformations):
-                    dfh_Qmo.append(np.asarray(dfh.get_tensor(i)))
+                    # grab transformed integrals
+                    dfh_Qmo = []
+                    for ind, i in enumerate(transformations):
+                        dfh_Qmo.append(np.asarray(dfh.get_tensor(i)))
 
-                test_string = 'Alg: ' + method + ' in core (AOs, MOs, met): [' 
-                test_string += str(AO_core) + ', ' + str(MO_core) + ', ' + str(hold_met) + ']' 
+                    test_string = 'Alg: ' + method + ' + ' + form + ' core (AOs, MOs, met): [' 
+                    test_string += str(AO_core) + ', ' + str(MO_core) + ', ' + str(hold_met) +  ']' 
 
-                # am i right?
-                for i in range(ntransforms):
-                    psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, test_string)
+                    # am i right?
+                    for i in range(ntransforms):
+                        if(form == 'pqQ'):    
+                            psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pqQ[i], 9, test_string)
+                        elif(form == 'pQq'):
+                            psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pQq[i], 9, test_string)
+                        else:
+                            psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, test_string)
 
-                del dfh
+                    del dfh
 
 # TODO:
 # test tensor slicing grabs

--- a/tests/python/3-index-transforms/input.dat
+++ b/tests/python/3-index-transforms/input.dat
@@ -17,7 +17,8 @@ aux = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pVTZ-jkfit")
 # setup ~
 nbf = primary.nbf()
 naux = aux.nbf()
-mem = 1000000
+mem = 100000
+mem_bump = naux * naux
 ntransforms = 6
 
 # form metric
@@ -77,7 +78,7 @@ for method in methods:
     for form in forms:
         if(form != 'pqQ' and method == 'DIRECT_iaQ'): continue
         for AO_core in [False, True]:
-            for MO_core in [True, False]:
+            for MO_core in [False, True]:
                 for hold_met in [False, True]:
                             
                     # get object
@@ -85,7 +86,9 @@ for method in methods:
                     
                     # set test options
                     dfh.set_method(method)
-                    dfh.set_memory(mem)
+                    memory = mem_bump if hold_met else 0
+                    memory += 10*mem if AO_core else mem
+                    dfh.set_memory(memory)
                     dfh.set_AO_core(AO_core)
                     dfh.set_MO_core(MO_core)
                     dfh.hold_met(hold_met)
@@ -113,11 +116,13 @@ for method in methods:
                     test_string = 'Alg: ' + method + ' + ' + form + ' core (AOs, MOs, met): [' 
                     test_string += str(AO_core) + ', ' + str(MO_core) + ', ' + str(hold_met) +  ']' 
 
+                    print(test_string)
                     # am i right?
                     for i in range(ntransforms):
                         if(form == 'pqQ'):    
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pqQ[i], 9, test_string)
                         elif(form == 'pQq'):
+                            #print(np.linalg.norm(np.asarray(dfh_Qmo[i])), np.linalg.norm(Qmo_pqQ[i])) 
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo_pQq[i], 9, test_string)
                         else:
                             psi4.compare_arrays(np.asarray(dfh_Qmo[i]), Qmo[i], 9, test_string)

--- a/tests/python/3-index-transforms/input.dat
+++ b/tests/python/3-index-transforms/input.dat
@@ -1,6 +1,5 @@
 import psi4
 import numpy as np
-import random
 from collections import OrderedDict
 
 mol = psi4.geometry("""
@@ -39,11 +38,7 @@ Qpq = Qpq.reshape(naux, nbf, -1)
 # construct spaces
 names = ['C1', 'C2', 'C3', 'C4']
 sizes = [_ * 5 for _ in range(1, 5)]
-spaces = {names[ind]: psi4.core.Matrix(nbf, _) for ind, _ in enumerate(sizes)}
-
-# make fake spaces
-for ind, i in enumerate(spaces):
-    spaces[i].np[:] = ind + 1
+spaces = {names[ind]: psi4.core.Matrix.from_array(np.random.rand(nbf, _)) for ind, _ in enumerate(sizes)}
 
 # set transformed integrals
 Qmo = []
@@ -95,7 +90,8 @@ for method in methods:
 
                     # build
                     dfh.initialize()
-                    
+                    dfh.print_header()                   
+ 
                     # add spaces
                     for i in spaces:
                         dfh.add_space(i, spaces[i])
@@ -110,8 +106,15 @@ for method in methods:
 
                     # grab transformed integrals
                     dfh_Qmo = []
-                    for ind, i in enumerate(transformations):
-                        dfh_Qmo.append(np.asarray(dfh.get_tensor(i)))
+                    if(form == 'pqQ'):    
+                        for ind, i in enumerate(transformations):
+                            j = space_pairs[ind]
+                            dfh_Qmo.append(np.zeros((sizes[j[0]], sizes[j[1]], naux)))
+                            for k in range(sizes[j[0]]):
+                                dfh_Qmo[ind][k,:,:] = np.asarray(dfh.get_tensor(i, [k, k+1], [0, sizes[j[1]]], [0, naux]))
+                    else:
+                        for ind, i in enumerate(transformations):
+                            dfh_Qmo.append(np.asarray(dfh.get_tensor(i)))
 
                     test_string = 'Alg: ' + method + ' + ' + form + ' core (AOs, MOs, met): [' 
                     test_string += str(AO_core) + ', ' + str(MO_core) + ', ' + str(hold_met) +  ']' 


### PR DESCRIPTION
## Description
Furthers the generality of integral transformations and enables a special workflow, `DIRECT_iaQ`, to alleviate disk IO when transforming to `pqQ` forms.  Timings comparing the `DIRECT_iaQ` and `DIRECT` methods are inbound.

Edit: Here are some tests that (almost comically) display the efficacy of `DIRECT_iaQ` over `DIRECT` + `pqQ`.

1. Test1: 
[input.txt](https://github.com/psi4/psi4/files/1740970/input.txt)
[timer.txt](https://github.com/psi4/psi4/files/1740977/timer.txt)

2. Test2:  
[input.txt](https://github.com/psi4/psi4/files/1740966/input.txt)
[timer.txt](https://github.com/psi4/psi4/files/1740974/timer.txt)

Notice the difference between the `DFH: MO to disk` timers.  

Edit2: I added a reduction on `max_val` in `prepare_sparsity` to ensure thread safety.  This was incorrect before.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - DF_Helper now has three methods for integral transformations:
    `STORE`:  Contracts metric with AO integrals, stores, then transforms.
    `DIRECT`: Transforms integrals, contracts with metric.
    `DIRECT_iaQ`: Optimized `DIRECT` workflow when using `pqQ` transformed integrals.

  - DF_Helper outputs any transformed integral form you want: `Qpq`, `pQq`, or `pqQ`.  The following can be used for each of the respective methods listed above:
    `STORE`:  `Qpq`, `pQq`, or (ill-advised) `pqQ`
    `DIRECT`:  `Qpq`, `pQq`, or (ill-advised) `pqQ`
    `DIRECT_iaQ`:   `pqQ`

## Status
- [x] Ready to go
