### PR TITLE
testing whether DSD trouble is just in my build

### DIFF
--- a/tests/dft-custom-dhdf/CMakeLists.txt
+++ b/tests/dft-custom-dhdf/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-custom-dhdf "psi;dft;scf")
+add_regression_test(dft-custom-dhdf "psi;dft;quicktests;scf")


### PR DESCRIPTION
## Description
DSD-BLYP and DSD-PBE-PBE86 subtests in dft-custom-dhdf are failing. This is the easiest way to get it tested externally.