### PR TITLE
PSI_API exports for v2rdm_casscf

### DIFF
--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,8 +16,10 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
-            GIT_TAG v0.6
+            #GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
+            #GIT_TAG fbbf734  # v0.6 + 11
+            GIT_REPOSITORY https://github.com/loriab/v2rdm_casscf
+            GIT_TAG 7d4507d
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/src/psi4/libciomr/tstart.cc
+++ b/psi4/src/psi4/libciomr/tstart.cc
@@ -60,7 +60,7 @@ double user_stop, sys_stop;
 **
 ** \ingroup CIOMR
 */
-void tstart()
+void PSI_API tstart()
 {
   int error;
   char *name;

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -524,7 +524,7 @@ public:
  */
 extern dpd_gbl dpd_main;
 extern PSI_API DPD* global_dpd_;
-extern int dpd_default;
+extern PSI_API int dpd_default;
 extern DPD* dpd_list[2];
 extern PSI_API int dpd_set_default(int dpd_num);
 extern int dpd_init(int dpd_num, int nirreps, long int memory, int cachetype,

--- a/psi4/src/psi4/libiwl/buf_close.cc
+++ b/psi4/src/psi4/libiwl/buf_close.cc
@@ -66,7 +66,7 @@ void IWL::close()
 ** Close a Integrals With Labels Buffer
 ** \ingroup IWL
 */
-void iwl_buf_close(struct iwlbuf *Buf, int keep)
+void PSI_API iwl_buf_close(struct iwlbuf *Buf, int keep)
 {
 
    psio_close(Buf->itap, keep ? 1 : 0);

--- a/psi4/src/psi4/libiwl/buf_init.cc
+++ b/psi4/src/psi4/libiwl/buf_init.cc
@@ -113,7 +113,7 @@ void IWL::init(PSIO *psio, int it, double coff, int oldfile, int readflag)
 ** Revised 6/26/96 by CDS for new format
 ** \ingroup IWL
 */
-void iwl_buf_init(struct iwlbuf *Buf, int itape, double cutoff,
+void PSI_API iwl_buf_init(struct iwlbuf *Buf, int itape, double cutoff,
       int oldfile, int readflag)
 {
 

--- a/psi4/src/psi4/libmints/get_writer_file_prefix.cc
+++ b/psi4/src/psi4/libmints/get_writer_file_prefix.cc
@@ -61,7 +61,7 @@ namespace psi {
 ** \ingroup MINTS
 */
 
-std::string get_writer_file_prefix(const std::string& molecule_name)
+std::string PSI_API get_writer_file_prefix(const std::string& molecule_name)
 {
     const std::string pid= "." + std::to_string(getpid());
     const std::string label = Process::environment.options.get_str("WRITER_FILE_LABEL");

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -351,7 +351,7 @@ bool Data::is_array() const { return ptr_->is_array(); }
 
 size_t Data::size() const { return ptr_->size(); }
 
-bool Data::has_changed() const { return ptr_->has_changed(); }
+bool PSI_API Data::has_changed() const { return ptr_->has_changed(); }
 
 void Data::changed() { ptr_->changed(); }
 

--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -134,7 +134,7 @@ public:
 /**
 * Exception for sanity checks being performed, e.g. checking alignment of matrix multiplication.
 */
-class SanityCheckError : public PsiException
+class PSI_API SanityCheckError : public PsiException
 {
 
 public:

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -116,7 +116,7 @@ void C_DCOPY(size_t length, double *x, int inc_x,
              double *y, int inc_y);
 void C_DAXPY(size_t length, double a, double *x, int inc_x,
              double *y, int inc_y);
-double C_DDOT(size_t n, double *X, int inc_x, double *Y, int inc_y);
+PSI_API double C_DDOT(size_t n, double *X, int inc_x, double *Y, int inc_y);
 double C_DNRM2(size_t n, double *X, int inc_x);
 double C_DASUM(size_t n, double *X, int inc_x);
 size_t C_IDAMAX(size_t n, double *X, int inc_x);


### PR DESCRIPTION
## Description
Make v2rdm_casscf work with psi in the v2.2.2 pybind11 era

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] half done adding `PSI_API` to psi where v2rdm wants it
  - [x] corresponding v2rdm repo change is https://github.com/loriab/v2rdm_casscf/commit/7d4507d8979b61b3333fc6ceab450a61392836ff

## Questions
- [ ] @jturney, @edeprince3, I intended to finish this, but I'm confused by `C_DDOT`. `core.so` has the symbol that `v2rdm_casscf.so` wants, but the test file complains about DDOT anyway. Maybe there's some more complicated place that `PSI_API` needs to be inserted that I'm not seeing from simple pattern following. So consider this work a start and a puzzle.
```
>>> ../hrw-qcdb/objdir/stage/usr/local/psi4/bin/psi4 tests/v2rdm3/input.dat 
        H3 / cc-pvdz / D+D3 vs full CI, scf_type = PK
/home/psilocaluser/miniconda3/envs/idp35p4/bin/python: symbol lookup error: /home/psilocaluser/gits/hrw-qcdb/objdir/stage/usr/local/psi4/lib/v2rdm_casscf/v2rdm_casscf.so: undefined symbol: _ZN3psi6C_DDOTEmPdiS0_i
>>> nm v2rdm_casscf.so | grep DDOT
                 U _ZN3psi6C_DDOTEmPdiS0_i
>>> nm ../hrw-qcdb/objdir/stage/usr/local/psi4/lib/psi4/core.so | grep DDOT
00000000006013c0 t _ZN3psi6C_DDOTEmPdiS0_i
00000000017384d0 t _ZN3psi8PSI_DDOTEimSt10shared_ptrINS_6VectorEEiS2_i
```

## Status
- [ ] Ready for review
- [ ] Ready for merge
