### PR TITLE
Addon: Bumps snsmp2 back upstream

### DIFF
--- a/external/downstream/snsmp2/CMakeLists.txt
+++ b/external/downstream/snsmp2/CMakeLists.txt
@@ -14,10 +14,8 @@ if(${ENABLE_snsmp2})
 
         ExternalProject_Add(snsmp2_external
             BUILD_ALWAYS 1
-            #GIT_REPOSITORY https://github.com/DEShawResearch/sns-mp2
-            GIT_REPOSITORY https://github.com/loriab/sns-mp2
-            #GIT_TAG 83281dc
-            GIT_TAG importfixes
+            GIT_REPOSITORY https://github.com/DEShawResearch/sns-mp2
+            GIT_TAG a70c56f  # v1.0 + 13
             CONFIGURE_COMMAND ""
             UPDATE_COMMAND ""
             BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build


### PR DESCRIPTION
## Description
Addon: Bumps snsmp2 back upstream. This got fixed over winter break, but I never redirected back upstream.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] snsmp2 w/o sneaking scipy import (a70c56f  # v1.0 + 13)

## Status
- [x] Ready for review
- [x] Ready for merge
