### PR TITLE
Adds NumPy to the psi4-dev clone.

### DIFF
--- a/doc/sphinxman/source/conda.rst
+++ b/doc/sphinxman/source/conda.rst
@@ -228,7 +228,7 @@ How to use conda to compile Psi4 faster and easier
 
     # Linux or Mac or Windows
     # substitute x.x by 2.7|3.5|3.6 for alternate python versions
-    >>> conda create -n p4dev python=x.x psi4-dev -c psi4
+    >>> conda create -n p4dev python=x.x psi4-dev numpy -c psi4
 
 Same for Linux/Mac/Windows. Substitute desired python version: 2.7, 3.5, 3.6. Fine
 to choose your own env name. Activate environment, ``source activate
@@ -237,8 +237,9 @@ It gives you a basic cmake command covering python, sphinx, link-time qc
 addons, and run-time qc addons. There's a help menu -h that gives more
 info. There's other options that will also pre-configure compilers. For
 example, at GaTech ``psi4-path-advisor --intel`` works. On Macs with
-XCode, ``psi4-path-advisor --clang`` works. Just read the help. For DGAS,
-there's a ``--disable-addons``, but I don't encourage it. It gives you a fully
+XCode, ``psi4-path-advisor --clang`` works. Just read the help. For users
+who want a quicker build, there's a ``--disable-addons``, but it is generally not
+encouraged. It gives you a fully
 functional cmake command, but those are just setting up CMake cache
 |w---w| like the plugins you can always add your own CMake variables to
 the command.

--- a/doc/sphinxman/source/conda.rst
+++ b/doc/sphinxman/source/conda.rst
@@ -228,17 +228,19 @@ How to use conda to compile Psi4 faster and easier
 
     # Linux or Mac or Windows
     # substitute x.x by 2.7|3.5|3.6 for alternate python versions
-    >>> conda create -n p4dev python=x.x psi4-dev numpy -c psi4
+    >>> conda create -n p4dev python=x.x psi4-dev numpy deepdiff [-c psi4/label/dev] -c psi4
 
 Same for Linux/Mac/Windows. Substitute desired python version: 2.7, 3.5, 3.6. Fine
-to choose your own env name. Activate environment, ``source activate
+to choose your own env name. Include ``-c psi4/label/dev`` to get dependencies to
+build current master, as opposed to latest release. 
+Activate environment, ``source activate
 p4dev``.  Go to where you've cloned psi4. Execute ``psi4-path-advisor``.
 It gives you a basic cmake command covering python, sphinx, link-time qc
 addons, and run-time qc addons. There's a help menu -h that gives more
 info. There's other options that will also pre-configure compilers. For
 example, at GaTech ``psi4-path-advisor --intel`` works. On Macs with
 XCode, ``psi4-path-advisor --clang`` works. Just read the help. For users
-who want a quicker build, there's a ``--disable-addons``, but it is generally not
+who want a minimal build, there's a ``--disable-addons``, but it is generally not
 encouraged. It gives you a fully
 functional cmake command, but those are just setting up CMake cache
 |w---w| like the plugins you can always add your own CMake variables to


### PR DESCRIPTION
## Description
Adds NumPy to the psi4-dev environment as it is 1) required to build gau2grid and 2) required to run Psi4.

We also need to install deep-diff here as well which is only available on pip/conda-forge. Should this be: `conda create -n p4dev python=x.x psi4-dev numpy deep-diff -c psi4 -c conda-forge`
 
## Status
- [x] Ready for review
- [x] Ready for merge
