### PR TITLE
Bump gau2grid to v1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #    - BLAS/LAPACK (also runtime; e.g., `conda install mkl mkl-include`)
 #    - Python (also runtime; interpreter and headers; e.g., `conda install python`)
 #    - NumPy (also runtime; avoidable at buildtime if gau2grid pre-built; e.g., `conda install numpy`)
-#    - mpmath (avoidable if gau2grid pre-built; e.g., `conda install mpmath`)
 #    - deepdiff (runtime only; e.g., `conda install deepdiff -c conda-forge`)
 
 #  These three "###  Options  ###" sections contain useful CMake variables for build configuration.

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -194,7 +194,7 @@ that software for |PSIfour| and any notes and warnings pertaining to it.
 
 * NumPy (needed at runtime *and* buildtime) http://www.numpy.org/
 
-* mpmath (needed at buildtime) http://mpmath.org/
+* mpmath (only needed if you build gau2grid to angular momentum >16) http://mpmath.org/
 
 * System utilities: GNU make, GNU install, POSIX threads (Pthreads) library
 

--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -148,9 +148,10 @@ A typical input for a Hartree--Fock calculation with PCM would look like the fol
     }
 
 More examples can be found in the directories with PCM tests
-:srcsample:`pcmsolver/pcm-scf`,
-:srcsample:`pcmsolver/pcm-dft`, and
-:srcsample:`pcmsolver/pcm-dipole`.
+:srcsample:`pcmsolver/ccsd-pte`,
+:srcsample:`pcmsolver/scf`,
+:srcsample:`pcmsolver/dft`, and
+:srcsample:`pcmsolver/dipole`.
 
 Keywords for PCMSolver
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/external/upstream/gau2grid/CMakeLists.txt
+++ b/external/upstream/gau2grid/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
     ExternalProject_Add(gau2grid_external
         DEPENDS pybind11_external
         GIT_REPOSITORY https://github.com/dgasmith/gau2grid
-        GIT_TAG v1.0
+        GIT_TAG v1.0.1
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/gau2grid/CMakeLists.txt
+++ b/external/upstream/gau2grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(gau2grid CONFIG QUIET 0.1)
+find_package(gau2grid CONFIG QUIET 1.0)
 
 if(${gau2grid_FOUND})
     get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
@@ -14,7 +14,7 @@ else()
     ExternalProject_Add(gau2grid_external
         DEPENDS pybind11_external
         GIT_REPOSITORY https://github.com/dgasmith/gau2grid
-        GIT_TAG v0.1  #v3.0.0  # TODO tag when stable
+        GIT_TAG v1.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -99,7 +99,7 @@ else()
     message(STATUS "Disabled erd")
 endif()
 
-find_package(gau2grid 0.1 CONFIG REQUIRED)
+find_package(gau2grid 1.0 CONFIG REQUIRED)
 get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using gau2grid${ColourReset}: ${_loc} (version ${gau2grid_VERSION})")


### PR DESCRIPTION
## Description
Bump gau2grid to v1.0 and lose `mpmath`.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] gau2grid is `v1.0` now, so pointing to that. This drops the `mpmath` requirement.
    - Note that bumping the `find_package(gau2grid 1.0)` is only for appearances sake since 0.1 tag worked just fine. 
  - [x] Fix pcm test links closes #967
* **User-Facing for Release Notes**

## Status
- [x] Ready for review
- [ ] Ready for merge
