### PR TITLE
SAPT(DFT) flexibility changes

### DIFF
--- a/psi4/driver/procrouting/sapt/__init__.py
+++ b/psi4/driver/procrouting/sapt/__init__.py
@@ -26,4 +26,4 @@
 # @END LICENSE
 #
 
-from .sapt_proc import run_sapt_dft
+from .sapt_proc import run_sapt_dft, sapt_dft

--- a/psi4/driver/procrouting/sapt/sapt_jk_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_jk_terms.py
@@ -250,7 +250,7 @@ def exchange(cache, jk, do_print=True):
     return {"Exch10(S^2)": Exch_s2, "Exch10": Exch10}
 
 
-def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True, Sinf=False):
+def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True, Sinf=False, sapt_jk_B=None):
     """
     Compute Ind20 and Exch-Ind20 quantities from a SAPT cache and JK object.
     """
@@ -523,7 +523,7 @@ def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True
         core.print_out("\n   => Coupled Induction <= \n\n")
 
         x_B_MOA, x_A_MOB = _sapt_cpscf_solve(
-            cache, jk, w_B_MOA, w_A_MOB, 20, 1.e-6)
+            cache, jk, w_B_MOA, w_A_MOB, 20, 1.e-6, sapt_jk_B=sapt_jk_B)
 
         ind_ab = 2.0 * x_B_MOA.vector_dot(w_B_MOA)
         ind_ba = 2.0 * x_A_MOB.vector_dot(w_A_MOB)
@@ -576,13 +576,16 @@ def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True
     return ret
 
 
-def _sapt_cpscf_solve(cache, jk, rhsA, rhsB, maxiter, conv):
+def _sapt_cpscf_solve(cache, jk, rhsA, rhsB, maxiter, conv, sapt_jk_B=None):
     """
     Solve the SAPT CPHF (or CPKS) equations.
     """
 
     cache["wfn_A"].set_jk(jk)
-    cache["wfn_B"].set_jk(jk)
+    if sapt_jk_B:
+        cache["wfn_B"].set_jk(sapt_jk_B)
+    else:
+        cache["wfn_B"].set_jk(jk)
 
     # Make a preconditioner function
     P_A = core.Matrix(cache["eps_occ_A"].shape[0], cache["eps_vir_A"].shape[0])

--- a/psi4/driver/procrouting/sapt/sapt_jk_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_jk_terms.py
@@ -411,28 +411,28 @@ def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True
         T_B = core.Matrix.triplet(cache["Cocc_B"], Tmo_BB, cache["Cocc_B"], False, False, True)
         T_AB = core.Matrix.triplet(cache["Cocc_A"], Tmo_AB, cache["Cocc_B"], False, False, True)
 
