### PR TITLE
SCF NumPy restart files

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -242,14 +242,17 @@ if args["verbose"]:
     psi4.core.print_out('-' * 75)
 
 # Handle Messy
+_clean_functions = [psi4.core.clean, psi4.extras.clean_numpy_files]
 if args["messy"]:
 
     if sys.version_info >= (3, 0):
-        atexit.unregister(psi4.core.clean)
+        for func in _clean_functions:
+            atexit.unregister(func)
     else:
         for handler in atexit._exithandlers:
-            if handler[0] == psi4.core.clean:
-                atexit._exithandlers.remove(handler)
+            for func in _clean_functions:
+                if handler[0] == func: 
+                    atexit._exithandlers.remove(handler)
 
 # Register exit printing, failure GOTO coffee ELSE beer
 atexit.register(psi4.extras.exit_printing)


### PR DESCRIPTION
## Description
Adds NumPy file to the `messy` flag and ensures that those files are correctly parsed through the restart renaming.

File names are going haywire a bit with different conventions for either PSIO or "user facing names" like Molden and cube files. Anyone have a good idea how to rectify this? It would also be good to have restart work for gradients, Hessians, and properties as well. Ill add this to the wish ilst.

## Status
- [x] Ready to go