### PR TITLE
Workaround for icc 18 crash

### DIFF
--- a/psi4/src/psi4/dcft/CMakeLists.txt
+++ b/psi4/src/psi4/dcft/CMakeLists.txt
@@ -1,2 +1,13 @@
 set(sources_list dcft_lambda_UHF.cc main.cc AO_contribute.cc dcft.cc dcft_gradient.cc dcft_density_UHF.cc dcft_integrals_UHF.cc dcft_tau_UHF.cc dcft_oo_UHF.cc dcft_qc.cc half_transform.cc dcft_compute.cc dcft_compute_UHF.cc dcft_compute_RHF.cc dcft_scf_UHF.cc dcft_memory.cc dcft_n_representability.cc dcft_mp2_UHF.cc dcft_triples.cc dcft_intermediates_UHF.cc dcft_energy_RHF.cc dcft_energy_UHF.cc dcft_gradient_RHF.cc dcft_gradient_UHF.cc dcft_integrals_RHF.cc dcft_intermediates_RHF.cc dcft_lambda_RHF.cc dcft_mp2_RHF.cc dcft_oo_RHF.cc dcft_scf_RHF.cc dcft_tau_RHF.cc dcft_density_RHF.cc dcft_sort_mo_tpdm.cc dcft_df_tensor.cc)
+
+# See https://github.com/psi4/psi4/issues/923
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.1 AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18.0)
+
+    message(WARNING "Intel C++ (ICC) 18.0 fails to compile dcft_gradient_UHF.cc with aggressive optimization flags")
+    set_source_files_properties(dcft_gradient_UHF.cc PROPERTIES
+        COMPILE_FLAGS -O1)
+endif ()
+
 psi4_add_module(bin dcft sources_list mints diis)


### PR DESCRIPTION
This adds a CMAke patch to lower the optimization flags for a particular file to work around a compiler crash icc 18.0.1 discussed in #923.