### PR TITLE
adding DFT-NL scheme

### DIFF
--- a/doc/sphinxman/CMakeLists.txt
+++ b/doc/sphinxman/CMakeLists.txt
@@ -51,7 +51,7 @@ if(PERL_FOUND AND SPHINX_FOUND AND SPHINX_STUFF_FOUND)
     manage_addon.rst numpy.rst build_planning.rst build_faq.rst
     build_obtaining.rst libint.rst erd.rst simint.rst gcp.rst
     index_tutorials.rst prog_faq.rst manage_index.rst manage_git.rst
-    style_c.rst prog_blas.rst add_tests.rst plugin_snsmp2.rst
+    style_c.rst prog_blas.rst add_tests.rst plugin_snsmp2.rst dftnl.rst
     )
 
     # * compute relative path btwn top_srcdir and objdir/doc/sphinxman

--- a/doc/sphinxman/source/dft.rst
+++ b/doc/sphinxman/source/dft.rst
@@ -672,9 +672,11 @@ for something like::
 Dispersion Corrections
 ~~~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Dispersion corrections are discussed here. <sec:dftd3>`
+:ref:`DFT-D dispersion corrections are discussed here. <sec:dftd3>`
 
 :ref:`HF-3c and PBEh-3c dispersion and BSSE corrections are discussed here. <sec:gcp>`
+
+:ref:`DFT-NL dispersion corrections are discussed here. <sec:dftnl>`
 
 Recommendations
 ~~~~~~~~~~~~~~~

--- a/doc/sphinxman/source/dftnl.rst
+++ b/doc/sphinxman/source/dftnl.rst
@@ -1,0 +1,73 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2018 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. index:: DFTNL
+.. _`sec:dftnl`:
+
+
+DFT-NL
+======
+
+.. sectionauthor:: Holger Kruse
+
+Non-local (NL), density based correlation energy from the VV10 kernel can be added
+to arbitrary functionals.
+
+.. math:: E_{DFT-NL}=E_{DFT}+E_{NL}
+
+For pre-defined functionals (see Functional overview in :ref:`this Table <table:dft_all>` ) it is sufficient to add `-NL` to 
+the functional name::
+
+    energy('b3lyp-nl')
+
+Modification of the parameters `b` and `C` is done setting |scf__DFT_VV10_B| and |scf__DFT_VV10_C|. The `C` is usually left unchanged and the originally proposed
+value of `C=0.0093` is used. 
+
+Adding |scf__DFT_VV10_B| to any functional activates the calculation of the VV10 kernel. A BLYP-NL calculation can be set as follows::
+   
+    set DFT_VV10_B 4.0
+    energy('blyp')
+
+The default `C` parameter will be used.
+
+Similar to |scf_DFT_DISPERSION_PARAMETERS| the tuple |scf_NL_DISPERSION_PARAMETERS| can used::
+    
+    set NL_DISPERSION_PARAMTERS [4.0]
+    energy('blyp')
+
+which is equivalent to the example above.
+
+Further examples can be found in the respective :source:`regression test <tests/dft-vv10/input.dat>`
+
+post-SCF time savings
+~~~~~~~~~~~~~~~~~~~~~
+
+Substantial time-savings for energy calculations are available by evaluating the VV10 kernel only at the converged electron density, i.e. in a post-SCF fashion.
+The deviations from the fully self-consistent treatment are usually minimal. To activate this set |scf_DFT_VV10_POSTSCF| to `true`.

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -348,6 +348,32 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
            sup.set_vv10_c(d_params["params"]["c"])
         dispersion = d_params
 
+    # custom options for NL dispersion
+    # wants to be where the functional is build
+    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
+       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
+       sup.set_vv10_b(nl_tuple[0])
+       if len(nl_tuple) > 1:
+          sup.set_vv10_c(nl_tuple[1])
+       if len(nl_tuple) > 2:
+          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
+    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
+       if(name.lower()=='scf'):
+          raise ValidationError("SCF: HF with -NL not implemented")
+       vv10_b = core.get_option("SCF", "DFT_VV10_B")
+       vv10_c = core.get_option("SCF", "DFT_VV10_C")
+       sup.set_vv10_b(vv10_b)
+       sup.set_vv10_c(vv10_c)
+    elif core.has_option_changed("SCF", "DFT_VV10_B"):
+       if(name.lower()=='scf'):
+          raise ValidationError("SCF: HF with -NL not implemented")
+       vv10_b = core.get_option("SCF", "DFT_VV10_B")
+       sup.set_vv10_b(vv10_b)
+       if (abs(sup.vv10_c() - 0.0) <= 1e-8):
+           core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
+           sup.set_vv10_c(0.0093)
+
+
     sup.set_max_points(npoints)
     sup.set_deriv(deriv)
     sup.set_name(func_dictionary["name"].lower())

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -324,7 +324,6 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
                 sup.set_c_os_alpha(c_params["os"])
                 sup.set_c_alpha(1.0)
 
-
         # Merge descriptions and citations from above components obtained from LibXC as a fallback.
         descr = "\n".join(descr)
         citation = "\n".join(citation)
@@ -342,10 +341,10 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
     if "dispersion" in func_dictionary:
         d_params = func_dictionary["dispersion"]
         if "citation" not in d_params:
-           d_params["citation"] = False
-        if d_params["type"]=='nl':
-           sup.set_vv10_b(d_params["params"]["b"])
-           sup.set_vv10_c(d_params["params"]["c"])
+            d_params["citation"] = False
+        if d_params["type"] == 'nl':
+            sup.set_vv10_b(d_params["params"]["b"])
+            sup.set_vv10_c(d_params["params"]["c"])
         dispersion = d_params
 
     sup.set_max_points(npoints)

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -348,31 +348,6 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
            sup.set_vv10_c(d_params["params"]["c"])
         dispersion = d_params
 
-    # custom options for NL dispersion
-#    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
-#       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
-#       sup.set_vv10_b(nl_tuple[0])
-#       if len(nl_tuple) > 1:
-#          sup.set_vv10_c(nl_tuple[1])
-#       if len(nl_tuple) > 2:
-#          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
-#    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
-#       if(name.lower()=='hf'):
-#          raise ValidationError("SCF: HF with -NL not implemented")
-#       vv10_b = core.get_option("SCF", "DFT_VV10_B")
-#       vv10_c = core.get_option("SCF", "DFT_VV10_C")
-#       sup.set_vv10_b(vv10_b)
-#       sup.set_vv10_c(vv10_c)
-#    elif core.has_option_changed("SCF", "DFT_VV10_B"):
-#       if(name.lower()=='scf'):
-#          raise ValidationError("SCF: HF with -NL not implemented")
-#       vv10_b = core.get_option("SCF", "DFT_VV10_B")
-#       sup.set_vv10_b(vv10_b)
-#       if (abs(sup.vv10_c() - 0.0) <= 1e-8):
-#           core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
-#           sup.set_vv10_c(0.0093)
-
-
     sup.set_max_points(npoints)
     sup.set_deriv(deriv)
     sup.set_name(func_dictionary["name"].lower())

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -349,29 +349,28 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
         dispersion = d_params
 
     # custom options for NL dispersion
-    # wants to be where the functional is build
-    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
-       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
-       sup.set_vv10_b(nl_tuple[0])
-       if len(nl_tuple) > 1:
-          sup.set_vv10_c(nl_tuple[1])
-       if len(nl_tuple) > 2:
-          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
-    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
-       if(name.lower()=='scf'):
-          raise ValidationError("SCF: HF with -NL not implemented")
-       vv10_b = core.get_option("SCF", "DFT_VV10_B")
-       vv10_c = core.get_option("SCF", "DFT_VV10_C")
-       sup.set_vv10_b(vv10_b)
-       sup.set_vv10_c(vv10_c)
-    elif core.has_option_changed("SCF", "DFT_VV10_B"):
-       if(name.lower()=='scf'):
-          raise ValidationError("SCF: HF with -NL not implemented")
-       vv10_b = core.get_option("SCF", "DFT_VV10_B")
-       sup.set_vv10_b(vv10_b)
-       if (abs(sup.vv10_c() - 0.0) <= 1e-8):
-           core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
-           sup.set_vv10_c(0.0093)
+#    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
+#       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
+#       sup.set_vv10_b(nl_tuple[0])
+#       if len(nl_tuple) > 1:
+#          sup.set_vv10_c(nl_tuple[1])
+#       if len(nl_tuple) > 2:
+#          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
+#    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
+#       if(name.lower()=='hf'):
+#          raise ValidationError("SCF: HF with -NL not implemented")
+#       vv10_b = core.get_option("SCF", "DFT_VV10_B")
+#       vv10_c = core.get_option("SCF", "DFT_VV10_C")
+#       sup.set_vv10_b(vv10_b)
+#       sup.set_vv10_c(vv10_c)
+#    elif core.has_option_changed("SCF", "DFT_VV10_B"):
+#       if(name.lower()=='scf'):
+#          raise ValidationError("SCF: HF with -NL not implemented")
+#       vv10_b = core.get_option("SCF", "DFT_VV10_B")
+#       sup.set_vv10_b(vv10_b)
+#       if (abs(sup.vv10_c() - 0.0) <= 1e-8):
+#           core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
+#           sup.set_vv10_c(0.0093)
 
 
     sup.set_max_points(npoints)

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -324,6 +324,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
                 sup.set_c_os_alpha(c_params["os"])
                 sup.set_c_alpha(1.0)
 
+
         # Merge descriptions and citations from above components obtained from LibXC as a fallback.
         descr = "\n".join(descr)
         citation = "\n".join(citation)
@@ -341,7 +342,10 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
     if "dispersion" in func_dictionary:
         d_params = func_dictionary["dispersion"]
         if "citation" not in d_params:
-            d_params["citation"] = False
+           d_params["citation"] = False
+        if d_params["type"]=='nl':
+           sup.set_vv10_b(d_params["params"]["b"])
+           sup.set_vv10_c(d_params["params"]["c"])
         dispersion = d_params
 
     sup.set_max_points(npoints)

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -349,7 +349,6 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
 
     sup.set_max_points(npoints)
     sup.set_deriv(deriv)
-#    sup.set_name(func_dictionary["name"].lower())
     sup.set_name(func_dictionary["name"].upper())
     sup.allocate()
     return (sup, dispersion)

--- a/psi4/driver/procrouting/dft_funcs/dict_builder.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_builder.py
@@ -349,6 +349,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
 
     sup.set_max_points(npoints)
     sup.set_deriv(deriv)
-    sup.set_name(func_dictionary["name"].lower())
+#    sup.set_name(func_dictionary["name"].lower())
+    sup.set_name(func_dictionary["name"].upper())
     sup.allocate()
     return (sup, dispersion)

--- a/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
@@ -140,6 +140,44 @@ funcs.append({
 })
 
 funcs.append({
+# note by H.Kruse: Uses the full-core parameters in the Yu paper. But my and L. Georigk's experience shows that it hardly matters.
+# Use FC is recommended by S. Grimme.
+# May this madness never end.
+    "name": "DSD-BLYP-NL",
+    "x_functionals": {
+        "GGA_X_B88": {
+            "alpha": 0.29
+        }
+    },
+    "x_hf": {
+        "alpha": 0.71
+    },
+    "c_functionals": {
+        "GGA_C_LYP": {
+            "alpha": 0.54
+        }
+    },
+    "c_mp2": {
+        "alpha": 1.0,
+        "os": 0.47,
+        "ss": 0.40,
+    },
+    "dispersion": {
+        "type": "nl",
+        "params": {
+            "b": 12.00,
+            "c": 0.0093,
+        },
+        "citation": "    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014\n" 
+    },
+    "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
+    "description": '    DSD-BLYP-NL (D3BJ,FC functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+})
+
+
+
+
+funcs.append({
     "name": "CORE-DSD-BLYP",
     "x_functionals": {
         "GGA_X_B88": {

--- a/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
@@ -445,7 +445,7 @@ funcs.append({
             "b": 9.6,
             "c": 0.0093,
         },
-        "citation": ' M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016\n'
+        "citation": '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016\n'
     },
 })
 
@@ -689,7 +689,3 @@ functional_list = {}
 for functional in funcs:
     functional_list[functional["name"].lower()] = functional
 
-        'dsd-pbepbe'  : {'b':  9.600, 'c': 0.0093}, 
-        'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
-        'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
-        'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},

--- a/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
@@ -266,6 +266,40 @@ funcs.append({
 })
 
 funcs.append({
+# note: Using the D3BJ form for NL, which is sensible but not explicitly mentioned in the paper
+    "name": "DSD-PBEP86-NL",
+    "x_functionals": {
+        "GGA_X_PBE": {
+            "alpha": 0.31
+        }
+    },
+    "x_hf": {
+        "alpha": 0.69
+    },
+    "c_functionals": {
+        "GGA_C_P86": {
+            "alpha": 0.44
+        }
+    },
+    "c_mp2": {
+        "os": 0.52,
+        "ss": 0.22
+    },
+    "dispersion": {
+        "type": "nl",
+        "params": {
+            "b": 12.8,
+            "c": 0.0093,
+        },
+        "citation": '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'
+    },
+    "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
+    "description": '    DSD-PBEP86-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+})
+
+
+
+funcs.append({
     "name": "DSD-PBEP86-D2",
     "x_functionals": {
         "GGA_X_PBE": {
@@ -381,6 +415,40 @@ funcs.append({
         "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n'
     },
 })
+
+
+funcs.append({
+    "name": "DSD-PBEPBE-NL",
+    "x_functionals": {
+        "GGA_X_PBE": {
+            "alpha": 0.32
+        }
+    },
+    "x_hf": {
+        "alpha": 0.68
+    },
+    "c_functionals": {
+        "GGA_C_PBE": {
+            "alpha": 0.49
+        }
+    },
+    "c_mp2": {
+        "alpha": 1.0,
+        "os": 0.55,
+        "ss": 0.13
+    },
+    "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
+    "description": '    DSD-PBEPBE-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+    "dispersion": {
+        "type": "nl",
+        "params": {
+            "b": 9.6,
+            "c": 0.0093,
+        },
+        "citation": ' M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016\n'
+    },
+})
+
 
 funcs.append({
     "name": "DSD-BP86-D2",
@@ -620,3 +688,8 @@ funcs.append({
 functional_list = {}
 for functional in funcs:
     functional_list[functional["name"].lower()] = functional
+
+        'dsd-pbepbe'  : {'b':  9.600, 'c': 0.0093}, 
+        'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
+        'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
+        'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},

--- a/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
@@ -723,6 +723,38 @@ funcs.append({
     },
 })
 
+funcs.append({
+    "name": "DSD-PBEB95-NL",
+    "x_functionals": {
+        "GGA_X_PBE": {
+            "alpha": 0.34
+        }
+    },
+    "x_hf": {
+        "alpha": 0.66
+    },
+    "c_functionals": {
+      "MGGA_C_BC95": {
+            "alpha": 0.55
+        }
+    },
+    "c_mp2": {
+        "os": 0.46,
+        "ss": 0.09
+    },
+    "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
+    "description": '    DSD-PBEB95-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid Meta-GGA XC Functional\n',
+    "dispersion": {
+        "type": "nl",
+        "params": {
+            "b": 12.50,
+            "c": 0.0093,
+        },
+        "citation": '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016\n'
+    },
+})
+
+
 functional_list = {}
 for functional in funcs:
     functional_list[functional["name"].lower()] = functional

--- a/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_dh_funcs.py
@@ -171,7 +171,7 @@ funcs.append({
         "citation": "    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014\n" 
     },
     "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
-    "description": '    DSD-BLYP-NL (D3BJ,FC functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+    "description": '    DSD-BLYP-NL (D3BJ,FC parameters) VV10 SCS Double Hybrid XC Functional\n',
 })
 
 
@@ -332,7 +332,7 @@ funcs.append({
         "citation": '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'
     },
     "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
-    "description": '    DSD-PBEP86-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+    "description": '    DSD-PBEP86-NL (D3BJ parameters) VV10 SCS Double Hybrid XC Functional\n',
 })
 
 
@@ -476,7 +476,7 @@ funcs.append({
         "ss": 0.13
     },
     "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
-    "description": '    DSD-PBEPBE-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid XC Functional\n',
+    "description": '    DSD-PBEPBE-NL (D3BJ parameters) VV10 SCS Double Hybrid XC Functional\n',
     "dispersion": {
         "type": "nl",
         "params": {
@@ -743,7 +743,7 @@ funcs.append({
         "ss": 0.09
     },
     "citation": '    S. Kozuch, J.M.L. Martin, J. Comp. Chem., 34, 2327-2344, 2013\n',
-    "description": '    DSD-PBEB95-NL (D3BJ functional parameters) Dispersion-corrected SCS Double Hybrid Meta-GGA XC Functional\n',
+    "description": '    DSD-PBEB95-NL (D3BJ parameters) VV10 SCS Double Hybrid Meta-GGA XC Functional\n',
     "dispersion": {
         "type": "nl",
         "params": {

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -99,14 +99,15 @@ def build_superfunctional(name, restricted):
     if core.has_option_changed("SCF", "DFT_ALPHA_C"):
         sup[0].set_c_alpha(core.get_option("SCF", "DFT_ALPHA_C"))
 
-    # customization of NL dispersion:
-    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
+    # customization of existing VV10 dispersion:
+    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS") and sup[0].vv10_b() > 0.0):
        nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
        sup[0].set_vv10_b(nl_tuple[0])
        if len(nl_tuple) > 1:
           sup[0].set_vv10_c(nl_tuple[1])
        if len(nl_tuple) > 2:
           raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
+    # add VV10 correlation to any functional or modify existing
     # custom procedures using name 'scf' without any quadrature grid like HF will fail and are not detected
     if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
         if(name.lower()=='hf'):

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -100,13 +100,13 @@ def build_superfunctional(name, restricted):
         sup[0].set_c_alpha(core.get_option("SCF", "DFT_ALPHA_C"))
 
     # customization of existing VV10 dispersion:
-    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS") and sup[0].vv10_b() > 0.0):
-       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
+    if (core.has_option_changed("SCF", "NL_DISPERSION_PARAMETERS") and sup[0].vv10_b() > 0.0):
+       nl_tuple = core.get_option("SCF", "NL_DISPERSION_PARAMETERS")
        sup[0].set_vv10_b(nl_tuple[0])
        if len(nl_tuple) > 1:
           sup[0].set_vv10_c(nl_tuple[1])
        if len(nl_tuple) > 2:
-          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
+          raise ValidationError("too many entries in NL_DISPERSION_PARAMETERS for DFT-NL")
     # add VV10 correlation to any functional or modify existing
     # custom procedures using name 'scf' without any quadrature grid like HF will fail and are not detected
     if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
@@ -125,6 +125,9 @@ def build_superfunctional(name, restricted):
             core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
             sup[0].set_vv10_c(0.0093)
 
+    if (core.has_option_changed("SCF", "NL_DISPERSION_PARAMETERS") and core.has_option_changed("SCF", "DFT_VV10_B")):
+        raise ValidationError("SCF: Decide between NL_DISPERSION_PARAMETERS and DFT_VV10_B !!")
+    
 
     # Check SCF_TYPE
     if sup[0].is_x_lrc() and (core.get_option("SCF", "SCF_TYPE") not in ["DIRECT", "DF", "OUT_OF_CORE", "PK"]):

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -99,7 +99,14 @@ def build_superfunctional(name, restricted):
     if core.has_option_changed("SCF", "DFT_ALPHA_C"):
         sup[0].set_c_alpha(core.get_option("SCF", "DFT_ALPHA_C"))
 
-    # change options for VV10 correlation
+    # customization of NL dispersion:
+    if (core.has_option_changed("SCF", "DFT_DISPERSION_PARAMETERS")):
+       nl_tuple = core.get_option("SCF", "DFT_DISPERSION_PARAMETERS")
+       sup[0].set_vv10_b(nl_tuple[0])
+       if len(nl_tuple) > 1:
+          sup[0].set_vv10_c(nl_tuple[1])
+       if len(nl_tuple) > 2:
+          raise ValidationError("too many entries in DFT_DISPERSION_PARAMETERS for DFT-NL")
     # custom procedures using name 'scf' without any quadrature grid like HF will fail and are not detected
     if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
         if(name.lower()=='hf'):

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -133,7 +133,7 @@ def build_superfunctional(name, restricted):
         raise ValidationError('INTEGRAL_PACKAGE ERD does not play nicely with LRC DFT functionals, so stopping.')
 
     sup[0].set_lock(True)
-
+    
     return sup
 
 

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -75,7 +75,6 @@ def build_superfunctional(name, restricted):
     if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (sup[0].is_x_lrc() or sup[0].is_c_lrc()):
         raise ValidationError("INTEGRAL_PACKAGE ERD does not play nicely with omega ERI's, so stopping.")
 
-    
     # Lock and unlock the functional
     sup[0].set_lock(False)
 
@@ -99,35 +98,31 @@ def build_superfunctional(name, restricted):
     if core.has_option_changed("SCF", "DFT_ALPHA_C"):
         sup[0].set_c_alpha(core.get_option("SCF", "DFT_ALPHA_C"))
 
-    # customization of existing VV10 dispersion:
-    if (core.has_option_changed("SCF", "NL_DISPERSION_PARAMETERS") and sup[0].vv10_b() > 0.0):
-       nl_tuple = core.get_option("SCF", "NL_DISPERSION_PARAMETERS")
-       sup[0].set_vv10_b(nl_tuple[0])
-       if len(nl_tuple) > 1:
-          sup[0].set_vv10_c(nl_tuple[1])
-       if len(nl_tuple) > 2:
-          raise ValidationError("too many entries in NL_DISPERSION_PARAMETERS for DFT-NL")
     # add VV10 correlation to any functional or modify existing
     # custom procedures using name 'scf' without any quadrature grid like HF will fail and are not detected
-    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
-        if(name.lower()=='hf'):
-           raise ValidationError("SCF: HF with -NL not implemented")
-        vv10_b = core.get_option("SCF", "DFT_VV10_B")
-        vv10_c = core.get_option("SCF", "DFT_VV10_C")
-        sup[0].set_vv10_b(vv10_b)
-        sup[0].set_vv10_c(vv10_c)
+    if (core.has_option_changed("SCF", "NL_DISPERSION_PARAMETERS") and sup[0].vv10_b() > 0.0):
+        if (name.lower() == 'hf'):
+            raise ValidationError("SCF: HF with -NL not implemented")
+        nl_tuple = core.get_option("SCF", "NL_DISPERSION_PARAMETERS")
+        sup[0].set_vv10_b(nl_tuple[0])
+        if len(nl_tuple) > 1:
+            sup[0].set_vv10_c(nl_tuple[1])
+        if len(nl_tuple) > 2:
+            raise ValidationError("too many entries in NL_DISPERSION_PARAMETERS for DFT-NL")
     elif core.has_option_changed("SCF", "DFT_VV10_B"):
-        if(name.lower()=='hf'):
-           raise ValidationError("SCF: HF with -NL not implemented")
+        if (name.lower() == 'hf'):
+            raise ValidationError("SCF: HF with -NL not implemented")
         vv10_b = core.get_option("SCF", "DFT_VV10_B")
         sup[0].set_vv10_b(vv10_b)
+        if core.has_option_changed("SCF", "DFT_VV10_C"):
+            vv10_c = core.get_option("SCF", "DFT_VV10_C")
+            sup[0].set_vv10_c(vv10_c)
         if (abs(sup[0].vv10_c() - 0.0) <= 1e-8):
             core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
             sup[0].set_vv10_c(0.0093)
 
     if (core.has_option_changed("SCF", "NL_DISPERSION_PARAMETERS") and core.has_option_changed("SCF", "DFT_VV10_B")):
         raise ValidationError("SCF: Decide between NL_DISPERSION_PARAMETERS and DFT_VV10_B !!")
-    
 
     # Check SCF_TYPE
     if sup[0].is_x_lrc() and (core.get_option("SCF", "SCF_TYPE") not in ["DIRECT", "DF", "OUT_OF_CORE", "PK"]):

--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -99,6 +99,25 @@ def build_superfunctional(name, restricted):
     if core.has_option_changed("SCF", "DFT_ALPHA_C"):
         sup[0].set_c_alpha(core.get_option("SCF", "DFT_ALPHA_C"))
 
+    # change options for VV10 correlation
+    # custom procedures using name 'scf' without any quadrature grid like HF will fail and are not detected
+    if (core.has_option_changed("SCF", "DFT_VV10_B") and core.has_option_changed("SCF", "DFT_VV10_C")):
+        if(name.lower()=='hf'):
+           raise ValidationError("SCF: HF with -NL not implemented")
+        vv10_b = core.get_option("SCF", "DFT_VV10_B")
+        vv10_c = core.get_option("SCF", "DFT_VV10_C")
+        sup[0].set_vv10_b(vv10_b)
+        sup[0].set_vv10_c(vv10_c)
+    elif core.has_option_changed("SCF", "DFT_VV10_B"):
+        if(name.lower()=='hf'):
+           raise ValidationError("SCF: HF with -NL not implemented")
+        vv10_b = core.get_option("SCF", "DFT_VV10_B")
+        sup[0].set_vv10_b(vv10_b)
+        if (abs(sup[0].vv10_c() - 0.0) <= 1e-8):
+            core.print_out("SCF: VV10_C not specified. Using default (C=0.0093)!")
+            sup[0].set_vv10_c(0.0093)
+
+
     # Check SCF_TYPE
     if sup[0].is_x_lrc() and (core.get_option("SCF", "SCF_TYPE") not in ["DIRECT", "DF", "OUT_OF_CORE", "PK"]):
         raise ValidationError(

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -207,7 +207,7 @@ class EmpericalDispersion(object):
 
     def print_out(self, level=1):
 
-        core.print_out("   => %s: Empirical Dispersion <=\n\n" % self.dtype)
+        core.print_out("   => %s: Empirical Dispersion <=\n\n" % self.dtype.upper())
         core.print_out(self.description + "\n")
 
         core.print_out(self.citation + "\n\n")

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -104,7 +104,7 @@ class EmpericalDispersion(object):
                     raise Exception("Too many parameter in input tuple param.")
 
         # DFT-NL dispersion. 
-        elif self.dtype in ["-NL"]:
+        elif self.dtype in ["-nl"]:
              self.disp_type = 'nl'
 
 
@@ -193,7 +193,7 @@ class EmpericalDispersion(object):
             self.citation += "    Smith, D. G. A.; Burns, L. A.; Patkowski, K.; Sherrill, C. D. (2016), J. Phys. Chem. Lett.; 7: 2197"
             self.bibtex = "Grimme:2011:1456"
 
-        elif self.dtype == "-NL":
+        elif self.dtype == "-nl":
             self.description = "    Grimme's -NL (DFT plus  VV10 correlation) "
             self.citation = "    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 \n"
             self.bibtex = "Grimme:2011:3866"

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -34,7 +34,7 @@ from psi4.driver.qcdb import interface_gcp as gcp
 from psi4.driver.qcdb.dashparam import get_dispersion_aliases
 from psi4.driver.qcdb.dashparam import get_default_dashparams
 from psi4.driver import p4util
-import numpy as np
+#import numpy as np
 
 class EmpericalDispersion(object):
     def __init__(self, alias, dtype, **kwargs):
@@ -248,8 +248,6 @@ class EmpericalDispersion(object):
                     dashparam=self.dash_params,
                     verbose=False,
                     dertype=0)
-        elif self.disp_type == 'nl':
-             return 0
         else:
             return self.disp.compute_energy(molecule)
 
@@ -272,10 +270,6 @@ class EmpericalDispersion(object):
                     dashparam=self.dash_params,
                     verbose=False,
                     dertype=1)
-        elif self.disp_type in 'nl':
-             ZeroMat = np.zeros((molecule.natom(),3))
-             ZeroGrad= core.Matrix.from_array(ZeroMat)
-             return ZeroGrad
         else:
             return self.disp.compute_gradient(molecule)
 
@@ -283,12 +277,6 @@ class EmpericalDispersion(object):
         """
         #magic (if magic was easy)
         """
-
-        if self.disp_type in 'nl':
-             nat3=3*molecule.natom()
-             ZeroMat = np.zeros((nat3,nat3))
-             ZeroHess= core.Matrix.from_array(ZeroMat)
-             return ZeroHess
 
         optstash = p4util.OptionsState(['PRINT'])
         core.set_global_option('PRINT', 0)

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -102,19 +102,20 @@ class EmpericalDispersion(object):
                 if len(tuple_params) > 4:
                     raise Exception("Too many parameter in input tuple param.")
 
-        # DFT-NL dispersion
+        # DFT-NL dispersion. 
         elif self.dtype in ["-NL"]:
              self.disp_type = 'nl'
 
-             # consume custom tuples
-             if (tuple_params is not None):
-                self.tuple_params = None
-                self.dash_params['b'] = tuple_params[0]
-
-                if len(tuple_params) > 1:
-                        self.dash_params["c"] = tuple_params[1]
-                if len(tuple_params) > 2:
-                    raise Exception("Too many parameter in input tuple param.")
+             # since the functional is done and closed. This does not do anything.
+             #if (tuple_params is not None):
+             #   self.tuple_params = None
+             #   self.dash_params['b'] = tuple_params[0]
+             #
+             #  if len(tuple_params) > 1:
+             #     self.dash_params["c"] = tuple_params[1]
+             #
+             #  if len(tuple_params) > 2:
+             #     raise Exception("Too many parameter in input NL tuple param.")
 
 
         # 4b) Build coefficients for psi4
@@ -145,7 +146,7 @@ class EmpericalDispersion(object):
                 self.dash_params[k] = kwargs.pop(k)
 
         if len(kwargs):
-            raise Exception("The following DFTD3 parameters were not understood for %s dispersion type: %s" %
+            raise Exception("The following DFTD3 or NL parameters were not understood for %s dispersion type: %s" %
                             (dtype, ', '.join(kwargs.keys())))
 
         # 6) Process citations

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -102,6 +102,21 @@ class EmpericalDispersion(object):
                 if len(tuple_params) > 4:
                     raise Exception("Too many parameter in input tuple param.")
 
+        # DFT-NL dispersion
+        elif self.dtype in ["-NL"]:
+             self.disp_type = 'nl'
+
+             # consume custom tuples
+             if (tuple_params is not None):
+                self.tuple_params = None
+                self.dash_params['b'] = tuple_params[0]
+
+                if len(tuple_params) > 1:
+                        self.dash_params["c"] = tuple_params[1]
+                if len(tuple_params) > 2:
+                    raise Exception("Too many parameter in input tuple param.")
+
+
         # 4b) Build coefficients for psi4
         else:
             self.dtype = self.dtype.replace('-d2p4', '-d2')
@@ -187,12 +202,26 @@ class EmpericalDispersion(object):
             self.citation += "    Smith, D. G. A.; Burns, L. A.; Patkowski, K.; Sherrill, C. D. (2016), J. Phys. Chem. Lett.; 7: 2197"
             self.bibtex = "Grimme:2011:1456"
 
+        elif self.dtype == "-NL":
+            self.description = "    Grimme's -NL (DFT plus  VV10 correlation) "
+            self.citation = "    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 \n"
+            self.bibtex = "Grimme:2011:3866"
+
         else:
-            raise Exception("Emperical Dispersion type %s not understood." % self.dtype)
+            raise Exception("Empirical Dispersion type %s not understood." % self.dtype)
 
         # 6b) add custom citations if available
         if custom_citation:
             self.citation += "\n    Parametrisation from: \n" + custom_citation
+
+    def excludelist(self):
+        """
+         exclude list used to avoid explicit compute_energy/gradient/hessian calls in proc.py
+        """
+        if self.disp_type=='nl':
+           return True
+        else: 
+           return False
 
     def print_out(self, level=1):
 
@@ -200,6 +229,9 @@ class EmpericalDispersion(object):
         core.print_out(self.description + "\n")
 
         core.print_out(self.citation + "\n\n")
+       
+        if self.disp_type=='nl':
+           return
 
         core.print_out("        S6 = %14.6E\n" % self.dash_params["s6"])
         if "s8" in self.dash_params.keys():

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1223,7 +1223,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.set_legacy_wavefunction(ref_wfn)
 
         # Compute dftd3
-        if "_disp_functor" in dir(ref_wfn):
+        if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
             ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
@@ -1345,7 +1345,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         scf_wfn.basisset().print_detail_out()
 
     # Compute dftd3
-    if "_disp_functor" in dir(scf_wfn):
+    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
         disp_energy = scf_wfn._disp_functor.compute_energy(scf_wfn.molecule())
         scf_wfn.set_variable("-D Energy", disp_energy)
 
@@ -2063,7 +2063,7 @@ def run_scf_gradient(name, **kwargs):
     if core.get_option('SCF', 'REFERENCE') in ['ROHF', 'CUHF']:
         ref_wfn.semicanonicalize()
 
-    if "_disp_functor" in dir(ref_wfn):
+    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 
@@ -2131,7 +2131,7 @@ def run_scf_hessian(name, **kwargs):
     if badref or badint:
         raise ValidationError("Only RHF Hessians are currently implemented. SCF_TYPE either CD or OUT_OF_CORE not supported")
 
-    if "_disp_functor" in dir(ref_wfn):
+    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
         ref_wfn.set_array("-D Hessian", disp_hess)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1223,7 +1223,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.set_legacy_wavefunction(ref_wfn)
 
         # Compute dftd3
-        if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
+        if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
             ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
@@ -2063,7 +2063,7 @@ def run_scf_gradient(name, **kwargs):
     if core.get_option('SCF', 'REFERENCE') in ['ROHF', 'CUHF']:
         ref_wfn.semicanonicalize()
 
-    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 
@@ -2131,7 +2131,7 @@ def run_scf_hessian(name, **kwargs):
     if badref or badint:
         raise ValidationError("Only RHF Hessians are currently implemented. SCF_TYPE either CD or OUT_OF_CORE not supported")
 
-    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
         ref_wfn.set_array("-D Hessian", disp_hess)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1223,7 +1223,8 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.set_legacy_wavefunction(ref_wfn)
 
         # Compute dftd3
-        if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
+        if "_disp_functor" in dir(ref_wfn):
+        #if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
             ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
@@ -1345,7 +1346,8 @@ def scf_helper(name, post_scf=True, **kwargs):
         scf_wfn.basisset().print_detail_out()
 
     # Compute dftd3
-    if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(scf_wfn): 
+    #if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
         disp_energy = scf_wfn._disp_functor.compute_energy(scf_wfn.molecule())
         scf_wfn.set_variable("-D Energy", disp_energy)
 
@@ -2063,7 +2065,8 @@ def run_scf_gradient(name, **kwargs):
     if core.get_option('SCF', 'REFERENCE') in ['ROHF', 'CUHF']:
         ref_wfn.semicanonicalize()
 
-    if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(ref_wfn): 
+    #if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1223,7 +1223,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.set_legacy_wavefunction(ref_wfn)
 
         # Compute dftd3
-        if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
+        if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
             ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
@@ -2063,7 +2063,7 @@ def run_scf_gradient(name, **kwargs):
     if core.get_option('SCF', 'REFERENCE') in ['ROHF', 'CUHF']:
         ref_wfn.semicanonicalize()
 
-    if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 
@@ -2131,7 +2131,7 @@ def run_scf_hessian(name, **kwargs):
     if badref or badint:
         raise ValidationError("Only RHF Hessians are currently implemented. SCF_TYPE either CD or OUT_OF_CORE not supported")
 
-    if "_disp_functor" in dir(scf_wfn) and not ref_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
         ref_wfn.set_array("-D Hessian", disp_hess)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1021,6 +1021,8 @@ def scf_wavefunction_factory(name, ref_wfn, reference):
             wfn._disp_functor = empirical_dispersion.EmpericalDispersion(
                 disp_type[0], disp_type[1], tuple_params=modified_disp_params)
         wfn._disp_functor.print_out()
+        if (disp_type["type"] == 'nl'):
+             del wfn._disp_functor 
 
     # Set the DF basis sets
     if (core.get_option("SCF", "SCF_TYPE") == "DF") or \

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1224,7 +1224,6 @@ def scf_helper(name, post_scf=True, **kwargs):
 
         # Compute dftd3
         if "_disp_functor" in dir(ref_wfn):
-        #if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
             disp_energy = ref_wfn._disp_functor.compute_energy(ref_wfn.molecule())
             ref_wfn.set_variable("-D Energy", disp_energy)
         ref_wfn.compute_energy()
@@ -1347,7 +1346,6 @@ def scf_helper(name, post_scf=True, **kwargs):
 
     # Compute dftd3
     if "_disp_functor" in dir(scf_wfn): 
-    #if "_disp_functor" in dir(scf_wfn) and not scf_wfn._disp_functor.excludelist:
         disp_energy = scf_wfn._disp_functor.compute_energy(scf_wfn.molecule())
         scf_wfn.set_variable("-D Energy", disp_energy)
 
@@ -2066,7 +2064,6 @@ def run_scf_gradient(name, **kwargs):
         ref_wfn.semicanonicalize()
 
     if "_disp_functor" in dir(ref_wfn): 
-    #if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 
@@ -2134,7 +2131,7 @@ def run_scf_hessian(name, **kwargs):
     if badref or badint:
         raise ValidationError("Only RHF Hessians are currently implemented. SCF_TYPE either CD or OUT_OF_CORE not supported")
 
-    if "_disp_functor" in dir(ref_wfn) and not ref_wfn._disp_functor.excludelist:
+    if "_disp_functor" in dir(ref_wfn): 
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
         ref_wfn.set_array("-D Hessian", disp_hess)
 

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -311,23 +311,25 @@ dashcoeff = {
         'lcwpbe'      : {'s6': 1.000, 's8': 0.906564, 'a1': 0.563761, 'a2': 3.593680},
     },
     'nl': { # TODO: citations
-        'blyp'        : {'b': 4.000, 'c': 0.0093}, #http://pubs.acs.org/doi/full/10.1021/acs.jctc.5b01066
-        'revpbe'      : {'b': 3.700, 'c': 0.0093}, # and below
-        'b3lyp'       : {'b': 4.800, 'c': 0.0093},
-        'b3pw91'      : {'b': 4.500, 'c': 0.0093},
-        'revpbe0'     : {'b': 4.300, 'c': 0.0093},
-        'bp86'        : {'b': 4.400, 'c': 0.0093},
-        'pbe0'        : {'b': 6.900, 'c': 0.0093},
-        'pbe'         : {'b': 6.400, 'c': 0.0093},
-        'tpss0'       : {'b': 5.500, 'c': 0.0093},
-        'tpss'        : {'b': 5.000, 'c': 0.0093},
-        'dsd-pbepbe'  : {'b': 9.600, 'c': 0.0093},
+        'blyp'        : {'b':  4.000, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, 
+        'hf'          : {'b':  3.900, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, # not implemented
+        'revpbe'      : {'b':  3.700, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, 
+        'revpbe38'    : {'b':  4.700, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, 
+        'b3lyp'       : {'b':  4.800, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
+        'b3pw91'      : {'b':  4.500, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
+        'revpbe0'     : {'b':  4.300, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
+        'bp86'        : {'b':  4.400, 'c': 0.0093}, # taken from orca
+        'pbe0'        : {'b':  6.900, 'c': 0.0093}, # taken from orca
+        'pbe'         : {'b':  6.400, 'c': 0.0093}, # taken from orca
+        'tpss0'       : {'b':  5.500, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
+        'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'}
+        #'dsd-pbepbe'  : {'b':  9.600, 'c': 0.0093},
         'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
-        'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
-        'b2gpplyp'    : {'b': 9.900, 'c': 0.0093},
-        'b2plyp'      : {'b': 7.800, 'c': 0.0093}, # 10.1021/acs.jctc.5b00002
-        'dsd-blyp'    : {'b': 12.000, 'c': 0.0093}, #https://pubs.acs.org/doi/10.1021/ct500642x
-        'pwpb95'      : {'b': 11.100, 'c': 0.0093}, #https://pubs.acs.org/doi/10.1021/ct500642x
+        #'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
+        'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},
+        'b2plyp'      : {'b':  7.800, 'c': 0.0093, 'citation': '    J. Calbo, E. Orti, J. C. Sancho-Garcia, J. Arago, J. Chem. Theory Comput. 11, 932-939, 1015 \n'}, 
+        'dsd-blyp'    : {'b': 12.000, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
+        'pwpb95'      : {'b': 11.100, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
     },
 
 } # yapf: disable

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -53,6 +53,7 @@ def get_dispersion_aliases():
     dispersion_names["d2"] = "d2p4"
     dispersion_names["d3"] = "d3zero"
     dispersion_names["d3m"] = "d3mzero"
+    dispersion_names["nl"] = "nl"
     return(dispersion_names)
 
 dash_alias = get_dispersion_aliases()
@@ -309,6 +310,26 @@ dashcoeff = {
         'pbe0'        : {'s6': 1.000, 's8': 0.528823, 'a1': 0.007912, 'a2': 6.162326},
         'lcwpbe'      : {'s6': 1.000, 's8': 0.906564, 'a1': 0.563761, 'a2': 3.593680},
     },
+    'nl': { # TODO: citations
+        'blyp'        : {'b': 4.000, 'c': 0.0093}, #http://pubs.acs.org/doi/full/10.1021/acs.jctc.5b01066
+        'revpbe'      : {'b': 3.700, 'c': 0.0093}, # and below
+        'b3lyp'       : {'b': 4.800, 'c': 0.0093},
+        'b3pw91'      : {'b': 4.500, 'c': 0.0093},
+        'revpbe0'     : {'b': 4.300, 'c': 0.0093},
+        'bp86'        : {'b': 4.400, 'c': 0.0093},
+        'pbe0'        : {'b': 6.900, 'c': 0.0093},
+        'pbe'         : {'b': 6.400, 'c': 0.0093},
+        'tpss0'       : {'b': 5.500, 'c': 0.0093},
+        'tpss'        : {'b': 5.000, 'c': 0.0093},
+        'dsd-pbepbe'  : {'b': 9.600, 'c': 0.0093},
+        'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
+        'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
+        'b2gpplyp'    : {'b': 9.900, 'c': 0.0093},
+        'b2plyp'      : {'b': 7.800, 'c': 0.0093}, # 10.1021/acs.jctc.5b00002
+        'dsd-blyp'    : {'b': 12.000, 'c': 0.0093}, #https://pubs.acs.org/doi/10.1021/ct500642x
+        'pwpb95'      : {'b': 11.100, 'c': 0.0093}, #https://pubs.acs.org/doi/10.1021/ct500642x
+    },
+
 } # yapf: disable
 
 
@@ -408,5 +429,7 @@ def get_default_dashparams(dtype):
         return ({"s6": 1.0, "sr6": 1.0, "s8": 1.0, "beta": 1.0, "alpha6": 14.0})
     elif dtype == 'd3mbj':
         return ({"s6": 1.0, "a1": 1.0, "s8": 1.0, "a2": 1.0})
+    elif dtype == 'nl':
+        return ({"b": 1.0, "c": 0.0093})
     else:
         return ({"s6": 1.0})

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -326,7 +326,6 @@ dashcoeff = {
         #'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
         'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},
         'b2plyp'      : {'b':  7.800, 'c': 0.0093, 'citation': '    J. Calbo, E. Orti, J. C. Sancho-Garcia, J. Arago, J. Chem. Theory Comput. 11, 932-939, 1015 \n'}, 
-        'dsd-blyp'    : {'b': 12.000, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
         'pwpb95'      : {'b': 11.100, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
     },
 

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -310,7 +310,7 @@ dashcoeff = {
         'pbe0'        : {'s6': 1.000, 's8': 0.528823, 'a1': 0.007912, 'a2': 6.162326},
         'lcwpbe'      : {'s6': 1.000, 's8': 0.906564, 'a1': 0.563761, 'a2': 3.593680},
     },
-    'nl': { # TODO: citations
+    'nl': { 
         'blyp'        : {'b':  4.000, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, 
         'hf'          : {'b':  3.900, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, # not implemented
         'revpbe'      : {'b':  3.700, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'}, 
@@ -322,10 +322,8 @@ dashcoeff = {
         'pbe0'        : {'b':  6.900, 'c': 0.0093}, # taken from orca
         'pbe'         : {'b':  6.400, 'c': 0.0093}, # taken from orca
         'tpss0'       : {'b':  5.500, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
-        'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'}
-        #'dsd-pbepbe'  : {'b':  9.600, 'c': 0.0093},
-        'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
-        #'dsd-pbep86'  : {'b': 12.800, 'c': 0.0093},
+        'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
+        #'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
         'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},
         'b2plyp'      : {'b':  7.800, 'c': 0.0093, 'citation': '    J. Calbo, E. Orti, J. C. Sancho-Garcia, J. Arago, J. Chem. Theory Comput. 11, 932-939, 1015 \n'}, 
         'dsd-blyp'    : {'b': 12.000, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -318,9 +318,9 @@ dashcoeff = {
         'b3lyp'       : {'b':  4.800, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
         'b3pw91'      : {'b':  4.500, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
         'revpbe0'     : {'b':  4.300, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 \n'},
-        'bp86'        : {'b':  4.400, 'c': 0.0093}, # taken from orca
-        'pbe0'        : {'b':  6.900, 'c': 0.0093}, # taken from orca
-        'pbe'         : {'b':  6.400, 'c': 0.0093}, # taken from orca
+        'bp86'        : {'b':  4.400, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
+        'pbe0'        : {'b':  6.900, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
+        'pbe'         : {'b':  6.400, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
         'tpss0'       : {'b':  5.500, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
         'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
         #'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},

--- a/psi4/driver/qcdb/dashparam.py
+++ b/psi4/driver/qcdb/dashparam.py
@@ -321,12 +321,11 @@ dashcoeff = {
         'bp86'        : {'b':  4.400, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
         'pbe0'        : {'b':  6.900, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
         'pbe'         : {'b':  6.400, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'}, # unclear if this is the real origin
-        'tpss0'       : {'b':  5.500, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
-        'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : ' W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
-        #'dsd-pbeb95'  : {'b': 12.500, 'c': 0.0093},
-        'b2gpplyp'    : {'b':  9.900, 'c': 0.0093},
-        'b2plyp'      : {'b':  7.800, 'c': 0.0093, 'citation': '    J. Calbo, E. Orti, J. C. Sancho-Garcia, J. Arago, J. Chem. Theory Comput. 11, 932-939, 1015 \n'}, 
-        'pwpb95'      : {'b': 11.100, 'c': 0.0093, 'citation': '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
+        'tpss0'       : {'b':  5.500, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
+        'tpss'        : {'b':  5.000, 'c': 0.0093, 'citation' : '    W. Hujo, S. Grimme, J. Chem. Theory Comput. 9, 308-315, 2013 \n'},
+        'b2gpplyp'    : {'b':  9.900, 'c': 0.0093, 'citation' : '    M. K. Kesharwani, A. Karton, J.M. L. Martin, J. Chem. Theory Comput. 12, 444-454, 2016 \n'},
+        'b2plyp'      : {'b':  7.800, 'c': 0.0093, 'citation' : '    J. Calbo, E. Orti, J. C. Sancho-Garcia, J. Arago, J. Chem. Theory Comput. 11, 932-939, 1015 \n'}, 
+        'pwpb95'      : {'b': 11.100, 'c': 0.0093, 'citation' : '    F. Yu J. Chem. Theory Comput. 10, 4400-4407, 2014 \n'}, 
     },
 
 } # yapf: disable

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -174,6 +174,7 @@ public:
     // => Setters <= //
 
     void set_lock(bool locked) { locked_ = locked; }
+    void set_do_vv10( bool do_vv10) { needs_vv10_ = do_vv10;}
     void set_name(const std::string & name) { name_ = name; }
     void set_description(const std::string & description) { description_ = description; }
     void set_citation(const std::string & citation) { citation_ = citation; }

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -331,10 +331,10 @@ void HF::common_init()
     }
 
     // post-scf vv10 correlation
-    if(options_.get_bool("DFT_VV10_POSTSCF")) {
-    functional_->set_lock(false);
-    functional_->set_do_vv10(false);
-    functional_->set_lock(true);
+    if (options_.get_bool("DFT_VV10_POSTSCF")) {
+        functional_->set_lock(false);
+        functional_->set_do_vv10(false);
+        functional_->set_lock(true);
     }
 
     // -D is zero by default
@@ -489,14 +489,14 @@ double HF::finalize_E()
 {
 
     // post-scf vv10 correlation
-    if(options_.get_bool("DFT_VV10_POSTSCF")) {
-    functional_->set_lock(false);
-    functional_->set_do_vv10(true);
-    functional_->set_lock(true);
-    outfile->Printf( "  ==> calculating VV10 correction on post-scf density <==\n\n");
-    E_=0.0;
-    form_V();
-    E_+=compute_E();
+    if (options_.get_bool("DFT_VV10_POSTSCF")) {
+        functional_->set_lock(false);
+        functional_->set_do_vv10(true);
+        functional_->set_lock(true);
+        outfile->Printf( "  ==> calculating VV10 correction on post-scf density <==\n\n");
+        E_=0.0;
+        form_V();
+        E_+=compute_E();
     }
 
     // Perform wavefunction stability analysis before doing

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -143,6 +143,8 @@ void HF::common_init()
     else
         name_ = "SCF";
 
+
+
     // Read in DOCC and SOCC from memory
     int nirreps = factory_->nirrep();
     input_docc_ = false;
@@ -328,6 +330,13 @@ void HF::common_init()
         potential_ = nullptr;
     }
 
+    // post-scf vv10 correlation
+    if(options_.get_bool("DFT_VV10_POSTSCF")) {
+    functional_->set_lock(false);
+    functional_->set_do_vv10(false);
+    functional_->set_lock(true);
+    }
+
     // -D is zero by default
     variables_["-D Energy"] = 0.0;
     energies_["-D"] = 0.0;
@@ -478,6 +487,17 @@ double HF::compute_energy()
 
 double HF::finalize_E()
 {
+
+    // post-scf vv10 correlation
+    if(options_.get_bool("DFT_VV10_POSTSCF")) {
+    functional_->set_lock(false);
+    functional_->set_do_vv10(true);
+    functional_->set_lock(true);
+    outfile->Printf( "  ==> calculating VV10 correction on post-scf density <==\n\n");
+    form_V();
+    compute_E();
+    }
+
     // Perform wavefunction stability analysis before doing
     // anything on a wavefunction that may not be truly converged.
     if(options_.get_str("STABILITY_ANALYSIS") != "NONE") {

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -494,8 +494,9 @@ double HF::finalize_E()
     functional_->set_do_vv10(true);
     functional_->set_lock(true);
     outfile->Printf( "  ==> calculating VV10 correction on post-scf density <==\n\n");
+    E_=0.0;
     form_V();
-    compute_E();
+    E_+=compute_E();
     }
 
     // Perform wavefunction stability analysis before doing

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1481,6 +1481,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     :ref:`Dispersion Corrections <table:dashd>` for the order in which
     parameters are to be specified in this array option. -*/
     options.add("DFT_DISPERSION_PARAMETERS", new ArrayType());
+    /*- Parameters defining the -NL/-V dispersion correction. First b, then C -*/
+    options.add("NL_DISPERSION_PARAMETERS", new ArrayType());
     /*- Number of spherical points (A :ref:`Lebedev Points <table:lebedevorder>` number) for VV10 NL integration. -*/
     options.add_int("DFT_VV10_SPHERICAL_POINTS", 146);
     /*- Number of radial points for VV10 NL integration. -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1491,6 +1491,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_double("DFT_VV10_B", 0.0);
     /*- Define VV10 parameter C -*/
     options.add_double("DFT_VV10_C", 0.0);
+    /*- post-scf VV10 correction -*/
+    options.add_bool("DFT_VV10_POSTSCF", false);
     /*- The convergence on the orbital localization procedure -*/
     options.add_double("LOCAL_CONVERGENCE",1E-12);
     /*- The maxiter on the orbital localization procedure -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1487,6 +1487,10 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_int("DFT_VV10_RADIAL_POINTS", 50);
     /*- Rho cutoff for VV10 NL integration. !expert -*/
     options.add_double("DFT_VV10_RHO_CUTOFF", 1.e-8);
+    /*- Define VV10 parameter b -*/
+    options.add_double("DFT_VV10_B", 0.0);
+    /*- Define VV10 parameter C -*/
+    options.add_double("DFT_VV10_C", 0.0);
     /*- The convergence on the orbital localization procedure -*/
     options.add_double("LOCAL_CONVERGENCE",1E-12);
     /*- The maxiter on the orbital localization procedure -*/

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -28,6 +28,7 @@ scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
     compare_values(v, psi4.get_variable(k), 9, k) # TEST
+scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
     
 set reference rks
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
@@ -37,3 +38,9 @@ compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLY
 set DFT_VV10_B  4.0
 scf_e, scf_wfn = energy("BLYP", return_wfn=True)
 compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+
+set DFT_VV10_POSTSCF true
+scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
+compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf') # TEST
+post_nl=psi4.get_variable('TOTAL SCF ENERGY')
+compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -1,4 +1,6 @@
 #! He Dimer VV10 functional test.
+#! notes: DFT_VV10_B/C overwrites the NL_.. tuple
+#
 
 bench = {"DFT VV10 ENERGY": 0.0187968521080026, # TEST
          "DFT XC ENERGY":  -2.1610005616974943, # TEST
@@ -29,18 +31,51 @@ scf_e, scf_wfn = energy("VV10", return_wfn=True)
 for k, v in bench.items():                        # TEST
     compare_values(v, psi4.get_variable(k), 9, k) # TEST
 scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
-    
+
+# dft-nl tests:
+
 set reference rks
-scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-0.0238582087067217
-compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b ') # TEST
-
-set DFT_VV10_B  4.0
-scf_e, scf_wfn = energy("BLYP", return_wfn=True)
-compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
-
-set DFT_VV10_POSTSCF true
 scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf') # TEST
-post_nl=psi4.get_variable('TOTAL SCF ENERGY')
-compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
+compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
+
+
+# tuple modified b
+set nl_dispersion_parameters [5.0]
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+compare_values(0.0238582087067217, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
+
+#tuple modified b and C
+set nl_dispersion_parameters [5.0, 0.1]
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
+
+#modified b and C
+set DFT_VV10_B  5.0
+set DFT_VV10_C  0.1
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
+revoke_global_option_changed('DFT_VV10_C') 
+revoke_global_option_changed('DFT_VV10_B') 
+
+# add VV10 without dashparam. Here scf_nl is saved
+set DFT_VV10_B  4.0
+scf_nl, scf_wfn = energy("BLYP", return_wfn=True)
+compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+revoke_global_option_changed('DFT_VV10_B') 
+
+#modify libxc func containing vv10
+set nl_dispersion_parameters [5.0]
+scf_e, scf_wfn = energy("wb97m-v", return_wfn=True)
+compare_values(0.0238946401122, psi4.get_variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
+
+
+# POST-SCF VV10 correction
+set DFT_VV10_POSTSCF true
+post_nl, scf_wfn = energy("BLYP-NL", return_wfn=True)
+compare_values(0.0328533763822404, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
+# check if result is sensible
+compare_values(scf_nl, post_nl, 6, 'BLYP-NL postscf 2') # TEST

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -6,6 +6,13 @@ bench = {"DFT VV10 ENERGY": 0.0187968521080026, # TEST
          "DFT XC ENERGY":  -2.1610005616974943, # TEST
          "CURRENT ENERGY": -5.8199580945288449} # TEST
 
+# references (from psi4)
+Enl_blypnl_b50_c01=0.0246749861696854
+Enl_blypnl_b50=0.0238582087067217
+Enl_blypnl_b40=0.0328523506642702
+Enl_blypnl_post=0.0328533763822404
+Enl_wb97mv_b50=0.0238946401121507
+
 molecule ne {
   0 1
   He 0 0 -2.0
@@ -36,46 +43,45 @@ scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
 
 set reference rks
 scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+compare_values(Enl_blypnl_b40, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
 scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
-
 
 # tuple modified b
 set nl_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(0.0238582087067217, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
+compare_values(Enl_blypnl_b50, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
 
 #tuple modified b and C
 set nl_dispersion_parameters [5.0, 0.1]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
+compare_values(Enl_blypnl_b50_c01, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
 
 #modified b and C
 set DFT_VV10_B  5.0
 set DFT_VV10_C  0.1
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
+compare_values(Enl_blypnl_b50_c01, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
 revoke_global_option_changed('DFT_VV10_C') 
 revoke_global_option_changed('DFT_VV10_B') 
 
 # add VV10 without dashparam. Here scf_nl is saved
 set DFT_VV10_B  4.0
 scf_nl, scf_wfn = energy("BLYP", return_wfn=True)
-compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+compare_values(Enl_blypnl_b40, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
 revoke_global_option_changed('DFT_VV10_B') 
 
 #modify libxc func containing vv10
 set nl_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("wb97m-v", return_wfn=True)
-compare_values(0.0238946401122, psi4.get_variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
+compare_values(Enl_wb97mv_b50, psi4.get_variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
-
 
 # POST-SCF VV10 correction
 set DFT_VV10_POSTSCF true
 post_nl, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(0.0328533763822404, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
-# check if result is sensible
+compare_values(Enl_blypnl_post, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
+
+# check if result is sensible and total scf is ok
 compare_values(scf_nl, post_nl, 6, 'BLYP-NL postscf 2') # TEST

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -17,6 +17,7 @@ set DFT_VV10_RADIAL_POINTS 20
 set E_CONVERGENCE 1.e-12
 set D_CONVERGENCE 1.e-10
 
+
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
@@ -27,3 +28,12 @@ scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
     compare_values(v, psi4.get_variable(k), 9, k) # TEST
+    
+set reference rks
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+0.0238582087067217
+compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b ') # TEST
+
+set DFT_VV10_B  4.0
+scf_e, scf_wfn = energy("BLYP", return_wfn=True)
+compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST

--- a/tests/dft-vv10/output.ref
+++ b/tests/dft-vv10/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.2a1.dev976 
+                               Psi4 1.2a1.dev997 
 
-                         Git: Rev {dft-nl} 443b2d8 dirty
+                         Git: Rev {vv10mod_fix} 52348f1 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -18,10 +18,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 07 April 2018 11:11AM
+    Psi4 started on: Saturday, 28 April 2018 06:49PM
 
-    Process ID:  13988
-    PSIDATADIR: /usr/qc/psi4.dev/share/psi4
+    Process ID: 32671
+    Host:       think
+    PSIDATADIR: /usr/qc/psi4.bin/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -29,6 +30,8 @@
 
 --------------------------------------------------------------------------
 #! He Dimer VV10 functional test.
+#! notes: DFT_VV10_B/C overwrites the NL_.. tuple
+#
 
 bench = {"DFT VV10 ENERGY": 0.0187968521080026, # TEST
          "DFT XC ENERGY":  -2.1610005616974943, # TEST
@@ -55,34 +58,59 @@ for k, v in bench.items():                        # TEST
 
 
 scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
 scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
 
-set dft_dispersion_parameters [5.0]
+# tuple modified b
+set nl_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-0.0238582087067217
-compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b ') # TEST
+compare_values(0.0238582087067217, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
 
+#tuple modified b and C
+set nl_dispersion_parameters [5.0, 0.1]
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
+
+#modified b and C
+set DFT_VV10_B  5.0
+set DFT_VV10_C  0.1
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+compare_values(0.0246750, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
+revoke_global_option_changed('DFT_VV10_C') 
+revoke_global_option_changed('DFT_VV10_B') 
+
+# add VV10 without dashparam. Here scf_nl is saved
 set DFT_VV10_B  4.0
-scf_e, scf_wfn = energy("BLYP", return_wfn=True)
-compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+scf_nl, scf_wfn = energy("BLYP", return_wfn=True)
+compare_values(0.032852665973, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+revoke_global_option_changed('DFT_VV10_B') 
 
+#modify libxc func containing vv10
+set nl_dispersion_parameters [5.0]
+scf_e, scf_wfn = energy("wb97m-v", return_wfn=True)
+compare_values(0.0238946401122, psi4.get_variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
+revoke_global_option_changed('nl_dispersion_parameters')
+
+
+# POST-SCF VV10 correction
 set DFT_VV10_POSTSCF true
-scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf') # TEST
-post_nl=psi4.get_variable('TOTAL SCF ENERGY')
-compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
+post_nl, scf_wfn = energy("BLYP-NL", return_wfn=True)
+compare_values(0.0328533763822404, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
+# check if result is sensible
+compare_values(scf_nl, post_nl, 6, 'BLYP-NL postscf 2') # TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on simien
-*** at Sat Apr  7 11:11:46 2018
+*** tstart() called on think
+*** at Sat Apr 28 18:49:17 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -186,7 +214,7 @@ compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -239,13 +267,13 @@ compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.81845100888131   -5.81845e+00   4.66154e-03 
-   @DF-RKS iter   1:    -5.81995325099754   -1.50224e-03   4.26151e-04 
-   @DF-RKS iter   2:    -5.81995736507169   -4.11407e-06   1.50825e-04 DIIS
-   @DF-RKS iter   3:    -5.81995809207186   -7.27000e-07   9.13153e-06 DIIS
-   @DF-RKS iter   4:    -5.81995809452888   -2.45703e-09   8.46387e-09 DIIS
-   @DF-RKS iter   5:    -5.81995809452889   -4.44089e-15   1.14044e-09 DIIS
-   @DF-RKS iter   6:    -5.81995809452889   -5.32907e-15   4.12514e-11 DIIS
+   @DF-RKS iter   0:    -5.81845100888130   -5.81845e+00   4.66154e-03 
+   @DF-RKS iter   1:    -5.81995325099751   -1.50224e-03   4.26151e-04 
+   @DF-RKS iter   2:    -5.81995736507167   -4.11407e-06   1.50825e-04 DIIS
+   @DF-RKS iter   3:    -5.81995809207184   -7.27000e-07   9.13153e-06 DIIS
+   @DF-RKS iter   4:    -5.81995809452886   -2.45703e-09   8.46387e-09 DIIS
+   @DF-RKS iter   5:    -5.81995809452887   -4.44089e-15   1.14044e-09 DIIS
+   @DF-RKS iter   6:    -5.81995809452887   -3.55271e-15   4.12515e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -271,17 +299,17 @@ compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.81995809452889
+  @DF-RKS Final Energy:    -5.81995809452887
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.8000083423393232
-    Two-Electron Energy =                   4.5930767488099296
-    DFT Exchange-Correlation Energy =      -2.1610005616975028
+    One-Electron Energy =                  -8.8000083423393196
+    Two-Electron Energy =                   4.5930767488099455
+    DFT Exchange-Correlation Energy =      -2.1610005616974988
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0187968521080026
-    Total Energy =                         -5.8199580945288938
+    Total Energy =                         -5.8199580945288707
 
 
 
@@ -302,28 +330,28 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Sat Apr  7 11:11:47 2018
+*** tstop() called on think at Sat Apr 28 18:49:18 2018
 Module time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 	DFT VV10 ENERGY...................................................PASSED
 	DFT XC ENERGY.....................................................PASSED
 	CURRENT ENERGY....................................................PASSED
 
-*** tstart() called on simien
-*** at Sat Apr  7 11:11:47 2018
+*** tstart() called on think
+*** at Sat Apr 28 18:49:18 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -429,13 +457,16 @@ Total time:
     Grimme's -NL (DFT plus  VV10 correlation) 
     Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
 
+    Parametrisation from: 
+    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 
+
 
    => Loading Basis Set <=
 
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -488,13 +519,13 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   5.08341e-03 
-   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   9.91993e-04 
-   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   4.29102e-04 DIIS
-   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   4.11363e-06 DIIS
-   @DF-RKS iter   4:    -5.76866030532114   -5.19525e-10   1.85042e-08 DIIS
-   @DF-RKS iter   5:    -5.76866030532115   -1.15463e-14   5.30742e-10 DIIS
-   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   6.32512e-12 DIIS
+   @DF-RKS iter   0:    -5.76659528067616   -5.76660e+00   5.08341e-03 
+   @DF-RKS iter   1:    -5.76863051510802   -2.03523e-03   9.91993e-04 
+   @DF-RKS iter   2:    -5.76865442104858   -2.39059e-05   4.29102e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480159   -5.88375e-06   4.11363e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532112   -5.19528e-10   1.85042e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532112   -7.99361e-15   5.30742e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532113   -3.55271e-15   6.32511e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -520,17 +551,17 @@ Total time:
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.76866030532115
+  @DF-RKS Final Energy:    -5.76866030532113
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
     One-Electron Energy =                  -8.7921415374883303
-    Two-Electron Energy =                   4.5786826871901223
+    Two-Electron Energy =                   4.5786826871901445
     DFT Exchange-Correlation Energy =      -2.1172310142772108
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0328523506642702
-    Total Energy =                         -5.7686603053211494
+    Total Energy =                         -5.7686603053211272
 
 
 
@@ -551,26 +582,26 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Sat Apr  7 11:11:48 2018
+*** tstop() called on think at Sat Apr 28 18:49:19 2018
 Module time:
-	user time   =       1.08 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.23 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 	BLYP-NL dashtest..................................................PASSED
 
-*** tstart() called on simien
-*** at Sat Apr  7 11:11:48 2018
+*** tstart() called on think
+*** at Sat Apr 28 18:49:19 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -676,13 +707,16 @@ Total time:
     Grimme's -NL (DFT plus  VV10 correlation) 
     Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
 
+    Parametrisation from: 
+    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 
+
 
    => Loading Basis Set <=
 
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -735,13 +769,13 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.77559359830675   -5.77559e+00   5.09299e-03 
-   @DF-RKS iter   1:    -5.77762611464431   -2.03252e-03   9.72313e-04 
-   @DF-RKS iter   2:    -5.77764909390123   -2.29793e-05   4.20976e-04 DIIS
-   @DF-RKS iter   3:    -5.77765475745573   -5.66355e-06   3.97339e-06 DIIS
-   @DF-RKS iter   4:    -5.77765475794104   -4.85311e-10   1.86131e-08 DIIS
-   @DF-RKS iter   5:    -5.77765475794105   -1.50990e-14   5.20463e-10 DIIS
-   @DF-RKS iter   6:    -5.77765475794105    7.99361e-15   6.19459e-12 DIIS
+   @DF-RKS iter   0:    -5.77559359830673   -5.77559e+00   5.09299e-03 
+   @DF-RKS iter   1:    -5.77762611464429   -2.03252e-03   9.72313e-04 
+   @DF-RKS iter   2:    -5.77764909390121   -2.29793e-05   4.20976e-04 DIIS
+   @DF-RKS iter   3:    -5.77765475745570   -5.66355e-06   3.97339e-06 DIIS
+   @DF-RKS iter   4:    -5.77765475794101   -4.85313e-10   1.86131e-08 DIIS
+   @DF-RKS iter   5:    -5.77765475794103   -1.33227e-14   5.20463e-10 DIIS
+   @DF-RKS iter   6:    -5.77765475794103    8.88178e-16   6.19474e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -767,17 +801,17 @@ Total time:
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.77765475794105
+  @DF-RKS Final Energy:    -5.77765475794103
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.7923958174323271
-    Two-Electron Energy =                   4.5791820431958037
-    DFT Exchange-Correlation Energy =      -2.1174764010012428
+    One-Electron Energy =                  -8.7923958174323253
+    Two-Electron Energy =                   4.5791820431958197
+    DFT Exchange-Correlation Energy =      -2.1174764010012406
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0238582087067217
-    Total Energy =                         -5.7776547579410451
+    Total Energy =                         -5.7776547579410256
 
 
 
@@ -798,26 +832,526 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Sat Apr  7 11:11:49 2018
+*** tstop() called on think at Sat Apr 28 18:49:20 2018
 Module time:
-	user time   =       1.01 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.25 seconds =       0.05 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       3.10 seconds =       0.05 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
-	BLYP-NL custom b .................................................PASSED
+	BLYP-NL tuple b ..................................................PASSED
 
-*** tstart() called on simien
-*** at Sat Apr  7 11:11:49 2018
+*** tstart() called on think
+*** at Sat Apr 28 18:49:20 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP-NL <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     5.0000E+00
+    VV10 C              =     1.0000E-01
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => -NL: Empirical Dispersion <=
+
+    Grimme's -NL (DFT plus  VV10 correlation) 
+    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
+
+    Parametrisation from: 
+    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 
+
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.77479560715294   -5.77480e+00   5.08297e-03 
+   @DF-RKS iter   1:    -5.77681064482151   -2.01504e-03   9.52157e-04 
+   @DF-RKS iter   2:    -5.77683271026324   -2.20654e-05   4.12243e-04 DIIS
+   @DF-RKS iter   3:    -5.77683814208618   -5.43182e-06   3.81097e-06 DIIS
+   @DF-RKS iter   4:    -5.77683814253304   -4.46865e-10   1.91385e-08 DIIS
+   @DF-RKS iter   5:    -5.77683814253306   -1.50990e-14   5.10073e-10 DIIS
+   @DF-RKS iter   6:    -5.77683814253306   -8.88178e-16   6.20938e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.577619     1B1u   -0.577162  
+
+    Virtual:                                                              
+
+       2Ag     0.067026     2B1u    0.111682     3Ag     0.344010  
+       1B2u    0.353234     1B3u    0.353234     1B3g    0.355876  
+       1B2g    0.355876     3B1u    0.375745     4Ag     1.355155  
+       4B1u    1.392110     5Ag     2.608215     2B2u    2.615236  
+       2B3u    2.615236     2B3g    2.617020     2B2g    2.617020  
+       5B1u    2.631482  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.77683814253306
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7926972800567533
+    Two-Electron Energy =                   4.5797384809549246
+    DFT Exchange-Correlation Energy =      -2.1177315381909128
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0246749861696854
+    Total Energy =                         -5.7768381425330571
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on think at Sat Apr 28 18:49:21 2018
+Module time:
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.11 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	BLYP-NL tuple b and C ............................................PASSED
+
+*** tstart() called on think
+*** at Sat Apr 28 18:49:21 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP-NL <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     5.0000E+00
+    VV10 C              =     1.0000E-01
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => -NL: Empirical Dispersion <=
+
+    Grimme's -NL (DFT plus  VV10 correlation) 
+    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
+
+    Parametrisation from: 
+    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 
+
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.77479560715294   -5.77480e+00   5.08297e-03 
+   @DF-RKS iter   1:    -5.77681064482151   -2.01504e-03   9.52157e-04 
+   @DF-RKS iter   2:    -5.77683271026324   -2.20654e-05   4.12243e-04 DIIS
+   @DF-RKS iter   3:    -5.77683814208618   -5.43182e-06   3.81097e-06 DIIS
+   @DF-RKS iter   4:    -5.77683814253304   -4.46865e-10   1.91385e-08 DIIS
+   @DF-RKS iter   5:    -5.77683814253306   -1.50990e-14   5.10073e-10 DIIS
+   @DF-RKS iter   6:    -5.77683814253306   -8.88178e-16   6.20938e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.577619     1B1u   -0.577162  
+
+    Virtual:                                                              
+
+       2Ag     0.067026     2B1u    0.111682     3Ag     0.344010  
+       1B2u    0.353234     1B3u    0.353234     1B3g    0.355876  
+       1B2g    0.355876     3B1u    0.375745     4Ag     1.355155  
+       4B1u    1.392110     5Ag     2.608215     2B2u    2.615236  
+       2B3u    2.615236     2B3g    2.617020     2B2g    2.617020  
+       5B1u    2.631482  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.77683814253306
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7926972800567533
+    Two-Electron Energy =                   4.5797384809549246
+    DFT Exchange-Correlation Energy =      -2.1177315381909128
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0246749861696854
+    Total Energy =                         -5.7768381425330571
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on think at Sat Apr 28 18:49:22 2018
+Module time:
+	user time   =       0.99 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.11 seconds =       0.09 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	BLYP-NL custom b and C ...........................................PASSED
+
+*** tstart() called on think
+*** at Sat Apr 28 18:49:22 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
 
 SCF: VV10_C not specified. Using default (C=0.0093)!
          ---------------------------------------------------------
@@ -923,7 +1457,7 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -976,13 +1510,13 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   5.08341e-03 
-   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   9.91993e-04 
-   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   4.29102e-04 DIIS
-   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   4.11363e-06 DIIS
-   @DF-RKS iter   4:    -5.76866030532114   -5.19525e-10   1.85042e-08 DIIS
-   @DF-RKS iter   5:    -5.76866030532115   -1.15463e-14   5.30742e-10 DIIS
-   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   6.32512e-12 DIIS
+   @DF-RKS iter   0:    -5.76659528067616   -5.76660e+00   5.08341e-03 
+   @DF-RKS iter   1:    -5.76863051510802   -2.03523e-03   9.91993e-04 
+   @DF-RKS iter   2:    -5.76865442104858   -2.39059e-05   4.29102e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480159   -5.88375e-06   4.11363e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532112   -5.19528e-10   1.85042e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532112   -7.99361e-15   5.30742e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532113   -3.55271e-15   6.32511e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -1008,17 +1542,17 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.76866030532115
+  @DF-RKS Final Energy:    -5.76866030532113
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
     One-Electron Energy =                  -8.7921415374883303
-    Two-Electron Energy =                   4.5786826871901223
+    Two-Electron Energy =                   4.5786826871901445
     DFT Exchange-Correlation Energy =      -2.1172310142772108
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0328523506642702
-    Total Energy =                         -5.7686603053211494
+    Total Energy =                         -5.7686603053211272
 
 
 
@@ -1039,26 +1573,268 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Sat Apr  7 11:11:50 2018
+*** tstop() called on think at Sat Apr 28 18:49:23 2018
 Module time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.25 seconds =       0.07 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       6.13 seconds =       0.10 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 	BLYP + custom VV10 ENERGY.........................................PASSED
 
-*** tstart() called on simien
-*** at Sat Apr  7 11:11:50 2018
+*** tstart() called on think
+*** at Sat Apr 28 18:49:23 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: WB97M-V <= 
+
+    WB97M-V Hyb-GGA Exchange-Correlation Functional
+
+    N. Mardirossian and M. Head-Gordon, (2016)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange-Correlation Functionals <=
+
+    1.0000   wB97M-V exchange-correlation functional
+
+   => Exact (HF) Exchange <=
+
+    0.8500            HF,LR [omega = 0.3000]
+    0.1500               HF 
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     5.0000E+00
+    VV10 C              =     1.0000E-02
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.77747882815834   -5.77748e+00   3.46767e-03 
+   @DF-RKS iter   1:    -5.77816337168116   -6.84544e-04   5.25364e-04 
+   @DF-RKS iter   2:    -5.77818392682149   -2.05551e-05   9.79113e-05 DIIS
+   @DF-RKS iter   3:    -5.77818454320872   -6.16387e-07   3.69628e-06 DIIS
+   @DF-RKS iter   4:    -5.77818454358416   -3.75439e-10   1.44473e-07 DIIS
+   @DF-RKS iter   5:    -5.77818454358551   -1.34559e-12   7.64589e-09 DIIS
+   @DF-RKS iter   6:    -5.77818454358551   -3.55271e-15   3.98649e-10 DIIS
+   @DF-RKS iter   7:    -5.77818454358551    2.66454e-15   6.14804e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.763585     1B1u   -0.763131  
+
+    Virtual:                                                              
+
+       2Ag     0.117219     2B1u    0.169383     3Ag     0.466547  
+       1B2u    0.476993     1B3u    0.476993     1B3g    0.479837  
+       1B2g    0.479837     3B1u    0.500397     4Ag     1.523857  
+       4B1u    1.559915     5Ag     2.798510     2B2u    2.805551  
+       2B3u    2.805551     2B3g    2.807327     2B2g    2.807327  
+       5B1u    2.821646  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.77818454358551
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.8075298174937267
+    Two-Electron Energy =                   3.7633341830486731
+    DFT Exchange-Correlation Energy =      -1.2870607578426037
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0238946401121507
+    Total Energy =                         -5.7781845435855068
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on think at Sat Apr 28 18:49:25 2018
+Module time:
+	user time   =       2.21 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       8.34 seconds =       0.14 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+	wB97M-V tuple b...................................................PASSED
+
+*** tstart() called on think
+*** at Sat Apr 28 18:49:25 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.bin/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -1164,13 +1940,16 @@ Total time:
     Grimme's -NL (DFT plus  VV10 correlation) 
     Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
 
+    Parametrisation from: 
+    W. Hujo, S. Grimme J. Chem. Theory Comput. 7, 3866-3871, 2011 
+
 
    => Loading Basis Set <=
 
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.bin/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1223,13 +2002,13 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.79946701401163   -5.79947e+00   5.09802e-03 
-   @DF-RKS iter   1:    -5.80148640702211   -2.01939e-03   9.39222e-04 
-   @DF-RKS iter   2:    -5.80150787282042   -2.14658e-05   4.07065e-04 DIIS
-   @DF-RKS iter   3:    -5.80151316857890   -5.29576e-06   3.73723e-06 DIIS
-   @DF-RKS iter   4:    -5.80151316900894   -4.30040e-10   1.93456e-08 DIIS
-   @DF-RKS iter   5:    -5.80151316900895   -1.24345e-14   5.02251e-10 DIIS
-   @DF-RKS iter   6:    -5.80151316900895    1.77636e-15   6.04372e-12 DIIS
+   @DF-RKS iter   0:    -5.79946701401161   -5.79947e+00   5.09802e-03 
+   @DF-RKS iter   1:    -5.80148640702209   -2.01939e-03   9.39222e-04 
+   @DF-RKS iter   2:    -5.80150787282039   -2.14658e-05   4.07065e-04 DIIS
+   @DF-RKS iter   3:    -5.80151316857888   -5.29576e-06   3.73723e-06 DIIS
+   @DF-RKS iter   4:    -5.80151316900892   -4.30042e-10   1.93456e-08 DIIS
+   @DF-RKS iter   5:    -5.80151316900893   -8.88178e-15   5.02251e-10 DIIS
+   @DF-RKS iter   6:    -5.80151316900893   -2.66454e-15   6.04371e-12 DIIS
   ==> calculating VV10 correction on post-scf density <==
 
 
@@ -1257,17 +2036,17 @@ Total time:
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.76865979261560
+  @DF-RKS Final Energy:    -5.76865979261557
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
     One-Electron Energy =                  -8.7928445147714598
-    Two-Electron Energy =                   4.5800423706621398
-    DFT Exchange-Correlation Energy =      -2.1178882334785185
+    Two-Electron Energy =                   4.5800423706621611
+    DFT Exchange-Correlation Energy =      -2.1178882334785154
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0328533763822404
-    Total Energy =                         -5.7686597926155994
+    Total Energy =                         -5.7686597926155745
 
 
 
@@ -1288,16 +2067,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Sat Apr  7 11:11:51 2018
+*** tstop() called on think at Sat Apr 28 18:49:26 2018
 Module time:
-	user time   =       0.90 seconds =       0.02 minutes
+	user time   =       0.88 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.15 seconds =       0.09 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
-	BLYP-NL postscf...................................................PASSED
-	BLYP-NL postscf2..................................................PASSED
+	user time   =       9.23 seconds =       0.15 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+	BLYP-NL postscf 1.................................................PASSED
+	BLYP-NL postscf 2.................................................PASSED
+
+    Psi4 stopped on: Saturday, 28 April 2018 06:49PM
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dft-vv10/output.ref
+++ b/tests/dft-vv10/output.ref
@@ -1,43 +1,38 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 (inplace)
+                               Psi4 1.2a1.dev970 
 
-                         Git: Rev (inplace)
-
-
-    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
-    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
-    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
-    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
-    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
-    (doi: 10.1002/wcms.93)
+                         Git: Rev {dft-nl} 1ddc794 dirty
 
 
-                         Additional Contributions by
-    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
-    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
-    B. P. Pritchard
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 19 January 2017 10:52AM
+    Psi4 started on: Friday, 06 April 2018 03:07PM
 
-    Process ID:   6831
-    PSIDATADIR: /Users/daniel/Gits/psixc/psi4/share/psi4
+    Process ID:   8330
+    PSIDATADIR: /usr/qc/psi4.dev/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    2
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
 #! He Dimer VV10 functional test.
 
-bench = {"DFT VV10 ENERGY": 0.0187972621212943, # TEST
-         "DFT XC ENERGY": -2.1610011925928672,  # TEST
-         "CURRENT ENERGY": -5.8199576848715910} # TEST
-
-memory 250 mb
+bench = {"DFT VV10 ENERGY": 0.0187968521080026, # TEST
+         "DFT XC ENERGY":  -2.1610005616974943, # TEST
+         "CURRENT ENERGY": -5.8199580945288449} # TEST
 
 molecule ne {
   0 1
@@ -46,18 +41,41 @@ molecule ne {
 }
 
 
-set basis aug-cc-pVDZ
+set BASIS aug-cc-pVDZ
+set DFT_VV10_SPHERICAL_POINTS 50
+set DFT_VV10_RADIAL_POINTS 20
+set E_CONVERGENCE 1.e-12
+set D_CONVERGENCE 1.e-10
+
 
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
-    compare_values(v, psi4.get_variable(k), 6, k) # TEST
+    compare_values(v, psi4.get_variable(k), 9, k) # TEST
+
+
+scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
+compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+
+set dft_dispersion_parameters [5.0]
+scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
+0.0238582087067217
+compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b ') # TEST
+
+set DFT_VV10_B  4.0
+scf_e, scf_wfn = energy("BLYP", return_wfn=True)
+compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
 --------------------------------------------------------------------------
 
-  Memory set to 250.000 MiB by Python script.
+*** tstart() called on simien
+*** at Fri Apr  6 15:07:11 2018
 
-*** tstart() called on ds23.sherrill.chemistry.gatech.edu
-*** at Thu Jan 19 10:52:42 2017
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -65,7 +83,7 @@ for k, v in bench.items():                        # TEST
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RKS Reference
-                        1 Threads,    250 MiB Core
+                        2 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -99,13 +117,14 @@ for k, v in bench.items():                        # TEST
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is SAD.
-  Energy threshold   = 1.00e-06
-  Density threshold  = 1.00e-06
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
   Integral threshold = 0.00e+00
 
   ==> Primary Basis <==
 
-  Basis Set: file /Users/daniel/Gits/psixc/psi4/share/psi4/basis/aug-cc-pvdz.gbs
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
     Number of shells: 10
     Number of basis function: 18
     Number of Cartesian functions: 18
@@ -125,11 +144,7 @@ for k, v in bench.items():                        # TEST
     Meta                =          FALSE
 
     Exchange Hybrid     =          FALSE
-    Exchange Alpha      =       0.000000
-
-    Exchange LRC        =          FALSE
-    Exchange Beta       =       0.000000
-    Exchange Omega      =       0.000000
+    MP2 Hybrid          =          FALSE
 
    => Exchange Functionals <=
 
@@ -138,7 +153,6 @@ for k, v in bench.items():                        # TEST
    => Correlation Functionals <=
 
     1.0000   Perdew, Burke & Ernzerhof
-
 
    => VV10 Non-Local Parameters <=
 
@@ -156,9 +170,16 @@ for k, v in bench.items():                        # TEST
     Radial Points       =             75
     Spherical Points    =            302
     Total Points        =          45300
-    Total Blocks        =            466
-    Max Points          =            200
+    Total Blocks        =            418
+    Max Points          =            251
     Max Functions       =             18
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -184,9 +205,9 @@ for k, v in bench.items():                        # TEST
     J tasked:                  Yes
     K tasked:                   No
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               178
+    OpenMP threads:              2
+    Integrals threads:           2
+    Memory (MB):               375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
@@ -194,7 +215,8 @@ for k, v in bench.items():                        # TEST
 
    => Auxiliary Basis Set <=
 
-  Basis Set: file /Users/daniel/Gits/psixc/psi4/share/psi4/basis/def2-qzvpp-jkfit.gbs + file /Users/daniel/Gits/psixc/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
     Number of shells: 18
     Number of basis function: 46
     Number of Cartesian functions: 50
@@ -210,11 +232,13 @@ for k, v in bench.items():                        # TEST
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.81845049316407   -5.81845e+00   4.66177e-03 
-   @DF-RKS iter   1:    -5.81995284220679   -1.50235e-03   4.26102e-04 
-   @DF-RKS iter   2:    -5.81995695582041   -4.11361e-06   1.50786e-04 DIIS
-   @DF-RKS iter   3:    -5.81995768240796   -7.26588e-07   9.13620e-06 DIIS
-   @DF-RKS iter   4:    -5.81995768487159   -2.46363e-09   8.47640e-09 DIIS
+   @DF-RKS iter   0:    -5.81845100888132   -5.81845e+00   4.97264e-03 
+   @DF-RKS iter   1:    -5.81995325099754   -1.50224e-03   4.89611e-04 
+   @DF-RKS iter   2:    -5.81995736507169   -4.11407e-06   1.98771e-04 DIIS
+   @DF-RKS iter   3:    -5.81995809207186   -7.27000e-07   1.29139e-05 DIIS
+   @DF-RKS iter   4:    -5.81995809452889   -2.45703e-09   1.04859e-08 DIIS
+   @DF-RKS iter   5:    -5.81995809452889   -3.55271e-15   1.21655e-09 DIIS
+   @DF-RKS iter   6:    -5.81995809452889    8.88178e-16   4.73942e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -227,12 +251,12 @@ for k, v in bench.items():                        # TEST
 
     Virtual:                                                              
 
-       2Ag     0.073643     2B1u    0.120367     3Ag     0.344983  
-       1B2u    0.354199     1B3u    0.354199     1B3g    0.356837  
-       1B2g    0.356837     3B1u    0.376557     4Ag     1.346440  
-       4B1u    1.383919     5Ag     2.604235     2B2u    2.611341  
-       2B3u    2.611341     2B2g    2.613141     2B3g    2.613141  
-       5B1u    2.627662  
+       2Ag     0.073640     2B1u    0.120363     3Ag     0.344981  
+       1B2u    0.354201     1B3u    0.354201     1B3g    0.356839  
+       1B2g    0.356839     3B1u    0.376553     4Ag     1.346435  
+       4B1u    1.383914     5Ag     2.604236     2B2u    2.611342  
+       2B3u    2.611342     2B2g    2.613142     2B3g    2.613142  
+       5B1u    2.627664  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
@@ -240,17 +264,17 @@ for k, v in bench.items():                        # TEST
 
   Energy converged.
 
-  @DF-RKS Final Energy:    -5.81995768487159
+  @DF-RKS Final Energy:    -5.81995809452889
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.8000086579080623
-    Two-Electron Energy =                   4.5930776949180441
-    DFT Exchange-Correlation Energy =      -2.1610011925928672
+    One-Electron Energy =                  -8.8000083423393178
+    Two-Electron Energy =                   4.5930767488099224
+    DFT Exchange-Correlation Energy =      -2.1610005616974957
     Empirical Dispersion Energy =           0.0000000000000000
-    VV10 Nonlocal Energy =                  0.0187972621212943
-    Total Energy =                         -5.8199576848715910
+    VV10 Nonlocal Energy =                  0.0187968521080026
+    Total Energy =                         -5.8199580945288885
 
 
 
@@ -271,17 +295,753 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on ds23.sherrill.chemistry.gatech.edu at Thu Jan 19 10:53:25 2017
+*** tstop() called on simien at Fri Apr  6 15:07:12 2018
 Module time:
-	user time   =      42.01 seconds =       0.70 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         43 seconds =       0.72 minutes
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      42.01 seconds =       0.70 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         43 seconds =       0.72 minutes
-	DFT XC ENERGY.....................................................PASSED
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 	DFT VV10 ENERGY...................................................PASSED
+	DFT XC ENERGY.....................................................PASSED
 	CURRENT ENERGY....................................................PASSED
+
+*** tstart() called on simien
+*** at Fri Apr  6 15:07:12 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        2 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP-NL <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     4.0000E+00
+    VV10 C              =     9.3000E-03
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => -NL: Empirical Dispersion <=
+
+    Grimme's -NL (DFT plus  VV10 correlation) 
+    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
+
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              2
+    Integrals threads:           2
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   6.69939e-03 
+   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   1.30734e-03 
+   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   6.06842e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   5.81755e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532114   -5.19530e-10   2.43866e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532115   -6.21725e-15   6.57538e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532115   -2.66454e-15   8.94505e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.576031     1B1u   -0.575573  
+
+    Virtual:                                                              
+
+       2Ag     0.068211     2B1u    0.112998     3Ag     0.345064  
+       1B2u    0.354298     1B3u    0.354298     1B3g    0.356941  
+       1B2g    0.356941     3B1u    0.376799     4Ag     1.356529  
+       4B1u    1.393533     5Ag     2.609797     2B2u    2.616819  
+       2B3u    2.616819     2B3g    2.618603     2B2g    2.618603  
+       5B1u    2.633059  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.76866030532115
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7921415374883320
+    Two-Electron Energy =                   4.5786826871901232
+    DFT Exchange-Correlation Energy =      -2.1172310142772117
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0328523506642702
+    PCM Polarization Energy =               0.0000000000000000
+    Total Energy =                         -5.7686603053211511
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on simien at Fri Apr  6 15:07:13 2018
+Module time:
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.36 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	BLYP-NL dashtest..................................................PASSED
+
+*** tstart() called on simien
+*** at Fri Apr  6 15:07:13 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        2 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP-NL <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     5.0000E+00
+    VV10 C              =     9.3000E-03
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => -NL: Empirical Dispersion <=
+
+    Grimme's -NL (DFT plus  VV10 correlation) 
+    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
+
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              2
+    Integrals threads:           2
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.77559359830675   -5.77559e+00   7.20257e-03 
+   @DF-RKS iter   1:    -5.77762611464431   -2.03252e-03   1.28140e-03 
+   @DF-RKS iter   2:    -5.77764909390124   -2.29793e-05   5.54801e-04 DIIS
+   @DF-RKS iter   3:    -5.77765475745573   -5.66355e-06   5.23650e-06 DIIS
+   @DF-RKS iter   4:    -5.77765475794104   -4.85318e-10   2.18257e-08 DIIS
+   @DF-RKS iter   5:    -5.77765475794105   -7.10543e-15   7.36045e-10 DIIS
+   @DF-RKS iter   6:    -5.77765475794105    8.88178e-16   7.26373e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.578029     1B1u   -0.577571  
+
+    Virtual:                                                              
+
+       2Ag     0.066154     2B1u    0.110918     3Ag     0.343264  
+       1B2u    0.352498     1B3u    0.352498     1B3g    0.355141  
+       1B2g    0.355141     3B1u    0.375002     4Ag     1.354577  
+       4B1u    1.391560     5Ag     2.607811     2B2u    2.614834  
+       2B3u    2.614834     2B3g    2.616618     2B2g    2.616618  
+       5B1u    2.631075  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.77765475794105
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7923958174323218
+    Two-Electron Energy =                   4.5791820431957948
+    DFT Exchange-Correlation Energy =      -2.1174764010012446
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0238582087067217
+    Total Energy =                         -5.7776547579410504
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on simien at Fri Apr  6 15:07:13 2018
+Module time:
+	user time   =       1.16 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.53 seconds =       0.06 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+	BLYP-NL custom b .................................................PASSED
+
+*** tstart() called on simien
+*** at Fri Apr  6 15:07:13 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+
+SCF: VV10_C not specified. Using default (C=0.0093)!
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        2 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     4.0000E+00
+    VV10 C              =     9.3000E-03
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              2
+    Integrals threads:           2
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   6.98061e-03 
+   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   1.20136e-03 
+   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   5.03167e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480162   -5.88375e-06   5.42132e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532114   -5.19527e-10   2.29250e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532115   -9.76996e-15   6.99461e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   7.41676e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.576031     1B1u   -0.575573  
+
+    Virtual:                                                              
+
+       2Ag     0.068211     2B1u    0.112998     3Ag     0.345064  
+       1B2u    0.354298     1B3u    0.354298     1B3g    0.356941  
+       1B2g    0.356941     3B1u    0.376799     4Ag     1.356529  
+       4B1u    1.393533     5Ag     2.609797     2B2u    2.616819  
+       2B3u    2.616819     2B3g    2.618603     2B2g    2.618603  
+       5B1u    2.633059  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.76866030532115
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7921415374883374
+    Two-Electron Energy =                   4.5786826871901276
+    DFT Exchange-Correlation Energy =      -2.1172310142772126
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0328523506642702
+    Total Energy =                         -5.7686603053211529
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on simien at Fri Apr  6 15:07:14 2018
+Module time:
+	user time   =       1.12 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.66 seconds =       0.08 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+	BLYP + custom VV10 ENERGY.........................................PASSED
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dft-vv10/output.ref
+++ b/tests/dft-vv10/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.2a1.dev970 
+                               Psi4 1.2a1.dev976 
 
-                         Git: Rev {dft-nl} 1ddc794 dirty
+                         Git: Rev {dft-nl} 443b2d8 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -18,12 +18,12 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 06 April 2018 03:07PM
+    Psi4 started on: Saturday, 07 April 2018 11:11AM
 
-    Process ID:   8330
+    Process ID:  13988
     PSIDATADIR: /usr/qc/psi4.dev/share/psi4
     Memory:     500.0 MiB
-    Threads:    2
+    Threads:    1
     
   ==> Input File <==
 
@@ -56,6 +56,7 @@ for k, v in bench.items():                        # TEST
 
 scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
 compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+scf_nl=psi4.get_variable('TOTAL SCF ENERGY')
 
 set dft_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
@@ -65,10 +66,16 @@ compare_values(0.0238582087067217,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLY
 set DFT_VV10_B  4.0
 scf_e, scf_wfn = energy("BLYP", return_wfn=True)
 compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+
+set DFT_VV10_POSTSCF true
+scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
+compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf') # TEST
+post_nl=psi4.get_variable('TOTAL SCF ENERGY')
+compare_values(scf_nl,post_nl,6,'BLYP-NL postscf2') # TEST
 --------------------------------------------------------------------------
 
 *** tstart() called on simien
-*** at Fri Apr  6 15:07:11 2018
+*** at Sat Apr  7 11:11:46 2018
 
    => Loading Basis Set <=
 
@@ -83,7 +90,7 @@ compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + 
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RKS Reference
-                        2 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -205,8 +212,8 @@ compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + 
     J tasked:                  Yes
     K tasked:                   No
     wK tasked:                  No
-    OpenMP threads:              2
-    Integrals threads:           2
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Algorithm:                Core
     Integral Cache:           NONE
@@ -232,13 +239,13 @@ compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + 
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.81845100888132   -5.81845e+00   4.97264e-03 
-   @DF-RKS iter   1:    -5.81995325099754   -1.50224e-03   4.89611e-04 
-   @DF-RKS iter   2:    -5.81995736507169   -4.11407e-06   1.98771e-04 DIIS
-   @DF-RKS iter   3:    -5.81995809207186   -7.27000e-07   1.29139e-05 DIIS
-   @DF-RKS iter   4:    -5.81995809452889   -2.45703e-09   1.04859e-08 DIIS
-   @DF-RKS iter   5:    -5.81995809452889   -3.55271e-15   1.21655e-09 DIIS
-   @DF-RKS iter   6:    -5.81995809452889    8.88178e-16   4.73942e-11 DIIS
+   @DF-RKS iter   0:    -5.81845100888131   -5.81845e+00   4.66154e-03 
+   @DF-RKS iter   1:    -5.81995325099754   -1.50224e-03   4.26151e-04 
+   @DF-RKS iter   2:    -5.81995736507169   -4.11407e-06   1.50825e-04 DIIS
+   @DF-RKS iter   3:    -5.81995809207186   -7.27000e-07   9.13153e-06 DIIS
+   @DF-RKS iter   4:    -5.81995809452888   -2.45703e-09   8.46387e-09 DIIS
+   @DF-RKS iter   5:    -5.81995809452889   -4.44089e-15   1.14044e-09 DIIS
+   @DF-RKS iter   6:    -5.81995809452889   -5.32907e-15   4.12514e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -269,12 +276,12 @@ compare_values(0.032852665973,psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.8000083423393178
-    Two-Electron Energy =                   4.5930767488099224
-    DFT Exchange-Correlation Energy =      -2.1610005616974957
+    One-Electron Energy =                  -8.8000083423393232
+    Two-Electron Energy =                   4.5930767488099296
+    DFT Exchange-Correlation Energy =      -2.1610005616975028
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0187968521080026
-    Total Energy =                         -5.8199580945288885
+    Total Energy =                         -5.8199580945288938
 
 
 
@@ -295,21 +302,21 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Fri Apr  6 15:07:12 2018
+*** tstop() called on simien at Sat Apr  7 11:11:47 2018
 Module time:
-	user time   =       1.22 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.22 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 	DFT VV10 ENERGY...................................................PASSED
 	DFT XC ENERGY.....................................................PASSED
 	CURRENT ENERGY....................................................PASSED
 
 *** tstart() called on simien
-*** at Fri Apr  6 15:07:12 2018
+*** at Sat Apr  7 11:11:47 2018
 
    => Loading Basis Set <=
 
@@ -324,7 +331,7 @@ Total time:
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RKS Reference
-                        2 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -454,8 +461,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                   No
     wK tasked:                  No
-    OpenMP threads:              2
-    Integrals threads:           2
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Algorithm:                Core
     Integral Cache:           NONE
@@ -481,13 +488,13 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   6.69939e-03 
-   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   1.30734e-03 
-   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   6.06842e-04 DIIS
-   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   5.81755e-06 DIIS
-   @DF-RKS iter   4:    -5.76866030532114   -5.19530e-10   2.43866e-08 DIIS
-   @DF-RKS iter   5:    -5.76866030532115   -6.21725e-15   6.57538e-10 DIIS
-   @DF-RKS iter   6:    -5.76866030532115   -2.66454e-15   8.94505e-12 DIIS
+   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   5.08341e-03 
+   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   9.91993e-04 
+   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   4.29102e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   4.11363e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532114   -5.19525e-10   1.85042e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532115   -1.15463e-14   5.30742e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   6.32512e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -518,15 +525,14 @@ Total time:
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.7921415374883320
-    Two-Electron Energy =                   4.5786826871901232
-    DFT Exchange-Correlation Energy =      -2.1172310142772117
+    One-Electron Energy =                  -8.7921415374883303
+    Two-Electron Energy =                   4.5786826871901223
+    DFT Exchange-Correlation Energy =      -2.1172310142772108
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0328523506642702
-    PCM Polarization Energy =               0.0000000000000000
-    Total Energy =                         -5.7686603053211511
+    Total Energy =                         -5.7686603053211494
 
-    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
 
@@ -545,19 +551,19 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Fri Apr  6 15:07:13 2018
+*** tstop() called on simien at Sat Apr  7 11:11:48 2018
 Module time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.36 seconds =       0.04 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 	BLYP-NL dashtest..................................................PASSED
 
 *** tstart() called on simien
-*** at Fri Apr  6 15:07:13 2018
+*** at Sat Apr  7 11:11:48 2018
 
    => Loading Basis Set <=
 
@@ -572,7 +578,7 @@ Total time:
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RKS Reference
-                        2 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -702,8 +708,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                   No
     wK tasked:                  No
-    OpenMP threads:              2
-    Integrals threads:           2
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Algorithm:                Core
     Integral Cache:           NONE
@@ -729,13 +735,13 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.77559359830675   -5.77559e+00   7.20257e-03 
-   @DF-RKS iter   1:    -5.77762611464431   -2.03252e-03   1.28140e-03 
-   @DF-RKS iter   2:    -5.77764909390124   -2.29793e-05   5.54801e-04 DIIS
-   @DF-RKS iter   3:    -5.77765475745573   -5.66355e-06   5.23650e-06 DIIS
-   @DF-RKS iter   4:    -5.77765475794104   -4.85318e-10   2.18257e-08 DIIS
-   @DF-RKS iter   5:    -5.77765475794105   -7.10543e-15   7.36045e-10 DIIS
-   @DF-RKS iter   6:    -5.77765475794105    8.88178e-16   7.26373e-12 DIIS
+   @DF-RKS iter   0:    -5.77559359830675   -5.77559e+00   5.09299e-03 
+   @DF-RKS iter   1:    -5.77762611464431   -2.03252e-03   9.72313e-04 
+   @DF-RKS iter   2:    -5.77764909390123   -2.29793e-05   4.20976e-04 DIIS
+   @DF-RKS iter   3:    -5.77765475745573   -5.66355e-06   3.97339e-06 DIIS
+   @DF-RKS iter   4:    -5.77765475794104   -4.85311e-10   1.86131e-08 DIIS
+   @DF-RKS iter   5:    -5.77765475794105   -1.50990e-14   5.20463e-10 DIIS
+   @DF-RKS iter   6:    -5.77765475794105    7.99361e-15   6.19459e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -749,7 +755,7 @@ Total time:
     Virtual:                                                              
 
        2Ag     0.066154     2B1u    0.110918     3Ag     0.343264  
-       1B2u    0.352498     1B3u    0.352498     1B3g    0.355141  
+       1B3u    0.352498     1B2u    0.352498     1B3g    0.355141  
        1B2g    0.355141     3B1u    0.375002     4Ag     1.354577  
        4B1u    1.391560     5Ag     2.607811     2B2u    2.614834  
        2B3u    2.614834     2B3g    2.616618     2B2g    2.616618  
@@ -766,12 +772,12 @@ Total time:
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.7923958174323218
-    Two-Electron Energy =                   4.5791820431957948
-    DFT Exchange-Correlation Energy =      -2.1174764010012446
+    One-Electron Energy =                  -8.7923958174323271
+    Two-Electron Energy =                   4.5791820431958037
+    DFT Exchange-Correlation Energy =      -2.1174764010012428
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0238582087067217
-    Total Energy =                         -5.7776547579410504
+    Total Energy =                         -5.7776547579410451
 
 
 
@@ -792,19 +798,19 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Fri Apr  6 15:07:13 2018
+*** tstop() called on simien at Sat Apr  7 11:11:49 2018
 Module time:
-	user time   =       1.16 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.53 seconds =       0.06 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       3.25 seconds =       0.05 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 	BLYP-NL custom b .................................................PASSED
 
 *** tstart() called on simien
-*** at Fri Apr  6 15:07:13 2018
+*** at Sat Apr  7 11:11:49 2018
 
    => Loading Basis Set <=
 
@@ -819,7 +825,7 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RKS Reference
-                        2 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -943,8 +949,8 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
     J tasked:                  Yes
     K tasked:                   No
     wK tasked:                  No
-    OpenMP threads:              2
-    Integrals threads:           2
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Algorithm:                Core
     Integral Cache:           NONE
@@ -970,13 +976,13 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   6.98061e-03 
-   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   1.20136e-03 
-   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   5.03167e-04 DIIS
-   @DF-RKS iter   3:    -5.76866030480162   -5.88375e-06   5.42132e-06 DIIS
-   @DF-RKS iter   4:    -5.76866030532114   -5.19527e-10   2.29250e-08 DIIS
-   @DF-RKS iter   5:    -5.76866030532115   -9.76996e-15   6.99461e-10 DIIS
-   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   7.41676e-12 DIIS
+   @DF-RKS iter   0:    -5.76659528067618   -5.76660e+00   5.08341e-03 
+   @DF-RKS iter   1:    -5.76863051510804   -2.03523e-03   9.91993e-04 
+   @DF-RKS iter   2:    -5.76865442104860   -2.39059e-05   4.29102e-04 DIIS
+   @DF-RKS iter   3:    -5.76866030480161   -5.88375e-06   4.11363e-06 DIIS
+   @DF-RKS iter   4:    -5.76866030532114   -5.19525e-10   1.85042e-08 DIIS
+   @DF-RKS iter   5:    -5.76866030532115   -1.15463e-14   5.30742e-10 DIIS
+   @DF-RKS iter   6:    -5.76866030532115   -8.88178e-16   6.32512e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -1007,12 +1013,12 @@ SCF: VV10_C not specified. Using default (C=0.0093)!
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.5291772085899999
-    One-Electron Energy =                  -8.7921415374883374
-    Two-Electron Energy =                   4.5786826871901276
-    DFT Exchange-Correlation Energy =      -2.1172310142772126
+    One-Electron Energy =                  -8.7921415374883303
+    Two-Electron Energy =                   4.5786826871901223
+    DFT Exchange-Correlation Energy =      -2.1172310142772108
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0328523506642702
-    Total Energy =                         -5.7686603053211529
+    Total Energy =                         -5.7686603053211494
 
 
 
@@ -1033,15 +1039,265 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on simien at Fri Apr  6 15:07:14 2018
+*** tstop() called on simien at Sat Apr  7 11:11:50 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
+	user time   =       1.00 seconds =       0.02 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.66 seconds =       0.08 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       4.25 seconds =       0.07 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 	BLYP + custom VV10 ENERGY.........................................PASSED
+
+*** tstart() called on simien
+*** at Sat Apr  7 11:11:50 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    50 file /usr/qc/psi4.dev/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          HE          0.000000000000     0.000000000000    -2.000000000000     4.002603254150
+          HE          0.000000000000     0.000000000000     2.000000000000     4.002603254150
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.52646  C =      0.52646 [cm^-1]
+  Rotational constants: A = ************  B =  15782.82223  C =  15782.82223 [MHz]
+  Nuclear repulsion =    0.529177208590000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 10
+    Number of basis function: 18
+    Number of Cartesian functions: 18
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFT Potential <==
+
+   => Composite Functional: BLYP-NL <= 
+
+    BLYP GGA Exchange-Correlation Functional
+
+    P.J. Stephens et. al., J. Phys. Chem., 98, 11623-11627, 1994
+    B. Miehlich et. al., Chem. Phys. Lett., 157(3), 200-206 1989
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000     XC_GGA_X_B88
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_LYP
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     4.0000E+00
+    VV10 C              =     9.3000E-03
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45300
+    Total Blocks        =            418
+    Max Points          =            251
+    Max Functions       =             18
+
+   => -NL: Empirical Dispersion <=
+
+    Grimme's -NL (DFT plus  VV10 correlation) 
+    Hujo, W.; Grimme, S; (2011), J. Chem. Theory Comput.; 7:3866 
+
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry HE         line    39 file /usr/qc/psi4.dev/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       0       0       0       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        5       5       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      18      18       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: DEF2-QZVPP-JKFIT
+    Number of shells: 18
+    Number of basis function: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.5587581359E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:    -5.79946701401163   -5.79947e+00   5.09802e-03 
+   @DF-RKS iter   1:    -5.80148640702211   -2.01939e-03   9.39222e-04 
+   @DF-RKS iter   2:    -5.80150787282042   -2.14658e-05   4.07065e-04 DIIS
+   @DF-RKS iter   3:    -5.80151316857890   -5.29576e-06   3.73723e-06 DIIS
+   @DF-RKS iter   4:    -5.80151316900894   -4.30040e-10   1.93456e-08 DIIS
+   @DF-RKS iter   5:    -5.80151316900895   -1.24345e-14   5.02251e-10 DIIS
+   @DF-RKS iter   6:    -5.80151316900895    1.77636e-15   6.04372e-12 DIIS
+  ==> calculating VV10 correction on post-scf density <==
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.583599     1B1u   -0.583142  
+
+    Virtual:                                                              
+
+       2Ag     0.060873     2B1u    0.105528     3Ag     0.338093  
+       1B2u    0.347313     1B3u    0.347313     1B3g    0.349955  
+       1B2g    0.349955     3B1u    0.369831     4Ag     1.349146  
+       4B1u    1.386091     5Ag     2.602267     2B2u    2.609289  
+       2B3u    2.609289     2B3g    2.611073     2B2g    2.611073  
+       5B1u    2.625534  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:    -5.76865979261560
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.5291772085899999
+    One-Electron Energy =                  -8.7928445147714598
+    Two-Electron Energy =                   4.5800423706621398
+    DFT Exchange-Correlation Energy =      -2.1178882334785185
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0328533763822404
+    Total Energy =                         -5.7686597926155994
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on simien at Sat Apr  7 11:11:51 2018
+Module time:
+	user time   =       0.90 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.15 seconds =       0.09 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	BLYP-NL postscf...................................................PASSED
+	BLYP-NL postscf2..................................................PASSED
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dft-vv10/ref_outputs/blyp-scnl.ref
+++ b/tests/dft-vv10/ref_outputs/blyp-scnl.ref
@@ -1,0 +1,832 @@
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+           --- An Ab Initio, DFT and Semiempirical electronic structure package ---
+
+                  #######################################################
+                  #                        -***-                        #
+                  #  Department of molecular theory and spectroscopy    #
+                  #              Directorship: Frank Neese              #
+                  # Max Planck Institute for Chemical Energy Conversion #
+                  #                  D-45470 Muelheim/Ruhr              #
+                  #                       Germany                       #
+                  #                                                     #
+                  #                  All rights reserved                #
+                  #                        -***-                        #
+                  #######################################################
+
+
+                         Program Version 4.0.1 -  RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Properties
+   Michael Atanasov       : Ab Initio Ligand Field Theory
+   Ute Becker             : Parallelization
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : SCF Hessian
+   Vijay G. Chilkuri      : MRCI spin determinant printing
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Yang Guo               : DLPNO-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, MP2 Hessian
+   Martin Krupicka        : AUTO-CI
+   Dagmar Lenk            : GEPOL surface
+   Dimitrios Liakos       : Extrapolation schemes; parallel MDCI
+   Dimitrios Manganas     : ROCIS; embedding schemes
+   Dimitrios Pantazis     : SARC Basis sets
+   Taras Petrenko         : DFT Hessian,TD-DFT gradient, ASA, ECA, R-Raman, ABS, FL, XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Tobias Risthaus        : Range-separated hybrids, TD-DFT gradient, RPA, STAB
+   Michael Roemelt        : Restricted open shell CIS
+   Masaaki Saitow         : Open-shell DLPNO
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence, NEVPT2, FIC-MRCI
+   Georgi Stoychev        : AutoAux
+   Boris Wezisla          : Elementary symmetry handling
+   Frank Wennmohs         : Technical directorship
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse,             : VdW corrections, initial TS optimization,
+                  C. Bannwarth                     DFT functionals, gCP, sTDA/sTD-DF
+   Ed Valeev                                     : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Andreas Klamt, Michael Diedenhofen            : otool_cosmo (COSMO solvation model)
+   Jiri Pittner, Ondrej Demel                    : Mk-CCSD
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+
+
+Your calculation utilizes the DFT-NL dispersion correction.
+Cite in your paper:
+Vydrov, O. A.; Van Voorhis, T. J. Chem. Phys. 2010, 133, 244103
+Hujo, W.; Grimme, S. J. Chem. Theory Comput. 2011, 7, 3866 
+   
+
+Your calculation utilizes the basis: aug-cc-pVDZ 
+    H, B-Ne : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              R. A. Kendall, T. H. Dunning, Jr., R. J. Harrison, J. Chem. Phys. 96, 6796 (1992)
+         He : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 100, 2975 (1994)
+  Li-Be, Na : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              B. P. Prascher, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., A. K. Wilson, Theor. Chem. Acc. 128, 69 (2011)
+         Mg : Obtained from the Peterson Research Group Website (tyr0.chem.wsu.edu/~kipeters) Feb. 2017
+              B. P. Prascher, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., A. K. Wilson, Theor. Chem. Acc. 128, 69 (2011)
+      Al-Ar : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              D. E. Woon, T. H. Dunning, Jr., J. Chem. Phys. 98, 1358 (1993)
+      Sc-Zn : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 123, 064107 (2005)
+              N. B. Balabanov, K. A. Peterson, J. Chem. Phys. 125, 074110 (2006)
+      Ga-Kr : Obtained from the ccRepo (grant-hill.group.shef.ac.uk/ccrepo) Feb. 2017
+              A. K. Wilson, D. E. Woon, K. A. Peterson, T. H. Dunning, Jr., J. Chem. Phys. 110, 7667 (1999)
+
+Your calculation utilizes the auxiliary basis: def2/J
+   F. Weigend, Phys. Chem. Chem. Phys. 8, 1057 (2006).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+Warning: TCutStore was < 0. Adjusted to Thresh (uncritical)
+
+INFO   : the flag for use of LIBINT has been found!
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = orca.in
+|  1> ! BLYP SCNL TightSCF  aug-cc-pVDZ vdwgrid3
+|  2> *xyz 0 1
+|  3>   He 0 0 -2.0
+|  4>   He 0 0  2.0
+|  5> *
+|  6> 
+|  7>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  He     0.000000    0.000000   -2.000000
+  He     0.000000    0.000000    2.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 He    2.0000    0     4.003    0.000000    0.000000   -3.779452
+   1 He    2.0000    0     4.003    0.000000    0.000000    3.779452
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ He     0   0   0     0.000000000000     0.00000000     0.00000000
+ He     1   0   0     4.000000000000     0.00000000     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ He     0   0   0     0.000000000000     0.00000000     0.00000000
+ He     1   0   0     7.558904535685     0.00000000     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type He  : 5s2p contracted to 3s2p pattern {311/11}
+
+Atom   0He   basis set group =>   1
+Atom   1He   basis set group =>   1
+-------------------------------
+AUXILIARY BASIS SET INFORMATION
+-------------------------------
+There are 1 groups of distinct atoms
+
+ Group   1 Type He  : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0He   basis set group =>   1
+Atom   1He   basis set group =>   1
+
+Checking for AutoStart:
+The File: orca.gbw exists
+Trying to determine its content:
+     ... Fine, the file contains calculation information
+     ... Fine, the calculation information was read
+     ... Fine, the file contains a basis set
+     ... Fine, the basis set was read
+     ... Fine, the file contains a geometry
+     ... Fine, the geometry was read
+     ... Fine, the file contains a set of orbitals
+     ... Fine, the orbitals can be read
+     => possible old guess file was deleted
+     => GBW file was renamed to GES file
+     => GES file is set as startup file
+     => Guess is set to MORead
+     ... now leaving AutoStart
+
+------------------------------------------------------------------------------
+                           ORCA GTO INTEGRAL CALCULATION
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+
+                         BASIS SET STATISTICS AND STARTUP INFO
+
+Gaussian basis set:
+ # of primitive gaussian shells          ...   14
+ # of primitive gaussian functions       ...   22
+ # of contracted shells                  ...   10
+ # of contracted basis functions         ...   18
+ Highest angular momentum                ...    1
+ Maximum contraction depth               ...    3
+Auxiliary gaussian basis set:
+ # of primitive gaussian shells          ...   16
+ # of primitive gaussian functions       ...   32
+ # of contracted shells                  ...   10
+ # of contracted aux-basis functions     ...   22
+ Highest angular momentum                ...    2
+ Maximum contraction depth               ...    3
+Ratio of auxiliary to basis functions    ...  1.22
+Integral package used                  ... LIBINT
+ One Electron integrals                  ... done
+ Ordering auxiliary basis shells         ... done
+ Integral threshhold             Thresh  ...  2.500e-11
+ Primitive cut-off               TCut    ...  2.500e-12
+ Pre-screening matrix                    ... done
+ Shell pair data                         ... 
+ Ordering of the shell pairs             ... done (   0.000 sec) 51 of 55 pairs
+ Determination of significant pairs      ... done (   0.000 sec)
+ Creation of shell pair data             ... done (   0.000 sec)
+ Storage of shell pair data              ... done (   0.000 sec)
+ Shell pair data done in (   0.000 sec)
+ Computing two index integrals           ... done
+ Cholesky decomposition of the V-matrix  ... done
+
+
+Timings:
+ Total evaluation time                   ...   0.119 sec (  0.002 min)
+ One electron matrix time                ...   0.004 sec (  0.000 min) =  3.1%
+ Schwartz matrix evaluation time         ...   0.096 sec (  0.002 min) = 80.8%
+ Two index repulsion integral time       ...   0.000 sec (  0.000 min) =  0.0%
+ Cholesky decomposition of V             ...   0.000 sec (  0.000 min) =  0.1%
+ Three index repulsion integral time     ...   0.000 sec (  0.000 min) =  0.0%
+
+-------------------------------------------------------------------------------
+                                 ORCA SCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+ Exchange Functional    Exchange        .... B88
+   X-Alpha parameter    XAlpha          ....  0.666667
+   Becke's b parameter  XBeta           ....  0.004200
+ Correlation Functional Correlation     .... LYP
+ Gradients option       PostSCFGGA      .... off
+   NL short-range parameter             ....  4.000000
+ RI-approximation to the Coulomb term is turned on
+   Number of auxiliary basis functions  .... 22
+
+
+General Settings:
+ Integral files         IntName         .... orca
+ Hartree-Fock type      HFTyp           .... RHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    1
+ Number of Electrons    NEL             ....    4
+ Basis Dimension        Dim             ....   18
+ Nuclear Repulsion      ENuc            ....      0.5291772083 Eh
+
+Convergence Acceleration:
+ DIIS                   CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ Newton-Raphson         CNVNR           .... off
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+ Fernandez-Rico         CNVRico         .... off
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... LIBINT
+ Reset frequeny         DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.559e-01
+Time for diagonalization                   ...    0.000 sec
+Threshold for overlap eigenvalues          ... 1.000e-08
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.000 sec
+
+---------------------
+INITIAL GUESS: MOREAD
+---------------------
+Guess MOs are being read from file: orca.ges
+Input Geometry matches current geometry (good)
+Input basis set matches current basis set (good)
+MOs were renormalized
+MOs were reorthogonalized (Cholesky)
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-110
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   1568 (   0.0 sec)
+# of grid points (after weights+screening)   ...   1560 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     1560
+Total number of batches                      ...       26
+Average number of points per batch           ...       60
+Average number of grid points per atom       ...      780
+Average number of shells per batch           ...     7.85 (78.52%)
+Average number of basis functions per batch  ...    13.78 (76.54%)
+Average number of large shells per batch     ...     7.19 (91.51%)
+Average number of large basis fcns per batch ...    12.81 (93.01%)
+Maximum spatial batch extension              ...  24.28, 24.28, 16.76 au
+Average spatial batch extension              ...   8.36,  9.27,  7.24 au
+
+
+Setting up the DFT-NL grid :
+
+General Integration Accuracy     IntAcc      ...  4.340
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-194
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   3016 (   0.0 sec)
+# of grid points (after weights+screening)   ...   3008 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     3008
+Total number of batches                      ...       48
+Average number of points per batch           ...       62
+Average number of grid points per atom       ...     1504
+Average number of shells per batch           ...     8.06 (80.61%)
+Average number of basis functions per batch  ...    14.18 (78.80%)
+Average number of large shells per batch     ...     6.82 (84.56%)
+Average number of large basis fcns per batch ...    12.24 (86.33%)
+Maximum spatial batch extension              ...  14.76, 24.28, 16.19 au
+Average spatial batch extension              ...   5.65,  6.12,  6.65 au
+
+Time for grid setup =    0.012 sec
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP      [F,P]     Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0     -5.80194395  -5.8019439505  0.000312  0.000312  0.000566  0.000057
+               *** Restarting incremental Fock matrix formation ***
+  1     -5.80194441  -0.0000004623  0.000116  0.000060  0.000191  0.000021
+  2     -5.80194443  -0.0000000205  0.000030  0.000018  0.000039  0.000004
+                 **** Energy Check signals convergence ****
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   3 CYCLES          *
+               *****************************************************
+
+Final grid after self-consistent DFT-NL
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :           -5.80194444 Eh            -157.87893 eV
+
+Components:
+Nuclear Repulsion  :            0.52917721 Eh              14.39964 eV
+Electronic Energy  :           -6.33112164 Eh            -172.27858 eV
+One Electron Energy:           -8.79347162 Eh            -239.28253 eV
+Two Electron Energy:            2.46234998 Eh              67.00395 eV
+
+Virial components:
+Potential Energy   :          -11.46926442 Eh            -312.09455 eV
+Kinetic Energy     :            5.66731999 Eh             154.21562 eV
+Virial Ratio       :            2.02375452
+
+
+DFT components:
+N(Alpha)           :        2.001242985710 electrons
+N(Beta)            :        2.001242985710 electrons
+N(Total)           :        4.002485971420 electrons
+E(X)               :       -2.031356324055 Eh       
+E(C)               :       -0.087429804685 Eh       
+E(XC)              :       -2.118786128741 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -2.1841e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    4.3631e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    5.5786e-07  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    1.9827e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    2.8156e-06  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (orca.gbw) ****
+             **** DENSITY FILE WAS UPDATED (orca.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (orca.en.tmp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -0.583498       -15.8778 
+   1   2.0000      -0.583039       -15.8653 
+   2   0.0000       0.063848         1.7374 
+   3   0.0000       0.108727         2.9586 
+   4   0.0000       0.337155         9.1745 
+   5   0.0000       0.349217         9.5027 
+   6   0.0000       0.349217         9.5027 
+   7   0.0000       0.351804         9.5731 
+   8   0.0000       0.351804         9.5731 
+   9   0.0000       0.368875        10.0376 
+  10   0.0000       1.349377        36.7184 
+  11   0.0000       1.386545        37.7298 
+  12   0.0000       2.602358        70.8138 
+  13   0.0000       2.609887        71.0186 
+  14   0.0000       2.609887        71.0186 
+  15   0.0000       2.611658        71.0668 
+  16   0.0000       2.611658        71.0668 
+  17   0.0000       2.625693        71.4487 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 He:   -0.000000
+   1 He:    0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Hes       :     2.000002  s :     2.000002
+      pz      :    -0.000002  p :    -0.000002
+      px      :     0.000000
+      py      :     0.000000
+  1 Hes       :     2.000002  s :     2.000002
+      pz      :    -0.000002  p :    -0.000002
+      px      :     0.000000
+      py      :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 He:    0.000000
+   1 He:   -0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Hes       :     1.999996  s :     1.999996
+      pz      :     0.000004  p :     0.000004
+      px      :     0.000000
+      py      :     0.000000
+  1 Hes       :     1.999996  s :     1.999996
+      pz      :     0.000004  p :     0.000004
+      px      :     0.000000
+      py      :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 He     2.0000     2.0000    -0.0000    -0.0002    -0.0002     0.0000
+  1 He     2.0000     2.0000     0.0000    -0.0002    -0.0002     0.0000
+
+  Mayer bond orders larger than 0.1
+
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 0 sec 
+
+Total time                  ....       0.329 sec
+Sum of individual times     ....       0.326 sec  ( 99.3%)
+
+Fock matrix formation       ....       0.314 sec  ( 95.4%)
+  Split-RI-J                ....       0.300 sec  ( 95.7% of F)
+  XC integration            ....       0.012 sec  (  3.9% of F)
+    Basis function eval.    ....       0.004 sec  ( 32.8% of XC)
+    Density eval.           ....       0.002 sec  ( 16.6% of XC)
+    XC-Functional eval.     ....       0.004 sec  ( 34.2% of XC)
+    XC-Potential eval.      ....       0.001 sec  (  7.3% of XC)
+Diagonalization             ....       0.000 sec  (  0.1%)
+Density matrix formation    ....       0.000 sec  (  0.0%)
+Population analysis         ....       0.000 sec  (  0.1%)
+Initial guess               ....       0.000 sec  (  0.0%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.000 sec  (  0.0%)
+SOSCF solution              ....       0.001 sec  (  0.2%)
+Grid generation             ....       0.012 sec  (  3.5%)
+
+
+
+-------------------------------------------------------------------------------
+              Self-consistent DFT-NL dispersion correction                     
+-------------------------------------------------------------------------------
+
+
+--------------
+SCF ITERATIONS
+--------------
+ITER       Energy         Delta-E        Max-DP      RMS-DP        Damp
+               ***  Starting incremental Fock matrix formation  ***
+                      *** Initiating the SOSCF procedure ***
+                      *** Re-Reading the Fockian *** 
+                      *** Removing any level shift *** 
+ITER      Energy       Delta-E        Grad      Rot      Max-DP    RMS-DP
+  0     -5.76909083   0.0328536066  0.000326  0.000326  0.000693  0.000073
+               *** Restarting incremental Fock matrix formation ***
+  1     -5.76909124  -0.0000004103  0.000192  0.000146  0.000357  0.000033
+  2     -5.76909126  -0.0000000229  0.000087  0.000046  0.000112  0.000010
+                  ***Gradient check signals convergence***
+              ***Rediagonalizing the Fockian in SOSCF/NRSCF***
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER   3 CYCLES          *
+               *****************************************************
+
+Setting up the final grid:
+
+General Integration Accuracy     IntAcc      ...  4.670
+Radial Grid Type                 RadialGrid  ... Gauss-Chebyshev
+Angular Grid (max. acc.)         AngularGrid ... Lebedev-302
+Angular grid pruning method      GridPruning ... 3 (G Style)
+Weight generation scheme         WeightScheme... Becke
+Basis function cutoff            BFCut       ...    1.0000e-11
+Integration weight cutoff        WCut        ...    1.0000e-14
+Grids for H and He will be reduced by one unit
+
+# of grid points (after initial pruning)     ...   7124 (   0.0 sec)
+# of grid points (after weights+screening)   ...   7114 (   0.0 sec)
+nearest neighbour list constructed           ...    0.0 sec
+Grid point re-assignment to atoms done       ...    0.0 sec
+Grid point division into batches done        ...    0.0 sec
+Reduced shell lists constructed in    0.0 sec
+
+Total number of grid points                  ...     7114
+Total number of batches                      ...      112
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     3557
+Average number of shells per batch           ...     7.59 (75.93%)
+Average number of basis functions per batch  ...    13.29 (73.84%)
+Average number of large shells per batch     ...     6.45 (84.97%)
+Average number of large basis fcns per batch ...    11.42 (85.95%)
+Maximum spatial batch extension              ...  25.05, 19.70, 17.02 au
+Average spatial batch extension              ...   4.42,  4.39,  4.09 au
+
+Final grid set up in    0.0 sec
+Final integration                            ... done (   0.2 sec)
+Change in XC energy                          ...     0.000605369
+Integrated number of electrons               ...     3.999999163
+Previous integrated no of electrons          ...     4.002485992
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :           -5.76848593 Eh            -156.96848 eV
+
+Components:
+Nuclear Repulsion  :            0.52917721 Eh              14.39964 eV
+Electronic Energy  :           -6.29766314 Eh            -171.36813 eV
+One Electron Energy:           -8.79278071 Eh            -239.26373 eV
+Two Electron Energy:            2.49511758 Eh              67.89560 eV
+
+Virial components:
+Potential Energy   :          -11.43304757 Eh            -311.10904 eV
+Kinetic Energy     :            5.66456165 Eh             154.14056 eV
+Virial Ratio       :            2.01834639
+
+
+DFT components:
+N(Alpha)           :        1.999999581653 electrons
+N(Beta)            :        1.999999581653 electrons
+N(Total)           :        3.999999163306 electrons
+E(X)               :       -2.030122835588 Eh       
+E(C)               :       -0.087449427039 Eh       
+NL Energy, E(C,NL) :        0.032852665973 Eh       
+E(XC)              :       -2.084719596653 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...   -3.3698e-08  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    8.8523e-09  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    1.4672e-09  Tolerance :   5.0000e-09
+  Last Orbital Gradient      ...    2.0470e-08  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    7.0352e-09  Tolerance :   1.0000e-05
+
+             **** THE GBW FILE WAS UPDATED (orca.gbw) ****
+             **** DENSITY FILE WAS UPDATED (orca.scfp.tmp) ****
+             **** ENERGY FILE WAS UPDATED (orca.en.tmp) ****
+----------------
+ORBITAL ENERGIES
+----------------
+
+  NO   OCC          E(Eh)            E(eV) 
+   0   2.0000      -0.575295       -15.6546 
+   1   2.0000      -0.574834       -15.6420 
+   2   0.0000       0.071365         1.9419 
+   3   0.0000       0.116380         3.1669 
+   4   0.0000       0.344668         9.3789 
+   5   0.0000       0.356736         9.7073 
+   6   0.0000       0.356736         9.7073 
+   7   0.0000       0.359324         9.7777 
+   8   0.0000       0.359324         9.7777 
+   9   0.0000       0.376403        10.2425 
+  10   0.0000       1.357344        36.9352 
+  11   0.0000       1.394567        37.9481 
+  12   0.0000       2.610508        71.0355 
+  13   0.0000       2.618038        71.2404 
+  14   0.0000       2.618038        71.2404 
+  15   0.0000       2.619809        71.2886 
+  16   0.0000       2.619809        71.2886 
+  17   0.0000       2.633837        71.6704 
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+-----------------------
+MULLIKEN ATOMIC CHARGES
+-----------------------
+   0 He:    0.000000
+   1 He:   -0.000000
+Sum of atomic charges:    0.0000000
+
+--------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES
+--------------------------------
+  0 Hes       :     2.000002  s :     2.000002
+      pz      :    -0.000002  p :    -0.000002
+      px      :     0.000000
+      py      :     0.000000
+  1 Hes       :     2.000002  s :     2.000002
+      pz      :    -0.000002  p :    -0.000002
+      px      :     0.000000
+      py      :     0.000000
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+----------------------
+LOEWDIN ATOMIC CHARGES
+----------------------
+   0 He:    0.000000
+   1 He:   -0.000000
+
+-------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES
+-------------------------------
+  0 Hes       :     1.999996  s :     1.999996
+      pz      :     0.000004  p :     0.000004
+      px      :     0.000000
+      py      :     0.000000
+  1 Hes       :     1.999996  s :     1.999996
+      pz      :     0.000004  p :     0.000004
+      px      :     0.000000
+      py      :     0.000000
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 He     2.0000     2.0000     0.0000    -0.0002    -0.0002     0.0000
+  1 He     2.0000     2.0000    -0.0000    -0.0002    -0.0002     0.0000
+
+  Mayer bond orders larger than 0.1
+
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+
+Total time                  ....       1.395 sec
+Sum of individual times     ....       1.392 sec  ( 99.8%)
+
+Fock matrix formation       ....       1.366 sec  ( 98.0%)
+  Split-RI-J                ....       0.297 sec  ( 21.7% of F)
+  XC integration            ....       1.068 sec  ( 78.2% of F)
+    Basis function eval.    ....       0.027 sec  (  2.6% of XC)
+    Density eval.           ....       0.009 sec  (  0.8% of XC)
+    XC-Functional eval.     ....       1.024 sec  ( 95.8% of XC)
+    XC-Potential eval.      ....       0.003 sec  (  0.3% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.000 sec  (  0.0%)
+Population analysis         ....       0.000 sec  (  0.0%)
+Initial guess               ....       0.000 sec  (  0.0%)
+Orbital Transformation      ....       0.000 sec  (  0.0%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.000 sec  (  0.0%)
+SOSCF solution              ....       0.000 sec  (  0.0%)
+Grid generation             ....       0.025 sec  (  1.8%)
+
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY        -5.768485927187
+-------------------------   --------------------
+
+
+                            ***************************************
+                            *     ORCA property calculations      *
+                            ***************************************
+
+                                    ---------------------
+                                    Active property flags
+                                    ---------------------
+   (+) Dipole Moment
+
+
+------------------------------------------------------------------------------
+                       ORCA ELECTRIC PROPERTIES CALCULATION
+------------------------------------------------------------------------------
+
+Dipole Moment Calculation                       ... on
+Quadrupole Moment Calculation                   ... off
+Polarizability Calculation                      ... off
+GBWName                                         ... orca.gbw
+Electron density file                           ... orca.scfp.tmp
+The origin for moment calculation is the CENTER OF MASS  = ( 0.000000,  0.000000  0.000000)
+
+-------------
+DIPOLE MOMENT
+-------------
+                                X             Y             Z
+Electronic contribution:      0.00000      -0.00000       0.00000
+Nuclear contribution   :      0.00000       0.00000       0.00000
+                        -----------------------------------------
+Total Dipole Moment    :      0.00000      -0.00000       0.00000
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.00000
+Magnitude (Debye)      :      0.00000
+
+
+Timings for individual modules:
+
+Sum of individual times         ...        1.873 sec (=   0.031 min)
+GTO integral calculation        ...        0.137 sec (=   0.002 min)   7.3 %
+SCF iterations                  ...        1.735 sec (=   0.029 min)  92.7 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 1 seconds 967 msec


### PR DESCRIPTION
## Description
DFT-NL (=non-local) adds the VV10 correlation energy to arbitrary DFT functionals using functional specific  vv10_b parameter. Conceptually similar to DFT-D. DOI: 10.1021/ct200644w

Fixes https://github.com/psi4/psi4/issues/870


* **User-Facing for Release Notes**
  - [x] SCF option `DFT_VV10_B` enables and adds VV10 correlation according to DFT-NL scheme (fixed `vv10_c`, user-supplied `vv10_b`). 
  - [x] `DFT_VV10_C` also gives access to the C parameter.
  - [x] `NL_DISPERSION_PARAMETERS` similar to `DFT_DISPERSION_PARAMETERS`
  - [x] `energy('functional-nl')` sets pre-defined vv10_b parameters for over 15 functionals. Recommended usage for most users.
  - [X] `DFT_VV10_POSTSCF` enables a post-scf VV10 calculation. Large gain in speed with minimal loss of VV10 correlation energy.
  - [x] added documentation. 

* **Developer notes**
  - [x] rebase+adjustment to PR https://github.com/psi4/psi4/pull/922
  - [x] figure out DSD variant and param citations
  - [x] re-integrate tests

* ** Notes**
   * forcing pure HF with VV10  will seg. fault. (no integration grid). Only `energy('hf')` with `set DFT_VV10_B` is caught, not `energy('scf')` to allow custom access to the scf.
   * NL parameters were entered manually, someone please check over them for strange values or typos
   * tests are kept short, but we also don't test every dispersion dash parameter out there.
   * for double-hybrids with multiple versions, the frozen core and/or D3BJ parent variant was chosen for a sensible consistency. 

## Status
- [x] Ready to go
