### PR TITLE
Avoid hungarian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,10 +141,8 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n p4env python=$PYTHON_VER numpy cmake ci-psi4-lt psi4-lt-mp gau2grid dftd3 gcp snsmp2 scipy -c psi4/label/dev -c psi4
+- conda create -q -n p4env python=$PYTHON_VER numpy cmake ci-psi4-lt psi4-lt-mp gau2grid dftd3 gcp snsmp2 scipy deepdiff -c psi4/label/dev -c psi4
 - source activate p4env
-- conda install hungarian networkx -c psi4
-- conda install deepdiff -c conda-forge
 - conda list
 before_script:
 - python -V

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
-project(psi4-core LANGUAGES C CXX VERSION 1.1)
+project(psi4-core
+        LANGUAGES C CXX)
 # no Fortran in psi4-core proper, but language needs to be declared
 #   for CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES to be populated so
 #   static Fortran add-ons can be linked
@@ -155,14 +156,19 @@ include_directories(src)
 add_subdirectory(src)
 
 # <<<  Version  >>>
+# * computes version from metadata.py and git info
+# * calls cmake to run write_basic_package_version_file
 
 add_custom_target(update_version ALL
                   COMMAND ${PYTHON_EXECUTABLE} versioner.py --metaout ${CMAKE_CURRENT_BINARY_DIR}/metadata.py
+                                                            --cmakeout ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+                  COMMAND cmake -DWTO="${CMAKE_CURRENT_BINARY_DIR}/${CMAKECONFIG_INSTALL_DIR}"
+                                -DPN="psi4"
+                                -P ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   COMMENT "Generating version info")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/metadata.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4)
-    # TODO absorb some version info into CM variables, write to package, adj psi4ConfigVersion to sort dev
 
 # <<<  Install  >>>
 
@@ -279,10 +285,6 @@ configure_package_config_file(
         psi4Config.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/share/cmake/psi4/psi4Config.cmake
         INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
-write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/share/cmake/psi4/psi4ConfigVersion.cmake
-        VERSION ${psi4_VERSION}
-        COMPATIBILITY SameMajorVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/cmake/psi4/psi4Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/share/cmake/psi4/psi4ConfigVersion.cmake
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -1893,10 +1893,6 @@ class LibmintsMolecule(object):
 
     def set_basis_all_atoms(self, name, role="BASIS"):
         """Assigns basis *name* to all atoms."""
-        uc = name.upper()
-        if uc in ['SPECIAL', 'GENERAL', 'CUSTOM']:
-            # These aren't really basis set specifications, just return.
-            return
         for atom in self.full_atoms:
             atom.set_basisset(name, role)
 

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2876,10 +2876,6 @@ int Molecule::ftrue_atomic_number(int atom) const {
 }
 
 void Molecule::set_basis_all_atoms(const std::string &name, const std::string &type) {
-    std::string uc = to_upper_copy(name);
-    // These aren't really basis set specifications, just return.
-    if (uc == "SPECIAL" || uc == "GENERAL" || uc == "CUSTOM") return;
-
     for (std::shared_ptr<CoordEntry> atom : full_atoms_) {
         atom->set_basisset(name, type);
     }

--- a/psi4/versioner.py
+++ b/psi4/versioner.py
@@ -36,16 +36,6 @@ import argparse
 import subprocess
 
 
-#    with open('../psi4-config.tmp', 'r') as handle:
-#        f = handle.read()
-#    with open('../psi4-config', 'w') as handle:
-#        handle.write(f)
-#        handle.write('    psiver = "%s"\n' % (mmp))
-#        handle.write('    githash = "{%s} %s %s"\n' % (branch, ghash, status))
-#        handle.write('    sys.exit(main(sys.argv))\n\n')
-#    os.chmod('../psi4-config', 0o755)
-
-
 def collect_version_input_from_fallback(meta_file='metadata.py'):
     """From *meta_file*, collect lines matching ``_version_{key} = {value}``
     and return as dictionary.
@@ -293,6 +283,20 @@ if __name__ == '__main__':
         handle.write(main_fn)
 
 
+def write_new_cmake_metafile(versdata, outfile='metadata.out.cmake'):
+    main_fn = """
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+        ${{WTO}}/${{PN}}ConfigVersion.cmake
+        VERSION {ver}
+        COMPATIBILITY AnyNewerVersion)
+"""
+
+    with open(os.path.abspath(outfile), 'w') as handle:
+        handle.write(main_fn.format(ver=versdata['__version_cmake']))
+
+
 def version_formatter(versdata, formatstring="""{version}"""):
     """Return version information string with data from *versdata* when
     supplied with *formatstring* suitable for ``formatstring.format()``.
@@ -321,11 +325,13 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Script to extract Psi4 version from source. Use psi4.version_formatter(fmt_string) after build.')
     parser.add_argument('--metaout', default='metadata.out.py', help='file to which the computed version info written')
+    parser.add_argument('--cmakeout', default='metadata.out.cmake', help='file to which the CMake ConfigVersion generator written')
     parser.add_argument('--format', default='all', help='string like "{version} {githash}" to be filled in and returned')
     parser.add_argument('--formatonly', action='store_true', help='print only the format string, not the detection info')
     args = parser.parse_args()
 
     ans = reconcile_and_compute_version_output(quiet=args.formatonly)
     write_new_metafile(ans, args.metaout)
+    write_new_cmake_metafile(ans, args.cmakeout)
     ans2 = version_formatter(ans, formatstring=args.format)
     print(ans2)

--- a/tests/pywrap-align-chiral/CMakeLists.txt
+++ b/tests/pywrap-align-chiral/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(pywrap-align-chiral "psi;quicktests;cart")
+add_regression_test(pywrap-align-chiral "psi;cart")
 

--- a/tests/pywrap-align/CMakeLists.txt
+++ b/tests/pywrap-align/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(pywrap-align "psi;quicktests;cart")
+add_regression_test(pywrap-align "psi;cart")


### PR DESCRIPTION
## Description
Misc.

## Todos
* **Developer Interest**
  - [x] CI: Removes align tests that require hungarian package from quicktests
  - [x] Allow basis set blocks to be names "custom", "special", "general" w/o spewing a page of errors at you.
  - [x] CMake: upgrade versioner to avoid hard-coded project version

## Status
- [x] Ready for review
- [x] Ready for merge