-        sT_A = core.Matrix.chain_dot(cache["Cvir_A"], unc_x_B_MOA, Tmo_AA, cache["Cocc_A"], 
+        sT_A = core.Matrix.chain_dot(cache["Cvir_A"], unc_x_B_MOA, Tmo_AA, cache["Cocc_A"],
             trans=[False, True, False, True])
-        sT_B = core.Matrix.chain_dot(cache["Cvir_B"], unc_x_A_MOB, Tmo_BB, cache["Cocc_B"], 
+        sT_B = core.Matrix.chain_dot(cache["Cvir_B"], unc_x_A_MOB, Tmo_BB, cache["Cocc_B"],
             trans=[False, True, False, True])
-        sT_AB = core.Matrix.chain_dot(cache["Cvir_A"], unc_x_B_MOA, Tmo_AB, cache["Cocc_B"], 
+        sT_AB = core.Matrix.chain_dot(cache["Cvir_A"], unc_x_B_MOA, Tmo_AB, cache["Cocc_B"],
             trans=[False, True, False, True])
-        sT_BA = core.Matrix.chain_dot(cache["Cvir_B"], unc_x_A_MOB, Tmo_AB, cache["Cocc_A"], 
+        sT_BA = core.Matrix.chain_dot(cache["Cvir_B"], unc_x_A_MOB, Tmo_AB, cache["Cocc_A"],
             trans=[False, True, True, True])
-        
+
         jk.C_clear()
-    
+
         jk.C_left_add(core.Matrix.chain_dot(cache["Cocc_A"], Tmo_AA))
         jk.C_right_add(cache["Cocc_A"])
-    
+
         jk.C_left_add(core.Matrix.chain_dot(cache["Cocc_B"], Tmo_BB))
         jk.C_right_add(cache["Cocc_B"])
-    
+
         jk.C_left_add(core.Matrix.chain_dot(cache["Cocc_A"], Tmo_AB))
         jk.C_right_add(cache["Cocc_B"])
-    
+
         jk.compute()
-    
+
         J_AA_inf, J_BB_inf, J_AB_inf = jk.J()
         K_AA_inf, K_BB_inf, K_AB_inf = jk.K()
 
@@ -501,12 +501,12 @@ def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True
         EX_BA_inf.axpy(-1.00, K_AB_inf.transpose())
         EX_BA_inf.axpy(1.00, core.Matrix.chain_dot(S, T_AB, K_AB_inf, trans=[False, False, True]))
         EX_BA_inf.axpy(1.00, core.Matrix.chain_dot(S, T_A, K_AB_inf, trans=[False, False, True]))
-        
+
         unc_ind_ab_total = 2.0 * (sT_A.vector_dot(EX_AA_inf) + sT_AB.vector_dot(EX_AB_inf))
         unc_ind_ba_total = 2.0 * (sT_B.vector_dot(EX_BB_inf) + sT_BA.vector_dot(EX_BA_inf))
         unc_indexch_ab_inf = unc_ind_ab_total - unc_ind_ab
         unc_indexch_ba_inf = unc_ind_ba_total - unc_ind_ba
-        
+
         ret["Exch-Ind20,u (A<-B) (S^inf)"] = unc_indexch_ab_inf
         ret["Exch-Ind20,u (A->B) (S^inf)"] = unc_indexch_ba_inf
         ret["Exch-Ind20,u (S^inf)"] = unc_indexch_ba_inf + unc_indexch_ab_inf
@@ -548,20 +548,20 @@ def induction(cache, jk, do_print=True, maxiter=12, conv=1.e-8, do_response=True
 
         # Exch-Ind without S^2
         if Sinf:
-            cT_A = core.Matrix.chain_dot(cache["Cvir_A"], x_B_MOA, Tmo_AA, cache["Cocc_A"], 
+            cT_A = core.Matrix.chain_dot(cache["Cvir_A"], x_B_MOA, Tmo_AA, cache["Cocc_A"],
                 trans=[False, True, False, True])
-            cT_B = core.Matrix.chain_dot(cache["Cvir_B"], x_A_MOB, Tmo_BB, cache["Cocc_B"], 
+            cT_B = core.Matrix.chain_dot(cache["Cvir_B"], x_A_MOB, Tmo_BB, cache["Cocc_B"],
                 trans=[False, True, False, True])
-            cT_AB = core.Matrix.chain_dot(cache["Cvir_A"], x_B_MOA, Tmo_AB, cache["Cocc_B"], 
+            cT_AB = core.Matrix.chain_dot(cache["Cvir_A"], x_B_MOA, Tmo_AB, cache["Cocc_B"],
                 trans=[False, True, False, True])
-            cT_BA = core.Matrix.chain_dot(cache["Cvir_B"], x_A_MOB, Tmo_AB, cache["Cocc_A"], 
+            cT_BA = core.Matrix.chain_dot(cache["Cvir_B"], x_A_MOB, Tmo_AB, cache["Cocc_A"],
                 trans=[False, True, True, True])
 
             ind_ab_total = 2.0 * (cT_A.vector_dot(EX_AA_inf) + cT_AB.vector_dot(EX_AB_inf))
             ind_ba_total = 2.0 * (cT_B.vector_dot(EX_BB_inf) + cT_BA.vector_dot(EX_BA_inf))
             indexch_ab_inf = ind_ab_total - ind_ab
             indexch_ba_inf = ind_ba_total - ind_ba
-        
+
             ret["Exch-Ind20,r (A<-B) (S^inf)"] = indexch_ab_inf
             ret["Exch-Ind20,r (A->B) (S^inf)"] = indexch_ba_inf
             ret["Exch-Ind20,r (S^inf)"] = indexch_ba_inf + indexch_ab_inf
@@ -580,6 +580,9 @@ def _sapt_cpscf_solve(cache, jk, rhsA, rhsB, maxiter, conv):
     """
     Solve the SAPT CPHF (or CPKS) equations.
     """
+
+    cache["wfn_A"].set_jk(jk)
+    cache["wfn_B"].set_jk(jk)
 
     # Make a preconditioner function
     P_A = core.Matrix(cache["eps_occ_A"].shape[0], cache["eps_vir_A"].shape[0])

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -32,6 +32,7 @@ import time
 from psi4 import core
 from psi4.driver.p4util.exceptions import *
 from psi4.driver import p4util
+from psi4.driver import constants
 
 from .sapt_util import print_sapt_var
 
@@ -254,8 +255,8 @@ def df_mp2_sapt_dispersion(dimer_wfn, wfn_A, wfn_B, primary_basis, aux_basis, ca
     core.set_local_option("SAPT", "SAPT_QUIET", True)
 
     if core.get_option('SCF', 'REFERENCE') == 'RHF':
-        core.IO.change_file_namespace(p4const.PSIF_SAPT_MONOMERA, 'monomerA', 'dimer')
-        core.IO.change_file_namespace(p4const.PSIF_SAPT_MONOMERB, 'monomerB', 'dimer')
+        core.IO.change_file_namespace(constants.PSIF_SAPT_MONOMERA, 'monomerA', 'dimer')
+        core.IO.change_file_namespace(constants.PSIF_SAPT_MONOMERB, 'monomerB', 'dimer')
 
     core.IO.set_default_namespace('dimer')
 

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -40,7 +40,7 @@ from .sapt_util import print_sapt_hf_summary, print_sapt_dft_summary
 from . import sapt_mp2_terms
 
 # Only export the run_ scripts
-__all__ = ['run_sapt_dft']
+__all__ = ['run_sapt_dft', 'sapt_dft']
 
 
 def run_sapt_dft(name, **kwargs):
@@ -227,11 +227,11 @@ def run_sapt_dft(name, **kwargs):
     return dimer_wfn
 
 
-def sapt_dft_header(sapt_dft_functional="user",
-                    mon_a_shift="user",
-                    mon_b_shift="user",
-                    do_delta_hf="user",
-                    jk_alg="user"):
+def sapt_dft_header(sapt_dft_functional="unknown",
+                    mon_a_shift=None,
+                    mon_b_shift=None,
+                    do_delta_hf="N/A",
+                    jk_alg="N/A"):
     # Print out the title and some information
     core.print_out("\n")
     core.print_out("         ---------------------------------------------------------\n")
@@ -243,22 +243,47 @@ def sapt_dft_header(sapt_dft_functional="user",
 
     core.print_out("  ==> Algorithm <==\n\n")
     core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
-    if mon_a_shift == "user":
-        core.print_out("   Monomer A GRAC Shift    %12s\n" % mon_a_shift)
-    else:
+    if mon_a_shift:
         core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
-    if mon_b_shift == "user":
-        core.print_out("   Monomer B GRAC Shift    %12s\n" % mon_b_shift)
-    else:
+    if mon_b_shift:
         core.print_out("   Monomer B GRAC Shift    %12.6f\n" % mon_b_shift)
     core.print_out("   Delta HF                %12s\n" % do_delta_hf)
     core.print_out("   JK Algorithm            %12s\n" % jk_alg)
 
 
 def sapt_dft(dimer_wfn, wfn_A, wfn_B, sapt_jk=None, data=None, print_header=True):
+    """
 
+    Example
+    -------
+
+    # Prepare the fragments
+    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(sapt_dimer, "dimer")
+
+    # Run the first monomer
+    set DFT_GRAC_SHIFT 0.203293
+    wfnA, energyA = energy("PBE0", monomer=monomerA, return_wfn=True)
+
+    # Run the second monomer
+    set DFT_GRAC_SHIFT 0.138264
+    wfnB, energyB = energy("PBE0", monomer=monomerB, return_wfn=True)
+
+    # Build the dimer wavefunction
+    wfnD =
+
+    driver.procrouting.sapt.sapt_dft(
+    """
+
+    # Handle the input options
     if print_header:
         sapt_dft_header()
+
+    if sapt_jk is None:
+        sapt_jk = core.JK.build(dimer_wfn.basisset())
+        sapt_jk.initialize()
+
+    if data is None:
+        data = {}
 
     # Build cache and JK
     sapt_jk.set_do_J(True)

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -200,6 +200,7 @@ void export_wavefunction(py::module& m) {
         .def("Va", &scf::HF::Va, "Returns the Alpha Kohn-Shame Potential Matrix.")
         .def("Vb", &scf::HF::Vb, "Returns the Alpha Kohn-Shame Potential Matrix.")
         .def("jk", &scf::HF::jk, "Returns the internal JK object.")
+        .def("set_jk", &scf::HF::set_jk, "Sets the internal JK object !expert.")
         .def("functional", &scf::HF::functional, "Returns the internal DFT Superfunctional.")
         .def("V_potential", &scf::HF::V_potential, "Returns the internal DFT V object.")
         .def("initialize", &scf::HF::initialize, "Initializes the Wavefunction.")
@@ -221,12 +222,12 @@ void export_wavefunction(py::module& m) {
         .def("moFeff", &scf::ROHF::moFeff, "docstring")
         .def("moFa", &scf::ROHF::moFa, "docstring")
         .def("moFb", &scf::ROHF::moFb, "docstring")
-        .def("c1_deep_copy", &scf::ROHF::c1_deep_copy, 
+        .def("c1_deep_copy", &scf::ROHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<scf::UHF, std::shared_ptr<scf::UHF>, scf::HF>(m, "UHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
-        .def("c1_deep_copy", &scf::UHF::c1_deep_copy, 
+        .def("c1_deep_copy", &scf::UHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed BasisSet *basis*", py::arg("basis"));
 
     py::class_<scf::CUHF, std::shared_ptr<scf::CUHF>, scf::HF>(m, "CUHF", "docstring")

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -226,6 +226,9 @@ public:
     /// The JK object (or null if it has been deleted)
     std::shared_ptr<JK> jk() const { return jk_; }
 
+    /// The JK object (or null if it has been deleted)
+    void set_jk(std::shared_ptr<JK> jk) { jk_ = jk; }
+
     /// The DFT Functional object (or null if it has been deleted)
     std::shared_ptr<SuperFunctional> functional() const { return functional_; }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-checkrun-rohf pywrap-checkrun-uhf pywrap-db1 pywrap-db2
                   pywrap-db3 pywrap-freq-e-sowreap pywrap-freq-g-sowreap
                   pywrap-molecule pywrap-opt-sowreap rasci-c2-active rasci-h2o
-                  rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api
+                  rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
                   sapt7 sapt8 scf-bz2 scf-ecp scf-guess-read1 scf-upcast-custom-basis scf-guess-read2 scf-bs scf1 scf-occ
                   scf2 scf3 scf4 scf5 scf6 scf7 scf-property soscf-large soscf-ref
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare dft-custom dft-reference

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-checkrun-rohf pywrap-checkrun-uhf pywrap-db1 pywrap-db2
                   pywrap-db3 pywrap-freq-e-sowreap pywrap-freq-g-sowreap
                   pywrap-molecule pywrap-opt-sowreap rasci-c2-active rasci-h2o
-                  rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6
+                  rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api
                   sapt7 sapt8 scf-bz2 scf-ecp scf-guess-read1 scf-upcast-custom-basis scf-guess-read2 scf-bs scf1 scf-occ
                   scf2 scf3 scf4 scf5 scf6 scf7 scf-property soscf-large soscf-ref
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare dft-custom dft-reference

--- a/tests/sapt-dft-api/CMakeLists.txt
+++ b/tests/sapt-dft-api/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(sapt-dft-api "psi;sapt")

--- a/tests/sapt-dft-api/input.dat
+++ b/tests/sapt-dft-api/input.dat
@@ -1,0 +1,41 @@
+#! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
+
+Eref = {"SAPT ELST ENERGY":  -0.10190449, # TEST
+        "SAPT EXCH ENERGY":   0.36545706, # TEST
+        "SAPT IND ENERGY":    0.00349281, # TEST
+        "SAPT DISP ENERGY":  -0.24398704, # TEST
+        "CURRENT ENERGY":     0.02305835} # TEST
+
+
+molecule dimer {
+  Ne
+  --
+  Ar 1 6.5
+  units bohr
+}
+
+# Set options
+set {
+    basis         aug-cc-pvdz
+    scf_type      df
+}
+
+# Prepare the fragments
+sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(dimer, "dimer")
+
+# Run the first monomer
+set DFT_GRAC_SHIFT 0.203293
+energyA, wfnA = energy("PBE0", molecule=monomerA, return_wfn=True)
+
+# Run the second monomer
+set DFT_GRAC_SHIFT 0.138264
+energyB, wfnB = energy("PBE0", molecule=monomerB, return_wfn=True)
+
+# Build a blank dimer wavefunction
+wfnD = core.Wavefunction.build(sapt_dimer) 
+
+# Compute SAPT(DFT) from the provided wavefunctions
+data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
+
+for k, v in Eref.items():                                  # TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST

--- a/tests/sapt-dft-api/input.dat
+++ b/tests/sapt-dft-api/input.dat
@@ -1,10 +1,10 @@
 #! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
 
-Eref = {"SAPT ELST ENERGY":  -0.10190449, # TEST
-        "SAPT EXCH ENERGY":   0.36545706, # TEST
-        "SAPT IND ENERGY":    0.00349281, # TEST
-        "SAPT DISP ENERGY":  -0.24398704, # TEST
-        "CURRENT ENERGY":     0.02305835} # TEST
+Eref = {"SAPT ELST ENERGY":  -0.10190449, #TEST
+        "SAPT EXCH ENERGY":   0.36545706, #TEST
+        "SAPT IND ENERGY":    0.00349281, #TEST
+        "SAPT DISP ENERGY":  -0.24398704, #TEST
+        "CURRENT ENERGY":     0.02305835} #TEST
 
 
 molecule dimer {
@@ -37,5 +37,5 @@ wfnD = core.Wavefunction.build(sapt_dimer)
 # Compute SAPT(DFT) from the provided wavefunctions
 data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
 
-for k, v in Eref.items():                                  # TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+for k, v in Eref.items():                                  #TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST

--- a/tests/sapt-dft-api/output.ref
+++ b/tests/sapt-dft-api/output.ref
@@ -1,0 +1,751 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 (inplace)
+
+                         Git: Rev (inplace)
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Saturday, 24 March 2018 05:51PM
+
+    Process ID:  53111
+    PSIDATADIR: /Users/daniel/Gits/dgaspsi/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
+
+Eref = {"SAPT ELST ENERGY":  -0.10190449, # TEST
+        "SAPT EXCH ENERGY":   0.36545706, # TEST
+        "SAPT IND ENERGY":    0.00349281, # TEST
+        "SAPT DISP ENERGY":  -0.24398704, # TEST
+        "CURRENT ENERGY":     0.02305835} # TEST
+
+
+molecule dimer {
+  Ne
+  --
+  Ar 1 6.5
+  units bohr
+}
+
+# Set options
+set {
+    basis         aug-cc-pvdz
+    scf_type      df
+}
+
+# Prepare the fragments
+sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(dimer, "dimer")
+
+# Run the first monomer
+set DFT_GRAC_SHIFT 0.203293
+energyA, wfnA = energy("PBE0", molecule=monomerA, return_wfn=True)
+
+# Run the second monomer
+set DFT_GRAC_SHIFT 0.138264
+energyB, wfnB = energy("PBE0", molecule=monomerB, return_wfn=True)
+
+# Build a blank dimer wavefunction
+wfnD = core.Wavefunction.build(sapt_dimer) 
+
+# Compute SAPT(DFT) from the provided wavefunctions
+data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
+
+for k, v in Eref.items():                                  # TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+--------------------------------------------------------------------------
+  SAPT does not make use of molecular symmetry, further calculations in C1 point group.
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 17:51:55 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NE         line   322 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2 entry AR         line   830 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          NE          0.000000000000     0.000000000000    -4.332520321268    19.992440175420
+          AR(Gh)      0.000000000000     0.000000000000     2.167479678732    39.962383122510
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      0.10692  C =      0.10692 [cm^-1]
+  Rotational constants: A = ************  B =   3205.49544  C =   3205.49544 [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 20
+    Number of basis function: 50
+    Number of Cartesian functions: 54
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: PBE0 <= 
+
+    PBE0 Hyb-GGA Exchange-Correlation Functional
+
+    J.P. Perdew et. al., J. Chem. Phys., 105(22), 9982-9985, 1996
+    C. Adamo et. a., J. Chem Phys., 110(13), 6158-6170, 1999
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.7500     XC_GGA_X_PBE
+
+   => Exact (HF) Exchange <=
+
+    0.2500               HF 
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_PBE
+
+   => Asymptotic Correction <=
+
+    X Functional        =    XC_GGA_X_LB
+    C Functional        =   XC_LDA_C_VWN
+    Bulk Shift          =       0.203293
+    GRAC Alpha          =       0.500000
+    GRAC Beta           =      40.000000
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45039
+    Total Blocks        =            425
+    Max Points          =            256
+    Max Functions       =             50
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NE         line   386 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2 entry AR         line   854 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         50      50       0       0       0       0
+   -------------------------------------------------------
+    Total      50      50       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 68
+    Number of basis function: 214
+    Number of Cartesian functions: 251
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.2959218804E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:  -128.81843295505158   -1.28818e+02   1.94450e-03 
+   @DF-RKS iter   1:  -128.82044311095441   -2.01016e-03   3.20581e-04 
+   @DF-RKS iter   2:  -128.82036836033697    7.47506e-05   3.25305e-04 DIIS
+   @DF-RKS iter   3:  -128.82048295681679   -1.14596e-04   3.77689e-06 DIIS
+   @DF-RKS iter   4:  -128.82048280131164    1.55505e-07   5.49356e-08 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -31.293525     2A     -1.697822     3A     -0.788209  
+       4A     -0.788200     5A     -0.788200  
+
+    Virtual:                                                              
+
+       6A     -0.052465     7A      0.015103     8A      0.029301  
+       9A      0.029301    10A      0.070643    11A      0.093112  
+      12A      0.093112    13A      0.173201    14A      0.417826  
+      15A      0.464512    16A      0.464512    17A      0.478936  
+      18A      0.674679    19A      0.677718    20A      0.697553  
+      21A      0.697553    22A      0.741850    23A      1.315621  
+      24A      1.315629    25A      1.317452    26A      1.317452  
+      27A      1.327602    28A      1.472987    29A      1.472987  
+      30A      1.512039    31A      1.799477    32A      2.295288  
+      33A      2.331256    34A      2.333552    35A      2.333552  
+      36A      2.985185    37A      2.985185    38A      2.985869  
+      39A      2.986585    40A      3.027383    41A      5.682526  
+      42A      5.682561    43A      5.683544    44A      5.683544  
+      45A      5.691612    46A      9.088342    47A     27.622850  
+      48A     27.622850    49A     27.639303    50A    176.480016  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:  -128.82048280131164
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -182.2941045200658436
+    Two-Electron Energy =                  62.8448360173149467
+    DFT Exchange-Correlation Energy =      -9.3712142985607425
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -128.8204828013116412
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:   -43.3252
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:    43.3262
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:    -0.0000      Z:     0.0010     Total:     0.0010
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:    -0.0000      Z:     0.0026     Total:     0.0026
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 17:51:57 2018
+Module time:
+	user time   =       1.73 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       1.73 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 17:51:57 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NE         line   322 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2 entry AR         line   830 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          NE(Gh)      0.000000000000     0.000000000000    -4.332520321268    19.992440175420
+          AR          0.000000000000     0.000000000000     2.167479678732    39.962383122510
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      0.10692  C =      0.10692 [cm^-1]
+  Rotational constants: A = ************  B =   3205.49544  C =   3205.49544 [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 18
+  Nalpha       = 9
+  Nbeta        = 9
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 20
+    Number of basis function: 50
+    Number of Cartesian functions: 54
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: PBE0 <= 
+
+    PBE0 Hyb-GGA Exchange-Correlation Functional
+
+    J.P. Perdew et. al., J. Chem. Phys., 105(22), 9982-9985, 1996
+    C. Adamo et. a., J. Chem Phys., 110(13), 6158-6170, 1999
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.7500     XC_GGA_X_PBE
+
+   => Exact (HF) Exchange <=
+
+    0.2500               HF 
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_PBE
+
+   => Asymptotic Correction <=
+
+    X Functional        =    XC_GGA_X_LB
+    C Functional        =   XC_LDA_C_VWN
+    Bulk Shift          =       0.138264
+    GRAC Alpha          =       0.500000
+    GRAC Beta           =      40.000000
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =          45039
+    Total Blocks        =            425
+    Max Points          =            256
+    Max Functions       =             50
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NE         line   386 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2 entry AR         line   854 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         50      50       0       0       0       0
+   -------------------------------------------------------
+    Total      50      50       9       9       9       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 68
+    Number of basis function: 214
+    Number of Cartesian functions: 251
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 4.2959218804E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:  -527.36137383768289   -5.27361e+02   3.66167e-03 
+   @DF-RKS iter   1:  -527.36590926893405   -4.53543e-03   1.34541e-03 
+   @DF-RKS iter   2:  -527.36720523274869   -1.29596e-03   8.92449e-04 DIIS
+   @DF-RKS iter   3:  -527.36810050622978   -8.95273e-04   8.80579e-06 DIIS
+   @DF-RKS iter   4:  -527.36810105210054   -5.45871e-07   1.14159e-07 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A   -115.425712     2A    -11.352475     3A     -8.873603  
+       4A     -8.873602     5A     -8.873602     6A     -1.130781  
+       7A     -0.578157     8A     -0.578157     9A     -0.578157  
+
+    Virtual:                                                              
+
+      10A     -0.058100    11A     -0.017373    12A     -0.014743  
+      13A     -0.014743    14A      0.108313    15A      0.163096  
+      16A      0.163096    17A      0.164104    18A      0.242998  
+      19A      0.242998    20A      0.258092    21A      0.258092  
+      22A      0.329637    23A      0.645497    24A      0.645497  
+      25A      0.656369    26A      0.940808    27A      1.001538  
+      28A      1.181909    29A      1.181909    30A      1.202108  
+      31A      1.202131    32A      1.220925    33A      1.235816  
+      34A      1.235816    35A      1.296834    36A      2.016812  
+      37A      2.016812    38A      2.021274    39A      2.021275  
+      40A      2.034102    41A      4.583385    42A      8.833815  
+      43A      8.834358    44A      8.834358    45A      8.845684  
+      46A      8.845688    47A      8.850015    48A      8.850015  
+      49A      8.888584    50A     53.322228  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     9 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:  -527.36810105210054
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -728.3107237271754002
+    Two-Electron Energy =                 224.1425445166635484
+    DFT Exchange-Correlation Energy =     -23.1999218415887292
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    Total Energy =                       -527.3681010521006556
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    39.0146
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:   -39.0139
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.0007     Total:     0.0007
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     0.0019     Total:     0.0019
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 17:51:59 2018
+Module time:
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       3.47 seconds =       0.06 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: None
+    atoms 1 entry NE         line   322 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2 entry AR         line   830 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+               SAPT(DFT): Intermolecular Interaction Segment       
+
+                   by Daniel G. A. Smith and Rob Parrish           
+         ---------------------------------------------------------
+
+  ==> Algorithm <==
+
+   SAPT DFT Functional          unknown
+   Delta HF                         N/A
+   JK Algorithm                     N/A
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NE         line   386 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2 entry AR         line   854 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+
+  ==> Preparing SAPT Data Cache <== 
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               244
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 68
+    Number of basis function: 214
+    Number of Cartesian functions: 251
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  ==> E10 Electostatics <== 
+
+    Elst10,r                 -0.10195524 [mEh]
+
+  ==> E10 Exchange <== 
+
+    Exch10(S^2)               0.36554717 [mEh]
+    Exch10                    0.36563185 [mEh]
+
+  ==> E20 Induction <== 
+
+   => Uncoupled Induction <= 
+
+    Ind20,u (A<-B)           -0.01336023 [mEh]
+    Ind20,u (A->B)           -0.08757164 [mEh]
+    Ind20,u                  -0.10093187 [mEh]
+    Exch-Ind20,u (A<-B)       0.01265468 [mEh]
+    Exch-Ind20,u (A->B)       0.09118428 [mEh]
+    Exch-Ind20,u              0.10383896 [mEh]
+
+   => Coupled Induction <= 
+
+   ---------------------------------------------------
+              SAPT Coupled Induction Solver           
+   ---------------------------------------------------
+    Maxiter             =          20
+    Convergence         =   1.000E-06
+   ---------------------------------------------------
+     Iter       (A<-B)           (B->A)      Time [s]
+   ---------------------------------------------------
+    Guess    3.129655e-02     2.150313e-02          0
+        1    1.311725e-02     5.176591e-03          0
+        2    3.446536e-04     3.081156e-04          1
+        3    1.755964e-05     2.933493e-05          1
+        4    3.491789e-06     5.571054e-06          2
+        5    1.269277e-07*    2.308051e-07*         2
+   ---------------------------------------------------
+
+    Ind20,r (A<-B)           -0.01381631 [mEh]
+    Ind20,r (A->B)           -0.09085985 [mEh]
+    Ind20,r                  -0.10467617 [mEh]
+    Exch-Ind20,r (A<-B)       0.01307480 [mEh]
+    Exch-Ind20,r (A->B)       0.09509393 [mEh]
+    Exch-Ind20,r              0.10816872 [mEh]
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1 entry NE         line   296 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2 entry AR         line   632 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+
+  ==> E20 Dispersion (CHF FDDS) <== 
+
+   Legendre Points:          10
+   Lambda Shift:          0.300
+   Fxc Kernal:             ALDA
+   (P|Fxc|Q) Thresh:  1.000e-06
+
+   => Time Integration <= 
+
+       Omega       Weight       Disp20,u         Disp20   time [s]
+   2.269e+01    6.667e-02      2.365e-06      2.350e-06          0
+   4.147e+00    1.495e-01      9.740e-05      9.009e-05          0
+   1.572e+00    2.191e-01      3.985e-04      3.196e-04          0
+   7.589e-01    2.693e-01      5.750e-04      4.055e-04          0
+   4.049e-01    2.955e-01      5.010e-04      3.299e-04          0
+   2.223e-01    2.955e-01      3.466e-04      2.224e-04          0
+   1.186e-01    2.693e-01      2.204e-04      1.402e-04          0
+   5.727e-02    2.191e-01      1.341e-04      8.512e-05          0
+   2.170e-02    1.495e-01      7.472e-05      4.738e-05          0
+   3.966e-03    6.667e-02      2.979e-05      1.889e-05          0
+
+    Disp20,u                 -0.37875881 [mEh]
+    Disp20                   -0.26441984 [mEh]
+
+  ==> E20 Dispersion (MP2) <== 
+
+
+    Disp20 (MP2)             -0.37878985 [mEh]
+    Exch-Disp20,u             0.02037023 [mEh]
+
+   SAPT(DFT) Results
+  -------------------------------------------------------------------------------------------------
+    Electrostatics           -0.10195524 [mEh]     -0.06397788 [kcal/mol]     -0.26768349 [kJ/mol]
+      Elst1,r                -0.10195524 [mEh]     -0.06397788 [kcal/mol]     -0.26768349 [kJ/mol]
+
+    Exchange                  0.36563185 [mEh]      0.22943746 [kcal/mol]      0.95996642 [kJ/mol]
+      Exch1                   0.36563185 [mEh]      0.22943746 [kcal/mol]      0.95996642 [kJ/mol]
+      Exch1(S^2)              0.36554717 [mEh]      0.22938432 [kcal/mol]      0.95974410 [kJ/mol]
+
+    Induction                 0.00349256 [mEh]      0.00219161 [kcal/mol]      0.00916971 [kJ/mol]
+      Ind2,r                 -0.10467617 [mEh]     -0.06568529 [kcal/mol]     -0.27482728 [kJ/mol]
+      Exch-Ind2,r             0.10816872 [mEh]      0.06787690 [kcal/mol]      0.28399699 [kJ/mol]
+      Induction (A<-B)       -0.00074152 [mEh]     -0.00046531 [kcal/mol]     -0.00194685 [kJ/mol]
+      Induction (A->B)        0.00423407 [mEh]      0.00265692 [kcal/mol]      0.01111656 [kJ/mol]
+
+    Dispersion               -0.24404961 [mEh]     -0.15314345 [kcal/mol]     -0.64075224 [kJ/mol]
+      Disp2,r                -0.26441984 [mEh]     -0.16592596 [kcal/mol]     -0.69423429 [kJ/mol]
+      Disp2,u                -0.37878985 [mEh]     -0.23769423 [kcal/mol]     -0.99451274 [kJ/mol]
+      Exch-Disp2,u            0.02037023 [mEh]      0.01278251 [kcal/mol]      0.05348204 [kJ/mol]
+
+   Total SAPT(DFT)            0.02311956 [mEh]      0.01450774 [kcal/mol]      0.06070039 [kJ/mol]
+  -------------------------------------------------------------------------------------------------
+	SAPT ELST ENERGY..................................................PASSED
+	SAPT EXCH ENERGY..................................................PASSED
+	SAPT IND ENERGY...................................................PASSED
+	SAPT DISP ENERGY..................................................PASSED
+	CURRENT ENERGY....................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/sapt-dft-lrc/CMakeLists.txt
+++ b/tests/sapt-dft-lrc/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(sapt-dft-lrc "psi;sapt")

--- a/tests/sapt-dft-lrc/input.dat
+++ b/tests/sapt-dft-lrc/input.dat
@@ -1,0 +1,41 @@
+#! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
+
+Eref = {"SAPT ELST ENERGY":  -0.12885645, # TEST
+        "SAPT EXCH ENERGY":   0.48043027, # TEST
+        "SAPT IND ENERGY":    0.00398419, # TEST
+        "SAPT DISP ENERGY":  -0.23304893, # TEST
+        "CURRENT ENERGY":     0.12250908} # TEST
+
+
+molecule dimer {
+  Ne
+  --
+  Ar 1 6.5
+  units bohr
+}
+
+# Set options
+set {
+    basis         aug-cc-pvdz
+    scf_type      df
+}
+
+# Prepare the fragments
+sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(dimer, "dimer")
+
+# Run the first monomer
+set DFT_OMEGA 0.3
+energyA, wfnA = energy("wB97", molecule=monomerA, return_wfn=True)
+
+# Run the second monomer
+set DFT_OMEGA 0.4
+energyB, wfnB = energy("wB97", molecule=monomerB, return_wfn=True)
+
+# Build a blank dimer wavefunction
+wfnD = core.Wavefunction.build(sapt_dimer) 
+
+# Compute SAPT(DFT) from the provided wavefunctions
+data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
+
+for k, v in Eref.items():                                  # TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST

--- a/tests/sapt-dft-lrc/input.dat
+++ b/tests/sapt-dft-lrc/input.dat
@@ -1,10 +1,10 @@
 #! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
 
-Eref = {"SAPT ELST ENERGY":  -0.12885645, # TEST
-        "SAPT EXCH ENERGY":   0.48043027, # TEST
-        "SAPT IND ENERGY":    0.00398419, # TEST
-        "SAPT DISP ENERGY":  -0.23304893, # TEST
-        "CURRENT ENERGY":     0.12250908} # TEST
+Eref = {"SAPT ELST ENERGY":  -0.12885645, #TEST
+        "SAPT EXCH ENERGY":   0.48043027, #TEST
+        "SAPT IND ENERGY":    0.00398419, #TEST
+        "SAPT DISP ENERGY":  -0.23304893, #TEST
+        "CURRENT ENERGY":     0.12250908} #TEST
 
 
 molecule dimer {
@@ -37,5 +37,5 @@ wfnD = core.Wavefunction.build(sapt_dimer)
 # Compute SAPT(DFT) from the provided wavefunctions
 data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
 
-for k, v in Eref.items():                                  # TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+for k, v in Eref.items():                                  #TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST

--- a/tests/sapt-dft1/input.dat
+++ b/tests/sapt-dft1/input.dat
@@ -1,10 +1,10 @@
 #! SAPT(DFT) aug-cc-pVDZ interaction energy between Ne and Ar atoms.
 
-Eref = {"SAPT ELST ENERGY":  -0.10190449, # TEST
-        "SAPT EXCH ENERGY":   0.36545706, # TEST
-        "SAPT IND ENERGY":   -0.00840483, # TEST
-        "SAPT DISP ENERGY":  -0.24398704, # TEST
-        "CURRENT ENERGY":     0.01122234} # TEST
+Eref = {"SAPT ELST ENERGY":  -0.10190449, #TEST
+        "SAPT EXCH ENERGY":   0.36545706, #TEST
+        "SAPT IND ENERGY":   -0.00840483, #TEST
+        "SAPT DISP ENERGY":  -0.24398704, #TEST
+        "CURRENT ENERGY":     0.01122234} #TEST
 
 
 molecule dimer {
@@ -23,5 +23,5 @@ set {
 
 energy('sapt(dft)', molecule=dimer)
 
-for k, v in Eref.items():                                  # TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+for k, v in Eref.items():                                  #TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST

--- a/tests/sapt-dft2/input.dat
+++ b/tests/sapt-dft2/input.dat
@@ -1,10 +1,10 @@
 #! SAPT(DFT) aug-cc-pVDZ computation for the water dimer interaction energy.
 
-Eref = {"SAPT ELST ENERGY":  -12.86731900, # TEST
-        "SAPT EXCH ENERGY":   12.77393901, # TEST
-        "SAPT IND ENERGY":    -3.53895378, # TEST 
-        "SAPT DISP ENERGY":   -2.67884677, # TEST
-        "CURRENT ENERGY":     -6.31117998} # TEST
+Eref = {"SAPT ELST ENERGY":  -12.86731900, #TEST
+        "SAPT EXCH ENERGY":   12.77393901, #TEST
+        "SAPT IND ENERGY":    -3.53895378, #TEST 
+        "SAPT DISP ENERGY":   -2.67884677, #TEST
+        "CURRENT ENERGY":     -6.31117998} #TEST
 
 molecule dimer {
   O -2.930978458   -0.216411437    0.000000000
@@ -29,6 +29,6 @@ set {
 
 energy('sapt(dft)', molecule=dimer)
 
-for k, v in Eref.items():                                  # TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+for k, v in Eref.items():                                  #TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST
 

--- a/tests/sapt-dft2/output.ref
+++ b/tests/sapt-dft2/output.ref
@@ -1,44 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1a2.dev219 
+                               Psi4 (inplace)
 
-                         Git: Rev {libxc} ba8b2b1 dirty
-
-
-    J. M. Turney, A. C. Simmonett, R. M. Parrish, E. G. Hohenstein,
-    F. A. Evangelista, J. T. Fermann, B. J. Mintz, L. A. Burns, J. J. Wilke,
-    M. L. Abrams, N. J. Russ, M. L. Leininger, C. L. Janssen, E. T. Seidl,
-    W. D. Allen, H. F. Schaefer, R. A. King, E. F. Valeev, C. D. Sherrill,
-    and T. D. Crawford, WIREs Comput. Mol. Sci. 2, 556-565 (2012)
-    (doi: 10.1002/wcms.93)
+                         Git: Rev (inplace)
 
 
-                         Additional Contributions by
-    A. E. DePrince, U. Bozkaya, A. Yu. Sokolov, D. G. A. Smith, R. Di Remigio,
-    R. M. Richard, J. F. Gonthier, H. R. McAlexander, M. Saitow, and
-    B. P. Pritchard
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 14 January 2017 04:11PM
+    Psi4 started on: Saturday, 24 March 2018 06:09PM
 
-    Process ID:  77280
-    PSIDATADIR: /Users/daniel/Gits/psixc/objdir/stage/usr/local/share/psi4
+    Process ID:  55199
+    PSIDATADIR: /Users/daniel/Gits/dgaspsi/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
-#! SAPT0 cc-pVDZ computation of the ethene-ethyne interaction energy, using the cc-pVDZ-JKFIT RI basis for SCF
-#! and cc-pVDZ-RI for SAPT.  Monomer geometries are specified using Cartesian coordinates.
+#! SAPT(DFT) aug-cc-pVDZ computation for the water dimer interaction energy.
 
-memory 1250 mb
-
-Eref = {"SAPT ELST ENERGY":  -0.00007808151, # TEST
-        "SAPT EXCH ENERGY":   0.00030618033, # TEST
-        "SAPT IND ENERGY":    0.00000124532} # TEST
+Eref = {"SAPT ELST ENERGY":  -12.86731900, # TEST
+        "SAPT EXCH ENERGY":   12.77393901, # TEST
+        "SAPT IND ENERGY":    -3.53895378, # TEST 
+        "SAPT DISP ENERGY":   -2.67884677, # TEST
+        "CURRENT ENERGY":     -6.31117998} # TEST
 
 molecule dimer {
   O -2.930978458   -0.216411437    0.000000000
@@ -49,8 +45,6 @@ molecule dimer {
   H  3.175492012   -0.706268134   -1.433472544
   H  3.175492012   -0.706268134    1.433472544
   units bohr
-  no_com
-  no_reorient
 }
 
 set {
@@ -59,34 +53,19 @@ set {
     d_convergence 1e-8
     sapt_dft_grac_shift_a 0.136
     sapt_dft_grac_shift_b 0.136
-    SCF_TYPE OUT_OF_CORE
-    #DFT_BS_RADIUS_ALPHA 3.0
-
-    #sapt_dft_grac_shift_a 0.000000000001
-    #sapt_dft_grac_shift_b 0.000000000001
-    #DFT_BLOCK_MAX_RADIUS 10.0
-    #DFT_BASIS_TOLERANCE 1.e-16
-    #DFT_RADIAL_POINTS   200
-    #DFT_SPHERICAL_POINTS 590
-    #DFT_BLOCK_MAX_POINTS 2000
-    #DFT_BLOCK_MIN_POINTS 500
-    # DFT_BLOCK_SCHEME    naive
-    # DFT_PRUNING_SCHEME P_GAUSSIAN
     SAPT_DFT_FUNCTIONAL PBE0
+    SAPT_DFT_MP2_DISP_ALG FISAPT
 }
 
 energy('sapt(dft)', molecule=dimer)
 
-#for k, v in Eref.items():                         # TEST
-#    compare_values(v, psi4.get_variable(k), 6, k) # TEST
-#energy('FISAPT0')
+for k, v in Eref.items():                                  # TEST
+    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
 
 --------------------------------------------------------------------------
 
-  Memory set to   1.250 GiB by Python script.
-
-*** tstart() called on verizon-ar.imtc.gatech.edu
-*** at Sat Jan 14 16:11:15 2017
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:30 2018
 
   SAPT does not make use of molecular symmetry, further calculations in C1 point group.
 
@@ -101,24 +80,40 @@ energy('sapt(dft)', molecule=dimer)
    SAPT DFT Functional             PBE0
    Monomer A GRAC Shift        0.136000
    Monomer B GRAC Shift        0.136000
-   Delta HF                       False
-   JK Algorithm             OUT_OF_CORE
+   Delta HF                        True
+   JK Algorithm                      DF
 
    Required computations:
+     HF  (Dimer)
+     HF  (Monomer A)
+     HF  (Monomer B)
      DFT (Monomer A)
      DFT (Monomer B)
+
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:30 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line   250 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3, 5-6 entry H          line    36 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
 
     There are an even number of electrons - assuming singlet.
     Specify the multiplicity in the molecule input block.
 
 
          ---------------------------------------------------------
-                          SAPT(DFT): DFT Monomer A                 
+                         SAPT(DFT): delta HF Dimer                 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                              RKS Reference
-                        1 Threads,   1250 MiB Core
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -130,28 +125,28 @@ energy('sapt(dft)', molecule=dimer)
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O         -2.930978458000    -0.216411437000     0.000000000000    15.994914619560
-           H         -3.655219777000     1.440921844000     0.000000000000     1.007825032070
-           H         -1.133225297000     0.076934530000     0.000000000000     1.007825032070
-           O(Gh)      2.552311356000     0.210645882000     0.000000000000    15.994914619560
-           H(Gh)      3.175492012000    -0.706268134000    -1.433472544000     1.007825032070
-           H(Gh)      3.175492012000    -0.706268134000     1.433472544000     1.007825032070
+           O         -2.806551984509    -0.216798006758     0.000000000000    15.994914619560
+           H         -3.530793303509     1.440535274242     0.000000000000     1.007825032070
+           H         -1.008798823509     0.076547960242     0.000000000000     1.007825032070
+           O          2.676737829491     0.210259312242     0.000000000000    15.994914619560
+           H          3.299918485491    -0.706654703758    -1.433472544000     1.007825032070
+           H          3.299918485491    -0.706654703758     1.433472544000     1.007825032070
 
   Running in c1 symmetry.
 
-  Rotational constants: A =      7.15091  B =      0.21415  C =      0.21404 [cm^-1]
-  Rotational constants: A = 214378.98507  B =   6419.94535  C =   6416.86901 [MHz]
-  Nuclear repulsion =    9.163830152278887
+  Rotational constants: A =      7.15151  B =      0.21457  C =      0.21447 [cm^-1]
+  Rotational constants: A = 214396.91710  B =   6432.69057  C =   6429.61814 [MHz]
+  Nuclear repulsion =   36.662847880726765
 
   Charge       = 0
   Multiplicity = 1
-  Electrons    = 10
-  Nalpha       = 5
-  Nbeta        = 5
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is OUT_OF_CORE.
+  SCF Algorithm Type is DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -162,63 +157,243 @@ energy('sapt(dft)', molecule=dimer)
 
   ==> Primary Basis <==
 
-  Basis Set: file /Users/daniel/Gits/psixc/objdir/stage/usr/local/share/psi4/basis/aug-cc-pvdz.gbs
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
     Number of shells: 38
     Number of basis function: 82
     Number of Cartesian functions: 86
     Spherical Harmonics?: true
     Max angular momentum: 2
 
-  ==> DFT Potential <==
+   => Loading Basis Set <=
 
-   => Composite Functional: PBE0 <= 
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   270 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    70 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
-    PBE GGA Exchange-Correlation Functional
+  ==> Pre-Iterations <==
 
-    J.P. Perdew et. al., Phys. Rev. Lett., 77(18), 3865-3868, 1996
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         82      82       0       0       0       0
+   -------------------------------------------------------
+    Total      82      82      10      10      10       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.5458174102E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:  -152.11460115705788   -1.52115e+02   2.99105e-02 
+   @DF-RHF iter   1:  -152.01019106557558    1.04410e-01   4.97151e-03 
+   @DF-RHF iter   2:  -152.07047454449707   -6.02835e-02   2.60791e-03 DIIS
+   @DF-RHF iter   3:  -152.08714684918760   -1.66723e-02   4.94342e-04 DIIS
+   @DF-RHF iter   4:  -152.08840223992433   -1.25539e-03   1.31473e-04 DIIS
+   @DF-RHF iter   5:  -152.08854900086138   -1.46761e-04   3.35153e-05 DIIS
+   @DF-RHF iter   6:  -152.08855847275902   -9.47190e-06   1.34543e-05 DIIS
+   @DF-RHF iter   7:  -152.08855923355742   -7.60798e-07   2.81862e-06 DIIS
+   @DF-RHF iter   8:  -152.08855930592995   -7.23725e-08   6.05971e-07 DIIS
+   @DF-RHF iter   9:  -152.08855930994574   -4.01579e-09   1.60368e-07 DIIS
+   @DF-RHF iter  10:  -152.08855931023155   -2.85809e-10   3.46839e-08 DIIS
+   @DF-RHF iter  11:  -152.08855931024368   -1.21361e-11   5.61536e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.602639     2A    -20.546335     3A     -1.383460  
+       4A     -1.326570     5A     -0.743791     6A     -0.696317  
+       7A     -0.615222     8A     -0.561295     9A     -0.530321  
+      10A     -0.481154  
+
+    Virtual:                                                              
+
+      11A      0.028509    12A      0.055390    13A      0.056015  
+      14A      0.090965    15A      0.156904    16A      0.185106  
+      17A      0.211368    18A      0.214763    19A      0.226647  
+      20A      0.236784    21A      0.261716    22A      0.284391  
+      23A      0.294520    24A      0.332786    25A      0.351553  
+      26A      0.364132    27A      0.382424    28A      0.441710  
+      29A      0.458373    30A      0.486897    31A      0.524480  
+      32A      0.534279    33A      0.553359    34A      0.608919  
+      35A      0.647361    36A      0.667426    37A      0.682457  
+      38A      0.787323    39A      0.800411    40A      0.919334  
+      41A      0.967205    42A      1.036646    43A      1.116578  
+      44A      1.145280    45A      1.147183    46A      1.178827  
+      47A      1.208787    48A      1.221972    49A      1.354001  
+      50A      1.380942    51A      1.437306    52A      1.472782  
+      53A      1.593147    54A      1.597655    55A      1.641265  
+      56A      1.964711    57A      2.003803    58A      2.017525  
+      59A      2.043660    60A      2.071695    61A      2.157424  
+      62A      2.274268    63A      2.337492    64A      2.461918  
+      65A      2.472755    66A      2.580463    67A      2.620593  
+      68A      2.700541    69A      2.771041    70A      2.791336  
+      71A      3.018081    72A      3.122743    73A      3.694159  
+      74A      3.698103    75A      3.709431    76A      3.741715  
+      77A      3.771102    78A      3.790699    79A      4.043224  
+      80A      4.159440    81A      4.287651    82A      4.410083  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -152.08855931024368
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             36.6628478807267655
+    One-Electron Energy =                -282.5286055286337614
+    Two-Electron Energy =                  93.7771983376633216
+    Total Energy =                       -152.0885593102436815
 
 
-    Deriv            =              1
-    GGA              =           TRUE
-    Meta             =          FALSE
 
-    Exchange Hybrid  =           TRUE
-    Exchange Alpha   =       0.250000
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
 
-    Exchange LRC     =          FALSE
-    Exchange Beta    =       0.000000
-    Exchange Omega   =       0.000000
+Properties computed using the SCF density matrix
 
-   => Exchange Functionals <=
+  Nuclear Dipole Moment: (a.u.)
+     X:     1.0217      Y:     0.0515      Z:     0.0000
 
-    0.7500   XC_GGA_X_PBE
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0163      Y:    -0.0169      Z:    -0.0000
 
-   => Correlation Functionals <=
+  Dipole Moment: (a.u.)
+     X:     1.0380      Y:     0.0345      Z:    -0.0000     Total:     1.0386
 
-    1.0000   XC_GGA_C_PBE
+  Dipole Moment: (Debye)
+     X:     2.6383      Y:     0.0878      Z:    -0.0000     Total:     2.6398
 
-   => Asymptotic Correction <=
 
-    X Functional     =    XC_GGA_X_LB
-    C Functional     =   XC_LDA_C_VWN
-    Bulk Shift       =       0.136000
-    GRAC Alpha       =       0.500000
-    GRAC Beta        =      40.000000
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:09:31 2018
+Module time:
+	user time   =       1.24 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.25 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-   => Molecular Quadrature <=
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:31 2018
 
-    Radial Scheme    =       TREUTLER
-    Pruning Scheme   =           FLAT
-    Nuclear Scheme   =       TREUTLER
+   => Loading Basis Set <=
 
-    BS radius alpha  =              1
-    Pruning alpha    =              1
-    Radial Points    =             75
-    Spherical Points =            302
-    Total Points     =         135900
-    Total Blocks     =           1242
-    Max Points       =            200
-    Max Functions    =             82
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line   250 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3, 5-6 entry H          line    36 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                       SAPT(DFT): delta HF Monomer A               
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -2.806551984509    -0.216798006758     0.000000000000    15.994914619560
+           H         -3.530793303509     1.440535274242     0.000000000000     1.007825032070
+           H         -1.008798823509     0.076547960242     0.000000000000     1.007825032070
+           O(Gh)      2.676737829491     0.210259312242     0.000000000000    15.994914619560
+           H(Gh)      3.299918485491    -0.706654703758    -1.433472544000     1.007825032070
+           H(Gh)      3.299918485491    -0.706654703758     1.433472544000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.15151  B =      0.21457  C =      0.21447 [cm^-1]
+  Rotational constants: A = 214396.91710  B =   6432.69057  C =   6429.61814 [MHz]
+  Nuclear repulsion =    9.163830152278891
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 38
+    Number of basis function: 82
+    Number of Cartesian functions: 86
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   270 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    70 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -232,13 +407,28 @@ energy('sapt(dft)', molecule=dimer)
 
   ==> Integral Setup <==
 
-  ==> DiskJK: Disk-Based J/K Matrices <==
+  ==> DFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               894
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
     Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
 
   Minimum eigenvalue in the overlap matrix is 1.5458174102E-03.
   Using Symmetric Orthogonalization.
@@ -247,5 +437,1149 @@ energy('sapt(dft)', molecule=dimer)
 
   ==> Iterations <==
 
-                        Total Energy        Delta E     RMS |[F,P]|
+                           Total Energy        Delta E     RMS |[F,P]|
 
+   @DF-RHF iter   0:   -76.06213844330766   -7.60621e+01   2.09338e-02 
+   @DF-RHF iter   1:   -75.99679967216238    6.53388e-02   3.76404e-03 
+   @DF-RHF iter   2:   -76.03024945571340   -3.34498e-02   2.04560e-03 DIIS
+   @DF-RHF iter   3:   -76.04047845281315   -1.02290e-02   3.75634e-04 DIIS
+   @DF-RHF iter   4:   -76.04116348198700   -6.85029e-04   9.91498e-05 DIIS
+   @DF-RHF iter   5:   -76.04124546029210   -8.19783e-05   2.02768e-05 DIIS
+   @DF-RHF iter   6:   -76.04124963905048   -4.17876e-06   2.72638e-06 DIIS
+   @DF-RHF iter   7:   -76.04124970835511   -6.93046e-08   3.92628e-07 DIIS
+   @DF-RHF iter   8:   -76.04124970958512   -1.23001e-09   8.65717e-08 DIIS
+   @DF-RHF iter   9:   -76.04124970965289   -6.77716e-11   2.30059e-08 DIIS
+   @DF-RHF iter  10:   -76.04124970965810   -5.21538e-12   4.68453e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.577858     2A     -1.355087     3A     -0.717142  
+       4A     -0.585307     5A     -0.509181  
+
+    Virtual:                                                              
+
+       6A      0.026528     7A      0.050726     8A      0.061604  
+       9A      0.086392    10A      0.129583    11A      0.147351  
+      12A      0.188792    13A      0.191379    14A      0.216554  
+      15A      0.226859    16A      0.233498    17A      0.278536  
+      18A      0.337937    19A      0.361009    20A      0.365602  
+      21A      0.392758    22A      0.400796    23A      0.416682  
+      24A      0.440286    25A      0.445310    26A      0.490038  
+      27A      0.520808    28A      0.531066    29A      0.565751  
+      30A      0.626264    31A      0.636729    32A      0.659655  
+      33A      0.752311    34A      0.841446    35A      0.938922  
+      36A      0.978936    37A      1.107481    38A      1.108419  
+      39A      1.145292    40A      1.153650    41A      1.190741  
+      42A      1.199682    43A      1.269429    44A      1.290489  
+      45A      1.334965    46A      1.345243    47A      1.387876  
+      48A      1.460914    49A      1.499151    50A      1.590279  
+      51A      1.759609    52A      2.017361    53A      2.019199  
+      54A      2.063881    55A      2.111443    56A      2.257187  
+      57A      2.381281    58A      2.509103    59A      2.520118  
+      60A      2.535996    61A      2.575037    62A      2.697583  
+      63A      2.748538    64A      2.823618    65A      2.987136  
+      66A      3.444151    67A      3.680922    68A      3.715098  
+      69A      3.743887    70A      3.902466    71A      4.082346  
+      72A      4.138139    73A      4.358595    74A      4.954505  
+      75A      4.958024    76A      5.036448    77A      5.104272  
+      78A      5.366871    79A      5.935280    80A      6.625257  
+      81A      7.039183    82A     33.536834  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.04124970965810
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1638301522788908
+    One-Electron Energy =                -122.9210105904753902
+    Two-Electron Energy =                  37.7159307285383960
+    Total Energy =                        -76.0412497096581035
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -26.9920      Y:    -0.2173      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:    27.3712      Y:     0.9088      Z:    -0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.3792      Y:     0.6915      Z:    -0.0000     Total:     0.7887
+
+  Dipole Moment: (Debye)
+     X:     0.9638      Y:     1.7576      Z:    -0.0000     Total:     2.0046
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:09:32 2018
+Module time:
+	user time   =       1.30 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.57 seconds =       0.04 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:32 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line   250 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3, 5-6 entry H          line    36 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                       SAPT(DFT): delta HF Monomer B               
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O(Gh)     -2.806551984509    -0.216798006758     0.000000000000    15.994914619560
+           H(Gh)     -3.530793303509     1.440535274242     0.000000000000     1.007825032070
+           H(Gh)     -1.008798823509     0.076547960242     0.000000000000     1.007825032070
+           O          2.676737829491     0.210259312242     0.000000000000    15.994914619560
+           H          3.299918485491    -0.706654703758    -1.433472544000     1.007825032070
+           H          3.299918485491    -0.706654703758     1.433472544000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.15151  B =      0.21457  C =      0.21447 [cm^-1]
+  Rotational constants: A = 214396.91710  B =   6432.69057  C =   6429.61814 [MHz]
+  Nuclear repulsion =    9.178038911705691
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 38
+    Number of basis function: 82
+    Number of Cartesian functions: 86
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   270 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    70 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         82      82       0       0       0       0
+   -------------------------------------------------------
+    Total      82      82       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.5458174102E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.00163171828930   -7.60016e+01   2.08996e-02 
+   @DF-RHF iter   1:   -76.00767430260018   -6.04258e-03   3.36187e-03 
+   @DF-RHF iter   2:   -76.03255630488854   -2.48820e-02   1.87056e-03 DIIS
+   @DF-RHF iter   3:   -76.04102364453827   -8.46734e-03   2.98807e-04 DIIS
+   @DF-RHF iter   4:   -76.04153819510826   -5.14551e-04   8.99400e-05 DIIS
+   @DF-RHF iter   5:   -76.04161633543129   -7.81403e-05   2.26922e-05 DIIS
+   @DF-RHF iter   6:   -76.04162279948382   -6.46405e-06   3.72708e-06 DIIS
+   @DF-RHF iter   7:   -76.04162296990904   -1.70425e-07   6.43257e-07 DIIS
+   @DF-RHF iter   8:   -76.04162297471497   -4.80593e-09   1.43090e-07 DIIS
+   @DF-RHF iter   9:   -76.04162297496745   -2.52484e-10   2.70660e-08 DIIS
+   @DF-RHF iter  10:   -76.04162297497456   -7.10543e-12   3.07068e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.577709     2A     -1.355581     3A     -0.718219  
+       4A     -0.585007     5A     -0.509212  
+
+    Virtual:                                                              
+
+       6A      0.032632     7A      0.054318     8A      0.057834  
+       9A      0.083164    10A      0.154115    11A      0.171149  
+      12A      0.176338    13A      0.189705    14A      0.218522  
+      15A      0.232962    16A      0.240222    17A      0.280124  
+      18A      0.298204    19A      0.344974    20A      0.386471  
+      21A      0.403055    22A      0.409576    23A      0.460879  
+      24A      0.462722    25A      0.483575    26A      0.531414  
+      27A      0.548614    28A      0.557343    29A      0.559268  
+      30A      0.639489    31A      0.674849    32A      0.677877  
+      33A      0.755276    34A      0.821005    35A      0.938460  
+      36A      0.951802    37A      0.972541    38A      1.151505  
+      39A      1.157906    40A      1.162603    41A      1.210530  
+      42A      1.228959    43A      1.291515    44A      1.339092  
+      45A      1.342961    46A      1.427749    47A      1.458943  
+      48A      1.490231    49A      1.515925    50A      1.605489  
+      51A      1.786836    52A      2.005217    53A      2.096315  
+      54A      2.164087    55A      2.208994    56A      2.366911  
+      57A      2.400893    58A      2.415593    59A      2.484018  
+      60A      2.551450    61A      2.639341    62A      2.682989  
+      63A      2.727123    64A      2.784583    65A      3.091250  
+      66A      3.492474    67A      3.725266    68A      3.727066  
+      69A      3.821335    70A      3.960177    71A      4.064947  
+      72A      4.088597    73A      4.314045    74A      4.913073  
+      75A      4.955873    76A      5.013658    77A      5.205190  
+      78A      5.492538    79A      5.702443    80A      6.695068  
+      81A      7.147393    82A     33.583918  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:   -76.04162297497456
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1780389117056913
+    One-Electron Energy =                -122.9478680833121302
+    Two-Electron Energy =                  37.7282061966318736
+    Total Energy =                        -76.0416229749745582
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:    28.0137      Y:     0.2688      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:   -27.5751      Y:    -0.9172      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.4386      Y:    -0.6484      Z:     0.0000     Total:     0.7828
+
+  Dipole Moment: (Debye)
+     X:     1.1148      Y:    -1.6481      Z:     0.0000     Total:     1.9897
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:09:34 2018
+Module time:
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       3.89 seconds =       0.06 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+         ---------------------------------------------------------
+                        SAPT(DFT): delta HF Segement               
+
+                   by Daniel G. A. Smith and Rob Parrish           
+         ---------------------------------------------------------
+
+
+  ==> Preparing SAPT Data Cache <== 
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  ==> E10 Electostatics <== 
+
+    Elst10,r                -13.37793677 [mEh]
+
+  ==> E10 Exchange <== 
+
+    Exch10(S^2)              11.13548986 [mEh]
+    Exch10                   11.21567419 [mEh]
+
+  ==> E20 Induction <== 
+
+   => Uncoupled Induction <= 
+
+    Ind20,u (A<-B)           -1.25768952 [mEh]
+    Ind20,u (A->B)           -2.47398576 [mEh]
+    Ind20,u                  -3.73167528 [mEh]
+    Exch-Ind20,u (A<-B)       0.83326420 [mEh]
+    Exch-Ind20,u (A->B)       1.12437985 [mEh]
+    Exch-Ind20,u              1.95764405 [mEh]
+
+   => Coupled Induction <= 
+
+   ---------------------------------------------------
+              SAPT Coupled Induction Solver           
+   ---------------------------------------------------
+    Maxiter             =          20
+    Convergence         =   1.000E-06
+   ---------------------------------------------------
+     Iter       (A<-B)           (B->A)      Time [s]
+   ---------------------------------------------------
+    Guess    1.004354e-01     1.870045e-01          0
+        1    3.431604e-02     7.038773e-02          0
+        2    9.474534e-03     1.838019e-02          0
+        3    2.948481e-03     4.369438e-03          0
+        4    4.378947e-04     8.110535e-04          0
+        5    7.667161e-05     1.415653e-04          0
+        6    1.679466e-05     2.928748e-05          0
+        7    3.444136e-06     5.926979e-06          0
+        8    7.271317e-07*    1.154623e-06          0
+        9    7.271317e-07*    3.251373e-07*         0
+   ---------------------------------------------------
+
+    Ind20,r (A<-B)           -1.43958505 [mEh]
+    Ind20,r (A->B)           -3.13700793 [mEh]
+    Ind20,r                  -4.57659297 [mEh]
+    Exch-Ind20,r (A<-B)       0.94873361 [mEh]
+    Exch-Ind20,r (A->B)       1.52970415 [mEh]
+    Exch-Ind20,r              2.47843776 [mEh]
+
+   SAPT(HF) Results
+  -------------------------------------------------------------------------------------------------
+    Electrostatics          -13.37793677 [mEh]     -8.39478241 [kcal/mol]    -35.12377298 [kJ/mol]
+      Elst10,r              -13.37793677 [mEh]     -8.39478241 [kcal/mol]    -35.12377298 [kJ/mol]
+
+    Exchange                 11.21567419 [mEh]      7.03794210 [kcal/mol]     29.44675257 [kJ/mol]
+      Exch10                 11.21567419 [mEh]      7.03794210 [kcal/mol]     29.44675257 [kJ/mol]
+      Exch10(S^2)            11.13548986 [mEh]      6.98762567 [kcal/mol]     29.23622862 [kJ/mol]
+
+    Induction                -2.09815521 [mEh]     -1.31661233 [kcal/mol]     -5.50870652 [kJ/mol]
+      Ind20,r                -4.57659297 [mEh]     -2.87185557 [kcal/mol]    -12.01584485 [kJ/mol]
+      Exch-Ind20,r            2.47843776 [mEh]      1.55524324 [kcal/mol]      6.50713834 [kJ/mol]
+      Induction (A<-B)       -0.49085143 [mEh]     -0.30801394 [kcal/mol]     -1.28873043 [kJ/mol]
+      Induction (A->B)       -1.60730378 [mEh]     -1.00859839 [kcal/mol]     -4.21997608 [kJ/mol]
+
+   Total SAPT                -4.26041779 [mEh]     -2.67345264 [kcal/mol]    -11.18572692 [kJ/mol]
+   Total HF                  -5.68662561 [mEh]     -3.56841159 [kcal/mol]    -14.93023554 [kJ/mol]
+   Delta HF                  -1.42620782 [mEh]     -0.89495895 [kcal/mol]     -3.74450862 [kJ/mol]
+  -------------------------------------------------------------------------------------------------
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:34 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line   250 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3, 5-6 entry H          line    36 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                          SAPT(DFT): DFT Monomer A                 
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O         -2.806551984509    -0.216798006758     0.000000000000    15.994914619560
+           H         -3.530793303509     1.440535274242     0.000000000000     1.007825032070
+           H         -1.008798823509     0.076547960242     0.000000000000     1.007825032070
+           O(Gh)      2.676737829491     0.210259312242     0.000000000000    15.994914619560
+           H(Gh)      3.299918485491    -0.706654703758    -1.433472544000     1.007825032070
+           H(Gh)      3.299918485491    -0.706654703758     1.433472544000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.15151  B =      0.21457  C =      0.21447 [cm^-1]
+  Rotational constants: A = 214396.91710  B =   6432.69057  C =   6429.61814 [MHz]
+  Nuclear repulsion =    9.163830152278891
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 38
+    Number of basis function: 82
+    Number of Cartesian functions: 86
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: PBE0 <= 
+
+    PBE0 Hyb-GGA Exchange-Correlation Functional
+
+    J.P. Perdew et. al., J. Chem. Phys., 105(22), 9982-9985, 1996
+    C. Adamo et. a., J. Chem Phys., 110(13), 6158-6170, 1999
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.7500     XC_GGA_X_PBE
+
+   => Exact (HF) Exchange <=
+
+    0.2500               HF 
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_PBE
+
+   => Asymptotic Correction <=
+
+    X Functional        =    XC_GGA_X_LB
+    C Functional        =   XC_LDA_C_VWN
+    Bulk Shift          =       0.136000
+    GRAC Alpha          =       0.500000
+    GRAC Beta           =      40.000000
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =         135900
+    Total Blocks        =           1092
+    Max Points          =            256
+    Max Functions       =             82
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   270 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    70 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         82      82       0       0       0       0
+   -------------------------------------------------------
+    Total      82      82       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.5458174102E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:   -76.36971589651394   -7.63697e+01   1.96858e-02 
+   @DF-RKS iter   1:   -76.29186991767020    7.78460e-02   5.09865e-03 
+   @DF-RKS iter   2:   -76.20759002651602    8.42799e-02   7.75759e-03 DIIS
+   @DF-RKS iter   3:   -76.35981834368837   -1.52228e-01   2.13982e-04 DIIS
+   @DF-RKS iter   4:   -76.35996839113928   -1.50047e-04   4.32486e-05 DIIS
+   @DF-RKS iter   5:   -76.35997085429338   -2.46315e-06   5.56939e-06 DIIS
+   @DF-RKS iter   6:   -76.35997018607985    6.68214e-07   1.07201e-06 DIIS
+   @DF-RKS iter   7:   -76.35997008918645    9.68934e-08   1.34881e-07 DIIS
+   @DF-RKS iter   8:   -76.35997007564322    1.35432e-08   2.05114e-08 DIIS
+   @DF-RKS iter   9:   -76.35997007576776   -1.24544e-10   1.51399e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -19.364412     2A     -1.181733     3A     -0.685205  
+       4A     -0.545490     5A     -0.467081  
+
+    Virtual:                                                              
+
+       6A     -0.120510     7A     -0.059434     8A     -0.014412  
+       9A     -0.002452    10A      0.006174    11A      0.021681  
+      12A      0.039084    13A      0.052694    14A      0.069836  
+      15A      0.093456    16A      0.106621    17A      0.123660  
+      18A      0.153019    19A      0.183791    20A      0.184675  
+      21A      0.220276    22A      0.251681    23A      0.272951  
+      24A      0.295223    25A      0.315159    26A      0.368751  
+      27A      0.378370    28A      0.404298    29A      0.418328  
+      30A      0.444143    31A      0.453098    32A      0.521507  
+      33A      0.523656    34A      0.588762    35A      0.689599  
+      36A      0.780677    37A      0.796151    38A      0.845816  
+      39A      0.875470    40A      0.947710    41A      0.992772  
+      42A      1.024505    43A      1.061373    44A      1.111778  
+      45A      1.132257    46A      1.155513    47A      1.195230  
+      48A      1.197644    49A      1.249654    50A      1.250737  
+      51A      1.438438    52A      1.637744    53A      1.650977  
+      54A      1.754293    55A      1.920965    56A      2.035801  
+      57A      2.097548    58A      2.131315    59A      2.317616  
+      60A      2.361192    61A      2.361212    62A      2.419433  
+      63A      2.435479    64A      2.557280    65A      2.609468  
+      66A      3.178777    67A      3.205768    68A      3.240310  
+      69A      3.281463    70A      3.606586    71A      3.771797  
+      72A      3.831297    73A      3.994581    74A      4.809475  
+      75A      4.811364    76A      4.887589    77A      4.957980  
+      78A      5.220587    79A      5.779581    80A      6.479873  
+      81A      6.902019    82A     33.374399  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:   -76.35997007576776
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1638301522788908
+    One-Electron Energy =                -122.9197495015051658
+    Two-Electron Energy =                  44.4081661898460425
+    DFT Exchange-Correlation Energy =      -7.0122169163875299
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -76.3599700757677624
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:   -26.9920      Y:    -0.2173      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:    27.3447      Y:     0.8603      Z:    -0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.3527      Y:     0.6430      Z:    -0.0000     Total:     0.7333
+
+  Dipole Moment: (Debye)
+     X:     0.8964      Y:     1.6342      Z:    -0.0000     Total:     1.8639
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:09:45 2018
+Module time:
+	user time   =      10.89 seconds =       0.18 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+Total time:
+	user time   =      15.50 seconds =       0.26 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =         15 seconds =       0.25 minutes
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Sat Mar 24 18:09:45 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line   250 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3, 5-6 entry H          line    36 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                          SAPT(DFT): DFT Monomer B                 
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O(Gh)     -2.806551984509    -0.216798006758     0.000000000000    15.994914619560
+           H(Gh)     -3.530793303509     1.440535274242     0.000000000000     1.007825032070
+           H(Gh)     -1.008798823509     0.076547960242     0.000000000000     1.007825032070
+           O          2.676737829491     0.210259312242     0.000000000000    15.994914619560
+           H          3.299918485491    -0.706654703758    -1.433472544000     1.007825032070
+           H          3.299918485491    -0.706654703758     1.433472544000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.15151  B =      0.21457  C =      0.21447 [cm^-1]
+  Rotational constants: A = 214396.91710  B =   6432.69057  C =   6429.61814 [MHz]
+  Nuclear repulsion =    9.178038911705691
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 38
+    Number of basis function: 82
+    Number of Cartesian functions: 86
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: PBE0 <= 
+
+    PBE0 Hyb-GGA Exchange-Correlation Functional
+
+    J.P. Perdew et. al., J. Chem. Phys., 105(22), 9982-9985, 1996
+    C. Adamo et. a., J. Chem Phys., 110(13), 6158-6170, 1999
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.7500     XC_GGA_X_PBE
+
+   => Exact (HF) Exchange <=
+
+    0.2500               HF 
+
+   => Correlation Functionals <=
+
+    1.0000     XC_GGA_C_PBE
+
+   => Asymptotic Correction <=
+
+    X Functional        =    XC_GGA_X_LB
+    C Functional        =   XC_LDA_C_VWN
+    Bulk Shift          =       0.136000
+    GRAC Alpha          =       0.500000
+    GRAC Beta           =      40.000000
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             75
+    Spherical Points    =            302
+    Total Points        =         135900
+    Total Blocks        =           1092
+    Max Points          =            256
+    Max Functions       =             82
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   270 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    70 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         82      82       0       0       0       0
+   -------------------------------------------------------
+    Total      82      82       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.5458174102E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:   -76.32485124181422   -7.63249e+01   1.96783e-02 
+   @DF-RKS iter   1:   -76.29795425647171    2.68970e-02   4.88136e-03 
+   @DF-RKS iter   2:   -76.21875039542296    7.92039e-02   7.48782e-03 DIIS
+   @DF-RKS iter   3:   -76.36002960581156   -1.41279e-01   1.58265e-04 DIIS
+   @DF-RKS iter   4:   -76.36011676985976   -8.71640e-05   3.36993e-05 DIIS
+   @DF-RKS iter   5:   -76.36011781416957   -1.04431e-06   4.95860e-06 DIIS
+   @DF-RKS iter   6:   -76.36011732549079    4.88679e-07   1.53350e-07 DIIS
+   @DF-RKS iter   7:   -76.36011732268395    2.80684e-09   2.09588e-08 DIIS
+   @DF-RKS iter   8:   -76.36011732384536   -1.16141e-09   4.42100e-09 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -19.364333     2A     -1.182303     3A     -0.686226  
+       4A     -0.545232     5A     -0.467216  
+
+    Virtual:                                                              
+
+       6A     -0.120515     7A     -0.058379     8A     -0.036847  
+       9A     -0.003718    10A      0.025354    11A      0.031556  
+      12A      0.048870    13A      0.068738    14A      0.070205  
+      15A      0.079326    16A      0.099376    17A      0.115446  
+      18A      0.133412    19A      0.153217    20A      0.183220  
+      21A      0.221905    22A      0.277882    23A      0.310399  
+      24A      0.324371    25A      0.332798    26A      0.361433  
+      27A      0.374483    28A      0.382198    29A      0.403341  
+      30A      0.437222    31A      0.444118    32A      0.500065  
+      33A      0.535473    34A      0.589311    35A      0.686647  
+      36A      0.807584    37A      0.812826    38A      0.851553  
+      39A      0.870408    40A      0.919150    41A      1.006052  
+      42A      1.023997    43A      1.073896    44A      1.109778  
+      45A      1.166323    46A      1.214361    47A      1.220932  
+      48A      1.288210    49A      1.306585    50A      1.349726  
+      51A      1.490338    52A      1.623934    53A      1.741036  
+      54A      1.815656    55A      1.971961    56A      2.038756  
+      57A      2.055200    58A      2.173250    59A      2.230182  
+      60A      2.252417    61A      2.303519    62A      2.388753  
+      63A      2.452998    64A      2.626859    65A      2.691575  
+      66A      3.214982    67A      3.222821    68A      3.317919  
+      69A      3.357369    70A      3.566902    71A      3.785192  
+      72A      3.817832    73A      3.934885    74A      4.782191  
+      75A      4.824439    76A      4.881865    77A      5.069177  
+      78A      5.361877    79A      5.569624    80A      6.553545  
+      81A      6.995510    82A     33.451910  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:   -76.36011732384536
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1780389117056913
+    One-Electron Energy =                -122.9449555301004295
+    Two-Electron Energy =                  44.4201121875596883
+    DFT Exchange-Correlation Energy =      -7.0133128930103146
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    Total Energy =                        -76.3601173238453583
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:    28.0137      Y:     0.2688      Z:     0.0000
+
+  Electronic Dipole Moment: (a.u.)
+     X:   -27.6023      Y:    -0.8730      Z:     0.0000
+
+  Dipole Moment: (a.u.)
+     X:     0.4114      Y:    -0.6043      Z:     0.0000     Total:     0.7310
+
+  Dipole Moment: (Debye)
+     X:     1.0457      Y:    -1.5359      Z:     0.0000     Total:     1.8581
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:09:55 2018
+Module time:
+	user time   =       9.70 seconds =       0.16 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+Total time:
+	user time   =      25.21 seconds =       0.42 minutes
+	system time =       0.82 seconds =       0.01 minutes
+	total time  =         25 seconds =       0.42 minutes
+
+         ---------------------------------------------------------
+               SAPT(DFT): Intermolecular Interaction Segment       
+
+                   by Daniel G. A. Smith and Rob Parrish           
+         ---------------------------------------------------------
+
+  ==> Algorithm <==
+
+   SAPT DFT Functional             PBE0
+   Monomer A GRAC Shift        0.136000
+   Monomer B GRAC Shift        0.136000
+   Delta HF                        True
+   JK Algorithm                      DF
+
+  ==> Preparing SAPT Data Cache <== 
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 104
+    Number of basis function: 300
+    Number of Cartesian functions: 342
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  ==> E10 Electostatics <== 
+
+    Elst10,r                -12.86731964 [mEh]
+
+  ==> E10 Exchange <== 
+
+    Exch10(S^2)              12.67339646 [mEh]
+    Exch10                   12.77393984 [mEh]
+
+  ==> E20 Induction <== 
+
+   => Uncoupled Induction <= 
+
+    Ind20,u (A<-B)           -1.69925606 [mEh]
+    Ind20,u (A->B)           -3.46496643 [mEh]
+    Ind20,u                  -5.16422249 [mEh]
+    Exch-Ind20,u (A<-B)       1.17548979 [mEh]
+    Exch-Ind20,u (A->B)       1.74827807 [mEh]
+    Exch-Ind20,u              2.92376786 [mEh]
+
+   => Coupled Induction <= 
+
+   ---------------------------------------------------
+              SAPT Coupled Induction Solver           
+   ---------------------------------------------------
+    Maxiter             =          20
+    Convergence         =   1.000E-06
+   ---------------------------------------------------
+     Iter       (A<-B)           (B->A)      Time [s]
+   ---------------------------------------------------
+    Guess    1.110374e-01     1.758544e-01          2
+        1    3.311672e-02     6.270134e-02          4
+        2    8.240456e-03     1.746531e-02          6
+        3    9.941316e-04     1.022648e-03          9
+        4    1.437439e-04     1.028856e-04         11
+        5    1.337157e-05     1.367886e-05         13
+        6    1.165030e-06     2.205980e-06         15
+        7    1.132748e-07*    1.731138e-07*        18
+   ---------------------------------------------------
+
+    Ind20,r (A<-B)           -1.71220226 [mEh]
+    Ind20,r (A->B)           -3.62389674 [mEh]
+    Ind20,r                  -5.33609900 [mEh]
+    Exch-Ind20,r (A<-B)       1.26796555 [mEh]
+    Exch-Ind20,r (A->B)       1.95538740 [mEh]
+    Exch-Ind20,r              3.22335294 [mEh]
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1, 4     entry O          line   204 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3, 5-6 entry H          line    30 file /Users/daniel/Gits/dgaspsi/psi4/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+
+  ==> E20 Dispersion (CHF FDDS) <== 
+
+   Legendre Points:          10
+   Lambda Shift:          0.300
+   Fxc Kernal:             ALDA
+   (P|Fxc|Q) Thresh:  1.000e-06
+
+   => Time Integration <= 
+
+       Omega       Weight       Disp20,u         Disp20   time [s]
+   2.269e+01    6.667e-02      2.586e-05      2.579e-05          0
+   4.147e+00    1.495e-01      1.082e-03      1.038e-03          0
+   1.572e+00    2.191e-01      4.405e-03      3.777e-03          0
+   7.589e-01    2.693e-01      7.148e-03      5.326e-03          0
+   4.049e-01    2.955e-01      7.047e-03      4.750e-03          0
+   2.223e-01    2.955e-01      5.289e-03      3.388e-03          0
+   1.186e-01    2.693e-01      3.494e-03      2.193e-03          0
+   5.727e-02    2.191e-01      2.157e-03      1.344e-03          0
+   2.170e-02    1.495e-01      1.206e-03      7.502e-04          0
+   3.966e-03    6.667e-02      4.811e-04      2.992e-04          0
+
+    Disp20,u                 -5.14632759 [mEh]
+    Disp20                   -3.64311560 [mEh]
+
+  ==> E20 Dispersion (MP2) <== 
+
+
+    ==> DF_Helper <==
+      nao           = 82
+      naux          = 236
+      Scwarz cutoff = 1.000000E-12
+      mem (doubles) = 58942056
+      nthreads      = 1
+      Algorithm     = DIRECT_iaQ
+      AO_core?      = 1
+      MO_core?      = 0
+      hold metric   = 0
+      metric power  = -5.000000E-01
+  Fitting condition = 1.000000E-12
+  Mask sparsity (%) = (0.000000)
+
+
+
+    Disp20 (MP2)             -5.14618855 [mEh]
+    Exch-Disp20,u             0.96426884 [mEh]
+
+   SAPT(DFT) Results
+  -------------------------------------------------------------------------------------------------
+    Electrostatics          -12.86731964 [mEh]     -8.07436532 [kcal/mol]    -33.78314773 [kJ/mol]
+      Elst1,r               -12.86731964 [mEh]     -8.07436532 [kcal/mol]    -33.78314773 [kJ/mol]
+
+    Exchange                 12.77393984 [mEh]      8.01576860 [kcal/mol]     33.53797904 [kJ/mol]
+      Exch1                  12.77393984 [mEh]      8.01576860 [kcal/mol]     33.53797904 [kJ/mol]
+      Exch1(S^2)             12.67339646 [mEh]      7.95267667 [kcal/mol]     33.27400240 [kJ/mol]
+
+    Induction                -3.53895387 [mEh]     -2.22072718 [kcal/mol]     -9.29152339 [kJ/mol]
+      Ind2,r                 -5.33609900 [mEh]     -3.34845282 [kcal/mol]    -14.00992793 [kJ/mol]
+      Exch-Ind2,r             3.22335294 [mEh]      2.02268459 [kcal/mol]      8.46291316 [kJ/mol]
+      Induction (A<-B)       -0.44423671 [mEh]     -0.27876276 [kcal/mol]     -1.16634349 [kJ/mol]
+      Induction (A->B)       -1.66850935 [mEh]     -1.04700546 [kcal/mol]     -4.38067129 [kJ/mol]
+      delta HF,r (2)         -1.42620782 [mEh]     -0.89495895 [kcal/mol]     -3.74450862 [kJ/mol]
+
+    Dispersion               -2.67884676 [mEh]     -1.68100179 [kcal/mol]     -7.03331218 [kJ/mol]
+      Disp2,r                -3.64311560 [mEh]     -2.28608965 [kcal/mol]     -9.56500002 [kJ/mol]
+      Disp2,u                -5.14618855 [mEh]     -3.22928220 [kcal/mol]    -13.51131803 [kJ/mol]
+      Exch-Disp2,u            0.96426884 [mEh]      0.60508786 [kcal/mol]      2.53168784 [kJ/mol]
+
+   Total SAPT(DFT)           -6.31118045 [mEh]     -3.96032569 [kcal/mol]    -16.57000426 [kJ/mol]
+  -------------------------------------------------------------------------------------------------
+
+*** tstop() called on Daniels-MacBook-Pro.local at Sat Mar 24 18:10:15 2018
+Module time:
+	user time   =      30.11 seconds =       0.50 minutes
+	system time =       1.07 seconds =       0.02 minutes
+	total time  =         30 seconds =       0.50 minutes
+Total time:
+	user time   =      45.62 seconds =       0.76 minutes
+	system time =       1.67 seconds =       0.03 minutes
+	total time  =         45 seconds =       0.75 minutes
+	SAPT ELST ENERGY..................................................PASSED
+	SAPT EXCH ENERGY..................................................PASSED
+	SAPT IND ENERGY...................................................PASSED
+	SAPT DISP ENERGY..................................................PASSED
+	CURRENT ENERGY....................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Makes SAPT(DFT) quite a bit more flexible by allowing a potential user to build SCF wavefunctions (any will work, HF or DFT). An example can be found in `tests/sapt-dft-api`.

I have also added LRC references with SAPT(DFT). @ajmisquitta please checkout `tests/sapt-dft-lrc` and verify these are working as expected.

Closes #939 .

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Users can now call SAPT(DFT) directly with reference wave functions.

## Status
- [x] Ready to go