### PR TITLE
Some ECP fixes.

### DIFF
--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -468,7 +468,7 @@ def nbody_gufunc(func, method_string, **kwargs):
         ret_ptype = ret_energy
 
     # Build and set a wavefunction
-    wfn = core.Wavefunction.build(molecule, 'sto-3g')
+    wfn = core.Wavefunction.build(molecule, 'def2-svp')
     wfn.nbody_energy = energies_dict
     wfn.nbody_ptype = ptype_dict
     wfn.nbody_body_energy = energy_body_dict

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -468,7 +468,7 @@ def nbody_gufunc(func, method_string, **kwargs):
         ret_ptype = ret_energy
 
     # Build and set a wavefunction
-    wfn = core.Wavefunction.build(molecule)
+    wfn = core.Wavefunction.build(molecule, 'sto-3g')
     wfn.nbody_energy = energies_dict
     wfn.nbody_ptype = ptype_dict
     wfn.nbody_body_energy = energy_body_dict

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -468,7 +468,7 @@ def nbody_gufunc(func, method_string, **kwargs):
         ret_ptype = ret_energy
 
     # Build and set a wavefunction
-    wfn = core.Wavefunction.build(molecule, 'sto-3g')
+    wfn = core.Wavefunction.build(molecule)
     wfn.nbody_energy = energies_dict
     wfn.nbody_ptype = ptype_dict
     wfn.nbody_body_energy = energy_body_dict

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -150,7 +150,7 @@ class BasisSet(object):
             isinstance(args[0], basestring) and \
             isinstance(args[1], Molecule) and \
             isinstance(args[2], OrderedDict) and \
-            args[3] == True:
+            isinstance(args[3], bool):
             self.constructor_role_mol_shellmap(*args)
         else:
             raise ValidationError('BasisSet::constructor: Inappropriate configuration of constructor arguments')

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -352,7 +352,7 @@ class BasisSet(object):
                     self.uoriginal_coefficients[tst:tsp],
                     self.uexponents[tst:tsp],
                     'Pure' if self.puream else 'Cartesian',
-                    n, xyz_ptr, bf_count, pt='Normalised' if is_ecp else 'Unnormalized',
+                    n, xyz_ptr, bf_count, pt='Normalized' if is_ecp else 'Unnormalized',
                     rpowers=rpowers[tst:tsp])
                 for thisbf in range(thisshell.nfunction()):
                     self.function_to_shell[bf_count] = shell_count

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -146,6 +146,12 @@ class BasisSet(object):
             isinstance(args[1], Molecule) and \
             isinstance(args[2], OrderedDict):
             self.constructor_role_mol_shellmap(*args)
+        elif len(args) == 4 and \
+            isinstance(args[0], basestring) and \
+            isinstance(args[1], Molecule) and \
+            isinstance(args[2], OrderedDict) and \
+            args[3] == True:
+            self.constructor_role_mol_shellmap(*args)
         else:
             raise ValidationError('BasisSet::constructor: Inappropriate configuration of constructor arguments')
 
@@ -220,7 +226,7 @@ class BasisSet(object):
         self.shells.append(ShellInfo(0, self.uoriginal_coefficients,
             self.uexponents, 'Cartesian', 0, self.xyz, 0))
 
