### PR TITLE
Fix #941, Incorrect #Displacements Reported

### DIFF
--- a/psi4/src/psi4/findif/fd_geoms_freq_0.cc
+++ b/psi4/src/psi4/findif/fd_geoms_freq_0.cc
@@ -162,7 +162,7 @@ std::vector< SharedMatrix > fd_geoms_freq_0(std::shared_ptr<Molecule> mol, Optio
     Ndisp_all += Ndisp_pi[h];
 
   if (print_lvl) {
-    outfile->Printf("\tNumber of geometries (including reference) is %d.\n", Ndisp_all);
+    outfile->Printf("\tNumber of geometries (including reference) is %d.\n", Ndisp_all + 1);
     outfile->Printf("\tNumber of displacements per irrep:\n");
     for (int h=0; h<Nirrep; ++h)
       outfile->Printf("\t  Irrep %d: %d\n", h+1, Ndisp_pi[h]);


### PR DESCRIPTION
## Description
Closes #941.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [x] Fixes a bug where the incorrect number of displacements would be reported during a hessian obtained by fintie difference of energies.

## Checklist
- [ ] _Somehow_, I don't think running test cases for this one is necessary

## Status
- [x] Ready for review
- [x] Ready for merge
