### PR TITLE
User facing dict_funcs

### DIFF
--- a/psi4/driver/procrouting/dft_funcs/superfuncs.py
+++ b/psi4/driver/procrouting/dft_funcs/superfuncs.py
@@ -43,8 +43,8 @@ superfunctionals = {}
 
 superfunctional_list = []
 superfunctional_noxc_names = ["hf"]
-for key in dict_builder.functionals.keys():
-    sup = dict_builder.build_superfunctional_from_dictionary(key, 1, 1, True)[0]
+for key in dict_builder.functionals:
+    sup = dict_builder.build_superfunctional_from_dictionary(dict_builder.functionals[key], 1, 1, True)[0]
     superfunctional_list.append(sup)
     if not sup.needs_xc():
         superfunctional_noxc_names.append(sup.name().lower())
@@ -74,10 +74,14 @@ def build_superfunctional(name, restricted):
         sup[0].set_max_points(npoints)
         sup[0].set_deriv(deriv)
         sup[0].allocate()
-
-    # Check for dict-based functionals
-    elif name.upper() in dict_builder.functionals.keys():
-        sup = dict_builder.build_superfunctional_from_dictionary(name.upper(), npoints, deriv, restricted)
+    
+    # Check for supplied dict_func functionals
+    elif isinstance(name, dict):
+        sup = dict_builder.build_superfunctional_from_dictionary(name, npoints, deriv, restricted)
+    # Check for pre-defined dict-based functionals
+    elif name.upper() in dict_builder.functionals:
+        sup = dict_builder.build_superfunctional_from_dictionary(dict_builder.functionals[name.upper()], 
+                                                                 npoints, deriv, restricted)
     else:
         raise ValidationError("SCF: Functional (%s) not found!" % name)
 

--- a/tests/dft-smoke/input.dat
+++ b/tests/dft-smoke/input.dat
@@ -27,3 +27,15 @@ for k, v in test_dict.items():
         continue
     ret = energy(k)
     compare_values(v, ret, 5, "RKS 0 1  %15s Energy" % k)
+
+pbe = {
+    "name": "PBE",
+    "x_functionals": { "GGA_X_PBE": {} },
+    "c_functionals": { "GGA_C_PBE": {} },
+}
+
+ret = energy("scf", dft_functional="PBE")
+compare_values(test_dict["PBE"], ret, 5, "RKS 0 1              PBE Energy, dft_functional='PBE'")  #TEST
+
+ret = energy("scf", dft_functional=pbe)
+compare_values(test_dict["PBE"], ret, 5, "RKS 0 1              PBE Energy, dft_functional=dict()") #TEST


### PR DESCRIPTION
## Description
Allow users to provide custom functionals using the new `dict_func` syntax. The following calls are now equivalent:
```
energy("PBE")
energy("SCF", dft_functional="PBE")
energy("SCF", dft_functional={ "name": "PBE",
                               "x_functionals": { "GGA_X_PBE": {} },
                               "c_functionals": { "GGA_C_PBE": {} }, 
                             } )
```



## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] `dict_builder.build_superfunctional_from_dictionary()` now builds superfunctionals from dictionaries, not strings 
* **User-Facing for Release Notes**
  - [x] allow users to supply DFT functionals using the new syntax directly

## Checklist
- [x] Tests added for any new features - modified `dft_smoke`; if that's not appropriate let me know
- [x] original part of `dft_smoke` runs fine

## Status
- [x] Ready for review
- [x] Ready for merge