-    def constructor_role_mol_shellmap(self, role, mol, shell_map):
+    def constructor_role_mol_shellmap(self, role, mol, shell_map, is_ecp = False):
         """The most commonly used constructor. Extracts basis set name for *role*
         from each atom of *mol*, looks up basis and role entries in the
         *shell_map* dictionary, retrieves the ShellInfo objects and returns
@@ -346,7 +352,8 @@ class BasisSet(object):
                     self.uoriginal_coefficients[tst:tsp],
                     self.uexponents[tst:tsp],
                     'Pure' if self.puream else 'Cartesian',
-                    n, xyz_ptr, bf_count, pt='Unnormalized', rpowers=rpowers[tst:tsp])
+                    n, xyz_ptr, bf_count, pt='Normalised' if is_ecp else 'Unnormalized',
+                    rpowers=rpowers[tst:tsp])
                 for thisbf in range(thisshell.nfunction()):
                     self.function_to_shell[bf_count] = shell_count
                     self.function_center[bf_count] = n
@@ -873,7 +880,7 @@ class BasisSet(object):
         for atom in ecp_atom_basis_ncore:
             ncore += ecp_atom_basis_ncore[atom]
         if ncore and key == 'BASIS':
-            ecpbasisset = BasisSet(key, mol, ecp_atom_basis_shell)
+            ecpbasisset = BasisSet(key, mol, ecp_atom_basis_shell, True)
             ecpbasisset.ecp_coreinfo = ecp_atom_basis_ncore
 
         # Construct all the one-atom BasisSet-s for mol's CoordEntry-s

--- a/psi4/driver/qcdb/libmintsbasissetparser.py
+++ b/psi4/driver/qcdb/libmintsbasissetparser.py
@@ -199,7 +199,8 @@ class Gaussian94BasisSetParser(object):
                                         1: 1,   'p': 1,   'P': 1,
                                         2: 2,   'd': 2,   'D': 2,
                                         3: 3,   'f': 3,   'F': 3,
-                                        4: 4,   'g': 4,   'G': 4}
+                                        4: 4,   'g': 4,   'G': 4,
+                                        5: 5,   'h': 5,   'H': 5}
                         # This is an ECP spec like "KR-ECP    3     28"
                         matchobj = atom_ecp.match(line)
                         sl = line.split()

--- a/psi4/driver/qcdb/libmintsgshell.py
+++ b/psi4/driver/qcdb/libmintsgshell.py
@@ -182,14 +182,10 @@ class ShellInfo(object):
         self.PYnfunction = INT_NFUNC(self.puream, self.l)
         # These are the radial factors for ECPs.  They are not defined for regular shells.
         self.rpowers = rpowers
-
         # Compute the normalization constants
         if pt == 'Unnormalized':
             self.normalize_shell()
-            if isinstance(self.rpowers, list) and sum([s if s != None else 0 for s in self.rpowers]) != 0:
-                pass
-            else:
-                self.erd_normalize_shell()
+            self.erd_normalize_shell()
         else:
             self.PYerd_coef = [0.0] * self.nprimitive() 
 

--- a/psi4/driver/qcdb/libmintsgshell.py
+++ b/psi4/driver/qcdb/libmintsgshell.py
@@ -169,7 +169,7 @@ class ShellInfo(object):
         # ERD normalized contraction coefficients (of length nprimitives_)
         self.PYerd_coef = []
         # Original (un-normalized) contraction coefficients (of length nprimitives)
-        self.PYoriginal_coef = [c[n] if c[n] > 1E-10 else c[n] + 1E-10 for n in range(len(c))]
+        self.PYoriginal_coef = [c[n] for n in range(len(c))]
         # Atom number this shell goes to. Needed when indexing integral derivatives.
         self.nc = nc
         # Atomic center number in the Molecule
@@ -186,7 +186,10 @@ class ShellInfo(object):
         # Compute the normalization constants
         if pt == 'Unnormalized':
             self.normalize_shell()
-            self.erd_normalize_shell()
+            if isinstance(self.rpowers, list) and sum([s if s != None else 0 for s in self.rpowers]) != 0:
+                pass
+            else:
+                self.erd_normalize_shell()
         else:
             self.PYerd_coef = [0.0] * self.nprimitive() 
 

--- a/psi4/driver/qcdb/libmintsgshell.py
+++ b/psi4/driver/qcdb/libmintsgshell.py
@@ -169,7 +169,7 @@ class ShellInfo(object):
         # ERD normalized contraction coefficients (of length nprimitives_)
         self.PYerd_coef = []
         # Original (un-normalized) contraction coefficients (of length nprimitives)
-        self.PYoriginal_coef = [c[n] + (1E-10)*(not c[n]) for n in range(len(c))]
+        self.PYoriginal_coef = [c[n] if c[n] > 1E-10 else c[n] + 1E-10 for n in range(len(c))]
         # Atom number this shell goes to. Needed when indexing integral derivatives.
         self.nc = nc
         # Atomic center number in the Molecule

--- a/psi4/driver/qcdb/libmintsgshell.py
+++ b/psi4/driver/qcdb/libmintsgshell.py
@@ -169,7 +169,7 @@ class ShellInfo(object):
         # ERD normalized contraction coefficients (of length nprimitives_)
         self.PYerd_coef = []
         # Original (un-normalized) contraction coefficients (of length nprimitives)
-        self.PYoriginal_coef = [c[n] for n in range(len(c))]
+        self.PYoriginal_coef = [c[n] + (1E-10)*(not c[n]) for n in range(len(c))]
         # Atom number this shell goes to. Needed when indexing integral derivatives.
         self.nc = nc
         # Atomic center number in the Molecule


### PR DESCRIPTION
## Description
Minor ECP fixes, so that more ECP's from EMSL Basis set exchange work out of the box. See issue #926 .

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Extended naming tables to include H-shell (Stuttgart-Cologne ECP's eg. for Hg need it)
  - [x] Trapping "0.0" in contraction coefficients

## Status
- [x] Ready to go
