### PR TITLE
Handle ECP's in n_frozen_core(), fixes #976

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1336,7 +1336,8 @@ void export_mints(py::module& m) {
         .def("shell", center_version(&BasisSet::shell), py::return_value_policy::copy,
              "Return the si'th Gaussian shell on center", py::arg("center"), py::arg("si"))
         .def("n_frozen_core", &BasisSet::n_frozen_core,
-             "Returns the number of frozen core electrons, accounting for the presence of any ECPs.")
+             "Returns the number of orbital (non-ECP) frozen core electrons. For a given molecule and "
+             "|globals__freeze_core|, `(n_ecp_core()/2 + n_frozen_core()) = constant`.")
         .def("n_ecp_core", ncore_no_args(&BasisSet::n_ecp_core),
              "Returns the total number of core electrons associated with all ECPs in this basis.")
         .def("n_ecp_core", ncore_one_arg(&BasisSet::n_ecp_core),

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -188,8 +188,6 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
         // will still have 3d electrons active.  Alkali earth atoms will
         // have one valence electron in this scheme.
         for (int A = 0; A < mymol->natom(); A++) {
-            // If this center as an ECP present, move along.
-            if (n_ecp_core(mymol->label(A))) continue;
             double Z = mymol->Z(A);
             if (Z > 2) nfzc += 1;
             if (Z > 10) nfzc += 4;
@@ -200,6 +198,9 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
             if (Z > 108) {
                 throw PSIEXCEPTION("Invalid atomic number");
             }
+            // If this center has an ECP, some pairs are already frozen
+            double ECP = n_ecp_core(mymol->label(A));
+            if (ECP > 0) nfzc -= ECP/2;
         }
         return nfzc;
     } else {

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -189,7 +189,7 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
         // have one valence electron in this scheme.
         for (int A = 0; A < mymol->natom(); A++) {
             double Z   = mymol->Z(A);
-            // Add ECPs to the number of electrons
+            // Add ECPs to Z, the number of electrons less ECP-treated electrons
             double ECP = n_ecp_core(mymol->label(A));
             if (Z + ECP > 2) nfzc += 1;
             if (Z + ECP > 10) nfzc += 4;

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -188,18 +188,19 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
         // will still have 3d electrons active.  Alkali earth atoms will
         // have one valence electron in this scheme.
         for (int A = 0; A < mymol->natom(); A++) {
-            double Z = mymol->Z(A);
-            if (Z > 2) nfzc += 1;
-            if (Z > 10) nfzc += 4;
-            if (Z > 18) nfzc += 4;
-            if (Z > 36) nfzc += 9;
-            if (Z > 54) nfzc += 9;
-            if (Z > 86) nfzc += 16;
-            if (Z > 108) {
+            double Z   = mymol->Z(A);
+            // Add ECPs to the number of electrons
+            double ECP = n_ecp_core(mymol->label(A));
+            if (Z + ECP > 2) nfzc += 1;
+            if (Z + ECP > 10) nfzc += 4;
+            if (Z + ECP > 18) nfzc += 4;
+            if (Z + ECP > 36) nfzc += 9;
+            if (Z + ECP > 54) nfzc += 9;
+            if (Z + ECP > 86) nfzc += 16;
+            if (Z + ECP > 108) {
                 throw PSIEXCEPTION("Invalid atomic number");
             }
             // If this center has an ECP, some pairs are already frozen
-            double ECP = n_ecp_core(mymol->label(A));
             if (ECP > 0) nfzc -= ECP/2;
         }
         return nfzc;

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -295,7 +295,7 @@ public:
     /// Set the number of electrons associated with the given atom label, for an ECP basis set.
     void set_n_ecp_core(const std::string &label, int n) { ncore_[std::string(label)] = n; }
 
-    /// Number of frozen core for molecule given freezing state, accounting for any ECP present
+    /// Number of frozen core for molecule given freezing state, less any ECP present
     int n_frozen_core(const std::string& depth = "", SharedMolecule mol=nullptr);
 
     /** @{

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -2,7 +2,8 @@
 
 refnuc =   45.86202474447                                                                #TEST
 refall = -457.47320868249                                                                #TEST
-reffzc = -457.47130951838                                                                #TEST
+reffzc = -457.38127218548                                                                #TEST
+reffHe = -457.47130951838                                                                #TEST
 
 molecule dimer {
     Ne
@@ -14,13 +15,20 @@ set {
     print 2
 }
 
-# All electrons on Ne correlated
+# All electrons on Ne correlated, all non-ECP electrons on Xe correlated
 Eall = energy('mp2')
 compare_values(refnuc, dimer.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy")  #TEST 
-compare_values(refall, Eall, 8, "All Ne electrons correlated MP2 energy with ECP")       #TEST
+compare_values(refall, Eall, 8, "MP2 energy with all-electron Ne and ECP on Xe")         #TEST
 
 set freeze_core true
 set guess read
-# 1s electrons on Ne frozen, but Xe should not be affected
+# [He] electrons on Ne frozen, [Kr] electrons on Xe frozen
 Efzc = energy('mp2')
-compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")                       #TEST
+compare_values(reffzc, Efzc, 8, "MP2 energy with frozen [He] and [Kr]")                  #TEST
+
+set freeze_core false
+set num_frozen_docc 1
+set guess read
+# [He] electrons on Ne frozen,  only ECP electrons on Xe frozen
+EfHe = energy('mp2')
+compare_values(reffHe, EfHe, 8, "MP2 energy with frozen [He] and ECP")                   #TEST

--- a/tests/dfmp2-ecp/output.ref
+++ b/tests/dfmp2-ecp/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc2.dev31 
+                               Psi4 1.2a1.dev1146 
 
-                         Git: Rev {ecp} a8f543a dirty
+                         Git: Rev {ecp_fc_fix} ab1c6e4 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -12,15 +12,17 @@
     H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
     P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
     F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    submitted.
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 24 April 2017 10:58PM
+    Psi4 started on: Tuesday, 01 May 2018 11:30AM
 
-    Process ID:  87650
-    PSIDATADIR: /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4
+    Process ID: 29021
+    Host:       dream
+    PSIDATADIR: /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -31,7 +33,8 @@
 
 refnuc =   45.86202474447                                                                #TEST
 refall = -457.47320868249                                                                #TEST
-reffzc = -457.47130951838                                                                #TEST
+reffzc = -457.38127218548                                                                #TEST
+reffHe = -457.47130951838                                                                #TEST
 
 molecule dimer {
     Ne
@@ -43,29 +46,36 @@ set {
     print 2
 }
 
-# All electrons on Ne correlated
+# All electrons on Ne correlated, all non-ECP electrons on Xe correlated
 Eall = energy('mp2')
 compare_values(refnuc, dimer.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy")  #TEST 
-compare_values(refall, Eall, 8, "All Ne electrons correlated MP2 energy with ECP")       #TEST
+compare_values(refall, Eall, 8, "MP2 energy with all-electron Ne and ECP on Xe")         #TEST
 
 set freeze_core true
 set guess read
-# 1s electrons on Ne frozen, but Xe should not be affected
+# [He] electrons on Ne frozen, [Kr] electrons on Xe frozen
 Efzc = energy('mp2')
-compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")                       #TEST
+compare_values(reffzc, Efzc, 8, "MP2 energy with frozen [He] and [Kr]")                  #TEST
+
+set freeze_core false
+set num_frozen_docc 1
+set guess read
+# [He] electrons on Ne frozen,  only ECP electrons on Xe frozen
+EfHe = energy('mp2')
+compare_values(reffHe, EfHe, 8, "MP2 energy with frozen [He] and ECP")                   #TEST
 --------------------------------------------------------------------------
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on QuickSilver.local
-*** at Mon Apr 24 22:58:27 2017
+*** tstart() called on dream
+*** at Tue May  1 11:30:54 2018
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2829) file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
 
     There are an even number of electrons - assuming singlet.
     Specify the multiplicity in the molecule input block.
@@ -73,7 +83,8 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -94,7 +105,7 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
 
   Rotational constants: A = ************  B =      0.10789  C =      0.10789 [cm^-1]
   Rotational constants: A = ************  B =   3234.43513  C =   3234.43513 [MHz]
-  Nuclear repulsion =   45.862024744466659
+  Nuclear repulsion =   45.862024744466652
 
   Charge       = 0
   Multiplicity = 1
@@ -132,8 +143,6 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
        2    XE     11s 10p 8d 2f // 6s 5p 3d 2f 
 
   -CORE POTENTIAL INFORMATION:
-    Name                     = DEF2-SVP
-    Blend                    = DEF2-SVP
     Total number of shells   = 4
     Number of terms          = 29
     Number of core electrons = 28
@@ -150,8 +159,8 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 1 entry NE         line   443 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 2 entry XE         line  5086 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -199,7 +208,7 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
        1    NE     14s 10p 6d 2f 1g // 10s 8p 4d 2f 1g 
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
-  Minimum eigenvalue in the overlap matrix is 6.0588497331E-03.
+  Minimum eigenvalue in the overlap matrix is 6.0588497784E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -208,63 +217,63 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   151.01850141496206    1.51019e+02   7.29185e-01 
+   @DF-RHF iter   0:   150.90460272667428    1.50905e+02   7.29484e-01 
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [     8,    2,    4,    4 ]
 
-   @DF-RHF iter   1:  -315.34645650344811   -4.66365e+02   5.02510e-01 
+   @DF-RHF iter   1:  -315.35482173927250   -4.66259e+02   5.02471e-01 
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-   @DF-RHF iter   2:  -313.66789580747809    1.67856e+00   3.77628e-01 DIIS
+   @DF-RHF iter   2:  -313.66878811225735    1.68603e+00   3.77629e-01 DIIS
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [     8,    2,    4,    4 ]
 
-   @DF-RHF iter   3:  -420.22569124857006   -1.06558e+02   1.35020e-01 DIIS
+   @DF-RHF iter   3:  -420.22777104451234   -1.06559e+02   1.34973e-01 DIIS
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-   @DF-RHF iter   4:  -418.33608575613567    1.88961e+00   8.23144e-02 DIIS
+   @DF-RHF iter   4:  -418.33422098582162    1.89355e+00   8.23324e-02 DIIS
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [    10,    1,    4,    3 ]
 
-   @DF-RHF iter   5:  -425.80810064050502   -7.47201e+00   1.18314e-01 DIIS
+   @DF-RHF iter   5:  -425.83361086970478   -7.49939e+00   1.18458e-01 DIIS
     Occupation by irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-   @DF-RHF iter   6:  -436.85521843534246   -1.10471e+01   1.10238e-01 DIIS
-   @DF-RHF iter   7:  -452.26319405789854   -1.54080e+01   8.85560e-02 DIIS
-   @DF-RHF iter   8:  -451.14900780875627    1.11419e+00   9.81371e-02 DIIS
-   @DF-RHF iter   9:  -452.55265043170164   -1.40364e+00   8.45789e-02 DIIS
-   @DF-RHF iter  10:  -453.93186163547881   -1.37921e+00   7.05887e-02 DIIS
-   @DF-RHF iter  11:  -455.23149003679350   -1.29963e+00   5.38296e-02 DIIS
-   @DF-RHF iter  12:  -456.36393300808834   -1.13244e+00   2.65890e-02 DIIS
-   @DF-RHF iter  13:  -456.63840478647853   -2.74472e-01   9.20544e-03 DIIS
-   @DF-RHF iter  14:  -456.67092959735766   -3.25248e-02   4.94222e-04 DIIS
-   @DF-RHF iter  15:  -456.67108503153639   -1.55434e-04   1.04518e-04 DIIS
-   @DF-RHF iter  16:  -456.67109561580918   -1.05843e-05   3.14235e-05 DIIS
-   @DF-RHF iter  17:  -456.67109625661703   -6.40808e-07   1.34516e-05 DIIS
-   @DF-RHF iter  18:  -456.67109632899246   -7.23754e-08   1.64309e-06 DIIS
-   @DF-RHF iter  19:  -456.67109633060522   -1.61276e-09   1.54907e-07 DIIS
-   @DF-RHF iter  20:  -456.67109633064365   -3.84262e-11   2.76695e-08 DIIS
-   @DF-RHF iter  21:  -456.67109633064484   -1.19371e-12   5.45923e-09 DIIS
+   @DF-RHF iter   6:  -436.84424699101100   -1.10106e+01   1.10181e-01 DIIS
+   @DF-RHF iter   7:  -452.27227063553551   -1.54280e+01   8.84737e-02 DIIS
+   @DF-RHF iter   8:  -451.17332750319770    1.09894e+00   9.79093e-02 DIIS
+   @DF-RHF iter   9:  -452.56218410660716   -1.38886e+00   8.44928e-02 DIIS
+   @DF-RHF iter  10:  -453.94473926032657   -1.38256e+00   7.04559e-02 DIIS
+   @DF-RHF iter  11:  -455.24218451702711   -1.29745e+00   5.36549e-02 DIIS
+   @DF-RHF iter  12:  -456.37078848645240   -1.12860e+00   2.63008e-02 DIIS
+   @DF-RHF iter  13:  -456.63955833338963   -2.68770e-01   9.04202e-03 DIIS
+   @DF-RHF iter  14:  -456.67093864841888   -3.13803e-02   4.75955e-04 DIIS
+   @DF-RHF iter  15:  -456.67108534751367   -1.46699e-04   1.03911e-04 DIIS
+   @DF-RHF iter  16:  -456.67109564913420   -1.03016e-05   3.08032e-05 DIIS
+   @DF-RHF iter  17:  -456.67109626083015   -6.11696e-07   1.30944e-05 DIIS
+   @DF-RHF iter  18:  -456.67109632929277   -6.84626e-08   1.61905e-06 DIIS
+   @DF-RHF iter  19:  -456.67109633084630   -1.55353e-09   1.49995e-07 DIIS
+   @DF-RHF iter  20:  -456.67109633088228   -3.59819e-11   2.66231e-08 DIIS
+   @DF-RHF iter  21:  -456.67109633088353   -1.25056e-12   5.21926e-09 DIIS
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1A1   -32.759855     2A1    -8.395838     1B1    -6.129623  
-       1B2    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
+       1B2    -6.129623     3A1    -6.129417     4A1    -2.660067  
+       1A2    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
        8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
        4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
@@ -284,9 +293,9 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
        5A2     3.645789    21A1     3.645789    13B2     3.645994  
       13B1     3.645994    22A1     3.649244    23A1     4.512135  
        6A2     4.512135    14B1     4.512759    14B2     4.512759  
-      24A1     4.516149    25A1     4.894649    15B1    34.655679  
-      15B2    34.655679    26A1    34.664721    27A1    45.102919  
-      28A1   109.278507  
+      24A1     4.516149    25A1     4.894649    15B1    34.655678  
+      15B2    34.655678    26A1    34.664720    27A1    45.102918  
+      28A1   109.278497  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
@@ -294,50 +303,46 @@ compare_values(reffzc, Efzc, 8, "Frozen core MP2 energy with ECP")              
 
   Energy converged.
 
-  @DF-RHF Final Energy:  -456.67109633064484
+  @DF-RHF Final Energy:  -456.67109633088353
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             45.8620247444666589
-    One-Electron Energy =                -845.7929915398301546
-    Two-Electron Energy =                 343.2598704647186310
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -456.6710963306448434
+    Nuclear Repulsion Energy =             45.8620247444666518
+    One-Electron Energy =                -845.7929915506095995
+    Two-Electron Energy =                 343.2598704752593903
+    Total Energy =                       -456.6710963308835289
 
 
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:   -29.8297
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    29.7500
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0797     Total:     0.0797
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on QuickSilver.local at Mon Apr 24 22:58:36 2017
+*** tstop() called on dream at Tue May  1 11:30:56 2018
 Module time:
-	user time   =       7.92 seconds =       0.13 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       7.92 seconds =       0.13 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on QuickSilver.local
-*** at Mon Apr 24 22:58:36 2017
+*** tstart() called on dream
+*** at Tue May  1 11:30:56 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -349,8 +354,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2974 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -389,52 +394,53 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963306448434 [Eh]
-	 Singles Energy            =      -0.0000000000000061 [Eh]
-	 Same-Spin Energy          =      -0.2734241007857262 [Eh]
-	 Opposite-Spin Energy      =      -0.5286882510606981 [Eh]
-	 Correlation Energy        =      -0.8021123518464303 [Eh]
-	 Total Energy              =    -457.4732086824912471 [Eh]
+	 Reference Energy          =    -456.6710963308835289 [Eh]
+	 Singles Energy            =      -0.0000000000000056 [Eh]
+	 Same-Spin Energy          =      -0.2734241011725143 [Eh]
+	 Opposite-Spin Energy      =      -0.5286882515253885 [Eh]
+	 Correlation Energy        =      -0.8021123526979085 [Eh]
+	 Total Energy              =    -457.4732086835814471 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0911413669285754 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.6344259012728376 [Eh]
-	 SCS Correlation Energy    =      -0.7255672682014190 [Eh]
-	 SCS Total Energy          =    -457.3966635988462599 [Eh]
+	 SCS Same-Spin Energy      =      -0.0911413670575048 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.6344259018304661 [Eh]
+	 SCS Correlation Energy    =      -0.7255672688879765 [Eh]
+	 SCS Total Energy          =    -457.3966635997715002 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on QuickSilver.local at Mon Apr 24 22:58:36 2017
+*** tstop() called on dream at Tue May  1 11:30:56 2018
 Module time:
-	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.34 seconds =       0.14 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       2.28 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 	Nuclear repulsion energy..........................................PASSED
-	All Ne electrons correlated MP2 energy with ECP...................PASSED
+	MP2 energy with all-electron Ne and ECP on Xe.....................PASSED
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on QuickSilver.local
-*** at Mon Apr 24 22:58:36 2017
+*** tstart() called on dream
+*** at Tue May  1 11:30:56 2018
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2829) file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -455,7 +461,7 @@ Total time:
 
   Rotational constants: A = ************  B =      0.10789  C =      0.10789 [cm^-1]
   Rotational constants: A = ************  B =   3234.43513  C =   3234.43513 [MHz]
-  Nuclear repulsion =   45.862024744466659
+  Nuclear repulsion =   45.862024744466645
 
   Charge       = 0
   Multiplicity = 1
@@ -493,8 +499,6 @@ Total time:
        2    XE     11s 10p 8d 2f // 6s 5p 3d 2f 
 
   -CORE POTENTIAL INFORMATION:
-    Name                     = DEF2-SVP
-    Blend                    = DEF2-SVP
     Total number of shells   = 4
     Number of terms          = 29
     Number of core electrons = 28
@@ -511,8 +515,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 1 entry NE         line   443 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 2 entry XE         line  5086 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
 
   Reading orbitals from file 180, no projection.
 
@@ -562,7 +566,7 @@ Total time:
        1    NE     14s 10p 6d 2f 1g // 10s 8p 4d 2f 1g 
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
-  Minimum eigenvalue in the overlap matrix is 6.0588497331E-03.
+  Minimum eigenvalue in the overlap matrix is 6.0588497784E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -571,19 +575,19 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -456.67109633064490   -4.56671e+02   7.52725e-10 
-   @DF-RHF iter   1:  -456.67109633064479    1.13687e-13   2.84643e-10 
+   @DF-RHF iter   0:  -456.67109633076615   -4.56671e+02   7.10001e-10 
+   @DF-RHF iter   1:  -456.67109633076598    1.70530e-13   2.66909e-10 
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
-       1B1    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
+       1B1    -6.129623     3A1    -6.129417     4A1    -2.660067  
+       1A2    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
        8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
        4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
@@ -592,20 +596,20 @@ Total time:
 
        5B1     0.300476     5B2     0.300476    10A1     0.314526  
       11A1     0.354930     2A2     0.354930     6B2     0.354978  
-       6B1     0.354978    12A1     0.371454    13A1     0.516044  
+       6B1     0.354978    12A1     0.371453    13A1     0.516044  
       14A1     1.147785     7B2     1.152918     7B1     1.152918  
        8B2     1.153132     8B1     1.153132     3A2     1.153213  
       15A1     1.153213    16A1     1.532716     9B1     1.553626  
        9B2     1.553626    17A1     1.598406    10B2     1.646537  
-      10B1     1.646537    18A1     1.687129     4A2     1.687129  
+      10B1     1.646537     4A2     1.687129    18A1     1.687129  
       19A1     1.703758    11B2     1.748135    11B1     1.748135  
       20A1     1.994860    12B2     3.645570    12B1     3.645570  
        5A2     3.645789    21A1     3.645789    13B2     3.645994  
       13B1     3.645994    22A1     3.649244    23A1     4.512135  
        6A2     4.512135    14B2     4.512759    14B1     4.512759  
-      24A1     4.516149    25A1     4.894649    15B2    34.655679  
-      15B1    34.655679    26A1    34.664721    27A1    45.102919  
-      28A1   109.278507  
+      24A1     4.516149    25A1     4.894649    15B2    34.655678  
+      15B1    34.655678    26A1    34.664720    27A1    45.102918  
+      28A1   109.278498  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
@@ -613,50 +617,46 @@ Total time:
 
   Energy converged.
 
-  @DF-RHF Final Energy:  -456.67109633064479
+  @DF-RHF Final Energy:  -456.67109633076598
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             45.8620247444666589
-    One-Electron Energy =                -845.7929919740553260
-    Two-Electron Energy =                 343.2598708989438592
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -456.6710963306447866
+    Nuclear Repulsion Energy =             45.8620247444666447
+    One-Electron Energy =                -845.7929919414604001
+    Two-Electron Energy =                 343.2598708662277431
+    Total Energy =                       -456.6710963307659767
 
 
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:   -29.8297
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    29.7500
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0797     Total:     0.0797
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on QuickSilver.local at Mon Apr 24 22:58:44 2017
+*** tstop() called on dream at Tue May  1 11:30:58 2018
 Module time:
-	user time   =       6.93 seconds =       0.12 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      15.30 seconds =       0.26 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =       4.00 seconds =       0.07 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on QuickSilver.local
-*** at Mon Apr 24 22:58:44 2017
+*** tstart() called on dream
+*** at Tue May  1 11:30:58 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -668,8 +668,321 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /Users/andysim/programming/psi4/obj_ecp/stage/usr/local/psi4/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2974 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-SVP-RI
+    Total number of shells = 54
+    Number of primitives   = 60
+    Number of AO           = 319
+    Number of SO           = 232
+    Maximum AM             = 5
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     8s 6p 5d 3f // 6s 5p 4d 1f 
+       2    XE     9s 8p 8d 6f 4g 3h // 9s 8p 8d 6f 4g 3h 
+
+	 --------------------------------------------------------
+	                 NBF =    64, NAUX =   232
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       5      18      13      46      46       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =    -456.6710963307659767 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.2465524814168708 [Eh]
+	 Opposite-Spin Energy      =      -0.4636233732964010 [Eh]
+	 Correlation Energy        =      -0.7101758547132717 [Eh]
+	 Total Energy              =    -457.3812721854792471 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0821841604722902 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.5563480479556812 [Eh]
+	 SCS Correlation Energy    =      -0.6385322084279714 [Eh]
+	 SCS Total Energy          =    -457.3096285391939659 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue May  1 11:30:58 2018
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.17 seconds =       0.07 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+	MP2 energy with frozen [He] and [Kr]..............................PASSED
+    SCF Algorithm Type (re)set to DF.
+
+*** tstart() called on dream
+*** at Tue May  1 11:30:58 2018
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NE         line   170 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+          NE          0.000000000000     0.000000000000    -2.605143742253    19.992440175420
+          XE          0.000000000000     0.000000000000     0.394856257747   131.904153457000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =      0.10789  C =      0.10789 [cm^-1]
+  Rotational constants: A = ************  B =   3234.43513  C =   3234.43513 [MHz]
+  Nuclear repulsion =   45.862024744466645
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 36
+  Nalpha       = 18
+  Nbeta        = 18
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = DEF2-SVP
+    Blend                  = DEF2-SVP
+    Total number of shells = 22
+    Number of primitives   = 43
+    Number of AO           = 74
+    Number of SO           = 64
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     7s 4p 1d // 3s 2p 1d 
+       2    XE     11s 10p 8d 2f // 6s 5p 3d 2f 
+
+  -CORE POTENTIAL INFORMATION:
+    Total number of shells   = 4
+    Number of terms          = 29
+    Number of core electrons = 28
+    Maximum AM               = 3
+
+  -Contraction Scheme:
+    Atom   Type  #elec    All terms // Shells:   
+   ------ ------ ----- --------------------------
+       1    NE      0   
+       2    XE     28   7s 8p 10d 4f // 1s 1p 1d 1f 
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NE         line   443 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 2 entry XE         line  5086 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-jkfit.gbs 
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        28      28       0       0       0       0
+     A2         6       6       0       0       0       0
+     B1        15      15       0       0       0       0
+     B2        15      15       0       0       0       0
+   -------------------------------------------------------
+    Total      64      64      18      18      18       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-SVP-JKFIT
+    Total number of shells = 71
+    Number of primitives   = 86
+    Number of AO           = 402
+    Number of SO           = 295
+    Maximum AM             = 5
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     14s 10p 6d 2f 1g // 10s 8p 4d 2f 1g 
+       2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
+
+  Minimum eigenvalue in the overlap matrix is 6.0588497784E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:  -456.67109633076586   -4.56671e+02   1.17933e-10 
+   @DF-RHF iter   1:  -456.67109633076598   -1.13687e-13   5.24218e-11 
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
+       1B1    -6.129623     3A1    -6.129417     4A1    -2.660067  
+       1A2    -2.660067     2B2    -2.659818     2B1    -2.659818  
+       5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
+       8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
+       4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
+
+    Virtual:                                                              
+
+       5B1     0.300476     5B2     0.300476    10A1     0.314526  
+      11A1     0.354930     2A2     0.354930     6B2     0.354978  
+       6B1     0.354978    12A1     0.371453    13A1     0.516044  
+      14A1     1.147785     7B2     1.152918     7B1     1.152918  
+       8B2     1.153132     8B1     1.153132     3A2     1.153213  
+      15A1     1.153213    16A1     1.532716     9B1     1.553626  
+       9B2     1.553626    17A1     1.598406    10B2     1.646537  
+      10B1     1.646537     4A2     1.687129    18A1     1.687129  
+      19A1     1.703758    11B2     1.748135    11B1     1.748135  
+      20A1     1.994860    12B2     3.645570    12B1     3.645570  
+       5A2     3.645789    21A1     3.645789    13B2     3.645994  
+      13B1     3.645994    22A1     3.649244    23A1     4.512135  
+       6A2     4.512135    14B2     4.512759    14B1     4.512759  
+      24A1     4.516149    25A1     4.894649    15B2    34.655678  
+      15B1    34.655678    26A1    34.664720    27A1    45.102918  
+      28A1   109.278498  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     9,    1,    4,    4 ]
+
+  Energy converged.
+
+  @DF-RHF Final Energy:  -456.67109633076598
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             45.8620247444666447
+    One-Electron Energy =                -845.7929919901384892
+    Two-Electron Energy =                 343.2598709149058323
+    Total Energy =                       -456.6710963307659767
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:   -29.8297
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    29.7500
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0797     Total:     0.0797
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
+
+
+*** tstop() called on dream at Tue May  1 11:31:00 2018
+Module time:
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       5.88 seconds =       0.10 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on dream
+*** at Tue May  1 11:31:00 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1 entry NE         line   313 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2974 file /home/pk/psi4bin/ecp_fc-ab1c6e4a/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -708,33 +1021,36 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963306447866 [Eh]
+	 Reference Energy          =    -456.6710963307659767 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.2727087559075031 [Eh]
-	 Opposite-Spin Energy      =      -0.5275044318292150 [Eh]
-	 Correlation Energy        =      -0.8002131877367181 [Eh]
-	 Total Energy              =    -457.4713095183815312 [Eh]
+	 Same-Spin Energy          =      -0.2727087562868912 [Eh]
+	 Opposite-Spin Energy      =      -0.5275044322994045 [Eh]
+	 Correlation Energy        =      -0.8002131885862956 [Eh]
+	 Total Energy              =    -457.4713095193522463 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0909029186358344 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.6330053181950580 [Eh]
-	 SCS Correlation Energy    =      -0.7239082368308923 [Eh]
-	 SCS Total Energy          =    -457.3950045674756666 [Eh]
+	 SCS Same-Spin Energy      =      -0.0909029187622971 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.6330053187592853 [Eh]
+	 SCS Correlation Energy    =      -0.7239082375215824 [Eh]
+	 SCS Total Energy          =    -457.3950045682875611 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on QuickSilver.local at Mon Apr 24 22:58:44 2017
+*** tstop() called on dream at Tue May  1 11:31:00 2018
 Module time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.75 seconds =       0.26 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
-	Frozen core MP2 energy with ECP...................................PASSED
+	user time   =       6.06 seconds =       0.10 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+	MP2 energy with frozen [He] and ECP...............................PASSED
+
+    Psi4 stopped on: Tuesday, 01 May 2018 11:31AM
+    Psi4 wall time for execution: 0:00:06.13
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Freeze additional electron pairs on atoms with ECPs. This stops erratic behaviour in MP2 correlation energies as described in #976 .

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] `BasisSet::n_frozen_core()` now doesn't skip over ECP-containing atoms.

## Checklist
- [x] dfmp2-ecp modified to reflect new default behaviour

## Status
- [x] Ready for review
- [x] Ready for merge
