### PR TITLE
CI: Turns off v2RDM and PCM in Travis until conda modules are updated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,9 +167,9 @@ before_script:
     -DENABLE_libefp=ON
     -DENABLE_erd=ON
     -DENABLE_gdma=ON
-    -DENABLE_PCMSolver=ON
+    -DENABLE_PCMSolver=OFF
     -DENABLE_simint=ON
-    -DENABLE_v2rdm_casscf=ON
+    -DENABLE_v2rdm_casscf=OFF
     -DENABLE_snsmp2=ON
     -DENABLE_PLUGIN_TESTING=ON
     -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install


### PR DESCRIPTION
## Description
Switches off a few dependancies until they can be updated on the conda channel. Travis CI is hitting time limits fairly frequently when building these.

## Status
- [x] Ready to go
