### PR TITLE
VV10: Fixes UKS non-local dispersion

### DIFF
--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -1444,8 +1444,8 @@ void UV::compute_V(std::vector<SharedMatrix> ret) {
         throw PSIEXCEPTION("V: UKS should have two D/V Matrices");
     }
 
-    if (functional_->needs_grac() || functional_->needs_vv10()) {
-        throw PSIEXCEPTION("V: UKS cannot compute VV10 or GRAC corrections.");
+    if (functional_->needs_grac()) {
+        throw PSIEXCEPTION("V: UKS cannot compute GRAC corrections.");
     }
 
     // Thread info
@@ -1676,15 +1676,15 @@ void UV::compute_V(std::vector<SharedMatrix> ret) {
     if (functional_->needs_vv10()) {
         SharedMatrix Ds = D_AO_[0]->clone();
         Ds->axpy(1.0, D_AO_[1]);
-        Ds->scale(0.5); // Will be scaled by a factor of 2 later.
+        Ds->scale(0.5); // Will be scaled by a factor of 2 in vv10_nlc
 
-        SharedMatrix ret = Ds->clone();
-        ret->zero();
+        SharedMatrix V_vv10 = Ds->clone();
+        V_vv10->zero();
 
-        vv10_e = vv10_nlc(Ds, ret);
+        vv10_e = vv10_nlc(Ds, V_vv10);
 
-        Va_AO->axpy(0.5, ret);
-        Vb_AO->axpy(0.5, ret);
+        Va_AO->add(V_vv10);
+        Vb_AO->add(V_vv10);
     }
 
     // Set the result

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -2468,18 +2468,17 @@ SharedMatrix UV::compute_gradient() {
 
             double** Ds[2];
             Ds[0] = Dap;
-            Ds[1] = Dap;
+            Ds[1] = Dbp;
 
             double* v_tau_s[2];
             v_tau_s[0] = v_tau_a;
             v_tau_s[1] = v_tau_b;
 
             for (int s = 0; s < 2; s++) {
-                //                double** Dp = Ds[s];
                 double* v_tau = v_tau_s[s];
                 for (int i = 0; i < 3; i++) {
                     double*** phi_j = phi_ij[i];
-                    C_DGEMM('N', 'N', npoints, nlocal, nlocal, 1.0, phi_i[i][0], max_functions, Dap[0], max_functions,
+                    C_DGEMM('N', 'N', npoints, nlocal, nlocal, 1.0, phi_i[i][0], max_functions, Ds[s][0], max_functions,
                             0.0, Uap[0], max_functions);
                     for (int P = 0; P < npoints; P++) {
                         std::fill(Tap[P], Tap[P] + nlocal, 0.0);

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -392,6 +392,7 @@ double UHF::compute_E()
     Etotal += 0.5 * coulomb_E;
     Etotal += 0.5 * exchange_E;
     Etotal += XC_E;
+    Etotal += VV10_E;
     Etotal += dashD_E;
 
     return Etotal;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfomp2-1 dfomp2-2 dfomp2-3
                   dfomp2-4 dfomp2-grad1 dfomp2-grad2 dfomp2-grad3 dfomp3-1 dfomp3-2
                   dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1
-                  dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost 
+                  dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10 
                   dft1-alt dft2 dft3 dft-omega docs-bases docs-dft extern1 extern2
                   fsapt1 fsapt2 fsapt-terms fsapt-allterms isapt1 isapt2

--- a/tests/dft-bench-ionization/input.dat
+++ b/tests/dft-bench-ionization/input.dat
@@ -107,6 +107,11 @@ qchem_data = {                              #TEST
       'N12':     0.4479283791999933,        #TEST
      'VSXC':    0.45478941460000044,        #TEST
 'CAM-B3LYP':     0.4568003603999955,        #TEST
+     'VV10':    0.45513665939999726,        #TEST
+   'B97M-V':     0.4561660761999917,        #TEST
+  'LC-VV10':    0.45568725450000613,        #TEST
+  'wB97M-V':     0.4544676075000069,        #TEST
+  'wB97X-V':     0.4553026020000033,        #TEST
 ## The following functionals are not included 
 ## in Psi4 at the moment. 
 # 'wB97X-D3':    0.45707443810000825,       #TEST # needs Tweaks
@@ -133,11 +138,6 @@ excluded_qchem_convergence_probs = {
 # These tests are expected to fail with the current version of Psi4
 # due to lack of UKS support 
 excluded_qchem_not_uks_friendly = {
-   'B97M-V':     0.4561660761999917,        #TEST
-     'VV10':    0.45513665939999726,        #TEST
-  'LC-VV10':    0.45568725450000613,        #TEST
-  'wB97M-V':     0.4544676075000069,        #TEST
-  'wB97X-V':     0.4553026020000033,        #TEST
 }
 
 # The following data is from an older 

--- a/tests/dft-grad-meta/CMakeLists.txt
+++ b/tests/dft-grad-meta/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dft-grad-meta "psi;dft;scf;cart")

--- a/tests/dft-grad-meta/input.dat
+++ b/tests/dft-grad-meta/input.dat
@@ -1,0 +1,48 @@
+#! DF-BP86-D2 cc-pVDZ frozen core gradient of S22 HCN
+
+tpss_rks_grad = psi4.Matrix.from_list([ 
+    [-0.00010973017199,   0.00184569734216,  0.00000000000000],
+    [ 0.00071099771043,  -0.01092758183008,  0.00000000000000],
+    [-0.00060096146912,   0.00907798275181,  0.00000000000000]])
+
+tpss_uks_grad = psi4.Matrix.from_list([
+    [ 0.00859492001991,  -0.12709581531096,  0.00000000000000],
+    [-0.00681946116442,   0.10071104327839,  0.00000000000000],
+    [-0.00177510821711,   0.02638124717315,  0.00000000000000]])
+
+molecule {
+  0 1
+  N    -0.0034118    3.5353926    0.0000000
+  C     0.0751963    2.3707040    0.0000000
+  H     0.1476295    1.3052847    0.0000000
+}
+
+
+set {
+    scf_type              df
+    basis                 cc-pvdz
+    freeze_core           true
+    dft_radial_points     99
+    dft_spherical_points  302
+    e_convergence         8
+    d_convergence         8
+}
+
+analytic = gradient('TPSS', dertype=1)
+# finitediff = gradient('TPSS', dertype=0)
+# compare_matrices(analytic, finitediff, 5, "TPSS RKS Analytic vs FD Gradient")    #TEST
+compare_matrices(analytic, tpss_rks_grad, 6, "TPSS RKS Analytic vs Store")    #TEST
+
+molecule {
+  1 2
+  N    -0.0034118    3.5353926    0.0000000
+  C     0.0751963    2.3707040    0.0000000
+  H     0.1476295    1.3052847    0.0000000
+}
+
+set reference uks
+
+analytic = gradient('TPSS', dertype=1)
+#finitediff = gradient('TPSS', dertype=0)
+#compare_matrices(analytic, finitediff, 5, "TPSS UKS Analytic vs FD Gradient")    #TEST
+compare_matrices(analytic, tpss_uks_grad, 6, "TPSS UKS Analytic vs Store")    #TEST

--- a/tests/dft-grad-meta/output.ref
+++ b/tests/dft-grad-meta/output.ref
@@ -1,0 +1,851 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 (inplace)
+
+                         Git: Rev (inplace)
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 25 April 2018 10:08PM
+
+    Process ID: 66030
+    Host:       Daniels-MacBook-Pro.local
+    PSIDATADIR: /Users/daniel/Gits/psi4ds/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! DF-BP86-D2 cc-pVDZ frozen core gradient of S22 HCN
+
+tpss_rks_grad = psi4.Matrix.from_list([ 
+    [-0.00010973017199,   0.00184569734216,  0.00000000000000],
+    [ 0.00071099771043,  -0.01092758183008,  0.00000000000000],
+    [-0.00060096146912,   0.00907798275181,  0.00000000000000]])
+
+tpss_uks_grad = psi4.Matrix.from_list([
+    [ 0.00859492001991,  -0.12709581531096,  0.00000000000000],
+    [-0.00681946116442,   0.10071104327839,  0.00000000000000],
+    [-0.00177510821711,   0.02638124717315,  0.00000000000000]])
+
+molecule {
+  0 1
+  N    -0.0034118    3.5353926    0.0000000
+  C     0.0751963    2.3707040    0.0000000
+  H     0.1476295    1.3052847    0.0000000
+}
+
+
+set {
+    scf_type              df
+    basis                 cc-pvdz
+    freeze_core           true
+    dft_radial_points     99
+    dft_spherical_points  302
+    e_convergence         8
+    d_convergence         8
+}
+
+analytic = gradient('TPSS', dertype=1)
+# finitediff = gradient('TPSS', dertype=0)
+# compare_matrices(analytic, finitediff, 5, "TPSS RKS Analytic vs FD Gradient")    #TEST
+compare_matrices(analytic, tpss_rks_grad, 6, "TPSS RKS Analytic vs Store")    #TEST
+
+molecule {
+  1 2
+  N    -0.0034118    3.5353926    0.0000000
+  C     0.0751963    2.3707040    0.0000000
+  H     0.1476295    1.3052847    0.0000000
+}
+
+set reference uks
+
+analytic = gradient('TPSS', dertype=1)
+#finitediff = gradient('TPSS', dertype=0)
+#compare_matrices(analytic, finitediff, 5, "TPSS UKS Analytic vs FD Gradient")    #TEST
+compare_matrices(analytic, tpss_uks_grad, 6, "TPSS UKS Analytic vs Store")    #TEST
+--------------------------------------------------------------------------
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Wed Apr 25 22:08:26 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry N          line   168 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry C          line   138 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3 entry H          line    22 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           N         -0.040558457589     0.600639828526     0.000000000000    14.003074004780
+           C          0.038049642411    -0.564048771474     0.000000000000    12.000000000000
+           H          0.110482842411    -1.629468071474     0.000000000000     1.007825032070
+
+  Running in cs symmetry.
+
+  Rotational constants: A = 83386922.25089  B =      1.45345  C =      1.45345 [cm^-1]
+  Rotational constants: A = 2499877038665.02588  B =  43573.43250  C =  43573.43174 [MHz]
+  Nuclear repulsion =   23.669879231087002
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 15
+    Number of basis function: 33
+    Number of Cartesian functions: 35
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: TPSS <= 
+
+    TPSS Meta-GGA XC Functional
+
+   J. Tao, et al., Phys. Rev. Lett., 91, 146401, 2003
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             99
+    Spherical Points    =            302
+    Total Points        =          86317
+    Total Blocks        =            702
+    Max Points          =            256
+    Max Functions       =             33
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry N          line   171 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry C          line   121 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 3 entry H          line    51 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        24      24       0       0       0       0
+     A"         9       9       0       0       0       0
+   -------------------------------------------------------
+    Total      33      33       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 57
+    Number of basis function: 163
+    Number of Cartesian functions: 187
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.7788208310E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter   0:   -93.71396485861848   -9.37140e+01   8.23545e-02 
+   @DF-RKS iter   1:   -93.41886292168638    2.95102e-01   8.49423e-03 
+   @DF-RKS iter   2:   -93.35363796600338    6.52250e-02   1.67828e-02 DIIS
+   @DF-RKS iter   3:   -93.43090675240180   -7.72688e-02   7.06604e-03 DIIS
+   @DF-RKS iter   4:   -93.44650613557313   -1.55994e-02   2.18711e-04 DIIS
+   @DF-RKS iter   5:   -93.44651974672155   -1.36111e-05   2.56380e-05 DIIS
+   @DF-RKS iter   6:   -93.44651995367536   -2.06954e-07   1.45981e-06 DIIS
+   @DF-RKS iter   7:   -93.44651995419218   -5.16820e-10   4.56723e-07 DIIS
+   @DF-RKS iter   8:   -93.44651995426858   -7.63976e-11   4.79042e-08 DIIS
+   @DF-RKS iter   9:   -93.44651995426949   -9.09495e-13   1.06054e-08 DIIS
+   @DF-RKS iter  10:   -93.44651995426949    0.00000e+00   9.77360e-10 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -14.137699     2Ap   -10.054438     3Ap    -0.851575  
+       4Ap    -0.562268     5Ap    -0.333892     1App   -0.320120  
+       6Ap    -0.320120  
+
+    Virtual:                                                              
+
+       7Ap    -0.015417     2App   -0.015417     8Ap     0.049940  
+       9Ap     0.186647    10Ap     0.446664     3App    0.446664  
+      11Ap     0.529137    12Ap     0.647526    13Ap     0.729076  
+       4App    0.765672    14Ap     0.765672    15Ap     0.953689  
+       5App    1.058051    16Ap     1.058052    17Ap     1.064834  
+       6App    1.064834    18Ap     1.417142    19Ap     1.689877  
+       7App    1.689877    20Ap     1.834111     8App    1.834111  
+      21Ap     2.044656    22Ap     2.525524     9App    2.525524  
+      23Ap     2.754212    24Ap     3.060580  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+
+  Energy converged.
+
+  @DF-RKS Final Energy:   -93.44651995426949
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.6698792310870019
+    One-Electron Energy =                -172.4118061362198091
+    Two-Electron Energy =                  67.9143242948043877
+    DFT Exchange-Correlation Energy =     -12.6189173439410762
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -93.4465199542694904
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.1037      Y:    -1.5293      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0309      Y:     0.4542      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0728      Y:    -1.0752      Z:     0.0000     Total:     1.0776
+
+  Dipole Moment: [D]
+     X:     0.1851      Y:    -2.7328      Z:     0.0000     Total:     2.7390
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Wed Apr 25 22:08:34 2018
+Module time:
+	user time   =       7.89 seconds =       0.13 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+Total time:
+	user time   =       7.89 seconds =       0.13 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Wed Apr 25 22:08:34 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           N         -0.040558457589     0.600639828526     0.000000000000    14.003074004780
+           C          0.038049642411    -0.564048771474     0.000000000000    12.000000000000
+           H          0.110482842411    -1.629468071474     0.000000000000     1.007825032070
+
+  Nuclear repulsion =   23.669879231087002
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 15
+    Number of basis function: 33
+    Number of Cartesian functions: 35
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 57
+    Number of basis function: 163
+    Number of Cartesian functions: 187
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => Composite Functional: TPSS <= 
+
+    TPSS Meta-GGA XC Functional
+
+   J. Tao, et al., Phys. Rev. Lett., 91, 146401, 2003
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             99
+    Spherical Points    =            302
+    Total Points        =          86317
+    Total Blocks        =            702
+    Max Points          =            256
+    Max Functions       =             33
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000109730346     0.001845700014     0.000000000000
+       2        0.000710997814    -0.010927585218     0.000000000000
+       3       -0.000600961399     0.009077983469     0.000000000000
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Wed Apr 25 22:08:35 2018
+Module time:
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.90 seconds =       0.15 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
+	TPSS RKS Analytic vs Store........................................PASSED
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Wed Apr 25 22:08:35 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry N          line   168 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry C          line   138 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3 entry H          line    22 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           N         -0.040558457589     0.600639828526     0.000000000000    14.003074004780
+           C          0.038049642411    -0.564048771474     0.000000000000    12.000000000000
+           H          0.110482842411    -1.629468071474     0.000000000000     1.007825032070
+
+  Running in cs symmetry.
+
+  Rotational constants: A = 83386922.25089  B =      1.45345  C =      1.45345 [cm^-1]
+  Rotational constants: A = 2499877038665.02588  B =  43573.43250  C =  43573.43174 [MHz]
+  Nuclear repulsion =   23.669879231087002
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 13
+  Nalpha       = 7
+  Nbeta        = 6
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 15
+    Number of basis function: 33
+    Number of Cartesian functions: 35
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: TPSS <= 
+
+    TPSS Meta-GGA XC Functional
+
+   J. Tao, et al., Phys. Rev. Lett., 91, 146401, 2003
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             99
+    Spherical Points    =            302
+    Total Points        =          86317
+    Total Blocks        =            702
+    Max Points          =            256
+    Max Functions       =             33
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry N          line   171 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry C          line   121 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 3 entry H          line    51 file /Users/daniel/Gits/psi4ds/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        24      24       0       0       0       0
+     A"         9       9       0       0       0       0
+   -------------------------------------------------------
+    Total      33      33       7       6       6       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 57
+    Number of basis function: 163
+    Number of Cartesian functions: 187
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.7788208310E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ap   App 
+    DOCC [     5,    1 ]
+    SOCC [     1,    0 ]
+
+   @DF-UKS iter   1:   -92.26135258301086   -9.22614e+01   6.78667e-02 
+   @DF-UKS iter   2:   -90.33282822446830    1.92852e+00   7.65739e-02 DIIS
+    Occupation by irrep:
+             Ap   App 
+    DOCC [     6,    0 ]
+    SOCC [     0,    1 ]
+
+   @DF-UKS iter   3:   -91.00845319342190   -6.75625e-01   6.77924e-02 DIIS
+   @DF-UKS iter   4:   -92.94139342596173   -1.93294e+00   5.41905e-03 DIIS
+   @DF-UKS iter   5:   -92.95016410735315   -8.77068e-03   2.67848e-03 DIIS
+   @DF-UKS iter   6:   -92.95279728087419   -2.63317e-03   3.44480e-04 DIIS
+   @DF-UKS iter   7:   -92.95284920157114   -5.19207e-05   7.64792e-05 DIIS
+   @DF-UKS iter   8:   -92.95285370179450   -4.50022e-06   1.93861e-05 DIIS
+   @DF-UKS iter   9:   -92.95285412846211   -4.26668e-07   7.39674e-06 DIIS
+   @DF-UKS iter  10:   -92.95285423901234   -1.10550e-07   1.73798e-06 DIIS
+   @DF-UKS iter  11:   -92.95285424276389   -3.75155e-09   6.76162e-07 DIIS
+   @DF-UKS iter  12:   -92.95285424321733   -4.53440e-10   2.12069e-07 DIIS
+   @DF-UKS iter  13:   -92.95285424324329   -2.59632e-11   6.85438e-08 DIIS
+   @DF-UKS iter  14:   -92.95285424324541   -2.11742e-12   2.21852e-08 DIIS
+   @DF-UKS iter  15:   -92.95285424324555   -1.42109e-13   1.22249e-09 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.973928559E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519739286E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ap   -14.578916     2Ap   -10.497188     3Ap    -1.302978  
+       4Ap    -0.921839     1App   -0.761888     5Ap    -0.719107  
+       6Ap    -0.715788  
+
+    Alpha Virtual:                                                        
+
+       2App   -0.425325     7Ap    -0.388213     8Ap    -0.232651  
+       9Ap    -0.095435     3App    0.103885    10Ap     0.124205  
+      11Ap     0.212428    12Ap     0.315932     4App    0.407950  
+      13Ap     0.432334    14Ap     0.434006    15Ap     0.580410  
+       5App    0.665311    16Ap     0.666136     6App    0.683098  
+      17Ap     0.706446    18Ap     1.069338     7App    1.323789  
+      19Ap     1.344536     8App    1.416355    20Ap     1.416987  
+      21Ap     1.699300     9App    2.122350    22Ap     2.152518  
+      23Ap     2.358175    24Ap     2.689439  
+
+    Beta Occupied:                                                        
+
+       1Ap   -14.566570     2Ap   -10.488946     3Ap    -1.260431  
+       4Ap    -0.910439     5Ap    -0.701731     6Ap    -0.699728  
+
+    Beta Virtual:                                                         
+
+       1App   -0.664662     7Ap    -0.372080     2App   -0.346709  
+       8Ap    -0.215091     9Ap    -0.085640    10Ap     0.132760  
+       3App    0.141029    11Ap     0.229467    12Ap     0.335457  
+      13Ap     0.445561    14Ap     0.446908     4App    0.458386  
+      15Ap     0.613795     5App    0.707378    16Ap     0.713084  
+      17Ap     0.723606     6App    0.727626    18Ap     1.092065  
+      19Ap     1.357811     7App    1.361273     8App    1.466765  
+      20Ap     1.472338    21Ap     1.726435     9App    2.168847  
+      22Ap     2.170128    23Ap     2.391486    24Ap     2.747701  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    0 ]
+    SOCC [     0,    1 ]
+
+  Energy converged.
+
+  @DF-UKS Final Energy:   -92.95285424324555
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.6698792310870019
+    One-Electron Energy =                -166.6781687277195658
+    Two-Electron Energy =                  62.3486004427469709
+    DFT Exchange-Correlation Energy =     -12.2931651893599625
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -92.9528542432455538
+
+
+  UHF NO Occupations:
+  HONO-2 :    5 Ap 1.9996731
+  HONO-1 :    6 Ap 1.9994027
+  HONO-0 :    1App 1.0000000
+  LUNO+0 :    7 Ap 0.0005973
+  LUNO+1 :    8 Ap 0.0003269
+  LUNO+2 :    9 Ap 0.0000330
+  LUNO+3 :   10 Ap 0.0000297
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.1037      Y:    -1.5293      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0135      Y:     0.1965      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0902      Y:    -1.3328      Z:     0.0000     Total:     1.3359
+
+  Dipole Moment: [D]
+     X:     0.2293      Y:    -3.3877      Z:     0.0000     Total:     3.3954
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Wed Apr 25 22:08:48 2018
+Module time:
+	user time   =      13.53 seconds =       0.23 minutes
+	system time =       0.66 seconds =       0.01 minutes
+	total time  =         13 seconds =       0.22 minutes
+Total time:
+	user time   =      22.47 seconds =       0.37 minutes
+	system time =       1.01 seconds =       0.02 minutes
+	total time  =         22 seconds =       0.37 minutes
+
+*** tstart() called on Daniels-MacBook-Pro.local
+*** at Wed Apr 25 22:08:48 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           N         -0.040558457589     0.600639828526     0.000000000000    14.003074004780
+           C          0.038049642411    -0.564048771474     0.000000000000    12.000000000000
+           H          0.110482842411    -1.629468071474     0.000000000000     1.007825032070
+
+  Nuclear repulsion =   23.669879231087002
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 15
+    Number of basis function: 33
+    Number of Cartesian functions: 35
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                   No
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 57
+    Number of basis function: 163
+    Number of Cartesian functions: 187
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => Composite Functional: TPSS <= 
+
+    TPSS Meta-GGA XC Functional
+
+   J. Tao, et al., Phys. Rev. Lett., 91, 146401, 2003
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => Molecular Quadrature <=
+
+    Radial Scheme       =       TREUTLER
+    Pruning Scheme      =           FLAT
+    Nuclear Scheme      =       TREUTLER
+
+    BS radius alpha     =              1
+    Pruning alpha       =              1
+    Radial Points       =             99
+    Spherical Points    =            302
+    Total Points        =          86317
+    Total Blocks        =            702
+    Max Points          =            256
+    Max Functions       =             33
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.008594920020    -0.127095815317     0.000000000000
+       2       -0.006819461165     0.100711043291     0.000000000000
+       3       -0.001775108217     0.026381247166     0.000000000000
+
+
+*** tstop() called on Daniels-MacBook-Pro.local at Wed Apr 25 22:08:50 2018
+Module time:
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      23.81 seconds =       0.40 minutes
+	system time =       1.08 seconds =       0.02 minutes
+	total time  =         24 seconds =       0.40 minutes
+	TPSS UKS Analytic vs Store........................................PASSED
+
+    Psi4 stopped on: Wednesday, 25 April 2018 10:08PM
+    Psi4 wall time for execution: 0:00:23.91
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -21,3 +21,9 @@ scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
     compare_values(v, psi4.get_variable(k), 9, k) # TEST
+
+set reference uks
+scf_e, scf_wfn = energy("VV10", return_wfn=True)
+
+for k, v in bench.items():                        # TEST
+    compare_values(v, psi4.get_variable(k), 9, k) # TEST


### PR DESCRIPTION
## Description
Patch up VV10 UKS dispersion. This had been a nagging issue for awhile now, but it turns out the only real issue is that I forgot to add the VV10 energy to the total SCF energy. I had originally started blaming the Fock term as the VV10 energy was spot on and subsequently starting playing with those values. Quite the blooper on my part:

```
(p4dev) daniel:~/Gits/psi4ds/tests/dft-bench-ionization (vv10_uks)$ python ../../psi4/run_psi4.py --inplace input.dat
	VSXC: Psi4 vs. Q-Chem.............................................PASSED
	VV10: Psi4 vs. Q-Chem.............................................PASSED
	B97M-V: Psi4 vs. Q-Chem...........................................PASSED
	LC-VV10: Psi4 vs. Q-Chem..........................................PASSED
	wB97M-V: Psi4 vs. Q-Chem..........................................PASSED
	wB97X-V: Psi4 vs. Q-Chem..........................................PASSED
```

This also fixes a small bug in meta-GGA UKS gradients from the original implementation.

Fixes #982 and fixes #962.

## Status
- [x] Ready for review
- [x] Ready for merge