### PR TITLE
Force use of finite difference gradient with PCM

### DIFF
--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -110,9 +110,9 @@ polarization charges. It is mainly useful for debugging.
 .. warning:: ROHF with PCM is known **not to work**. See `issue #999 on GitHub <https://github.com/psi4/psi4/issues/999>`_.
              For the adventurous, a fix is available in `pull request #953 on GitHub <https://github.com/psi4/psi4/pull/953>`_
 
-.. warning:: Analytic gradients and Hessians **are not** available with PCM. You will need
-             to add the ``dertype='energy'`` to ``optimize`` to correctly perform a geometry
-             optimization using finite differences. See :srcsample:`pcmsolver/opt-fd` for a sample input.
+.. warning:: Analytic gradients and Hessians **are not** available with PCM. Finite differences will be used
+             regardless of the ``dertype`` passed to the ``optimize`` function.
+             See :srcsample:`pcmsolver/opt-fd` for a sample input.
 
 The PCM model and molecular cavity are specified in a ``pcm`` section that has
 to be explicitly typed in by the user. This additional section follows a syntax

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -86,6 +86,10 @@ def _find_derivative_type(ptype, method_name, user_dertype):
     if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (dertype != 0):
         raise ValidationError('INTEGRAL_PACKAGE ERD does not play nicely with derivatives, so stopping.')
 
+    if (core.get_global_option('PCM')) and (dertype != 0):
+        core.print_out('\nPCM analytic gradients are not implemented yet, re-routing to finite differences.\n')
+        dertype = 0
+
     # Summary validation
     if (dertype == 2) and (method_name in procedures['hessian']):
         pass

--- a/tests/pcmsolver/opt-fd/input.dat
+++ b/tests/pcmsolver/opt-fd/input.dat
@@ -36,7 +36,16 @@ pcm = {
   }
 }
 
+# Explicitly ask for numerical
 thisenergy = optimize('scf', molecule=h2o, dertype='energy')
+
+compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")    #TEST
+compare_values(refenergy, thisenergy, 7, "Reference energy")                                #TEST
+clean()
+
+# Check that numerical gradient is used anyway
+set g_convergence gau_tight
+thisenergy = optimize('scf', molecule=h2o)
 
 compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")    #TEST
 compare_values(refenergy, thisenergy, 7, "Reference energy")                                #TEST

--- a/tests/pcmsolver/opt-fd/output.ref
+++ b/tests/pcmsolver/opt-fd/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.2a1.dev1170 
+                               Psi4 1.2a1.dev1304 
 
-                         Git: Rev {update-pcmsolver} ef281b0 dirty
+                         Git: Rev {update-pcmsolver} fb2e367 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -18,9 +18,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 02 May 2018 02:17PM
+    Psi4 started on: Wednesday, 02 May 2018 07:40PM
 
-    Process ID: 6378
+    Process ID: 24260
     Host:       minazo
     PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4
     Memory:     500.0 MiB
@@ -67,7 +67,16 @@ pcm = {
   }
 }
 
+# Explicitly ask for numerical
 thisenergy = optimize('scf', molecule=h2o, dertype='energy')
+
+compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")    #TEST
+compare_values(refenergy, thisenergy, 7, "Reference energy")                                #TEST
+clean()
+
+# Check that numerical gradient is used anyway
+set g_convergence gau_tight
+thisenergy = optimize('scf', molecule=h2o)
 
 compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")    #TEST
 compare_values(refenergy, thisenergy, 7, "Reference energy")                                #TEST
@@ -91,7 +100,7 @@ gradient() will perform gradient computation by finite difference of analytic en
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:20 2018
+*** at Wed May  2 19:40:48 2018
 
    => Loading Basis Set <=
 
@@ -172,7 +181,7 @@ gradient() will perform gradient computation by finite difference of analytic en
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -236,6 +245,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -245,6 +255,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.7025904267E-01.
   Using Symmetric Orthogonalization.
 
@@ -254,34 +265,28 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00032752865993
-   @RHF iter   0:   -74.70317727340750   -7.47032e+01   1.95300e-01 
-   PCM polarization energy = -0.01441244209542
-   @RHF iter   1:   -74.92043694688748   -2.17260e-01   3.28228e-02 
-   PCM polarization energy = -0.00597157984629
-   @RHF iter   2:   -74.96742401878430   -4.69871e-02   6.42764e-03 DIIS
-   PCM polarization energy = -0.00586502142350
-   @RHF iter   3:   -74.96965838657424   -2.23437e-03   2.39658e-03 DIIS
-   PCM polarization energy = -0.00571605840556
-   @RHF iter   4:   -74.97008432103297   -4.25934e-04   3.62369e-04 DIIS
-   PCM polarization energy = -0.00573291317418
-   @RHF iter   5:   -74.97009534605817   -1.10250e-05   5.62853e-05 DIIS
-   PCM polarization energy = -0.00572695828107
-   @RHF iter   6:   -74.97009559509353   -2.49035e-07   9.88269e-06 DIIS
-   PCM polarization energy = -0.00572868010288
-   @RHF iter   7:   -74.97009559989530   -4.80178e-09   1.31730e-06 DIIS
-   PCM polarization energy = -0.00572859739914
-   @RHF iter   8:   -74.97009559999749   -1.02190e-10   2.80830e-07 DIIS
-   PCM polarization energy = -0.00572859985043
-   @RHF iter   9:   -74.97009560000349   -5.99698e-12   4.66200e-08 DIIS
-   PCM polarization energy = -0.00572860514010
-   @RHF iter  10:   -74.97009560000360   -1.13687e-13   7.38664e-09 DIIS
-   PCM polarization energy = -0.00572860419518
-   @RHF iter  11:   -74.97009560000350    9.94760e-14   1.34481e-09 DIIS
-   PCM polarization energy = -0.00572860432921
-   @RHF iter  12:   -74.97009560000355   -4.26326e-14   3.18417e-10 DIIS
-   PCM polarization energy = -0.00572860431759
-   @RHF iter  13:   -74.97009560000362   -7.10543e-14   1.54420e-12 DIIS
+   PCM polarization energy = -0.00040522172384
+   @RHF iter   0:   -74.60689903626538   -7.46069e+01   1.94334e-01 
+   PCM polarization energy = -0.00844204126427
+   @RHF iter   1:   -74.96333632062705   -3.56437e-01   1.39411e-02 
+   PCM polarization energy = -0.00562996450076
+   @RHF iter   2:   -74.96992550541547   -6.58918e-03   1.77849e-03 DIIS
+   PCM polarization energy = -0.00572304072380
+   @RHF iter   3:   -74.97006969920730   -1.44194e-04   6.05360e-04 DIIS
+   PCM polarization energy = -0.00571838033338
+   @RHF iter   4:   -74.97009473154856   -2.50323e-05   1.05824e-04 DIIS
+   PCM polarization energy = -0.00572807001883
+   @RHF iter   5:   -74.97009559432553   -8.62777e-07   8.72315e-06 DIIS
+   PCM polarization energy = -0.00572864693526
+   @RHF iter   6:   -74.97009559966621   -5.34068e-09   1.90485e-06 DIIS
+   PCM polarization energy = -0.00572860409170
+   @RHF iter   7:   -74.97009560000352   -3.37309e-10   2.57499e-08 DIIS
+   PCM polarization energy = -0.00572860429659
+   @RHF iter   8:   -74.97009560000355   -2.84217e-14   1.05361e-08 DIIS
+   PCM polarization energy = -0.00572860431540
+   @RHF iter   9:   -74.97009560000353    1.42109e-14   8.76954e-10 DIIS
+   PCM polarization energy = -0.00572860431723
+   @RHF iter  10:   -74.97009560000356   -2.84217e-14   7.91930e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -303,15 +308,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97009560000362
+  @RHF Final Energy:   -74.97009560000356
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8014968800864679
-    One-Electron Energy =                -121.7661671388252245
-    Two-Electron Energy =                  38.0003032630527429
-    PCM Polarization Energy =              -0.0057286043175919
-    Total Energy =                        -74.9700956000036030
+    One-Electron Energy =                -121.7661671389513600
+    Two-Electron Energy =                  38.0003032631785587
+    PCM Polarization Energy =              -0.0057286043172331
+    Total Energy =                        -74.9700956000035603
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -323,23 +328,23 @@ Properties computed using the SCF density matrix
      X:    -0.8073      Y:    -0.6219      Z:     0.0000
 
   Electronic Dipole Moment: [e a0]
-     X:     0.2595      Y:     0.1968      Z:     0.0000
+     X:     0.2595      Y:     0.1968      Z:    -0.0000
 
   Dipole Moment: [e a0]
-     X:    -0.5478      Y:    -0.4251      Z:     0.0000     Total:     0.6934
+     X:    -0.5478      Y:    -0.4251      Z:    -0.0000     Total:     0.6934
 
   Dipole Moment: [D]
-     X:    -1.3924      Y:    -1.0804      Z:     0.0000     Total:     1.7624
+     X:    -1.3924      Y:    -1.0804      Z:    -0.0000     Total:     1.7624
 
 
-*** tstop() called on minazo at Wed May  2 14:17:22 2018
+*** tstop() called on minazo at Wed May  2 19:40:50 2018
 Module time:
-	user time   =       1.90 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       1.90 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -347,7 +352,7 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:22 2018
+*** at Wed May  2 19:40:50 2018
 
    => Loading Basis Set <=
 
@@ -425,7 +430,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -489,6 +494,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -498,6 +504,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.7025904267E-01.
   Using Symmetric Orthogonalization.
 
@@ -508,31 +515,31 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00040057093186
-   @RHF iter   0:   -74.61806772146151   -7.46181e+01   1.94474e-01 
+   @RHF iter   0:   -74.61806772146154   -7.46181e+01   1.94474e-01 
    PCM polarization energy = -0.00888976505067
-   @RHF iter   1:   -74.95918554984166   -3.41118e-01   1.62654e-02 
+   @RHF iter   1:   -74.95918554984164   -3.41118e-01   1.62654e-02 
    PCM polarization energy = -0.00565305055605
-   @RHF iter   2:   -74.96933481119606   -1.01493e-02   3.11639e-03 DIIS
+   @RHF iter   2:   -74.96933481119605   -1.01493e-02   3.11639e-03 DIIS
    PCM polarization energy = -0.00573830240463
-   @RHF iter   3:   -74.96992834446192   -5.93533e-04   1.36357e-03 DIIS
+   @RHF iter   3:   -74.96992834446191   -5.93533e-04   1.36357e-03 DIIS
    PCM polarization energy = -0.00571478479473
    @RHF iter   4:   -74.97009228362981   -1.63939e-04   2.04466e-04 DIIS
    PCM polarization energy = -0.00573008707089
    @RHF iter   5:   -74.97009558144394   -3.29781e-06   1.57081e-05 DIIS
    PCM polarization energy = -0.00572883700226
-   @RHF iter   6:   -74.97009559813807   -1.66941e-08   4.95451e-06 DIIS
+   @RHF iter   6:   -74.97009559813806   -1.66941e-08   4.95451e-06 DIIS
    PCM polarization energy = -0.00572862140762
-   @RHF iter   7:   -74.97009559998871   -1.85064e-09   4.34837e-07 DIIS
+   @RHF iter   7:   -74.97009559998871   -1.85065e-09   4.34837e-07 DIIS
    PCM polarization energy = -0.00572860285865
-   @RHF iter   8:   -74.97009560000319   -1.44809e-11   5.05253e-08 DIIS
+   @RHF iter   8:   -74.97009560000315   -1.44382e-11   5.05253e-08 DIIS
    PCM polarization energy = -0.00572860378547
-   @RHF iter   9:   -74.97009560000338   -1.84741e-13   1.50405e-08 DIIS
+   @RHF iter   9:   -74.97009560000348   -3.26850e-13   1.50405e-08 DIIS
    PCM polarization energy = -0.00572860428579
-   @RHF iter  10:   -74.97009560000345   -7.10543e-14   1.88157e-09 DIIS
+   @RHF iter  10:   -74.97009560000336    1.13687e-13   1.88157e-09 DIIS
    PCM polarization energy = -0.00572860430499
-   @RHF iter  11:   -74.97009560000345    0.00000e+00   1.83045e-10 DIIS
+   @RHF iter  11:   -74.97009560000342   -5.68434e-14   1.83045e-10 DIIS
    PCM polarization energy = -0.00572860431632
-   @RHF iter  12:   -74.97009560000342    2.84217e-14   4.46080e-11 DIIS
+   @RHF iter  12:   -74.97009560000346   -4.26326e-14   4.46082e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -554,15 +561,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97009560000342
+  @RHF Final Energy:   -74.97009560000346
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8014968800864697
-    One-Electron Energy =                -121.7661671386828459
-    Two-Electron Energy =                  38.0003032629092701
-    PCM Polarization Energy =              -0.0057286043163169
-    Total Energy =                        -74.9700956000034182
+    One-Electron Energy =                -121.7661671386829454
+    Two-Electron Energy =                  38.0003032629093269
+    PCM Polarization Energy =              -0.0057286043163170
+    Total Energy =                        -74.9700956000034608
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -583,22 +590,22 @@ Properties computed using the SCF density matrix
      X:    -1.3947      Y:    -1.0775      Z:    -0.0000     Total:     1.7624
 
 
-*** tstop() called on minazo at Wed May  2 14:17:24 2018
+*** tstop() called on minazo at Wed May  2 19:40:53 2018
 Module time:
-	user time   =       1.80 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       3.73 seconds =       0.06 minutes
+	user time   =       4.28 seconds =       0.07 minutes
 	system time =       0.04 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:24 2018
+*** at Wed May  2 19:40:53 2018
 
    => Loading Basis Set <=
 
@@ -676,7 +683,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -740,6 +747,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -749,6 +757,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.7105727976E-01.
   Using Symmetric Orthogonalization.
 
@@ -759,25 +768,25 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00040265844012
-   @RHF iter   0:   -74.60990067943456   -7.46099e+01   1.93880e-01 
+   @RHF iter   0:   -74.60990067943462   -7.46099e+01   1.93880e-01 
    PCM polarization energy = -0.00867439210900
-   @RHF iter   1:   -74.96130310226305   -3.51402e-01   1.50395e-02 
+   @RHF iter   1:   -74.96130310226307   -3.51402e-01   1.50395e-02 
    PCM polarization energy = -0.00563114128878
-   @RHF iter   2:   -74.96961791333229   -8.31481e-03   2.48051e-03 DIIS
+   @RHF iter   2:   -74.96961791333233   -8.31481e-03   2.48051e-03 DIIS
    PCM polarization energy = -0.00571672526058
-   @RHF iter   3:   -74.96998496408759   -3.67051e-04   1.04629e-03 DIIS
+   @RHF iter   3:   -74.96998496408763   -3.67051e-04   1.04629e-03 DIIS
    PCM polarization energy = -0.00569733135659
-   @RHF iter   4:   -74.97008373363404   -9.87695e-05   1.73925e-04 DIIS
+   @RHF iter   4:   -74.97008373363401   -9.87695e-05   1.73925e-04 DIIS
    PCM polarization energy = -0.00570940120268
-   @RHF iter   5:   -74.97008633773412   -2.60410e-06   1.11250e-05 DIIS
+   @RHF iter   5:   -74.97008633773403   -2.60410e-06   1.11250e-05 DIIS
    PCM polarization energy = -0.00570882297294
-   @RHF iter   6:   -74.97008634663936   -8.90525e-09   3.37081e-06 DIIS
+   @RHF iter   6:   -74.97008634663941   -8.90537e-09   3.37081e-06 DIIS
    PCM polarization energy = -0.00570860230237
-   @RHF iter   7:   -74.97008634755949   -9.20124e-10   4.38114e-08 DIIS
+   @RHF iter   7:   -74.97008634755952   -9.20110e-10   4.38114e-08 DIIS
    PCM polarization energy = -0.00570859667328
-   @RHF iter   8:   -74.97008634755964   -1.56319e-13   6.72055e-10 DIIS
+   @RHF iter   8:   -74.97008634755970   -1.84741e-13   6.72055e-10 DIIS
    PCM polarization energy = -0.00570859655489
-   @RHF iter   9:   -74.97008634755970   -5.68434e-14   1.38604e-12 DIIS
+   @RHF iter   9:   -74.97008634755969    1.42109e-14   1.38548e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -799,15 +808,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97008634755970
+  @RHF Final Energy:   -74.97008634755969
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.7912166897170678
-    One-Electron Energy =                -121.7466383672876304
-    Two-Electron Energy =                  37.9910439265657516
-    PCM Polarization Energy =              -0.0057085965548857
-    Total Energy =                        -74.9700863475597004
+    One-Electron Energy =                -121.7466383672876162
+    Two-Electron Energy =                  37.9910439265657374
+    PCM Polarization Energy =              -0.0057085965548855
+    Total Energy =                        -74.9700863475596861
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -819,31 +828,31 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0224
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.3291
+     X:     0.0000      Y:     0.0000      Z:    -0.3291
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.6933     Total:     0.6933
+     X:     0.0000      Y:     0.0000      Z:     0.6933     Total:     0.6933
 
   Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:     1.7622     Total:     1.7622
+     X:     0.0000      Y:     0.0000      Z:     1.7622     Total:     1.7622
 
 
-*** tstop() called on minazo at Wed May  2 14:17:25 2018
+*** tstop() called on minazo at Wed May  2 19:40:55 2018
 Module time:
-	user time   =       1.56 seconds =       0.03 minutes
+	user time   =       1.94 seconds =       0.03 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       5.32 seconds =       0.09 minutes
+	user time   =       6.25 seconds =       0.10 minutes
 	system time =       0.06 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	total time  =          7 seconds =       0.12 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:25 2018
+*** at Wed May  2 19:40:55 2018
 
    => Loading Basis Set <=
 
@@ -921,7 +930,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -985,6 +994,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -994,6 +1004,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6951300188E-01.
   Using Symmetric Orthogonalization.
 
@@ -1004,23 +1015,23 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00035006081592
-   @RHF iter   0:   -74.69675489107161   -7.46968e+01   1.95371e-01 
+   @RHF iter   0:   -74.69675489107159   -7.46968e+01   1.95371e-01 
    PCM polarization energy = -0.01379314670250
-   @RHF iter   1:   -74.92783520750123   -2.31080e-01   3.04450e-02 
+   @RHF iter   1:   -74.92783520750125   -2.31080e-01   3.04450e-02 
    PCM polarization energy = -0.00605740780234
-   @RHF iter   2:   -74.96809432490315   -4.02591e-02   5.43809e-03 DIIS
+   @RHF iter   2:   -74.96809432490323   -4.02591e-02   5.43809e-03 DIIS
    PCM polarization energy = -0.00594767838487
-   @RHF iter   3:   -74.96970172188041   -1.60740e-03   2.23750e-03 DIIS
+   @RHF iter   3:   -74.96970172188037   -1.60740e-03   2.23750e-03 DIIS
    PCM polarization energy = -0.00571772407499
-   @RHF iter   4:   -74.97009185325112   -3.90131e-04   1.98850e-04 DIIS
+   @RHF iter   4:   -74.97009185325111   -3.90131e-04   1.98850e-04 DIIS
    PCM polarization energy = -0.00573041334084
-   @RHF iter   5:   -74.97009416801097   -2.31476e-06   1.52479e-05 DIIS
+   @RHF iter   5:   -74.97009416801106   -2.31476e-06   1.52479e-05 DIIS
    PCM polarization energy = -0.00572715160636
-   @RHF iter   6:   -74.97009417716365   -9.15267e-09   3.14757e-07 DIIS
+   @RHF iter   6:   -74.97009417716359   -9.15253e-09   3.14757e-07 DIIS
    PCM polarization energy = -0.00572721971375
-   @RHF iter   7:   -74.97009417716862   -4.97380e-12   3.34081e-09 DIIS
+   @RHF iter   7:   -74.97009417716859   -5.00222e-12   3.34081e-09 DIIS
    PCM polarization energy = -0.00572722040730
-   @RHF iter   8:   -74.97009417716858    4.26326e-14   4.16946e-11 DIIS
+   @RHF iter   8:   -74.97009417716856    2.84217e-14   4.16952e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -1042,15 +1053,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97009417716858
+  @RHF Final Energy:   -74.97009417716856
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8117184903234556
-    One-Electron Energy =                -121.7853980924420085
-    Two-Electron Energy =                  38.0093126453572765
+    One-Electron Energy =                -121.7853980924419375
+    Two-Electron Energy =                  38.0093126453572339
     PCM Polarization Energy =              -0.0057272204073030
-    Total Energy =                        -74.9700941771685763
+    Total Energy =                        -74.9700941771685478
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -1071,22 +1082,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:    -0.0000      Z:     1.7623     Total:     1.7623
 
 
-*** tstop() called on minazo at Wed May  2 14:17:27 2018
+*** tstop() called on minazo at Wed May  2 19:40:57 2018
 Module time:
-	user time   =       1.50 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       6.85 seconds =       0.11 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       8.24 seconds =       0.14 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:27 2018
+*** at Wed May  2 19:40:57 2018
 
    => Loading Basis Set <=
 
@@ -1164,7 +1175,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -1228,6 +1239,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -1237,6 +1249,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.7125954317E-01.
   Using Symmetric Orthogonalization.
 
@@ -1247,23 +1260,23 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00034899359042
-   @RHF iter   0:   -74.69037297325990   -7.46904e+01   1.94195e-01 
+   @RHF iter   0:   -74.69037297325991   -7.46904e+01   1.94195e-01 
    PCM polarization energy = -0.01381831245524
-   @RHF iter   1:   -74.92729480791024   -2.36922e-01   3.05357e-02 
+   @RHF iter   1:   -74.92729480791022   -2.36922e-01   3.05357e-02 
    PCM polarization energy = -0.00602027779538
-   @RHF iter   2:   -74.96790807521900   -4.06133e-02   5.46966e-03 DIIS
+   @RHF iter   2:   -74.96790807521899   -4.06133e-02   5.46966e-03 DIIS
    PCM polarization energy = -0.00591866040633
-   @RHF iter   3:   -74.96953240618379   -1.62433e-03   2.25302e-03 DIIS
+   @RHF iter   3:   -74.96953240618380   -1.62433e-03   2.25302e-03 DIIS
    PCM polarization energy = -0.00568701532997
    @RHF iter   4:   -74.96992959070214   -3.97185e-04   2.00894e-04 DIIS
    PCM polarization energy = -0.00570000276813
-   @RHF iter   5:   -74.96993196048187   -2.36978e-06   1.56466e-05 DIIS
+   @RHF iter   5:   -74.96993196048189   -2.36978e-06   1.56466e-05 DIIS
    PCM polarization energy = -0.00569665792742
-   @RHF iter   6:   -74.96993197016654   -9.68467e-09   2.56673e-07 DIIS
+   @RHF iter   6:   -74.96993197016651   -9.68463e-09   2.56673e-07 DIIS
    PCM polarization energy = -0.00569671325373
-   @RHF iter   7:   -74.96993197017012   -3.58114e-12   2.06360e-09 DIIS
+   @RHF iter   7:   -74.96993197017015   -3.63798e-12   2.06360e-09 DIIS
    PCM polarization energy = -0.00569671368396
-   @RHF iter   8:   -74.96993197017011    1.42109e-14   3.25506e-11 DIIS
+   @RHF iter   8:   -74.96993197017011    4.26326e-14   3.25502e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -1290,9 +1303,9 @@ Permittivity = 78.39
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.7882150957366072
-    One-Electron Energy =                -121.7431522114568168
-    Two-Electron Energy =                  37.9907018592340648
-    PCM Polarization Energy =              -0.0056967136839573
+    One-Electron Energy =                -121.7431522114568025
+    Two-Electron Energy =                  37.9907018592340577
+    PCM Polarization Energy =              -0.0056967136839572
     Total Energy =                        -74.9699319701701086
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
@@ -1305,31 +1318,31 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0191
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:    -0.3269
+     X:     0.0000      Y:    -0.0000      Z:    -0.3269
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:     0.6922     Total:     0.6922
+     X:     0.0000      Y:    -0.0000      Z:     0.6922     Total:     0.6922
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:     0.0000      Z:     1.7594     Total:     1.7594
+     X:     0.0000      Y:    -0.0000      Z:     1.7594     Total:     1.7594
 
 
-*** tstop() called on minazo at Wed May  2 14:17:28 2018
+*** tstop() called on minazo at Wed May  2 19:40:59 2018
 Module time:
-	user time   =       1.50 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.97 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       8.38 seconds =       0.14 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      10.25 seconds =       0.17 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:28 2018
+*** at Wed May  2 19:40:59 2018
 
    => Loading Basis Set <=
 
@@ -1407,7 +1420,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:40 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -1471,6 +1484,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -1480,6 +1494,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6930928934E-01.
   Using Symmetric Orthogonalization.
 
@@ -1490,25 +1505,25 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00037585432445
-   @RHF iter   0:   -74.66743724465074   -7.46674e+01   1.95407e-01 
+   @RHF iter   0:   -74.66743724465073   -7.46674e+01   1.95407e-01 
    PCM polarization energy = -0.01151709004728
-   @RHF iter   1:   -74.94139155250325   -2.73954e-01   2.46044e-02 
+   @RHF iter   1:   -74.94139155250329   -2.73954e-01   2.46044e-02 
    PCM polarization energy = -0.00590077955388
    @RHF iter   2:   -74.96804185660531   -2.66503e-02   5.14551e-03 DIIS
    PCM polarization energy = -0.00586918104945
-   @RHF iter   3:   -74.96975316091576   -1.71130e-03   2.28859e-03 DIIS
+   @RHF iter   3:   -74.96975316091567   -1.71130e-03   2.28859e-03 DIIS
    PCM polarization energy = -0.00571085906458
-   @RHF iter   4:   -74.97023708466207   -4.83924e-04   2.38585e-04 DIIS
+   @RHF iter   4:   -74.97023708466202   -4.83924e-04   2.38585e-04 DIIS
    PCM polarization energy = -0.00573786398662
-   @RHF iter   5:   -74.97024126510526   -4.18044e-06   3.47799e-05 DIIS
+   @RHF iter   5:   -74.97024126510533   -4.18044e-06   3.47799e-05 DIIS
    PCM polarization energy = -0.00573208817597
-   @RHF iter   6:   -74.97024132509067   -5.99854e-08   1.22718e-05 DIIS
+   @RHF iter   6:   -74.97024132509070   -5.99854e-08   1.22718e-05 DIIS
    PCM polarization energy = -0.00573435091866
-   @RHF iter   7:   -74.97024133158723   -6.49656e-09   1.25554e-06 DIIS
+   @RHF iter   7:   -74.97024133158730   -6.49661e-09   1.25554e-06 DIIS
    PCM polarization energy = -0.00573458793850
-   @RHF iter   8:   -74.97024133164571   -5.84777e-11   2.20253e-08 DIIS
+   @RHF iter   8:   -74.97024133164565   -5.83498e-11   2.20253e-08 DIIS
    PCM polarization energy = -0.00573459233266
-   @RHF iter   9:   -74.97024133164574   -2.84217e-14   4.52636e-11 DIIS
+   @RHF iter   9:   -74.97024133164570   -4.26326e-14   4.52640e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -1530,15 +1545,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97024133164574
+  @RHF Final Energy:   -74.97024133164570
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8147454299229153
-    One-Electron Energy =                -121.7888616798072832
-    Two-Electron Energy =                  38.0096095105712806
-    PCM Polarization Energy =              -0.0057345923326561
-    Total Energy =                        -74.9702413316457381
+    One-Electron Energy =                -121.7888616798071837
+    Two-Electron Energy =                  38.0096095105712379
+    PCM Polarization Energy =              -0.0057345923326563
+    Total Energy =                        -74.9702413316456955
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -1559,22 +1574,22 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:     1.7651     Total:     1.7651
 
 
-*** tstop() called on minazo at Wed May  2 14:17:30 2018
+*** tstop() called on minazo at Wed May  2 19:41:01 2018
 Module time:
-	user time   =       1.61 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       2.13 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      10.02 seconds =       0.17 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      12.42 seconds =       0.21 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 7 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:30 2018
+*** at Wed May  2 19:41:01 2018
 
    => Loading Basis Set <=
 
@@ -1652,7 +1667,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -1716,6 +1731,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -1725,6 +1741,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.7028400642E-01.
   Using Symmetric Orthogonalization.
 
@@ -1735,25 +1752,25 @@ Permittivity = 78.39
                         Total Energy        Delta E     RMS |[F,P]|
 
    PCM polarization energy = -0.00037578087843
-   @RHF iter   0:   -74.66374498172547   -7.46637e+01   1.94721e-01 
+   @RHF iter   0:   -74.66374498172546   -7.46637e+01   1.94721e-01 
    PCM polarization energy = -0.01150213281266
-   @RHF iter   1:   -74.94116274375159   -2.77418e-01   2.46132e-02 
+   @RHF iter   1:   -74.94116274375156   -2.77418e-01   2.46132e-02 
    PCM polarization energy = -0.00588187432761
-   @RHF iter   2:   -74.96787841754249   -2.67157e-02   5.15760e-03 DIIS
+   @RHF iter   2:   -74.96787841754256   -2.67157e-02   5.15760e-03 DIIS
    PCM polarization energy = -0.00585305367958
-   @RHF iter   3:   -74.96960033066219   -1.72191e-03   2.29828e-03 DIIS
+   @RHF iter   3:   -74.96960033066216   -1.72191e-03   2.29828e-03 DIIS
    PCM polarization energy = -0.00569394567971
-   @RHF iter   4:   -74.97009005019764   -4.89720e-04   2.39755e-04 DIIS
+   @RHF iter   4:   -74.97009005019756   -4.89720e-04   2.39755e-04 DIIS
    PCM polarization energy = -0.00572126087434
-   @RHF iter   5:   -74.97009428330759   -4.23311e-06   3.53179e-05 DIIS
+   @RHF iter   5:   -74.97009428330762   -4.23311e-06   3.53179e-05 DIIS
    PCM polarization energy = -0.00571540905213
    @RHF iter   6:   -74.97009434528439   -6.19768e-08   1.23684e-05 DIIS
    PCM polarization energy = -0.00571769260231
-   @RHF iter   7:   -74.97009435195456   -6.67016e-09   1.24404e-06 DIIS
+   @RHF iter   7:   -74.97009435195457   -6.67018e-09   1.24404e-06 DIIS
    PCM polarization energy = -0.00571792685097
-   @RHF iter   8:   -74.97009435201213   -5.75682e-11   2.28609e-08 DIIS
+   @RHF iter   8:   -74.97009435201213   -5.75540e-11   2.28609e-08 DIIS
    PCM polarization energy = -0.00571793140740
-   @RHF iter   9:   -74.97009435201214   -1.42109e-14   4.70950e-11 DIIS
+   @RHF iter   9:   -74.97009435201210    2.84217e-14   4.70937e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -1775,15 +1792,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97009435201214
+  @RHF Final Energy:   -74.97009435201210
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8014655299720665
-    One-Electron Energy =                -121.7660173511706603
-    Two-Electron Energy =                  38.0001754005938466
-    PCM Polarization Energy =              -0.0057179314073961
-    Total Energy =                        -74.9700943520121399
+    One-Electron Energy =                -121.7660173511705608
+    Two-Electron Energy =                  38.0001754005937826
+    PCM Polarization Energy =              -0.0057179314073959
+    Total Energy =                        -74.9700943520120973
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -1795,24 +1812,24 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0191
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.3257
+     X:     0.0000      Y:     0.0000      Z:    -0.3257
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.6933     Total:     0.6933
+     X:     0.0000      Y:     0.0000      Z:     0.6933     Total:     0.6933
 
   Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:     1.7623     Total:     1.7623
+     X:     0.0000      Y:     0.0000      Z:     1.7623     Total:     1.7623
 
 
-*** tstop() called on minazo at Wed May  2 14:17:32 2018
+*** tstop() called on minazo at Wed May  2 19:41:03 2018
 Module time:
-	user time   =       1.59 seconds =       0.03 minutes
+	user time   =       2.32 seconds =       0.04 minutes
 	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      11.64 seconds =       0.19 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      14.82 seconds =       0.25 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
 
 -------------------------------------------------------------
 
@@ -1835,9 +1852,9 @@ Total time:
 
                  1                   2                   3
 
-    1     0.00000000000000     0.00000000002150    -0.00104755041771
-    2     0.00000000000000    -0.02196057987130     0.00052377521718
-    3     0.00000000000000     0.02196057984980     0.00052377520053
+    1     0.00000000000000     0.00000000001075    -0.00104755041771
+    2     0.00000000000000    -0.02196057986290     0.00052377521302
+    3     0.00000000000000     0.02196057985215     0.00052377520469
 
 
 
@@ -1860,7 +1877,7 @@ Total time:
 	 H           0.0000000000        1.4941867505        1.0274461029
 	             0.0000000000        0.0000000000       -0.0010475504
 	             0.0000000000       -0.0219605799        0.0005237752
-	             0.0000000000        0.0219605798        0.0005237752
+	             0.0000000000        0.0219605799        0.0005237752
 
 	Previous optimization step data not found.  Starting new optimization.
 
@@ -1943,7 +1960,7 @@ gradient() will perform gradient computation by finite difference of analytic en
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:32 2018
+*** at Wed May  2 19:41:03 2018
 
    => Loading Basis Set <=
 
@@ -1974,15 +1991,15 @@ gradient() will perform gradient computation by finite difference of analytic en
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.054682535623     0.049065662386     0.000000000000    15.994914619560
-           H          0.054682535623    -0.929585612817     0.000000000000     1.007825032070
-           H         -0.922534058098     0.150877944683     0.000000000000     1.007825032070
+           O          0.054682535623     0.049065662385     0.000000000000    15.994914619560
+           H          0.054682535623    -0.929585612827     0.000000000000     1.007825032070
+           H         -0.922534058092     0.150877944702     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.85368  B =     15.76181  C =      9.15722 [cm^-1]
-  Rotational constants: A = 655156.71554  B = 472527.09651  C = 274526.68669 [MHz]
-  Nuclear repulsion =    8.997801896844326
+  Rotational constants: A = 655156.71555  B = 472527.09650  C = 274526.68668 [MHz]
+  Nuclear repulsion =    8.997801896817055
 
   Charge       = 0
   Multiplicity = 1
@@ -2024,7 +2041,7 @@ gradient() will perform gradient computation by finite difference of analytic en
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -2090,6 +2107,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -2099,6 +2117,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5772235212E-01.
   Using Symmetric Orthogonalization.
 
@@ -2108,32 +2127,32 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.06294816548968
-   @RHF iter   0:   -74.45167591060489   -7.44517e+01   5.17504e-02 
-   PCM polarization energy = -0.01857405446051
-   @RHF iter   1:   -74.85585847946703   -4.04183e-01   4.73662e-02 
-   PCM polarization energy = -0.00633094926610
-   @RHF iter   2:   -74.96146623434858   -1.05608e-01   1.09670e-02 DIIS
-   PCM polarization energy = -0.00617305283597
-   @RHF iter   3:   -74.96899315905384   -7.52692e-03   4.33455e-03 DIIS
-   PCM polarization energy = -0.00595594977513
-   @RHF iter   4:   -74.97048666155607   -1.49350e-03   5.13957e-04 DIIS
-   PCM polarization energy = -0.00600095217997
-   @RHF iter   5:   -74.97050790426793   -2.12427e-05   9.39552e-05 DIIS
-   PCM polarization energy = -0.00598370152582
-   @RHF iter   6:   -74.97050842040410   -5.16136e-07   1.45962e-05 DIIS
-   PCM polarization energy = -0.00598575785597
-   @RHF iter   7:   -74.97050843022528   -9.82118e-09   2.73496e-06 DIIS
-   PCM polarization energy = -0.00598545272440
-   @RHF iter   8:   -74.97050843066482   -4.39542e-10   5.82294e-07 DIIS
-   PCM polarization energy = -0.00598550094880
-   @RHF iter   9:   -74.97050843069184   -2.70148e-11   4.90922e-08 DIIS
-   PCM polarization energy = -0.00598550446396
-   @RHF iter  10:   -74.97050843069202   -1.84741e-13   1.23390e-08 DIIS
-   PCM polarization energy = -0.00598550212987
-   @RHF iter  11:   -74.97050843069202    0.00000e+00   1.44520e-10 DIIS
-   PCM polarization energy = -0.00598550213651
-   @RHF iter  12:   -74.97050843069204   -1.42109e-14   3.84713e-11 DIIS
+   PCM polarization energy = -0.06294816548823
+   @RHF iter   0:   -74.45167591061420   -7.44517e+01   5.17504e-02 
+   PCM polarization energy = -0.01857405446009
+   @RHF iter   1:   -74.85585847946936   -4.04183e-01   4.73662e-02 
+   PCM polarization energy = -0.00633094926605
+   @RHF iter   2:   -74.96146623434919   -1.05608e-01   1.09670e-02 DIIS
+   PCM polarization energy = -0.00617305283592
+   @RHF iter   3:   -74.96899315905438   -7.52692e-03   4.33455e-03 DIIS
+   PCM polarization energy = -0.00595594977507
+   @RHF iter   4:   -74.97048666155668   -1.49350e-03   5.13957e-04 DIIS
+   PCM polarization energy = -0.00600095217992
+   @RHF iter   5:   -74.97050790426840   -2.12427e-05   9.39552e-05 DIIS
+   PCM polarization energy = -0.00598370152577
+   @RHF iter   6:   -74.97050842040466   -5.16136e-07   1.45962e-05 DIIS
+   PCM polarization energy = -0.00598575785592
+   @RHF iter   7:   -74.97050843022575   -9.82109e-09   2.73496e-06 DIIS
+   PCM polarization energy = -0.00598545272435
+   @RHF iter   8:   -74.97050843066546   -4.39712e-10   5.82294e-07 DIIS
+   PCM polarization energy = -0.00598550094875
+   @RHF iter   9:   -74.97050843069239   -2.69296e-11   4.90922e-08 DIIS
+   PCM polarization energy = -0.00598550446391
+   @RHF iter  10:   -74.97050843069253   -1.42109e-13   1.23390e-08 DIIS
+   PCM polarization energy = -0.00598550212982
+   @RHF iter  11:   -74.97050843069253    0.00000e+00   1.44519e-10 DIIS
+   PCM polarization energy = -0.00598550213646
+   @RHF iter  12:   -74.97050843069256   -2.84217e-14   3.84715e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -2155,15 +2174,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97050843069204
+  @RHF Final Energy:   -74.97050843069256
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9978018968443259
-    One-Electron Energy =                -122.0638726724367586
-    Two-Electron Energy =                  38.1015478470369047
-    PCM Polarization Energy =              -0.0059855021365124
-    Total Energy =                        -74.9705084306920497
+    Nuclear Repulsion Energy =              8.9978018968170552
+    One-Electron Energy =                -122.0638726723947798
+    Two-Electron Energy =                  38.1015478470216351
+    PCM Polarization Energy =              -0.0059855021364615
+    Total Energy =                        -74.9705084306925613
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -2184,22 +2203,22 @@ Properties computed using the SCF density matrix
      X:    -1.3747      Y:    -1.2419      Z:    -0.0000     Total:     1.8526
 
 
-*** tstop() called on minazo at Wed May  2 14:17:33 2018
+*** tstop() called on minazo at Wed May  2 19:41:06 2018
 Module time:
-	user time   =       1.60 seconds =       0.03 minutes
+	user time   =       2.33 seconds =       0.04 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      13.28 seconds =       0.22 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      17.20 seconds =       0.29 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         18 seconds =       0.30 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:33 2018
+*** at Wed May  2 19:41:06 2018
 
    => Loading Basis Set <=
 
@@ -2228,14 +2247,14 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
            O          0.054467997143     0.049303714005     0.000000000000    15.994914619560
-           H          0.054467997143    -0.933202271632     0.000000000000     1.007825032070
-           H         -0.918914638256     0.150716551544     0.000000000000     1.007825032070
+           H          0.054467997143    -0.933202271642     0.000000000000     1.007825032070
+           H         -0.918914638249     0.150716551562     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.85368  B =     15.76181  C =      9.15722 [cm^-1]
-  Rotational constants: A = 655156.71554  B = 472527.09651  C = 274526.68669 [MHz]
-  Nuclear repulsion =    8.997801896842775
+  Rotational constants: A = 655156.71555  B = 472527.09650  C = 274526.68668 [MHz]
+  Nuclear repulsion =    8.997801896816281
 
   Charge       = 0
   Multiplicity = 1
@@ -2277,7 +2296,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -2343,6 +2362,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -2352,7 +2372,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.5772235212E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.5772235213E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -2361,22 +2382,22 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00598632230881
-   @RHF iter   0:   -74.97053627319917   -7.49705e+01   1.90424e-03 
-   PCM polarization energy = -0.00598543640882
-   @RHF iter   1:   -74.97050840571541    2.78675e-05   2.44756e-05 
-   PCM polarization energy = -0.00598550661563
-   @RHF iter   2:   -74.97050842763898   -2.19236e-08   6.86095e-06 DIIS
-   PCM polarization energy = -0.00598550073161
-   @RHF iter   3:   -74.97050843054328   -2.90430e-09   1.53987e-06 DIIS
-   PCM polarization energy = -0.00598550212631
-   @RHF iter   4:   -74.97050843069223   -1.48958e-10   4.98161e-08 DIIS
-   PCM polarization energy = -0.00598550199857
-   @RHF iter   5:   -74.97050843069232   -8.52651e-14   2.31557e-09 DIIS
-   PCM polarization energy = -0.00598550212291
-   @RHF iter   6:   -74.97050843069231    1.42109e-14   7.19709e-10 DIIS
-   PCM polarization energy = -0.00598550213014
-   @RHF iter   7:   -74.97050843069233   -2.84217e-14   5.34146e-11 DIIS
+   PCM polarization energy = -0.00598632230877
+   @RHF iter   0:   -74.97053627319954   -7.49705e+01   1.90424e-03 
+   PCM polarization energy = -0.00598543640879
+   @RHF iter   1:   -74.97050840571585    2.78675e-05   2.44756e-05 
+   PCM polarization energy = -0.00598550661560
+   @RHF iter   2:   -74.97050842763937   -2.19235e-08   6.86095e-06 DIIS
+   PCM polarization energy = -0.00598550073158
+   @RHF iter   3:   -74.97050843054355   -2.90417e-09   1.53987e-06 DIIS
+   PCM polarization energy = -0.00598550212628
+   @RHF iter   4:   -74.97050843069263   -1.49086e-10   4.98161e-08 DIIS
+   PCM polarization energy = -0.00598550199853
+   @RHF iter   5:   -74.97050843069275   -1.13687e-13   2.31557e-09 DIIS
+   PCM polarization energy = -0.00598550212287
+   @RHF iter   6:   -74.97050843069269    5.68434e-14   7.19710e-10 DIIS
+   PCM polarization energy = -0.00598550213011
+   @RHF iter   7:   -74.97050843069272   -2.84217e-14   5.34145e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -2398,15 +2419,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97050843069233
+  @RHF Final Energy:   -74.97050843069272
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9978018968427751
-    One-Electron Energy =                -122.0638726717475322
-    Two-Electron Energy =                  38.1015478463425552
-    PCM Polarization Energy =              -0.0059855021301399
-    Total Energy =                        -74.9705084306923482
+    Nuclear Repulsion Energy =              8.9978018968162807
+    One-Electron Energy =                -122.0638726717068607
+    Two-Electron Energy =                  38.1015478463279607
+    PCM Polarization Energy =              -0.0059855021301077
+    Total Energy =                        -74.9705084306927176
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -2418,31 +2439,31 @@ Properties computed using the SCF density matrix
      X:    -0.8101      Y:    -0.7333      Z:     0.0000
 
   Electronic Dipole Moment: [e a0]
-     X:     0.2681      Y:     0.2460      Z:    -0.0000
+     X:     0.2681      Y:     0.2460      Z:     0.0000
 
   Dipole Moment: [e a0]
-     X:    -0.5420      Y:    -0.4873      Z:    -0.0000     Total:     0.7289
+     X:    -0.5420      Y:    -0.4873      Z:     0.0000     Total:     0.7289
 
   Dipole Moment: [D]
-     X:    -1.3777      Y:    -1.2386      Z:    -0.0000     Total:     1.8526
+     X:    -1.3777      Y:    -1.2386      Z:     0.0000     Total:     1.8526
 
 
-*** tstop() called on minazo at Wed May  2 14:17:35 2018
+*** tstop() called on minazo at Wed May  2 19:41:08 2018
 Module time:
-	user time   =       1.18 seconds =       0.02 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       1.87 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      14.49 seconds =       0.24 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      19.12 seconds =       0.32 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         20 seconds =       0.33 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:35 2018
+*** at Wed May  2 19:41:08 2018
 
    => Loading Basis Set <=
 
@@ -2470,15 +2491,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.073689617423    15.994914619560
-           H          0.000000000000    -0.728414021767     0.584753851845     1.007825032070
-           H          0.000000000000     0.728414021767     0.584753851890     1.007825032070
+           O          0.000000000000     0.000000000000    -0.073689617422    15.994914619560
+           H          0.000000000000    -0.728414021775     0.584753851852     1.007825032070
+           H          0.000000000000     0.728414021775     0.584753851874     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.72150  B =     15.76249  C =      9.13416 [cm^-1]
-  Rotational constants: A = 651194.12471  B = 472547.49449  C = 273835.32549 [MHz]
-  Nuclear repulsion =    8.986117210360819
+  Rotational constants: A = 651194.12472  B = 472547.49448  C = 273835.32549 [MHz]
+  Nuclear repulsion =    8.986117210334125
 
   Charge       = 0
   Multiplicity = 1
@@ -2520,7 +2541,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -2586,6 +2607,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -2595,6 +2617,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5864478267E-01.
   Using Symmetric Orthogonalization.
 
@@ -2604,34 +2627,34 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.06344799931954
-   @RHF iter   0:   -74.45820080741315   -7.44582e+01   5.09234e-02 
-   PCM polarization energy = -0.01799202719144
-   @RHF iter   1:   -74.85375993225395   -3.95559e-01   4.76318e-02 
-   PCM polarization energy = -0.00624923996416
-   @RHF iter   2:   -74.96019976088715   -1.06440e-01   1.11456e-02 DIIS
-   PCM polarization energy = -0.00621542575094
-   @RHF iter   3:   -74.96839205060537   -8.19229e-03   4.93875e-03 DIIS
-   PCM polarization energy = -0.00591911602106
-   @RHF iter   4:   -74.97048397441519   -2.09192e-03   4.50247e-04 DIIS
-   PCM polarization energy = -0.00598842233318
-   @RHF iter   5:   -74.97049786091510   -1.38865e-05   1.15771e-04 DIIS
-   PCM polarization energy = -0.00597148863603
-   @RHF iter   6:   -74.97049852621458   -6.65299e-07   1.77451e-05 DIIS
-   PCM polarization energy = -0.00597366028871
-   @RHF iter   7:   -74.97049854612551   -1.99109e-08   3.52547e-06 DIIS
-   PCM polarization energy = -0.00597342382269
-   @RHF iter   8:   -74.97049854698943   -8.63920e-10   5.44074e-07 DIIS
-   PCM polarization energy = -0.00597347304963
-   @RHF iter   9:   -74.97049854701120   -2.17710e-11   7.98236e-08 DIIS
-   PCM polarization energy = -0.00597347444844
-   @RHF iter  10:   -74.97049854701177   -5.68434e-13   1.34865e-08 DIIS
-   PCM polarization energy = -0.00597347210303
-   @RHF iter  11:   -74.97049854701187   -9.94760e-14   9.03435e-10 DIIS
-   PCM polarization energy = -0.00597347220292
-   @RHF iter  12:   -74.97049854701173    1.42109e-13   1.12145e-10 DIIS
-   PCM polarization energy = -0.00597347222051
-   @RHF iter  13:   -74.97049854701184   -1.13687e-13   1.23408e-11 DIIS
+   PCM polarization energy = -0.06344799931861
+   @RHF iter   0:   -74.45820080741700   -7.44582e+01   5.09234e-02 
+   PCM polarization energy = -0.01799202719116
+   @RHF iter   1:   -74.85375993225567   -3.95559e-01   4.76318e-02 
+   PCM polarization energy = -0.00624923996414
+   @RHF iter   2:   -74.96019976088792   -1.06440e-01   1.11456e-02 DIIS
+   PCM polarization energy = -0.00621542575091
+   @RHF iter   3:   -74.96839205060606   -8.19229e-03   4.93875e-03 DIIS
+   PCM polarization energy = -0.00591911602102
+   @RHF iter   4:   -74.97048397441583   -2.09192e-03   4.50247e-04 DIIS
+   PCM polarization energy = -0.00598842233314
+   @RHF iter   5:   -74.97049786091577   -1.38865e-05   1.15771e-04 DIIS
+   PCM polarization energy = -0.00597148863599
+   @RHF iter   6:   -74.97049852621521   -6.65299e-07   1.77451e-05 DIIS
+   PCM polarization energy = -0.00597366028868
+   @RHF iter   7:   -74.97049854612622   -1.99110e-08   3.52547e-06 DIIS
+   PCM polarization energy = -0.00597342382265
+   @RHF iter   8:   -74.97049854699002   -8.63793e-10   5.44074e-07 DIIS
+   PCM polarization energy = -0.00597347304960
+   @RHF iter   9:   -74.97049854701193   -2.19131e-11   7.98236e-08 DIIS
+   PCM polarization energy = -0.00597347444840
+   @RHF iter  10:   -74.97049854701243   -4.97380e-13   1.34865e-08 DIIS
+   PCM polarization energy = -0.00597347210299
+   @RHF iter  11:   -74.97049854701243    0.00000e+00   9.03436e-10 DIIS
+   PCM polarization energy = -0.00597347220288
+   @RHF iter  12:   -74.97049854701243    0.00000e+00   1.12145e-10 DIIS
+   PCM polarization energy = -0.00597347222047
+   @RHF iter  13:   -74.97049854701243    0.00000e+00   1.23409e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -2653,15 +2676,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97049854701184
+  @RHF Final Energy:   -74.97049854701243
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9861172103608187
-    One-Electron Energy =                -122.0425084639874314
-    Two-Electron Energy =                  38.0918661788352750
-    PCM Polarization Energy =              -0.0059734722205051
-    Total Energy =                        -74.9704985470118430
+    Nuclear Repulsion Energy =              8.9861172103341254
+    One-Electron Energy =                -122.0425084639466604
+    Two-Electron Energy =                  38.0918661788205668
+    PCM Polarization Energy =              -0.0059734722204677
+    Total Energy =                        -74.9704985470124257
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -2670,7 +2693,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     1.0960
+     X:     0.0000      Y:     0.0000      Z:     1.0960
 
   Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:    -0.0000      Z:    -0.3673
@@ -2682,22 +2705,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:    -0.0000      Z:     1.8522     Total:     1.8522
 
 
-*** tstop() called on minazo at Wed May  2 14:17:36 2018
+*** tstop() called on minazo at Wed May  2 19:41:10 2018
 Module time:
-	user time   =       1.68 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.39 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      16.19 seconds =       0.27 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      21.56 seconds =       0.36 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:36 2018
+*** at Wed May  2 19:41:10 2018
 
    => Loading Basis Set <=
 
@@ -2725,15 +2748,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.073246973943    15.994914619560
-           H          0.000000000000    -0.728414021767     0.581241315222     1.007825032070
-           H          0.000000000000     0.728414021767     0.581241315267     1.007825032070
+           O          0.000000000000     0.000000000000    -0.073246973942    15.994914619560
+           H          0.000000000000    -0.728414021775     0.581241315228     1.007825032070
+           H          0.000000000000     0.728414021775     0.581241315251     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.98482  B =     15.76249  C =      9.18040 [cm^-1]
-  Rotational constants: A = 659088.45207  B = 472547.49449  C = 275221.54772 [MHz]
-  Nuclear repulsion =    9.009433079043786
+  Rotational constants: A = 659088.45208  B = 472547.49448  C = 275221.54772 [MHz]
+  Nuclear repulsion =    9.009433079016706
 
   Charge       = 0
   Multiplicity = 1
@@ -2775,7 +2798,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -2841,6 +2864,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -2850,6 +2874,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5685237127E-01.
   Using Symmetric Orthogonalization.
 
@@ -2859,20 +2884,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00590444325799
-   @RHF iter   0:   -74.97305039823289   -7.49731e+01   1.00419e-03 
-   PCM polarization energy = -0.00598668046620
-   @RHF iter   1:   -74.97052370707299    2.52669e-03   1.01046e-04 
-   PCM polarization energy = -0.00599102320081
-   @RHF iter   2:   -74.97052432952766   -6.22455e-07   4.38047e-05 DIIS
-   PCM polarization energy = -0.00599373464113
-   @RHF iter   3:   -74.97052447601264   -1.46485e-07   1.31071e-06 DIIS
-   PCM polarization energy = -0.00599390293017
-   @RHF iter   4:   -74.97052447612428   -1.11640e-10   1.73431e-07 DIIS
-   PCM polarization energy = -0.00599391490636
-   @RHF iter   5:   -74.97052447612542   -1.13687e-12   1.42053e-08 DIIS
-   PCM polarization energy = -0.00599391692785
-   @RHF iter   6:   -74.97052447612548   -5.68434e-14   3.19143e-12 DIIS
+   PCM polarization energy = -0.00590444325795
+   @RHF iter   0:   -74.97305039823358   -7.49731e+01   1.00419e-03 
+   PCM polarization energy = -0.00598668046616
+   @RHF iter   1:   -74.97052370707364    2.52669e-03   1.01046e-04 
+   PCM polarization energy = -0.00599102320077
+   @RHF iter   2:   -74.97052432952836   -6.22455e-07   4.38047e-05 DIIS
+   PCM polarization energy = -0.00599373464110
+   @RHF iter   3:   -74.97052447601327   -1.46485e-07   1.31071e-06 DIIS
+   PCM polarization energy = -0.00599390293013
+   @RHF iter   4:   -74.97052447612496   -1.11697e-10   1.73431e-07 DIIS
+   PCM polarization energy = -0.00599391490632
+   @RHF iter   5:   -74.97052447612609   -1.12266e-12   1.42053e-08 DIIS
+   PCM polarization energy = -0.00599391692781
+   @RHF iter   6:   -74.97052447612607    1.42109e-14   3.19173e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -2894,15 +2919,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97052447612548
+  @RHF Final Energy:   -74.97052447612607
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0094330790437862
-    One-Electron Energy =                -122.0851321831260492
-    Two-Electron Energy =                  38.1111685448846202
-    PCM Polarization Energy =              -0.0059939169278469
-    Total Energy =                        -74.9705244761254903
+    Nuclear Repulsion Energy =              9.0094330790167056
+    One-Electron Energy =                -122.0851321830846814
+    Two-Electron Energy =                  38.1111685448697202
+    PCM Polarization Energy =              -0.0059939169278093
+    Total Energy =                        -74.9705244761260730
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -2911,7 +2936,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0894
+     X:     0.0000      Y:    -0.0000      Z:     1.0894
 
   Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:    -0.0000      Z:    -0.3604
@@ -2923,22 +2948,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:    -0.0000      Z:     1.8530     Total:     1.8530
 
 
-*** tstop() called on minazo at Wed May  2 14:17:37 2018
+*** tstop() called on minazo at Wed May  2 19:41:12 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
+	user time   =       1.36 seconds =       0.02 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      17.34 seconds =       0.29 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =      22.95 seconds =       0.38 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         24 seconds =       0.40 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:38 2018
+*** at Wed May  2 19:41:12 2018
 
    => Loading Basis Set <=
 
@@ -2966,15 +2991,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.073468295683    15.994914619560
-           H          0.000000000000    -0.730277668391     0.582997583534     1.007825032070
-           H          0.000000000000     0.730277668391     0.582997583578     1.007825032070
+           O          0.000000000000     0.000000000000    -0.073468295682    15.994914619560
+           H          0.000000000000    -0.730277668400     0.582997583540     1.007825032070
+           H          0.000000000000     0.730277668400     0.582997583562     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.85257  B =     15.68214  C =      9.13008 [cm^-1]
-  Rotational constants: A = 655123.45232  B = 470138.71802  C = 273713.01385 [MHz]
-  Nuclear repulsion =    8.984662008046756
+  Rotational constants: A = 655123.45233  B = 470138.71801  C = 273713.01385 [MHz]
+  Nuclear repulsion =    8.984662008019848
 
   Charge       = 0
   Multiplicity = 1
@@ -3016,7 +3041,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -3082,6 +3107,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -3091,6 +3117,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5863517233E-01.
   Using Symmetric Orthogonalization.
 
@@ -3100,20 +3127,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00604399683840
-   @RHF iter   0:   -74.96845568521360   -7.49685e+01   9.79544e-04 
-   PCM polarization energy = -0.00597223698317
-   @RHF iter   1:   -74.97062540249888   -2.16972e-03   4.68307e-05 
-   PCM polarization energy = -0.00596960436713
-   @RHF iter   2:   -74.97062553263210   -1.30133e-07   1.99423e-05 DIIS
-   PCM polarization energy = -0.00596854933459
-   @RHF iter   3:   -74.97062556286811   -3.02360e-08   1.57095e-06 DIIS
-   PCM polarization energy = -0.00596837293544
-   @RHF iter   4:   -74.97062556305363   -1.85523e-10   1.19599e-07 DIIS
-   PCM polarization energy = -0.00596836634684
-   @RHF iter   5:   -74.97062556305416   -5.25802e-13   1.91720e-08 DIIS
-   PCM polarization energy = -0.00596836414538
-   @RHF iter   6:   -74.97062556305423   -7.10543e-14   2.68433e-13 DIIS
+   PCM polarization energy = -0.00604399683837
+   @RHF iter   0:   -74.96845568521418   -7.49685e+01   9.79544e-04 
+   PCM polarization energy = -0.00597223698313
+   @RHF iter   1:   -74.97062540249951   -2.16972e-03   4.68307e-05 
+   PCM polarization energy = -0.00596960436709
+   @RHF iter   2:   -74.97062553263270   -1.30133e-07   1.99423e-05 DIIS
+   PCM polarization energy = -0.00596854933455
+   @RHF iter   3:   -74.97062556286875   -3.02361e-08   1.57095e-06 DIIS
+   PCM polarization energy = -0.00596837293540
+   @RHF iter   4:   -74.97062556305428   -1.85537e-10   1.19599e-07 DIIS
+   PCM polarization energy = -0.00596836634680
+   @RHF iter   5:   -74.97062556305481   -5.25802e-13   1.91720e-08 DIIS
+   PCM polarization energy = -0.00596836414535
+   @RHF iter   6:   -74.97062556305474    7.10543e-14   2.69411e-13 DIIS
 
   ==> Post-Iterations <==
 
@@ -3135,15 +3162,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97062556305423
+  @RHF Final Energy:   -74.97062556305474
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9846620080467563
-    One-Electron Energy =                -122.0416035423041166
-    Two-Electron Energy =                  38.0922843353485234
-    PCM Polarization Energy =              -0.0059683641453842
-    Total Energy =                        -74.9706255630542273
+    Nuclear Repulsion Energy =              8.9846620080198480
+    One-Electron Energy =                -122.0416035422628056
+    Two-Electron Energy =                  38.0922843353335594
+    PCM Polarization Energy =              -0.0059683641453468
+    Total Energy =                        -74.9706255630547389
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -3152,7 +3179,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0927
+     X:     0.0000      Y:    -0.0000      Z:     1.0927
 
   Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:    -0.0000      Z:    -0.3650
@@ -3164,22 +3191,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:    -0.0000      Z:     1.8496     Total:     1.8496
 
 
-*** tstop() called on minazo at Wed May  2 14:17:39 2018
+*** tstop() called on minazo at Wed May  2 19:41:13 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      18.49 seconds =       0.31 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         19 seconds =       0.32 minutes
+	user time   =      24.34 seconds =       0.41 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         25 seconds =       0.42 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:39 2018
+*** at Wed May  2 19:41:13 2018
 
    => Loading Basis Set <=
 
@@ -3207,15 +3234,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.073468295683    15.994914619560
-           H          0.000000000000    -0.726550375142     0.582997583534     1.007825032070
-           H          0.000000000000     0.726550375142     0.582997583578     1.007825032070
+           O          0.000000000000     0.000000000000    -0.073468295682    15.994914619560
+           H          0.000000000000    -0.726550375151     0.582997583540     1.007825032070
+           H          0.000000000000     0.726550375151     0.582997583562     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.85257  B =     15.84345  C =      9.18453 [cm^-1]
-  Rotational constants: A = 655123.45232  B = 474974.83071  C = 275345.21159 [MHz]
-  Nuclear repulsion =    9.010901378562863
+  Rotational constants: A = 655123.45233  B = 474974.83070  C = 275345.21159 [MHz]
+  Nuclear repulsion =    9.010901378536001
 
   Charge       = 0
   Multiplicity = 1
@@ -3257,7 +3284,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -3323,6 +3350,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -3332,6 +3360,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5686127307E-01.
   Using Symmetric Orthogonalization.
 
@@ -3341,20 +3370,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00594001030277
-   @RHF iter   0:   -74.97224452861198   -7.49722e+01   9.72229e-04 
-   PCM polarization energy = -0.00599875920937
-   @RHF iter   1:   -74.97039475468830    1.84977e-03   1.47116e-05 
-   PCM polarization energy = -0.00599957865775
-   @RHF iter   2:   -74.97039476227607   -7.58777e-09   4.15037e-06 DIIS
-   PCM polarization energy = -0.00599923721400
-   @RHF iter   3:   -74.97039476344146   -1.16539e-09   1.41445e-06 DIIS
-   PCM polarization energy = -0.00599914550100
-   @RHF iter   4:   -74.97039476359161   -1.50152e-10   7.29383e-08 DIIS
-   PCM polarization energy = -0.00599914402636
-   @RHF iter   5:   -74.97039476359191   -2.98428e-13   1.39057e-08 DIIS
-   PCM polarization energy = -0.00599914505946
-   @RHF iter   6:   -74.97039476359195   -4.26326e-14   2.65285e-14 DIIS
+   PCM polarization energy = -0.00594001030273
+   @RHF iter   0:   -74.97224452861276   -7.49722e+01   9.72229e-04 
+   PCM polarization energy = -0.00599875920933
+   @RHF iter   1:   -74.97039475468921    1.84977e-03   1.47116e-05 
+   PCM polarization energy = -0.00599957865771
+   @RHF iter   2:   -74.97039476227692   -7.58772e-09   4.15037e-06 DIIS
+   PCM polarization energy = -0.00599923721396
+   @RHF iter   3:   -74.97039476344223   -1.16530e-09   1.41445e-06 DIIS
+   PCM polarization energy = -0.00599914550096
+   @RHF iter   4:   -74.97039476359248   -1.50251e-10   7.29383e-08 DIIS
+   PCM polarization energy = -0.00599914402632
+   @RHF iter   5:   -74.97039476359268   -1.98952e-13   1.39057e-08 DIIS
+   PCM polarization energy = -0.00599914505943
+   @RHF iter   6:   -74.97039476359271   -2.84217e-14   2.59862e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -3376,15 +3405,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97039476359195
+  @RHF Final Energy:   -74.97039476359271
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0109013785628633
-    One-Electron Energy =                -122.0860463902499902
-    Two-Electron Energy =                  38.1107493931546344
-    PCM Polarization Energy =              -0.0059991450594637
-    Total Energy =                        -74.9703947635919548
+    Nuclear Repulsion Energy =              9.0109013785360013
+    One-Electron Energy =                -122.0860463902091908
+    Two-Electron Energy =                  38.1107493931399048
+    PCM Polarization Energy =              -0.0059991450594259
+    Total Energy =                        -74.9703947635926937
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -3393,34 +3422,34 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0927
+     X:     0.0000      Y:    -0.0000      Z:     1.0927
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -0.3627
+     X:     0.0000      Y:    -0.0000      Z:    -0.3627
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.7300     Total:     0.7300
+     X:     0.0000      Y:    -0.0000      Z:     0.7300     Total:     0.7300
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:     1.8555     Total:     1.8555
+     X:     0.0000      Y:    -0.0000      Z:     1.8555     Total:     1.8555
 
 
-*** tstop() called on minazo at Wed May  2 14:17:40 2018
+*** tstop() called on minazo at Wed May  2 19:41:14 2018
 Module time:
-	user time   =       1.10 seconds =       0.02 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.62 seconds =       0.33 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	user time   =      25.69 seconds =       0.43 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =         26 seconds =       0.43 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 7 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:40 2018
+*** at Wed May  2 19:41:14 2018
 
    => Loading Basis Set <=
 
@@ -3448,15 +3477,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.073468295683    15.994914619560
-           H          0.000000000000    -0.728414021767     0.582997583534     1.007825032070
-           H          0.000000000000     0.728414021767     0.582997583578     1.007825032070
+           O          0.000000000000     0.000000000000    -0.073468295682    15.994914619560
+           H          0.000000000000    -0.728414021775     0.582997583540     1.007825032070
+           H          0.000000000000     0.728414021775     0.582997583562     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     21.85257  B =     15.76249  C =      9.15726 [cm^-1]
-  Rotational constants: A = 655123.45232  B = 472547.49449  C = 274527.73068 [MHz]
-  Nuclear repulsion =    8.997769094373446
+  Rotational constants: A = 655123.45233  B = 472547.49448  C = 274527.73067 [MHz]
+  Nuclear repulsion =    8.997769094346561
 
   Charge       = 0
   Multiplicity = 1
@@ -3498,7 +3527,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -3564,6 +3593,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -3573,6 +3603,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.5774747070E-01.
   Using Symmetric Orthogonalization.
 
@@ -3582,20 +3613,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00601348793440
-   @RHF iter   0:   -74.96960647632770   -7.49696e+01   4.85091e-04 
-   PCM polarization energy = -0.00598387018113
-   @RHF iter   1:   -74.97051629446729   -9.09818e-04   7.26941e-06 
-   PCM polarization energy = -0.00598349626836
-   @RHF iter   2:   -74.97051629635106   -1.88378e-09   2.09898e-06 DIIS
-   PCM polarization energy = -0.00598366690035
-   @RHF iter   3:   -74.97051629665114   -3.00076e-10   7.04108e-07 DIIS
-   PCM polarization energy = -0.00598371215662
-   @RHF iter   4:   -74.97051629668849   -3.73461e-11   3.49593e-08 DIIS
-   PCM polarization energy = -0.00598371284846
-   @RHF iter   5:   -74.97051629668864   -1.56319e-13   6.77963e-09 DIIS
-   PCM polarization energy = -0.00598371233669
-   @RHF iter   6:   -74.97051629668856    8.52651e-14   8.66013e-15 DIIS
+   PCM polarization energy = -0.00601348793436
+   @RHF iter   0:   -74.96960647632845   -7.49696e+01   4.85091e-04 
+   PCM polarization energy = -0.00598387018110
+   @RHF iter   1:   -74.97051629446788   -9.09818e-04   7.26941e-06 
+   PCM polarization energy = -0.00598349626833
+   @RHF iter   2:   -74.97051629635166   -1.88378e-09   2.09898e-06 DIIS
+   PCM polarization energy = -0.00598366690031
+   @RHF iter   3:   -74.97051629665188   -3.00219e-10   7.04108e-07 DIIS
+   PCM polarization energy = -0.00598371215659
+   @RHF iter   4:   -74.97051629668911   -3.72324e-11   3.49593e-08 DIIS
+   PCM polarization energy = -0.00598371284843
+   @RHF iter   5:   -74.97051629668921   -9.94760e-14   6.77963e-09 DIIS
+   PCM polarization energy = -0.00598371233666
+   @RHF iter   6:   -74.97051629668925   -4.26326e-14   1.00794e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -3617,15 +3648,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97051629668856
+  @RHF Final Energy:   -74.97051629668925
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9977690943734459
-    One-Electron Energy =                -122.0638146397456296
-    Two-Electron Energy =                  38.1015129610203260
-    PCM Polarization Energy =              -0.0059837123366932
-    Total Energy =                        -74.9705162966885581
+    Nuclear Repulsion Energy =              8.9977690943465607
+    One-Electron Energy =                -122.0638146397047450
+    Two-Electron Energy =                  38.1015129610055894
+    PCM Polarization Energy =              -0.0059837123366559
+    Total Energy =                        -74.9705162966892402
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -3634,7 +3665,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     1.0927
+     X:     0.0000      Y:     0.0000      Z:     1.0927
 
   Electronic Dipole Moment: [e a0]
      X:    -0.0000      Y:    -0.0000      Z:    -0.3639
@@ -3646,15 +3677,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:     1.8526     Total:     1.8526
 
 
-*** tstop() called on minazo at Wed May  2 14:17:41 2018
+*** tstop() called on minazo at Wed May  2 19:41:16 2018
 Module time:
-	user time   =       1.14 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      20.79 seconds =       0.35 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         21 seconds =       0.35 minutes
+	user time   =      27.08 seconds =       0.45 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         28 seconds =       0.47 minutes
 
 -------------------------------------------------------------
 
@@ -3677,9 +3708,9 @@ Total time:
 
                  1                   2                   3
 
-    1     0.00000000000000    -0.00000000003043    -0.00346914568116
-    2     0.00000000000000     0.01638371428570     0.00173457282687
-    3     0.00000000000000    -0.01638371425526     0.00173457285430
+    1     0.00000000000000    -0.00000000001594    -0.00346914568307
+    2     0.00000000000000     0.01638371426130     0.00173457283435
+    3     0.00000000000000    -0.01638371424536     0.00173457284872
 
 
 
@@ -3696,7 +3727,7 @@ Total time:
 	 H           0.0000000000        1.3765030125        1.1017057691
 	             0.0000000000       -0.0000000000       -0.0034691457
 	             0.0000000000        0.0163837143        0.0017345728
-	             0.0000000000       -0.0163837143        0.0017345729
+	             0.0000000000       -0.0163837142        0.0017345728
 
 	---Fragment 1 Intrafragment Coordinates---
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
@@ -3750,7 +3781,7 @@ Total time:
 	Structure for next step:
 	Cartesian Geometry (in Angstrom)
 	    O     0.0000000000   0.0000000000  -0.0580849659
-	    H     0.0000000000  -0.7569641542   0.5753059186
+	    H     0.0000000000  -0.7569641541   0.5753059186
 	    H     0.0000000000   0.7569641541   0.5753059187
 			--------------------------
 			 OPTKING Finished Execution 
@@ -3785,7 +3816,7 @@ gradient() will perform gradient computation by finite difference of analytic en
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:41 2018
+*** at Wed May  2 19:41:16 2018
 
    => Loading Basis Set <=
 
@@ -3816,15 +3847,15 @@ gradient() will perform gradient computation by finite difference of analytic en
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.054470917176     0.045362480252     0.000000000000    15.994914619560
-           H          0.054470917176    -0.939710981449     0.000000000000     1.007825032070
-           H         -0.918963901330     0.219775501106     0.000000000000     1.007825032070
+           O          0.054470917176     0.045362480253     0.000000000000    15.994914619560
+           H          0.054470917176    -0.939710981447     0.000000000000     1.007825032070
+           H         -0.918963901328     0.219775501089     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.47463  B =     14.59548  C =      8.99980 [cm^-1]
-  Rotational constants: A = 703751.58795  B = 437561.53223  C = 269807.31027 [MHz]
-  Nuclear repulsion =    8.927882576430191
+  Rotational constants: A = 703751.58794  B = 437561.53224  C = 269807.31027 [MHz]
+  Nuclear repulsion =    8.927882576459355
 
   Charge       = 0
   Multiplicity = 1
@@ -3866,7 +3897,7 @@ gradient() will perform gradient computation by finite difference of analytic en
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -3932,6 +3963,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -3941,6 +3973,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6157685565E-01.
   Using Symmetric Orthogonalization.
 
@@ -3950,34 +3983,34 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.05675060165068
-   @RHF iter   0:   -74.49230156760318   -7.44923e+01   4.95026e-02 
-   PCM polarization energy = -0.01786342564722
-   @RHF iter   1:   -74.85625710720242   -3.63956e-01   4.72062e-02 
-   PCM polarization energy = -0.00624892549244
-   @RHF iter   2:   -74.96203102799652   -1.05774e-01   1.10109e-02 DIIS
-   PCM polarization energy = -0.00606962580754
-   @RHF iter   3:   -74.96980618537077   -7.77516e-03   4.44870e-03 DIIS
-   PCM polarization energy = -0.00584189969753
+   PCM polarization energy = -0.05675060165268
+   @RHF iter   0:   -74.49230156759290   -7.44923e+01   4.95026e-02 
+   PCM polarization energy = -0.01786342564741
+   @RHF iter   1:   -74.85625710720238   -3.63956e-01   4.72062e-02 
+   PCM polarization energy = -0.00624892549246
+   @RHF iter   2:   -74.96203102799680   -1.05774e-01   1.10109e-02 DIIS
+   PCM polarization energy = -0.00606962580757
+   @RHF iter   3:   -74.96980618537101   -7.77516e-03   4.44870e-03 DIIS
+   PCM polarization energy = -0.00584189969757
    @RHF iter   4:   -74.97142533809601   -1.61915e-03   5.14795e-04 DIIS
-   PCM polarization energy = -0.00589091946841
-   @RHF iter   5:   -74.97144651854701   -2.11805e-05   1.01605e-04 DIIS
-   PCM polarization energy = -0.00587255185169
-   @RHF iter   6:   -74.97144709862114   -5.80074e-07   1.58670e-05 DIIS
-   PCM polarization energy = -0.00587473557828
-   @RHF iter   7:   -74.97144711053849   -1.19174e-08   2.89607e-06 DIIS
-   PCM polarization energy = -0.00587443714029
-   @RHF iter   8:   -74.97144711103769   -4.99199e-10   6.09257e-07 DIIS
-   PCM polarization energy = -0.00587448169523
-   @RHF iter   9:   -74.97144711106660   -2.89049e-11   5.36158e-08 DIIS
-   PCM polarization energy = -0.00587448607137
-   @RHF iter  10:   -74.97144711106678   -1.84741e-13   1.23891e-08 DIIS
-   PCM polarization energy = -0.00587448406440
-   @RHF iter  11:   -74.97144711106675    2.84217e-14   1.32936e-09 DIIS
-   PCM polarization energy = -0.00587448393666
-   @RHF iter  12:   -74.97144711106682   -7.10543e-14   1.71329e-10 DIIS
-   PCM polarization energy = -0.00587448396538
-   @RHF iter  13:   -74.97144711106684   -1.42109e-14   1.11741e-11 DIIS
+   PCM polarization energy = -0.00589091946845
+   @RHF iter   5:   -74.97144651854703   -2.11805e-05   1.01605e-04 DIIS
+   PCM polarization energy = -0.00587255185172
+   @RHF iter   6:   -74.97144709862123   -5.80074e-07   1.58670e-05 DIIS
+   PCM polarization energy = -0.00587473557832
+   @RHF iter   7:   -74.97144711053861   -1.19174e-08   2.89607e-06 DIIS
+   PCM polarization energy = -0.00587443714032
+   @RHF iter   8:   -74.97144711103788   -4.99270e-10   6.09257e-07 DIIS
+   PCM polarization energy = -0.00587448169527
+   @RHF iter   9:   -74.97144711106674   -2.88622e-11   5.36158e-08 DIIS
+   PCM polarization energy = -0.00587448607140
+   @RHF iter  10:   -74.97144711106688   -1.42109e-13   1.23891e-08 DIIS
+   PCM polarization energy = -0.00587448406443
+   @RHF iter  11:   -74.97144711106689   -1.42109e-14   1.32936e-09 DIIS
+   PCM polarization energy = -0.00587448393670
+   @RHF iter  12:   -74.97144711106685    4.26326e-14   1.71329e-10 DIIS
+   PCM polarization energy = -0.00587448396542
+   @RHF iter  13:   -74.97144711106691   -5.68434e-14   1.11748e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -3999,15 +4032,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144711106684
+  @RHF Final Energy:   -74.97144711106691
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9278825764301910
-    One-Electron Energy =                -121.9639791860877125
-    Two-Electron Energy =                  38.0705239825560753
-    PCM Polarization Energy =              -0.0058744839653848
-    Total Energy =                        -74.9714471110668228
+    Nuclear Repulsion Energy =              8.9278825764593552
+    One-Electron Energy =                -121.9639791861335141
+    Two-Electron Energy =                  38.0705239825726665
+    PCM Polarization Energy =              -0.0058744839654195
+    Total Energy =                        -74.9714471110669081
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -4028,22 +4061,22 @@ Properties computed using the SCF density matrix
      X:    -1.3882      Y:    -1.1642      Z:    -0.0000     Total:     1.8117
 
 
-*** tstop() called on minazo at Wed May  2 14:17:43 2018
+*** tstop() called on minazo at Wed May  2 19:41:18 2018
 Module time:
-	user time   =       1.68 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       2.01 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      22.51 seconds =       0.38 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         23 seconds =       0.38 minutes
+	user time   =      29.13 seconds =       0.49 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         30 seconds =       0.50 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:43 2018
+*** at Wed May  2 19:41:18 2018
 
    => Loading Basis Set <=
 
@@ -4071,15 +4104,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.054258144128     0.045616764773     0.000000000000    15.994914619560
-           H          0.054258144128    -0.943319657709     0.000000000000     1.007825032070
-           H         -0.915374265607     0.219348497484     0.000000000000     1.007825032070
+           O          0.054258144128     0.045616764774     0.000000000000    15.994914619560
+           H          0.054258144128    -0.943319657706     0.000000000000     1.007825032070
+           H         -0.915374265605     0.219348497467     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.47463  B =     14.59548  C =      8.99980 [cm^-1]
-  Rotational constants: A = 703751.58795  B = 437561.53223  C = 269807.31027 [MHz]
-  Nuclear repulsion =    8.927882576429909
+  Rotational constants: A = 703751.58794  B = 437561.53224  C = 269807.31027 [MHz]
+  Nuclear repulsion =    8.927882576459245
 
   Charge       = 0
   Multiplicity = 1
@@ -4121,7 +4154,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -4187,6 +4220,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -4196,6 +4230,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6157685565E-01.
   Using Symmetric Orthogonalization.
 
@@ -4205,22 +4240,22 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00587529315282
-   @RHF iter   0:   -74.97147500546295   -7.49715e+01   1.87283e-03 
-   PCM polarization energy = -0.00587441707531
-   @RHF iter   1:   -74.97144709146745    2.79140e-05   2.31809e-05 
-   PCM polarization energy = -0.00587448813660
-   @RHF iter   2:   -74.97144710873582   -1.72684e-08   5.95920e-06 DIIS
-   PCM polarization energy = -0.00587448283296
-   @RHF iter   3:   -74.97144711091696   -2.18114e-09   1.52411e-06 DIIS
-   PCM polarization energy = -0.00587448400740
-   @RHF iter   4:   -74.97144711106665   -1.49697e-10   8.68818e-08 DIIS
-   PCM polarization energy = -0.00587448384325
-   @RHF iter   5:   -74.97144711106696   -3.12639e-13   8.02059e-10 DIIS
-   PCM polarization energy = -0.00587448394941
-   @RHF iter   6:   -74.97144711106694    2.84217e-14   2.98836e-10 DIIS
-   PCM polarization energy = -0.00587448395848
-   @RHF iter   7:   -74.97144711106696   -2.84217e-14   7.79561e-11 DIIS
+   PCM polarization energy = -0.00587529315285
+   @RHF iter   0:   -74.97147500546308   -7.49715e+01   1.87283e-03 
+   PCM polarization energy = -0.00587441707535
+   @RHF iter   1:   -74.97144709146757    2.79140e-05   2.31809e-05 
+   PCM polarization energy = -0.00587448813664
+   @RHF iter   2:   -74.97144710873579   -1.72682e-08   5.95920e-06 DIIS
+   PCM polarization energy = -0.00587448283300
+   @RHF iter   3:   -74.97144711091698   -2.18120e-09   1.52411e-06 DIIS
+   PCM polarization energy = -0.00587448400744
+   @RHF iter   4:   -74.97144711106667   -1.49683e-10   8.68818e-08 DIIS
+   PCM polarization energy = -0.00587448384328
+   @RHF iter   5:   -74.97144711106698   -3.12639e-13   8.02060e-10 DIIS
+   PCM polarization energy = -0.00587448394944
+   @RHF iter   6:   -74.97144711106688    9.94760e-14   2.98836e-10 DIIS
+   PCM polarization energy = -0.00587448395852
+   @RHF iter   7:   -74.97144711106701   -1.27898e-13   7.79571e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -4242,15 +4277,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144711106696
+  @RHF Final Energy:   -74.97144711106701
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9278825764299086
-    One-Electron Energy =                -121.9639791854883697
-    Two-Electron Energy =                  38.0705239819499681
-    PCM Polarization Energy =              -0.0058744839584807
-    Total Energy =                        -74.9714471110669649
+    Nuclear Repulsion Energy =              8.9278825764592451
+    One-Electron Energy =                -121.9639791855344697
+    Two-Electron Energy =                  38.0705239819667440
+    PCM Polarization Energy =              -0.0058744839585192
+    Total Energy =                        -74.9714471110670075
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -4271,22 +4306,22 @@ Properties computed using the SCF density matrix
      X:    -1.3908      Y:    -1.1611      Z:     0.0000     Total:     1.8117
 
 
-*** tstop() called on minazo at Wed May  2 14:17:44 2018
+*** tstop() called on minazo at Wed May  2 19:41:19 2018
 Module time:
-	user time   =       1.22 seconds =       0.02 minutes
+	user time   =       1.41 seconds =       0.02 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      23.76 seconds =       0.40 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         24 seconds =       0.40 minutes
+	user time   =      30.57 seconds =       0.51 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:44 2018
+*** at Wed May  2 19:41:19 2018
 
    => Loading Basis Set <=
 
@@ -4314,15 +4349,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.071107182315    15.994914619560
-           H          0.000000000000    -0.756964154146     0.564261292272     1.007825032070
-           H          0.000000000000     0.756964154146     0.564261292281     1.007825032070
+           O          0.000000000000     0.000000000000    -0.071107182316    15.994914619560
+           H          0.000000000000    -0.756964154138     0.564261292279     1.007825032070
+           H          0.000000000000     0.756964154138     0.564261292282     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.32789  B =     14.59589  C =      8.97831 [cm^-1]
-  Rotational constants: A = 699352.50975  B = 437573.92163  C = 269162.90434 [MHz]
-  Nuclear repulsion =    8.916824370679121
+  Rotational constants: A = 699352.50974  B = 437573.92164  C = 269162.90434 [MHz]
+  Nuclear repulsion =    8.916824370708197
 
   Charge       = 0
   Multiplicity = 1
@@ -4364,7 +4399,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -4430,6 +4465,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -4439,6 +4475,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6243827882E-01.
   Using Symmetric Orthogonalization.
 
@@ -4448,34 +4485,34 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.05690816387801
-   @RHF iter   0:   -74.48689933091345   -7.44869e+01   4.98461e-02 
-   PCM polarization energy = -0.01685336018314
-   @RHF iter   1:   -74.85880347909436   -3.71904e-01   4.60416e-02 
-   PCM polarization energy = -0.00619682685204
-   @RHF iter   2:   -74.96083991322810   -1.02036e-01   1.11987e-02 DIIS
-   PCM polarization energy = -0.00610756139442
-   @RHF iter   3:   -74.96928813113863   -8.44822e-03   4.96800e-03 DIIS
-   PCM polarization energy = -0.00580727526438
-   @RHF iter   4:   -74.97143940362888   -2.15127e-03   4.52358e-04 DIIS
-   PCM polarization energy = -0.00587951771167
-   @RHF iter   5:   -74.97145334032780   -1.39367e-05   1.21431e-04 DIIS
-   PCM polarization energy = -0.00586137012332
-   @RHF iter   6:   -74.97145402408538   -6.83758e-07   1.83504e-05 DIIS
-   PCM polarization energy = -0.00586358203456
-   @RHF iter   7:   -74.97145404586971   -2.17843e-08   3.49899e-06 DIIS
-   PCM polarization energy = -0.00586337458639
-   @RHF iter   8:   -74.97145404673024   -8.60538e-10   5.49694e-07 DIIS
-   PCM polarization energy = -0.00586341984921
-   @RHF iter   9:   -74.97145404675257   -2.23253e-11   7.91006e-08 DIIS
-   PCM polarization energy = -0.00586342091847
-   @RHF iter  10:   -74.97145404675305   -4.83169e-13   1.39551e-08 DIIS
-   PCM polarization energy = -0.00586341898575
-   @RHF iter  11:   -74.97145404675308   -2.84217e-14   7.03814e-10 DIIS
-   PCM polarization energy = -0.00586341903416
-   @RHF iter  12:   -74.97145404675300    8.52651e-14   1.39472e-10 DIIS
-   PCM polarization energy = -0.00586341904882
-   @RHF iter  13:   -74.97145404675304   -4.26326e-14   2.13800e-11 DIIS
+   PCM polarization energy = -0.05690816387980
+   @RHF iter   0:   -74.48689933090628   -7.44869e+01   4.98461e-02 
+   PCM polarization energy = -0.01685336018339
+   @RHF iter   1:   -74.85880347909396   -3.71904e-01   4.60416e-02 
+   PCM polarization energy = -0.00619682685207
+   @RHF iter   2:   -74.96083991322840   -1.02036e-01   1.11987e-02 DIIS
+   PCM polarization energy = -0.00610756139446
+   @RHF iter   3:   -74.96928813113882   -8.44822e-03   4.96800e-03 DIIS
+   PCM polarization energy = -0.00580727526441
+   @RHF iter   4:   -74.97143940362893   -2.15127e-03   4.52358e-04 DIIS
+   PCM polarization energy = -0.00587951771170
+   @RHF iter   5:   -74.97145334032784   -1.39367e-05   1.21431e-04 DIIS
+   PCM polarization energy = -0.00586137012336
+   @RHF iter   6:   -74.97145402408547   -6.83758e-07   1.83504e-05 DIIS
+   PCM polarization energy = -0.00586358203460
+   @RHF iter   7:   -74.97145404586985   -2.17844e-08   3.49899e-06 DIIS
+   PCM polarization energy = -0.00586337458642
+   @RHF iter   8:   -74.97145404673036   -8.60510e-10   5.49694e-07 DIIS
+   PCM polarization energy = -0.00586341984925
+   @RHF iter   9:   -74.97145404675260   -2.22400e-11   7.91006e-08 DIIS
+   PCM polarization energy = -0.00586342091850
+   @RHF iter  10:   -74.97145404675308   -4.83169e-13   1.39551e-08 DIIS
+   PCM polarization energy = -0.00586341898579
+   @RHF iter  11:   -74.97145404675315   -7.10543e-14   7.03813e-10 DIIS
+   PCM polarization energy = -0.00586341903420
+   @RHF iter  12:   -74.97145404675305    9.94760e-14   1.39472e-10 DIIS
+   PCM polarization energy = -0.00586341904886
+   @RHF iter  13:   -74.97145404675312   -7.10543e-14   2.13804e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -4497,15 +4534,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97145404675304
+  @RHF Final Energy:   -74.97145404675312
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9168243706791213
-    One-Electron Energy =                -121.9434859812935201
-    Two-Electron Energy =                  38.0610709829101808
-    PCM Polarization Energy =              -0.0058634190488227
-    Total Energy =                        -74.9714540467530384
+    Nuclear Repulsion Energy =              8.9168243707081967
+    One-Electron Energy =                -121.9434859813392222
+    Two-Electron Energy =                  38.0610709829267790
+    PCM Polarization Energy =              -0.0058634190488596
+    Total Energy =                        -74.9714540467531094
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -4526,22 +4563,22 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:     1.8115     Total:     1.8115
 
 
-*** tstop() called on minazo at Wed May  2 14:17:46 2018
+*** tstop() called on minazo at Wed May  2 19:41:22 2018
 Module time:
-	user time   =       1.75 seconds =       0.03 minutes
+	user time   =       2.18 seconds =       0.04 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      25.54 seconds =       0.43 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         26 seconds =       0.43 minutes
+	user time   =      32.79 seconds =       0.55 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:46 2018
+*** at Wed May  2 19:41:22 2018
 
    => Loading Basis Set <=
 
@@ -4569,15 +4606,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.070664538835    15.994914619560
-           H          0.000000000000    -0.756964154146     0.560748755649     1.007825032070
-           H          0.000000000000     0.756964154146     0.560748755658     1.007825032070
+           O          0.000000000000     0.000000000000    -0.070664538836    15.994914619560
+           H          0.000000000000    -0.756964154138     0.560748755656     1.007825032070
+           H          0.000000000000     0.756964154138     0.560748755659     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.62106  B =     14.59589  C =      9.02140 [cm^-1]
-  Rotational constants: A = 708141.45508  B = 437573.92163  C = 270454.80917 [MHz]
-  Nuclear repulsion =    8.938884110873378
+  Rotational constants: A = 708141.45507  B = 437573.92164  C = 270454.80917 [MHz]
+  Nuclear repulsion =    8.938884110902810
 
   Charge       = 0
   Multiplicity = 1
@@ -4619,7 +4656,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -4685,6 +4722,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -4694,6 +4732,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6076755607E-01.
   Using Symmetric Orthogonalization.
 
@@ -4703,20 +4742,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00579742955495
-   @RHF iter   0:   -74.97385591737405   -7.49739e+01   9.47975e-04 
-   PCM polarization energy = -0.00587553815125
-   @RHF iter   1:   -74.97144635540259    2.40956e-03   9.81710e-05 
-   PCM polarization energy = -0.00587971430918
-   @RHF iter   2:   -74.97144695401556   -5.98613e-07   4.28254e-05 DIIS
-   PCM polarization energy = -0.00588257901950
+   PCM polarization energy = -0.00579742955499
+   @RHF iter   0:   -74.97385591737411   -7.49739e+01   9.47975e-04 
+   PCM polarization energy = -0.00587553815129
+   @RHF iter   1:   -74.97144635540255    2.40956e-03   9.81710e-05 
+   PCM polarization energy = -0.00587971430921
+   @RHF iter   2:   -74.97144695401548   -5.98613e-07   4.28254e-05 DIIS
+   PCM polarization energy = -0.00588257901954
    @RHF iter   3:   -74.97144709675807   -1.42743e-07   9.58724e-07 DIIS
-   PCM polarization energy = -0.00588269043807
-   @RHF iter   4:   -74.97144709681996   -6.18883e-11   9.55455e-08 DIIS
-   PCM polarization energy = -0.00588269669857
-   @RHF iter   5:   -74.97144709682024   -2.84217e-13   9.96351e-09 DIIS
-   PCM polarization energy = -0.00588269797373
-   @RHF iter   6:   -74.97144709682030   -5.68434e-14   3.49304e-12 DIIS
+   PCM polarization energy = -0.00588269043811
+   @RHF iter   4:   -74.97144709681994   -6.18741e-11   9.55455e-08 DIIS
+   PCM polarization energy = -0.00588269669861
+   @RHF iter   5:   -74.97144709682028   -3.41061e-13   9.96351e-09 DIIS
+   PCM polarization energy = -0.00588269797376
+   @RHF iter   6:   -74.97144709682023    5.68434e-14   3.49350e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -4738,15 +4777,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144709682030
+  @RHF Final Energy:   -74.97144709682023
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9388841108733779
-    One-Electron Energy =                -121.9843724303444361
-    Two-Electron Energy =                  38.0799239206244948
-    PCM Polarization Energy =              -0.0058826979737259
-    Total Energy =                        -74.9714470968202988
+    Nuclear Repulsion Energy =              8.9388841109028103
+    One-Electron Energy =                -121.9843724303903940
+    Two-Electron Energy =                  38.0799239206411144
+    PCM Polarization Energy =              -0.0058826979737634
+    Total Energy =                        -74.9714470968202420
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -4758,31 +4797,31 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0510
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.3382
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3382
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.7129     Total:     0.7129
+     X:    -0.0000      Y:    -0.0000      Z:     0.7129     Total:     0.7129
 
   Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:     1.8119     Total:     1.8119
+     X:    -0.0000      Y:    -0.0000      Z:     1.8119     Total:     1.8119
 
 
-*** tstop() called on minazo at Wed May  2 14:17:47 2018
+*** tstop() called on minazo at Wed May  2 19:41:24 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.92 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      26.68 seconds =       0.44 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         27 seconds =       0.45 minutes
+	user time   =      34.74 seconds =       0.58 minutes
+	system time =       0.44 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:47 2018
+*** at Wed May  2 19:41:24 2018
 
    => Loading Basis Set <=
 
@@ -4810,15 +4849,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.070885860575    15.994914619560
-           H          0.000000000000    -0.758827800770     0.562505023961     1.007825032070
-           H          0.000000000000     0.758827800770     0.562505023969     1.007825032070
+           O          0.000000000000     0.000000000000    -0.070885860576    15.994914619560
+           H          0.000000000000    -0.758827800763     0.562505023967     1.007825032070
+           H          0.000000000000     0.758827800763     0.562505023971     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.47379  B =     14.52429  C =      8.97256 [cm^-1]
-  Rotational constants: A = 703726.40167  B = 435427.23758  C = 268990.61947 [MHz]
-  Nuclear repulsion =    8.914581126705993
+  Rotational constants: A = 703726.40166  B = 435427.23759  C = 268990.61947 [MHz]
+  Nuclear repulsion =    8.914581126735245
 
   Charge       = 0
   Multiplicity = 1
@@ -4860,7 +4899,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -4926,6 +4965,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -4935,6 +4975,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6253633808E-01.
   Using Symmetric Orthogonalization.
 
@@ -4944,20 +4985,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00593239868800
-   @RHF iter   0:   -74.96923992966298   -7.49692e+01   9.58586e-04 
-   PCM polarization energy = -0.00586401588718
-   @RHF iter   1:   -74.97144925622567   -2.20933e-03   4.81252e-05 
-   PCM polarization energy = -0.00586017775658
-   @RHF iter   2:   -74.97144939849596   -1.42270e-07   2.06418e-05 DIIS
-   PCM polarization energy = -0.00585906572032
-   @RHF iter   3:   -74.97144943128950   -3.27935e-08   2.09216e-06 DIIS
-   PCM polarization energy = -0.00585883596953
-   @RHF iter   4:   -74.97144943163207   -3.42567e-10   6.52295e-08 DIIS
-   PCM polarization energy = -0.00585883346960
-   @RHF iter   5:   -74.97144943163229   -2.27374e-13   1.19854e-08 DIIS
-   PCM polarization energy = -0.00585883235536
-   @RHF iter   6:   -74.97144943163232   -2.84217e-14   8.03530e-13 DIIS
+   PCM polarization energy = -0.00593239868804
+   @RHF iter   0:   -74.96923992966305   -7.49692e+01   9.58586e-04 
+   PCM polarization energy = -0.00586401588722
+   @RHF iter   1:   -74.97144925622574   -2.20933e-03   4.81252e-05 
+   PCM polarization energy = -0.00586017775661
+   @RHF iter   2:   -74.97144939849606   -1.42270e-07   2.06418e-05 DIIS
+   PCM polarization energy = -0.00585906572036
+   @RHF iter   3:   -74.97144943128954   -3.27935e-08   2.09216e-06 DIIS
+   PCM polarization energy = -0.00585883596956
+   @RHF iter   4:   -74.97144943163222   -3.42681e-10   6.52295e-08 DIIS
+   PCM polarization energy = -0.00585883346963
+   @RHF iter   5:   -74.97144943163237   -1.42109e-13   1.19854e-08 DIIS
+   PCM polarization energy = -0.00585883235540
+   @RHF iter   6:   -74.97144943163238   -1.42109e-14   8.04409e-13 DIIS
 
   ==> Post-Iterations <==
 
@@ -4979,15 +5020,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144943163232
+  @RHF Final Energy:   -74.97144943163238
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9145811267059933
-    One-Electron Energy =                -121.9413238407001643
-    Two-Electron Energy =                  38.0611521147172098
-    PCM Polarization Energy =              -0.0058588323553623
-    Total Energy =                        -74.9714494316323226
+    Nuclear Repulsion Energy =              8.9145811267352446
+    One-Electron Energy =                -121.9413238407459801
+    Two-Electron Energy =                  38.0611521147337584
+    PCM Polarization Energy =              -0.0058588323553993
+    Total Energy =                        -74.9714494316323794
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -4996,7 +5037,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     1.0543
+     X:     0.0000      Y:     0.0000      Z:     1.0543
 
   Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:    -0.0000      Z:    -0.3427
@@ -5008,22 +5049,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:    -0.0000      Z:     1.8088     Total:     1.8088
 
 
-*** tstop() called on minazo at Wed May  2 14:17:48 2018
+*** tstop() called on minazo at Wed May  2 19:41:26 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.05 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      27.83 seconds =       0.46 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         28 seconds =       0.47 minutes
+	user time   =      36.85 seconds =       0.61 minutes
+	system time =       0.50 seconds =       0.01 minutes
+	total time  =         38 seconds =       0.63 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:48 2018
+*** at Wed May  2 19:41:26 2018
 
    => Loading Basis Set <=
 
@@ -5051,15 +5092,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.070885860575    15.994914619560
-           H          0.000000000000    -0.755100507521     0.562505023961     1.007825032070
-           H          0.000000000000     0.755100507521     0.562505023969     1.007825032070
+           O          0.000000000000     0.000000000000    -0.070885860576    15.994914619560
+           H          0.000000000000    -0.755100507514     0.562505023967     1.007825032070
+           H          0.000000000000     0.755100507514     0.562505023971     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.47379  B =     14.66803  C =      9.02721 [cm^-1]
-  Rotational constants: A = 703726.40167  B = 439736.51983  C = 270628.97534 [MHz]
-  Nuclear repulsion =    8.941146866550978
+  Rotational constants: A = 703726.40166  B = 439736.51984  C = 270628.97534 [MHz]
+  Nuclear repulsion =    8.941146866580233
 
   Charge       = 0
   Multiplicity = 1
@@ -5101,7 +5142,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -5167,6 +5208,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -5176,6 +5218,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6066841205E-01.
   Using Symmetric Orthogonalization.
 
@@ -5185,20 +5228,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00582827786947
-   @RHF iter   0:   -74.97349243643139   -7.49735e+01   9.86797e-04 
-   PCM polarization energy = -0.00588431667154
-   @RHF iter   1:   -74.97144879305063    2.04364e-03   2.09141e-05 
-   PCM polarization energy = -0.00588771535134
-   @RHF iter   2:   -74.97144880606209   -1.30115e-08   2.01089e-06 DIIS
-   PCM polarization energy = -0.00588745594500
-   @RHF iter   3:   -74.97144880628996   -2.27871e-10   8.01151e-07 DIIS
-   PCM polarization energy = -0.00588741157039
-   @RHF iter   4:   -74.97144880633806   -4.81037e-11   1.35588e-07 DIIS
-   PCM polarization energy = -0.00588740118109
-   @RHF iter   5:   -74.97144880633945   -1.39266e-12   2.15490e-09 DIIS
-   PCM polarization energy = -0.00588740135999
-   @RHF iter   6:   -74.97144880633947   -1.42109e-14   5.14623e-14 DIIS
+   PCM polarization energy = -0.00582827786951
+   @RHF iter   0:   -74.97349243643126   -7.49735e+01   9.86797e-04 
+   PCM polarization energy = -0.00588431667158
+   @RHF iter   1:   -74.97144879305060    2.04364e-03   2.09141e-05 
+   PCM polarization energy = -0.00588771535138
+   @RHF iter   2:   -74.97144880606197   -1.30114e-08   2.01089e-06 DIIS
+   PCM polarization energy = -0.00588745594504
+   @RHF iter   3:   -74.97144880628981   -2.27843e-10   8.01151e-07 DIIS
+   PCM polarization energy = -0.00588741157043
+   @RHF iter   4:   -74.97144880633792   -4.81037e-11   1.35588e-07 DIIS
+   PCM polarization energy = -0.00588740118113
+   @RHF iter   5:   -74.97144880633930   -1.37845e-12   2.15490e-09 DIIS
+   PCM polarization energy = -0.00588740136003
+   @RHF iter   6:   -74.97144880633930    0.00000e+00   5.13560e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -5220,15 +5263,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144880633947
+  @RHF Final Energy:   -74.97144880633930
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9411468665509783
-    One-Electron Energy =                -121.9865528131080481
-    Two-Electron Energy =                  38.0798445415775930
-    PCM Polarization Energy =              -0.0058874013599891
-    Total Energy =                        -74.9714488063394526
+    Nuclear Repulsion Energy =              8.9411468665802332
+    One-Electron Energy =                -121.9865528131536934
+    Two-Electron Energy =                  38.0798445415941771
+    PCM Polarization Energy =              -0.0058874013600271
+    Total Energy =                        -74.9714488063392963
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -5237,34 +5280,34 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0543
+     X:     0.0000      Y:    -0.0000      Z:     1.0543
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.3404
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3404
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.7139     Total:     0.7139
+     X:    -0.0000      Y:    -0.0000      Z:     0.7139     Total:     0.7139
 
   Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:     1.8146     Total:     1.8146
+     X:    -0.0000      Y:    -0.0000      Z:     1.8146     Total:     1.8146
 
 
-*** tstop() called on minazo at Wed May  2 14:17:49 2018
+*** tstop() called on minazo at Wed May  2 19:41:28 2018
 Module time:
-	user time   =       1.17 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.14 seconds =       0.04 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      29.03 seconds =       0.48 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      39.10 seconds =       0.65 minutes
+	system time =       0.56 seconds =       0.01 minutes
+	total time  =         40 seconds =       0.67 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 7 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:49 2018
+*** at Wed May  2 19:41:28 2018
 
    => Loading Basis Set <=
 
@@ -5292,15 +5335,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.070885860575    15.994914619560
-           H          0.000000000000    -0.756964154146     0.562505023961     1.007825032070
-           H          0.000000000000     0.756964154146     0.562505023969     1.007825032070
+           O          0.000000000000     0.000000000000    -0.070885860576    15.994914619560
+           H          0.000000000000    -0.756964154138     0.562505023967     1.007825032070
+           H          0.000000000000     0.756964154138     0.562505023971     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.47379  B =     14.59589  C =      8.99984 [cm^-1]
-  Rotational constants: A = 703726.40167  B = 437573.92163  C = 269808.31867 [MHz]
-  Nuclear repulsion =    8.927850186591307
+  Rotational constants: A = 703726.40166  B = 437573.92164  C = 269808.31868 [MHz]
+  Nuclear repulsion =    8.927850186620557
 
   Charge       = 0
   Multiplicity = 1
@@ -5342,7 +5385,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -5408,6 +5451,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -5417,6 +5461,7 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 3.6160178114E-01.
   Using Symmetric Orthogonalization.
 
@@ -5426,20 +5471,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00590297558727
-   @RHF iter   0:   -74.97044751221786   -7.49704e+01   4.92371e-04 
-   PCM polarization energy = -0.00587459457427
-   @RHF iter   1:   -74.97145505277759   -1.00754e-03   1.03031e-05 
-   PCM polarization energy = -0.00587292601565
-   @RHF iter   2:   -74.97145505593946   -3.16187e-09   1.02195e-06 DIIS
-   PCM polarization energy = -0.00587305536601
-   @RHF iter   3:   -74.97145505599882   -5.93587e-11   4.10452e-07 DIIS
-   PCM polarization energy = -0.00587307796659
-   @RHF iter   4:   -74.97145505601149   -1.26761e-11   6.70397e-08 DIIS
-   PCM polarization energy = -0.00587308313311
-   @RHF iter   5:   -74.97145505601186   -3.69482e-13   8.63152e-10 DIIS
-   PCM polarization energy = -0.00587308306051
-   @RHF iter   6:   -74.97145505601183    2.84217e-14   1.34533e-14 DIIS
+   PCM polarization energy = -0.00590297558731
+   @RHF iter   0:   -74.97044751221787   -7.49704e+01   4.92371e-04 
+   PCM polarization energy = -0.00587459457431
+   @RHF iter   1:   -74.97145505277764   -1.00754e-03   1.03031e-05 
+   PCM polarization energy = -0.00587292601569
+   @RHF iter   2:   -74.97145505593934   -3.16170e-09   1.02195e-06 DIIS
+   PCM polarization energy = -0.00587305536605
+   @RHF iter   3:   -74.97145505599875   -5.94014e-11   4.10452e-07 DIIS
+   PCM polarization energy = -0.00587307796663
+   @RHF iter   4:   -74.97145505601154   -1.27898e-11   6.70397e-08 DIIS
+   PCM polarization energy = -0.00587308313314
+   @RHF iter   5:   -74.97145505601178   -2.41585e-13   8.63152e-10 DIIS
+   PCM polarization energy = -0.00587308306054
+   @RHF iter   6:   -74.97145505601183   -5.68434e-14   1.40378e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -5465,10 +5510,10 @@ Permittivity = 78.39
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9278501865913071
-    One-Electron Energy =                -121.9639260631635409
-    Two-Electron Energy =                  38.0704939036208998
-    PCM Polarization Energy =              -0.0058730830605058
+    Nuclear Repulsion Energy =              8.9278501866205566
+    One-Electron Energy =                -121.9639260632094988
+    Two-Electron Energy =                  38.0704939036376544
+    PCM Polarization Energy =              -0.0058730830605438
     Total Energy =                        -74.9714550560118340
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
@@ -5490,15 +5535,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:     1.8117     Total:     1.8117
 
 
-*** tstop() called on minazo at Wed May  2 14:17:51 2018
+*** tstop() called on minazo at Wed May  2 19:41:30 2018
 Module time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.93 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      30.22 seconds =       0.50 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         31 seconds =       0.52 minutes
+	user time   =      41.13 seconds =       0.69 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =         42 seconds =       0.70 minutes
 
 -------------------------------------------------------------
 
@@ -5521,9 +5566,9 @@ Total time:
 
                  1                   2                   3
 
-    1     0.00000000000000    -0.00000000001344     0.00092985550871
-    2     0.00000000000000     0.00004438754290    -0.00046492775998
-    3     0.00000000000000    -0.00004438752947    -0.00046492774873
+    1     0.00000000000000    -0.00000000001045     0.00092985552963
+    2     0.00000000000000     0.00004438755755    -0.00046492776919
+    3     0.00000000000000    -0.00004438754710    -0.00046492776044
 
 
 
@@ -5539,8 +5584,8 @@ Total time:
 	 H           0.0000000000       -1.4304549437        1.0629804437
 	 H           0.0000000000        1.4304549437        1.0629804437
 	             0.0000000000       -0.0000000000        0.0009298555
-	             0.0000000000        0.0000443875       -0.0004649278
-	             0.0000000000       -0.0000443875       -0.0004649277
+	             0.0000000000        0.0000443876       -0.0004649278
+	             0.0000000000       -0.0000443875       -0.0004649278
 
 	---Fragment 1 Intrafragment Coordinates---
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
@@ -5591,7 +5636,7 @@ Total time:
 	Writing optimization data to binary file.
 	Structure for next step:
 	Cartesian Geometry (in Angstrom)
-	    O     0.0000000000   0.0000000000  -0.0717458858
+	    O     0.0000000000   0.0000000000  -0.0717458859
 	    H     0.0000000000  -0.7565043873   0.5629350366
 	    H     0.0000000000   0.7565043873   0.5629350366
 			--------------------------
@@ -5627,7 +5672,7 @@ gradient() will perform gradient computation by finite difference of analytic en
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:51 2018
+*** at Wed May  2 19:41:30 2018
 
    => Loading Basis Set <=
 
@@ -5658,15 +5703,15 @@ gradient() will perform gradient computation by finite difference of analytic en
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.054522348623     0.045526233396     0.000000000000    15.994914619560
-           H          0.054522348623    -0.940023455835     0.000000000000     1.007825032070
-           H         -0.919831587169     0.217489094266     0.000000000000     1.007825032070
+           O          0.054522348624     0.045526233398     0.000000000000    15.994914619560
+           H          0.054522348624    -0.940023455848     0.000000000000     1.007825032070
+           H         -0.919831587187     0.217489094253     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.37930  B =     14.61322  C =      8.99248 [cm^-1]
-  Rotational constants: A = 700893.85949  B = 438093.40947  C = 269587.71968 [MHz]
-  Nuclear repulsion =    8.923959196462896
+  Rotational constants: A = 700893.85946  B = 438093.40947  C = 269587.71967 [MHz]
+  Nuclear repulsion =    8.923959196327020
 
   Charge       = 0
   Multiplicity = 1
@@ -5708,7 +5753,7 @@ gradient() will perform gradient computation by finite difference of analytic en
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -5774,6 +5819,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -5783,7 +5829,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6189227601E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6189227602E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -5792,34 +5839,34 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.05733025431922
-   @RHF iter   0:   -74.48549453991670   -7.44855e+01   4.95799e-02 
-   PCM polarization energy = -0.01778870066330
-   @RHF iter   1:   -74.85758160485881   -3.72087e-01   4.67978e-02 
-   PCM polarization energy = -0.00625940129609
-   @RHF iter   2:   -74.96203650037485   -1.04455e-01   1.10255e-02 DIIS
-   PCM polarization energy = -0.00606837311295
-   @RHF iter   3:   -74.96982437219454   -7.78787e-03   4.43178e-03 DIIS
-   PCM polarization energy = -0.00583977892242
-   @RHF iter   4:   -74.97142611327475   -1.60174e-03   5.15233e-04 DIIS
-   PCM polarization energy = -0.00588825349933
-   @RHF iter   5:   -74.97144742123550   -2.13080e-05   1.00912e-04 DIIS
-   PCM polarization energy = -0.00586977270858
-   @RHF iter   6:   -74.97144799223895   -5.71003e-07   1.59716e-05 DIIS
-   PCM polarization energy = -0.00587198132862
-   @RHF iter   7:   -74.97144800431501   -1.20761e-08   2.90636e-06 DIIS
-   PCM polarization energy = -0.00587168094134
-   @RHF iter   8:   -74.97144800481587   -5.00862e-10   6.10640e-07 DIIS
-   PCM polarization energy = -0.00587172568896
-   @RHF iter   9:   -74.97144800484485   -2.89759e-11   5.41227e-08 DIIS
-   PCM polarization energy = -0.00587173026288
-   @RHF iter  10:   -74.97144800484506   -2.13163e-13   1.26468e-08 DIIS
-   PCM polarization energy = -0.00587172819502
-   @RHF iter  11:   -74.97144800484510   -4.26326e-14   1.35626e-09 DIIS
-   PCM polarization energy = -0.00587172807095
-   @RHF iter  12:   -74.97144800484506    4.26326e-14   1.71626e-10 DIIS
-   PCM polarization energy = -0.00587172809847
-   @RHF iter  13:   -74.97144800484512   -5.68434e-14   1.43267e-11 DIIS
+   PCM polarization energy = -0.05733025432131
+   @RHF iter   0:   -74.48549453989871   -7.44855e+01   4.95799e-02 
+   PCM polarization energy = -0.01778870066385
+   @RHF iter   1:   -74.85758160485381   -3.72087e-01   4.67978e-02 
+   PCM polarization energy = -0.00625940129591
+   @RHF iter   2:   -74.96203650037438   -1.04455e-01   1.10255e-02 DIIS
+   PCM polarization energy = -0.00606837311284
+   @RHF iter   3:   -74.96982437219441   -7.78787e-03   4.43178e-03 DIIS
+   PCM polarization energy = -0.00583977892229
+   @RHF iter   4:   -74.97142611327476   -1.60174e-03   5.15233e-04 DIIS
+   PCM polarization energy = -0.00588825349921
+   @RHF iter   5:   -74.97144742123554   -2.13080e-05   1.00912e-04 DIIS
+   PCM polarization energy = -0.00586977270845
+   @RHF iter   6:   -74.97144799223896   -5.71003e-07   1.59716e-05 DIIS
+   PCM polarization energy = -0.00587198132849
+   @RHF iter   7:   -74.97144800431514   -1.20762e-08   2.90636e-06 DIIS
+   PCM polarization energy = -0.00587168094121
+   @RHF iter   8:   -74.97144800481590   -5.00762e-10   6.10640e-07 DIIS
+   PCM polarization energy = -0.00587172568883
+   @RHF iter   9:   -74.97144800484497   -2.90754e-11   5.41227e-08 DIIS
+   PCM polarization energy = -0.00587173026275
+   @RHF iter  10:   -74.97144800484516   -1.84741e-13   1.26468e-08 DIIS
+   PCM polarization energy = -0.00587172819489
+   @RHF iter  11:   -74.97144800484519   -2.84217e-14   1.35626e-09 DIIS
+   PCM polarization energy = -0.00587172807083
+   @RHF iter  12:   -74.97144800484519    0.00000e+00   1.71625e-10 DIIS
+   PCM polarization energy = -0.00587172809834
+   @RHF iter  13:   -74.97144800484521   -2.84217e-14   1.43264e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -5841,15 +5888,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144800484512
+  @RHF Final Energy:   -74.97144800484521
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9239591964628957
-    One-Electron Energy =                -121.9562147301119381
-    Two-Electron Energy =                  38.0666792569023968
-    PCM Polarization Energy =              -0.0058717280984668
-    Total Energy =                        -74.9714480048451151
+    Nuclear Repulsion Energy =              8.9239591963270204
+    One-Electron Energy =                -121.9562147298668009
+    Two-Electron Energy =                  38.0666792567929235
+    PCM Polarization Energy =              -0.0058717280983401
+    Total Energy =                        -74.9714480048452003
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -5870,22 +5917,22 @@ Properties computed using the SCF density matrix
      X:    -1.3871      Y:    -1.1664      Z:    -0.0000     Total:     1.8123
 
 
-*** tstop() called on minazo at Wed May  2 14:17:52 2018
+*** tstop() called on minazo at Wed May  2 19:41:33 2018
 Module time:
-	user time   =       1.82 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.77 seconds =       0.05 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      32.08 seconds =       0.53 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =         32 seconds =       0.53 minutes
+	user time   =      44.01 seconds =       0.73 minutes
+	system time =       0.66 seconds =       0.01 minutes
+	total time  =         45 seconds =       0.75 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:53 2018
+*** at Wed May  2 19:41:33 2018
 
    => Loading Basis Set <=
 
@@ -5913,15 +5960,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.054309493114     0.045779945220     0.000000000000    15.994914619560
-           H          0.054309493114    -0.943632414589     0.000000000000     1.007825032070
-           H         -0.916240560261     0.217071462260     0.000000000000     1.007825032070
+           O          0.054309493115     0.045779945222     0.000000000000    15.994914619560
+           H          0.054309493115    -0.943632414602     0.000000000000     1.007825032070
+           H         -0.916240560278     0.217071462247     0.000000000000     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.37930  B =     14.61322  C =      8.99248 [cm^-1]
-  Rotational constants: A = 700893.85949  B = 438093.40947  C = 269587.71968 [MHz]
-  Nuclear repulsion =    8.923959196463633
+  Rotational constants: A = 700893.85946  B = 438093.40947  C = 269587.71967 [MHz]
+  Nuclear repulsion =    8.923959196327695
 
   Charge       = 0
   Multiplicity = 1
@@ -5963,7 +6010,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -6029,6 +6076,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -6038,7 +6086,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6189227601E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6189227602E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -6047,22 +6096,22 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00587253710144
-   @RHF iter   0:   -74.97147585547822   -7.49715e+01   1.87130e-03 
-   PCM polarization energy = -0.00587166116829
-   @RHF iter   1:   -74.97144798510261    2.78704e-05   2.32059e-05 
-   PCM polarization energy = -0.00587173231085
-   @RHF iter   2:   -74.97144800248849   -1.73859e-08   5.98793e-06 DIIS
-   PCM polarization energy = -0.00587172695032
-   @RHF iter   3:   -74.97144800469393   -2.20544e-09   1.52880e-06 DIIS
-   PCM polarization energy = -0.00587172814144
-   @RHF iter   4:   -74.97144800484462   -1.50692e-10   8.55061e-08 DIIS
-   PCM polarization energy = -0.00587172797463
-   @RHF iter   5:   -74.97144800484487   -2.55795e-13   7.68868e-10 DIIS
-   PCM polarization energy = -0.00587172808237
-   @RHF iter   6:   -74.97144800484490   -2.84217e-14   2.87761e-10 DIIS
-   PCM polarization energy = -0.00587172809130
-   @RHF iter   7:   -74.97144800484485    5.68434e-14   8.12369e-11 DIIS
+   PCM polarization energy = -0.00587253710132
+   @RHF iter   0:   -74.97147585547836   -7.49715e+01   1.87130e-03 
+   PCM polarization energy = -0.00587166116816
+   @RHF iter   1:   -74.97144798510266    2.78704e-05   2.32059e-05 
+   PCM polarization energy = -0.00587173231073
+   @RHF iter   2:   -74.97144800248854   -1.73859e-08   5.98793e-06 DIIS
+   PCM polarization energy = -0.00587172695019
+   @RHF iter   3:   -74.97144800469395   -2.20541e-09   1.52880e-06 DIIS
+   PCM polarization energy = -0.00587172814131
+   @RHF iter   4:   -74.97144800484462   -1.50663e-10   8.55061e-08 DIIS
+   PCM polarization energy = -0.00587172797450
+   @RHF iter   5:   -74.97144800484493   -3.12639e-13   7.68867e-10 DIIS
+   PCM polarization energy = -0.00587172808224
+   @RHF iter   6:   -74.97144800484492    1.42109e-14   2.87761e-10 DIIS
+   PCM polarization energy = -0.00587172809117
+   @RHF iter   7:   -74.97144800484482    9.94760e-14   8.12366e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -6084,15 +6133,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144800484485
+  @RHF Final Energy:   -74.97144800484482
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9239591964636329
-    One-Electron Energy =                -121.9562147295027614
-    Two-Electron Energy =                  38.0666792562855818
-    PCM Polarization Energy =              -0.0058717280912994
-    Total Energy =                        -74.9714480048448451
+    Nuclear Repulsion Energy =              8.9239591963276954
+    One-Electron Energy =                -121.9562147292572831
+    Two-Electron Energy =                  38.0666792561759308
+    PCM Polarization Energy =              -0.0058717280911710
+    Total Energy =                        -74.9714480048448166
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -6113,22 +6162,22 @@ Properties computed using the SCF density matrix
      X:    -1.3897      Y:    -1.1632      Z:     0.0000     Total:     1.8123
 
 
-*** tstop() called on minazo at Wed May  2 14:17:54 2018
+*** tstop() called on minazo at Wed May  2 19:41:35 2018
 Module time:
-	user time   =       1.28 seconds =       0.02 minutes
+	user time   =       1.59 seconds =       0.03 minutes
 	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      33.40 seconds =       0.56 minutes
-	system time =       0.48 seconds =       0.01 minutes
-	total time  =         34 seconds =       0.57 minutes
+	user time   =      45.65 seconds =       0.76 minutes
+	system time =       0.69 seconds =       0.01 minutes
+	total time  =         47 seconds =       0.78 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:54 2018
+*** at Wed May  2 19:41:35 2018
 
    => Loading Basis Set <=
 
@@ -6156,15 +6205,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.071251556744    15.994914619560
-           H          0.000000000000    -0.756504387299     0.565406955766     1.007825032070
-           H          0.000000000000     0.756504387299     0.565406955743     1.007825032070
+           O          0.000000000000     0.000000000000    -0.071251556746    15.994914619560
+           H          0.000000000000    -0.756504387305     0.565406955780     1.007825032070
+           H          0.000000000000     0.756504387305     0.565406955759     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.23345  B =     14.61364  C =      8.97097 [cm^-1]
-  Rotational constants: A = 696521.23618  B = 438105.95586  C = 268943.05380 [MHz]
-  Nuclear repulsion =    8.912894618374555
+  Rotational constants: A = 696521.23614  B = 438105.95586  C = 268943.05379 [MHz]
+  Nuclear repulsion =    8.912894618238871
 
   Charge       = 0
   Multiplicity = 1
@@ -6206,7 +6255,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -6272,6 +6321,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -6281,7 +6331,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6275569435E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6275569436E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -6290,34 +6341,34 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.05709461504398
-   @RHF iter   0:   -74.48577701957373   -7.44858e+01   4.98471e-02 
-   PCM polarization energy = -0.01690169054108
-   @RHF iter   1:   -74.85844701839414   -3.72670e-01   4.61140e-02 
-   PCM polarization energy = -0.00619010740150
-   @RHF iter   2:   -74.96081104555635   -1.02364e-01   1.12096e-02 DIIS
-   PCM polarization energy = -0.00610525696244
-   @RHF iter   3:   -74.96927484859215   -8.46380e-03   4.97711e-03 DIIS
-   PCM polarization energy = -0.00580408424165
-   @RHF iter   4:   -74.97143563475234   -2.16079e-03   4.54201e-04 DIIS
-   PCM polarization energy = -0.00587677651762
-   @RHF iter   5:   -74.97144969494175   -1.40602e-05   1.22054e-04 DIIS
-   PCM polarization energy = -0.00585848808224
-   @RHF iter   6:   -74.97145038661751   -6.91676e-07   1.84237e-05 DIIS
-   PCM polarization energy = -0.00586070199498
-   @RHF iter   7:   -74.97145040859458   -2.19771e-08   3.51306e-06 DIIS
-   PCM polarization energy = -0.00586049792619
-   @RHF iter   8:   -74.97145040946585   -8.71268e-10   5.53604e-07 DIIS
-   PCM polarization energy = -0.00586054325584
-   @RHF iter   9:   -74.97145040948854   -2.26947e-11   7.97764e-08 DIIS
-   PCM polarization energy = -0.00586054431027
-   @RHF iter  10:   -74.97145040948905   -5.11591e-13   1.40372e-08 DIIS
-   PCM polarization energy = -0.00586054235632
-   @RHF iter  11:   -74.97145040948908   -2.84217e-14   7.06410e-10 DIIS
-   PCM polarization energy = -0.00586054240699
-   @RHF iter  12:   -74.97145040948902    5.68434e-14   1.36774e-10 DIIS
-   PCM polarization energy = -0.00586054242168
-   @RHF iter  13:   -74.97145040948912   -9.94760e-14   2.13070e-11 DIIS
+   PCM polarization energy = -0.05709461504451
+   @RHF iter   0:   -74.48577701956401   -7.44858e+01   4.98471e-02 
+   PCM polarization energy = -0.01690169054157
+   @RHF iter   1:   -74.85844701838798   -3.72670e-01   4.61140e-02 
+   PCM polarization energy = -0.00619010740131
+   @RHF iter   2:   -74.96081104555520   -1.02364e-01   1.12096e-02 DIIS
+   PCM polarization energy = -0.00610525696233
+   @RHF iter   3:   -74.96927484859170   -8.46380e-03   4.97711e-03 DIIS
+   PCM polarization energy = -0.00580408424151
+   @RHF iter   4:   -74.97143563475215   -2.16079e-03   4.54201e-04 DIIS
+   PCM polarization energy = -0.00587677651749
+   @RHF iter   5:   -74.97144969494154   -1.40602e-05   1.22054e-04 DIIS
+   PCM polarization energy = -0.00585848808211
+   @RHF iter   6:   -74.97145038661741   -6.91676e-07   1.84237e-05 DIIS
+   PCM polarization energy = -0.00586070199485
+   @RHF iter   7:   -74.97145040859436   -2.19770e-08   3.51306e-06 DIIS
+   PCM polarization energy = -0.00586049792606
+   @RHF iter   8:   -74.97145040946573   -8.71367e-10   5.53604e-07 DIIS
+   PCM polarization energy = -0.00586054325571
+   @RHF iter   9:   -74.97145040948828   -2.25526e-11   7.97764e-08 DIIS
+   PCM polarization energy = -0.00586054431015
+   @RHF iter  10:   -74.97145040948878   -4.97380e-13   1.40372e-08 DIIS
+   PCM polarization energy = -0.00586054235619
+   @RHF iter  11:   -74.97145040948885   -7.10543e-14   7.06411e-10 DIIS
+   PCM polarization energy = -0.00586054240686
+   @RHF iter  12:   -74.97145040948881    4.26326e-14   1.36774e-10 DIIS
+   PCM polarization energy = -0.00586054242155
+   @RHF iter  13:   -74.97145040948885   -4.26326e-14   2.13069e-11 DIIS
 
   ==> Post-Iterations <==
 
@@ -6339,15 +6390,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97145040948912
+  @RHF Final Energy:   -74.97145040948885
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9128946183745548
-    One-Electron Energy =                -121.9357097447661005
-    Two-Electron Energy =                  38.0572252593241060
-    PCM Polarization Energy =              -0.0058605424216817
-    Total Energy =                        -74.9714504094891367
+    Nuclear Repulsion Energy =              8.9128946182388713
+    One-Electron Energy =                -121.9357097445205795
+    Two-Electron Energy =                  38.0572252592144196
+    PCM Polarization Energy =              -0.0058605424215533
+    Total Energy =                        -74.9714504094888525
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -6356,7 +6407,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0598
+     X:     0.0000      Y:    -0.0000      Z:     1.0598
 
   Electronic Dipole Moment: [e a0]
      X:    -0.0000      Y:     0.0000      Z:    -0.3469
@@ -6368,22 +6419,22 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:     1.8120     Total:     1.8120
 
 
-*** tstop() called on minazo at Wed May  2 14:17:56 2018
+*** tstop() called on minazo at Wed May  2 19:41:37 2018
 Module time:
-	user time   =       1.77 seconds =       0.03 minutes
+	user time   =       2.03 seconds =       0.03 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      35.19 seconds =       0.59 minutes
-	system time =       0.50 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
+	user time   =      47.71 seconds =       0.80 minutes
+	system time =       0.71 seconds =       0.01 minutes
+	total time  =         49 seconds =       0.82 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:56 2018
+*** at Wed May  2 19:41:37 2018
 
    => Loading Basis Set <=
 
@@ -6411,15 +6462,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.070808913264    15.994914619560
-           H          0.000000000000    -0.756504387299     0.561894419143     1.007825032070
-           H          0.000000000000     0.756504387299     0.561894419120     1.007825032070
+           O          0.000000000000     0.000000000000    -0.070808913266    15.994914619560
+           H          0.000000000000    -0.756504387305     0.561894419156     1.007825032070
+           H          0.000000000000     0.756504387305     0.561894419136     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.52483  B =     14.61364  C =      9.01409 [cm^-1]
-  Rotational constants: A = 705256.69705  B = 438105.95586  C = 270235.48356 [MHz]
-  Nuclear repulsion =    8.934967332568949
+  Rotational constants: A = 705256.69701  B = 438105.95586  C = 270235.48355 [MHz]
+  Nuclear repulsion =    8.934967332432818
 
   Charge       = 0
   Multiplicity = 1
@@ -6461,7 +6512,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -6527,6 +6578,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -6536,7 +6588,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6108092121E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6108092122E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -6545,20 +6598,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00579464567457
-   @RHF iter   0:   -74.97386501045845   -7.49739e+01   9.49013e-04 
-   PCM polarization energy = -0.00587279808282
-   @RHF iter   1:   -74.97145163030014    2.41338e-03   9.81465e-05 
-   PCM polarization energy = -0.00587697838767
-   @RHF iter   2:   -74.97145222875251   -5.98452e-07   4.28292e-05 DIIS
-   PCM polarization energy = -0.00587983507072
-   @RHF iter   3:   -74.97145237157420   -1.42822e-07   9.70130e-07 DIIS
-   PCM polarization energy = -0.00587994880354
-   @RHF iter   4:   -74.97145237163758   -6.33804e-11   9.83618e-08 DIIS
-   PCM polarization energy = -0.00587995521243
-   @RHF iter   5:   -74.97145237163787   -2.84217e-13   1.03410e-08 DIIS
-   PCM polarization energy = -0.00587995653958
-   @RHF iter   6:   -74.97145237163792   -5.68434e-14   3.49304e-12 DIIS
+   PCM polarization energy = -0.00579464567445
+   @RHF iter   0:   -74.97386501045848   -7.49739e+01   9.49013e-04 
+   PCM polarization energy = -0.00587279808269
+   @RHF iter   1:   -74.97145163030021    2.41338e-03   9.81465e-05 
+   PCM polarization energy = -0.00587697838754
+   @RHF iter   2:   -74.97145222875261   -5.98452e-07   4.28292e-05 DIIS
+   PCM polarization energy = -0.00587983507059
+   @RHF iter   3:   -74.97145237157427   -1.42822e-07   9.70130e-07 DIIS
+   PCM polarization energy = -0.00587994880341
+   @RHF iter   4:   -74.97145237163767   -6.33946e-11   9.83618e-08 DIIS
+   PCM polarization energy = -0.00587995521231
+   @RHF iter   5:   -74.97145237163807   -3.97904e-13   1.03410e-08 DIIS
+   PCM polarization energy = -0.00587995653945
+   @RHF iter   6:   -74.97145237163804    2.84217e-14   3.49389e-12 DIIS
 
   ==> Post-Iterations <==
 
@@ -6580,15 +6633,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97145237163792
+  @RHF Final Energy:   -74.97145237163804
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9349673325689487
-    One-Electron Energy =                -121.9766191561387245
-    Two-Electron Energy =                  38.0760794084714291
-    PCM Polarization Energy =              -0.0058799565395796
-    Total Energy =                        -74.9714523716379233
+    Nuclear Repulsion Energy =              8.9349673324328176
+    One-Electron Energy =                -121.9766191558930899
+    Two-Electron Energy =                  38.0760794083616858
+    PCM Polarization Energy =              -0.0058799565394521
+    Total Energy =                        -74.9714523716380370
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -6597,7 +6650,7 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     1.0532
+     X:     0.0000      Y:     0.0000      Z:     1.0532
 
   Electronic Dipole Moment: [e a0]
      X:    -0.0000      Y:     0.0000      Z:    -0.3401
@@ -6609,22 +6662,22 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:     1.8125     Total:     1.8125
 
 
-*** tstop() called on minazo at Wed May  2 14:17:57 2018
+*** tstop() called on minazo at Wed May  2 19:41:38 2018
 Module time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      36.37 seconds =       0.61 minutes
-	system time =       0.52 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
+	user time   =      49.09 seconds =       0.82 minutes
+	system time =       0.74 seconds =       0.01 minutes
+	total time  =         50 seconds =       0.83 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:57 2018
+*** at Wed May  2 19:41:38 2018
 
    => Loading Basis Set <=
 
@@ -6652,15 +6705,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.071030235004    15.994914619560
-           H          0.000000000000    -0.758368033924     0.563650687454     1.007825032070
-           H          0.000000000000     0.758368033924     0.563650687432     1.007825032070
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.758368033930     0.563650687468     1.007825032070
+           H          0.000000000000     0.758368033930     0.563650687447     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.37846  B =     14.54191  C =      8.96530 [cm^-1]
-  Rotational constants: A = 700868.55269  B = 435955.36030  C = 268772.84944 [MHz]
-  Nuclear repulsion =    8.910682175857685
+  Rotational constants: A = 700868.55266  B = 435955.36029  C = 268772.84944 [MHz]
+  Nuclear repulsion =    8.910682175722268
 
   Charge       = 0
   Multiplicity = 1
@@ -6702,7 +6755,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -6768,6 +6821,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -6777,7 +6831,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6285000004E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6285000005E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -6786,20 +6841,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00592960121976
-   @RHF iter   0:   -74.96924041013939   -7.49692e+01   9.58485e-04 
-   PCM polarization energy = -0.00586118873227
-   @RHF iter   1:   -74.97144927370888   -2.20886e-03   4.80075e-05 
-   PCM polarization energy = -0.00585738236035
-   @RHF iter   2:   -74.97144941521729   -1.41508e-07   2.05948e-05 DIIS
-   PCM polarization energy = -0.00585627685622
-   @RHF iter   3:   -74.97144944787784   -3.26606e-08   2.08345e-06 DIIS
-   PCM polarization energy = -0.00585604738948
-   @RHF iter   4:   -74.97144944821771   -3.39867e-10   6.74282e-08 DIIS
-   PCM polarization energy = -0.00585604476783
-   @RHF iter   5:   -74.97144944821794   -2.27374e-13   1.25526e-08 DIIS
-   PCM polarization energy = -0.00585604359688
-   @RHF iter   6:   -74.97144944821791    2.84217e-14   7.86255e-13 DIIS
+   PCM polarization energy = -0.00592960121963
+   @RHF iter   0:   -74.96924041013928   -7.49692e+01   9.58485e-04 
+   PCM polarization energy = -0.00586118873214
+   @RHF iter   1:   -74.97144927370877   -2.20886e-03   4.80075e-05 
+   PCM polarization energy = -0.00585738236022
+   @RHF iter   2:   -74.97144941521719   -1.41508e-07   2.05948e-05 DIIS
+   PCM polarization energy = -0.00585627685609
+   @RHF iter   3:   -74.97144944787775   -3.26606e-08   2.08345e-06 DIIS
+   PCM polarization energy = -0.00585604738935
+   @RHF iter   4:   -74.97144944821761   -3.39867e-10   6.74282e-08 DIIS
+   PCM polarization energy = -0.00585604476771
+   @RHF iter   5:   -74.97144944821781   -1.98952e-13   1.25526e-08 DIIS
+   PCM polarization energy = -0.00585604359675
+   @RHF iter   6:   -74.97144944821770    1.13687e-13   7.87855e-13 DIIS
 
   ==> Post-Iterations <==
 
@@ -6821,15 +6876,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97144944821791
+  @RHF Final Energy:   -74.97144944821770
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9106821758576853
-    One-Electron Energy =                -121.9335938951033427
-    Two-Electron Energy =                  38.0573183146246237
-    PCM Polarization Energy =              -0.0058560435968811
-    Total Energy =                        -74.9714494482179106
+    Nuclear Repulsion Energy =              8.9106821757222683
+    One-Electron Energy =                -121.9335938948583333
+    Two-Electron Energy =                  38.0573183145151006
+    PCM Polarization Energy =              -0.0058560435967533
+    Total Energy =                        -74.9714494482177116
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -6838,34 +6893,34 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     1.0565
+     X:     0.0000      Y:     0.0000      Z:     1.0565
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.3446
+     X:    -0.0000      Y:     0.0000      Z:    -0.3446
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.7119     Total:     0.7119
+     X:    -0.0000      Y:     0.0000      Z:     0.7119     Total:     0.7119
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     1.8094     Total:     1.8094
+     X:    -0.0000      Y:     0.0000      Z:     1.8094     Total:     1.8094
 
 
-*** tstop() called on minazo at Wed May  2 14:17:58 2018
+*** tstop() called on minazo at Wed May  2 19:41:40 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.30 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      37.52 seconds =       0.63 minutes
-	system time =       0.53 seconds =       0.01 minutes
-	total time  =         38 seconds =       0.63 minutes
+	user time   =      50.42 seconds =       0.84 minutes
+	system time =       0.76 seconds =       0.01 minutes
+	total time  =         52 seconds =       0.87 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:58 2018
+*** at Wed May  2 19:41:40 2018
 
    => Loading Basis Set <=
 
@@ -6893,15 +6948,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.071030235004    15.994914619560
-           H          0.000000000000    -0.754640740675     0.563650687454     1.007825032070
-           H          0.000000000000     0.754640740675     0.563650687432     1.007825032070
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.754640740681     0.563650687468     1.007825032070
+           H          0.000000000000     0.754640740681     0.563650687447     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.37846  B =     14.68591  C =      9.01982 [cm^-1]
-  Rotational constants: A = 700868.55269  B = 440272.50431  C = 270407.54602 [MHz]
-  Nuclear repulsion =    8.937199022999128
+  Rotational constants: A = 700868.55266  B = 440272.50430  C = 270407.54601 [MHz]
+  Nuclear repulsion =    8.937199022862725
 
   Charge       = 0
   Multiplicity = 1
@@ -6943,7 +6998,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:17 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -7009,6 +7064,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -7018,7 +7074,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6098554375E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6098554376E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -7027,20 +7084,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00582552483127
-   @RHF iter   0:   -74.97348941902153   -7.49735e+01   9.85493e-04 
-   PCM polarization energy = -0.00588157469913
-   @RHF iter   1:   -74.97145045178580    2.03897e-03   2.06935e-05 
-   PCM polarization energy = -0.00588490596759
-   @RHF iter   2:   -74.97145046451784   -1.27320e-08   2.08591e-06 DIIS
-   PCM polarization energy = -0.00588464208280
-   @RHF iter   3:   -74.97145046476736   -2.49514e-10   8.42841e-07 DIIS
-   PCM polarization energy = -0.00588459435914
-   @RHF iter   4:   -74.97145046482080   -5.34470e-11   1.32924e-07 DIIS
-   PCM polarization energy = -0.00588458417516
-   @RHF iter   5:   -74.97145046482214   -1.33582e-12   2.63136e-09 DIIS
-   PCM polarization energy = -0.00588458439136
-   @RHF iter   6:   -74.97145046482211    2.84217e-14   5.11015e-14 DIIS
+   PCM polarization energy = -0.00582552483115
+   @RHF iter   0:   -74.97348941902156   -7.49735e+01   9.85493e-04 
+   PCM polarization energy = -0.00588157469900
+   @RHF iter   1:   -74.97145045178581    2.03897e-03   2.06935e-05 
+   PCM polarization energy = -0.00588490596746
+   @RHF iter   2:   -74.97145046451794   -1.27321e-08   2.08591e-06 DIIS
+   PCM polarization energy = -0.00588464208267
+   @RHF iter   3:   -74.97145046476739   -2.49443e-10   8.42841e-07 DIIS
+   PCM polarization energy = -0.00588459435901
+   @RHF iter   4:   -74.97145046482078   -5.33902e-11   1.32924e-07 DIIS
+   PCM polarization energy = -0.00588458417503
+   @RHF iter   5:   -74.97145046482213   -1.35003e-12   2.63136e-09 DIIS
+   PCM polarization energy = -0.00588458439123
+   @RHF iter   6:   -74.97145046482217   -4.26326e-14   5.22235e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -7062,15 +7119,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97145046482211
+  @RHF Final Energy:   -74.97145046482217
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9371990229991276
-    One-Electron Energy =                -121.9787529735902893
-    Two-Electron Energy =                  38.0759880701604274
-    PCM Polarization Energy =              -0.0058845843913621
-    Total Energy =                        -74.9714504648221123
+    Nuclear Repulsion Energy =              8.9371990228627247
+    One-Electron Energy =                -121.9787529733442852
+    Two-Electron Energy =                  38.0759880700506343
+    PCM Polarization Energy =              -0.0058845843912343
+    Total Energy =                        -74.9714504648221549
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -7082,31 +7139,31 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0565
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.3423
+     X:    -0.0000      Y:     0.0000      Z:    -0.3423
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.7141     Total:     0.7141
+     X:    -0.0000      Y:     0.0000      Z:     0.7141     Total:     0.7141
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     1.8151     Total:     1.8151
+     X:    -0.0000      Y:     0.0000      Z:     1.8151     Total:     1.8151
 
 
-*** tstop() called on minazo at Wed May  2 14:17:59 2018
+*** tstop() called on minazo at Wed May  2 19:41:41 2018
 Module time:
-	user time   =       1.12 seconds =       0.02 minutes
+	user time   =       1.33 seconds =       0.02 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      38.67 seconds =       0.64 minutes
-	system time =       0.55 seconds =       0.01 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      51.78 seconds =       0.86 minutes
+	system time =       0.78 seconds =       0.01 minutes
+	total time  =         53 seconds =       0.88 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 7 of 7    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 *** tstart() called on minazo
-*** at Wed May  2 14:17:59 2018
+*** at Wed May  2 19:41:41 2018
 
    => Loading Basis Set <=
 
@@ -7134,15 +7191,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.071030235004    15.994914619560
-           H          0.000000000000    -0.756504387299     0.563650687454     1.007825032070
-           H          0.000000000000     0.756504387299     0.563650687432     1.007825032070
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.756504387305     0.563650687468     1.007825032070
+           H          0.000000000000     0.756504387305     0.563650687447     1.007825032070
 
   Running in c1 symmetry.
 
   Rotational constants: A =     23.37846  B =     14.61364  C =      8.99251 [cm^-1]
-  Rotational constants: A = 700868.55269  B = 438105.95586  C = 269588.72644 [MHz]
-  Nuclear repulsion =    8.923926861091351
+  Rotational constants: A = 700868.55266  B = 438105.95586  C = 269588.72643 [MHz]
+  Nuclear repulsion =    8.923926860955445
 
   Charge       = 0
   Multiplicity = 1
@@ -7184,7 +7241,7 @@ Total time:
 
  Source repository: https://github.com/PCMSolver/pcmsolver
  Documentation: https://pcmsolver.readthedocs.io/
- PCMSolver initialized on: Wednesday, 02 May 2018 02:18 PM
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
 -----------------------------------------------------------------------
 
 ~~~~~~~~~~ PCMSolver ~~~~~~~~~~
@@ -7250,6 +7307,7 @@ Permittivity = 78.39
   Using 812 doubles for integral storage.
   We computed 120 shell quartets total.
   Whereas there are 120 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -7259,7 +7317,8 @@ Permittivity = 78.39
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6191717500E-01.
+
+  Minimum eigenvalue in the overlap matrix is 3.6191717501E-01.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
@@ -7268,20 +7327,20 @@ Permittivity = 78.39
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   PCM polarization energy = -0.00590017079416
+   PCM polarization energy = -0.00590017079403
    @RHF iter   0:   -74.97045070585082   -7.49705e+01   4.91723e-04 
-   PCM polarization energy = -0.00587178763160
-   @RHF iter   1:   -74.97145590959344   -1.00520e-03   1.01945e-05 
-   PCM polarization energy = -0.00587015299984
-   @RHF iter   2:   -74.97145591268810   -3.09466e-09   1.06023e-06 DIIS
-   PCM polarization energy = -0.00587028462258
-   @RHF iter   3:   -74.97145591275316   -6.50573e-11   4.31464e-07 DIIS
-   PCM polarization energy = -0.00587030891949
-   @RHF iter   4:   -74.97145591276718   -1.40261e-11   6.55918e-08 DIIS
-   PCM polarization energy = -0.00587031397739
-   @RHF iter   5:   -74.97145591276754   -3.55271e-13   1.11016e-09 DIIS
-   PCM polarization energy = -0.00587031388502
-   @RHF iter   6:   -74.97145591276755   -1.42109e-14   1.53769e-14 DIIS
+   PCM polarization energy = -0.00587178763147
+   @RHF iter   1:   -74.97145590959343   -1.00520e-03   1.01945e-05 
+   PCM polarization energy = -0.00587015299971
+   @RHF iter   2:   -74.97145591268810   -3.09467e-09   1.06023e-06 DIIS
+   PCM polarization energy = -0.00587028462245
+   @RHF iter   3:   -74.97145591275309   -6.49862e-11   4.31464e-07 DIIS
+   PCM polarization energy = -0.00587030891936
+   @RHF iter   4:   -74.97145591276715   -1.40687e-11   6.55918e-08 DIIS
+   PCM polarization energy = -0.00587031397726
+   @RHF iter   5:   -74.97145591276748   -3.26850e-13   1.11016e-09 DIIS
+   PCM polarization energy = -0.00587031388489
+   @RHF iter   6:   -74.97145591276748    0.00000e+00   1.29835e-14 DIIS
 
   ==> Post-Iterations <==
 
@@ -7303,15 +7362,15 @@ Permittivity = 78.39
 
   Energy converged.
 
-  @RHF Final Energy:   -74.97145591276755
+  @RHF Final Energy:   -74.97145591276748
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.9239268610913509
-    One-Electron Energy =                -121.9561614548643433
-    Two-Electron Energy =                  38.0666489948904569
-    PCM Polarization Energy =              -0.0058703138850172
-    Total Energy =                        -74.9714559127675528
+    Nuclear Repulsion Energy =              8.9239268609554454
+    One-Electron Energy =                -121.9561614546187940
+    Two-Electron Energy =                  38.0666489947807491
+    PCM Polarization Energy =              -0.0058703138848895
+    Total Energy =                        -74.9714559127674818
 
     Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
 
@@ -7332,15 +7391,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:     1.8122     Total:     1.8122
 
 
-*** tstop() called on minazo at Wed May  2 14:18:00 2018
+*** tstop() called on minazo at Wed May  2 19:41:43 2018
 Module time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      39.83 seconds =       0.66 minutes
-	system time =       0.58 seconds =       0.01 minutes
-	total time  =         40 seconds =       0.67 minutes
+	user time   =      53.14 seconds =       0.89 minutes
+	system time =       0.80 seconds =       0.01 minutes
+	total time  =         55 seconds =       0.92 minutes
 
 -------------------------------------------------------------
 
@@ -7363,9 +7422,9 @@ Total time:
 
                  1                   2                   3
 
-    1     0.00000000000000     0.00000000002834    -0.00026252266600
-    2     0.00000000000000    -0.00007216548892     0.00013126134489
-    3     0.00000000000000     0.00007216546058     0.00013126132111
+    1     0.00000000000000     0.00000000004176    -0.00026252271734
+    2     0.00000000000000    -0.00007216551480     0.00013126137619
+    3     0.00000000000000     0.00007216547304     0.00013126134115
 
 
 
@@ -7381,7 +7440,7 @@ Total time:
 	 H           0.0000000000       -1.4295861103        1.0651454339
 	 H           0.0000000000        1.4295861103        1.0651454339
 	             0.0000000000        0.0000000000       -0.0002625227
-	             0.0000000000       -0.0000721655        0.0001312613
+	             0.0000000000       -0.0000721655        0.0001312614
 	             0.0000000000        0.0000721655        0.0001312613
 
 	---Fragment 1 Intrafragment Coordinates---
@@ -7440,13 +7499,13 @@ Total time:
    Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp  ~
   --------------------------------------------------------------------------------------------------------------- ~
       1     -74.970094352012    -74.970094352012      0.02462408      0.02026360      0.14926083      0.09123730  ~
-      2     -74.970516296689     -0.000421944676      0.02271231      0.01589818      0.07348009      0.04356710  ~
+      2     -74.970516296689     -0.000421944677      0.02271231      0.01589818      0.07348009      0.04356710  ~
       3     -74.971455056012     -0.000938759323      0.00061193      0.00044551      0.00260140      0.00167193  ~
-      4     -74.971455912768     -0.000000856756      0.00013965      0.00012810      0.00040098      0.00030791  ~
+      4     -74.971455912767     -0.000000856756      0.00013965      0.00012810      0.00040098      0.00030791  ~
   --------------------------------------------------------------------------------------------------------------- ~
 
 	Writing optimization data to binary file.
-	Final energy is    -74.9714559127676
+	Final energy is    -74.9714559127675
 	Final (previous) structure:
 	Cartesian Geometry (in Angstrom)
 	    O     0.0000000000   0.0000000000  -0.0710302350
@@ -7473,7 +7532,9350 @@ Total time:
 	Nuclear repulsion energy..........................................PASSED
 	Reference energy..................................................PASSED
 
-    Psi4 stopped on: Wednesday, 02 May 2018 02:18PM
-    Psi4 wall time for execution: 0:00:40.58
+PCM analytic gradients are not implemented yet, re-routing to finite differences.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 7.
+	Translations projected? 1. Rotations projected? 1.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:43 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054522348624     0.045526233398     0.000000000000    15.994914619560
+           H          0.054522348624    -0.940023455848     0.000000000000     1.007825032070
+           H         -0.919831587187     0.217489094253     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.37930  B =     14.61322  C =      8.99248 [cm^-1]
+  Rotational constants: A = 700893.85946  B = 438093.40947  C = 269587.71967 [MHz]
+  Nuclear repulsion =    8.923959196327019
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054522     0.045526     0.000000
+   2      H    1.4430   1.00     0.054522     -0.940023     0.000000
+   3      H    1.4430   1.00     -0.919832     0.217489     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6189227602E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00039148854655
+   @RHF iter   0:   -74.66686833133087   -7.46669e+01   2.01510e-01 
+   PCM polarization energy = -0.00996670652541
+   @RHF iter   1:   -74.95380989660994   -2.86942e-01   1.97012e-02 
+   PCM polarization energy = -0.00583334979856
+   @RHF iter   2:   -74.96991954694181   -1.61097e-02   4.37901e-03 DIIS
+   PCM polarization energy = -0.00590000714957
+   @RHF iter   3:   -74.97112323739900   -1.20369e-03   1.91139e-03 DIIS
+   PCM polarization energy = -0.00585258563364
+   @RHF iter   4:   -74.97144265724469   -3.19420e-04   2.64912e-04 DIIS
+   PCM polarization energy = -0.00587480356211
+   @RHF iter   5:   -74.97144796384632   -5.30660e-06   2.49817e-05 DIIS
+   PCM polarization energy = -0.00587151737583
+   @RHF iter   6:   -74.97144800220224   -3.83559e-08   6.42777e-06 DIIS
+   PCM polarization energy = -0.00587173441648
+   @RHF iter   7:   -74.97144800477997   -2.57774e-09   8.72517e-07 DIIS
+   PCM polarization energy = -0.00587174381082
+   @RHF iter   8:   -74.97144800484398   -6.40057e-11   1.32399e-07 DIIS
+   PCM polarization energy = -0.00587172628190
+   @RHF iter   9:   -74.97144800484502   -1.03739e-12   1.75056e-08 DIIS
+   PCM polarization energy = -0.00587172802896
+   @RHF iter  10:   -74.97144800484504   -2.84217e-14   2.87296e-09 DIIS
+   PCM polarization energy = -0.00587172806610
+   @RHF iter  11:   -74.97144800484503    1.42109e-14   3.43896e-10 DIIS
+   PCM polarization energy = -0.00587172809590
+   @RHF iter  12:   -74.97144800484509   -5.68434e-14   5.90345e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240831     2A     -1.254747     3A     -0.590561  
+       4A     -0.461586     5A     -0.392051  
+
+    Virtual:                                                              
+
+       6A      0.594044     7A      0.702239  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144800484509
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9239591963270186
+    One-Electron Energy =                -121.9562147296336434
+    Two-Electron Energy =                  38.0666792565574426
+    PCM Polarization Energy =              -0.0058717280958981
+    Total Energy =                        -74.9714480048450724
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8109      Y:    -0.6771      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2652      Y:     0.2183      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5457      Y:    -0.4589      Z:     0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3871      Y:    -1.1664      Z:     0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:41:45 2018
+Module time:
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      55.31 seconds =       0.92 minutes
+	system time =       0.82 seconds =       0.01 minutes
+	total time  =         57 seconds =       0.95 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:45 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054309493115     0.045779945222     0.000000000000    15.994914619560
+           H          0.054309493115    -0.943632414602     0.000000000000     1.007825032070
+           H         -0.916240560278     0.217071462247     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.37930  B =     14.61322  C =      8.99248 [cm^-1]
+  Rotational constants: A = 700893.85946  B = 438093.40947  C = 269587.71967 [MHz]
+  Nuclear repulsion =    8.923959196327695
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054309     0.045780     0.000000
+   2      H    1.4430   1.00     0.054309     -0.943632     0.000000
+   3      H    1.4430   1.00     -0.916241     0.217071     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6189227602E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00038808735944
+   @RHF iter   0:   -74.67294468267833   -7.46729e+01   2.01576e-01 
+   PCM polarization energy = -0.01023625766077
+   @RHF iter   1:   -74.95170365866728   -2.78759e-01   2.07315e-02 
+   PCM polarization energy = -0.00584611392455
+   @RHF iter   2:   -74.96973141325830   -1.80278e-02   4.65734e-03 DIIS
+   PCM polarization energy = -0.00590605881358
+   @RHF iter   3:   -74.97108920968753   -1.35780e-03   2.01802e-03 DIIS
+   PCM polarization energy = -0.00585152483711
+   @RHF iter   4:   -74.97144207884313   -3.52869e-04   2.79232e-04 DIIS
+   PCM polarization energy = -0.00587511258691
+   @RHF iter   5:   -74.97144795649982   -5.87766e-06   2.73921e-05 DIIS
+   PCM polarization energy = -0.00587134210197
+   @RHF iter   6:   -74.97144800208683   -4.55870e-08   6.75891e-06 DIIS
+   PCM polarization energy = -0.00587172678471
+   @RHF iter   7:   -74.97144800476713   -2.68030e-09   9.44553e-07 DIIS
+   PCM polarization energy = -0.00587174953693
+   @RHF iter   8:   -74.97144800484323   -7.60991e-11   1.67886e-07 DIIS
+   PCM polarization energy = -0.00587172602773
+   @RHF iter   9:   -74.97144800484483   -1.60583e-12   1.78770e-08 DIIS
+   PCM polarization energy = -0.00587172802389
+   @RHF iter  10:   -74.97144800484490   -7.10543e-14   3.12577e-09 DIIS
+   PCM polarization energy = -0.00587172805390
+   @RHF iter  11:   -74.97144800484492   -1.42109e-14   4.06791e-10 DIIS
+   PCM polarization energy = -0.00587172809489
+   @RHF iter  12:   -74.97144800484492    0.00000e+00   6.94066e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240831     2A     -1.254747     3A     -0.590561  
+       4A     -0.461586     5A     -0.392051  
+
+    Virtual:                                                              
+
+       6A      0.594044     7A      0.702239  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144800484492
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9239591963276954
+    One-Electron Energy =                -121.9562147295566632
+    Two-Electron Energy =                  38.0666792564789418
+    PCM Polarization Energy =              -0.0058717280948850
+    Total Energy =                        -74.9714480048449161
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8078      Y:    -0.6809      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2610      Y:     0.2233      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5467      Y:    -0.4577      Z:     0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3897      Y:    -1.1632      Z:     0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:41:47 2018
+Module time:
+	user time   =       2.35 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      57.70 seconds =       0.96 minutes
+	system time =       0.85 seconds =       0.01 minutes
+	total time  =         59 seconds =       0.98 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:47 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071251556746    15.994914619560
+           H          0.000000000000    -0.756504387305     0.565406955780     1.007825032070
+           H          0.000000000000     0.756504387305     0.565406955759     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.23345  B =     14.61364  C =      8.97097 [cm^-1]
+  Rotational constants: A = 696521.23614  B = 438105.95586  C = 268943.05379 [MHz]
+  Nuclear repulsion =    8.912894618238870
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071252
+   2      H    1.4430   1.00     0.000000     -0.756504     0.565407
+   3      H    1.4430   1.00     0.000000     0.756504     0.565407
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6275569436E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00036352098441
+   @RHF iter   0:   -74.71519410026740   -7.47152e+01   2.01092e-01 
+   PCM polarization energy = -0.01300374430177
+   @RHF iter   1:   -74.93630427896140   -2.21110e-01   2.75842e-02 
+   PCM polarization energy = -0.00608555206547
+   @RHF iter   2:   -74.96927519750447   -3.29709e-02   5.37138e-03 DIIS
+   PCM polarization energy = -0.00602777360775
+   @RHF iter   3:   -74.97099490410113   -1.71971e-03   2.29686e-03 DIIS
+   PCM polarization energy = -0.00584087525511
+   @RHF iter   4:   -74.97144594537376   -4.51041e-04   2.47170e-04 DIIS
+   PCM polarization energy = -0.00586358993667
+   @RHF iter   5:   -74.97145034023197   -4.39486e-06   3.32599e-05 DIIS
+   PCM polarization energy = -0.00585762874404
+   @RHF iter   6:   -74.97145040220487   -6.19729e-08   1.37575e-05 DIIS
+   PCM polarization energy = -0.00586029896616
+   @RHF iter   7:   -74.97145040943467   -7.22980e-09   1.19758e-06 DIIS
+   PCM polarization energy = -0.00586054428450
+   @RHF iter   8:   -74.97145040948894   -5.42713e-11   9.98531e-09 DIIS
+   PCM polarization energy = -0.00586054245058
+   @RHF iter   9:   -74.97145040948894    0.00000e+00   1.42400e-10 DIIS
+   PCM polarization energy = -0.00586054242184
+   @RHF iter  10:   -74.97145040948891    2.84217e-14   8.41243e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241175     2A     -1.254326     3A     -0.589623  
+       4A     -0.461811     5A     -0.392092  
+
+    Virtual:                                                              
+
+       6A      0.593116     7A      0.700304  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145040948891
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9128946182388695
+    One-Electron Energy =                -121.9357097445393663
+    Two-Electron Energy =                  38.0572252592334337
+    PCM Polarization Energy =              -0.0058605424218361
+    Total Energy =                        -74.9714504094889094
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0598
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3469
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7129     Total:     0.7129
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8120     Total:     1.8120
+
+
+*** tstop() called on minazo at Wed May  2 19:41:50 2018
+Module time:
+	user time   =       2.65 seconds =       0.04 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      60.46 seconds =       1.01 minutes
+	system time =       0.90 seconds =       0.02 minutes
+	total time  =         62 seconds =       1.03 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:50 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070808913266    15.994914619560
+           H          0.000000000000    -0.756504387305     0.561894419156     1.007825032070
+           H          0.000000000000     0.756504387305     0.561894419136     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.52483  B =     14.61364  C =      9.01409 [cm^-1]
+  Rotational constants: A = 705256.69701  B = 438105.95586  C = 270235.48355 [MHz]
+  Nuclear repulsion =    8.934967332432819
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070809
+   2      H    1.4430   1.00     0.000000     -0.756504     0.561894
+   3      H    1.4430   1.00     0.000000     0.756504     0.561894
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6108092122E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00036768413101
+   @RHF iter   0:   -74.71550028415510   -7.47155e+01   2.02142e-01 
+   PCM polarization energy = -0.01259700529938
+   @RHF iter   1:   -74.93861775413167   -2.23117e-01   2.66158e-02 
+   PCM polarization energy = -0.00609032170094
+   @RHF iter   2:   -74.96929923624695   -3.06815e-02   5.28334e-03 DIIS
+   PCM polarization energy = -0.00603388185521
+   @RHF iter   3:   -74.97099935698448   -1.70012e-03   2.27480e-03 DIIS
+   PCM polarization energy = -0.00585925306900
+   @RHF iter   4:   -74.97144804586884   -4.48689e-04   2.43466e-04 DIIS
+   PCM polarization energy = -0.00588293466708
+   @RHF iter   5:   -74.97145230910554   -4.26324e-06   3.24149e-05 DIIS
+   PCM polarization energy = -0.00587717248067
+   @RHF iter   6:   -74.97145236488723   -5.57817e-08   1.32662e-05 DIIS
+   PCM polarization energy = -0.00587967064020
+   @RHF iter   7:   -74.97145237156390   -6.67667e-09   1.41276e-06 DIIS
+   PCM polarization energy = -0.00587995692781
+   @RHF iter   8:   -74.97145237163798   -7.40812e-11   4.23472e-09 DIIS
+   PCM polarization energy = -0.00587995656717
+   @RHF iter   9:   -74.97145237163797    1.42109e-14   1.36080e-10 DIIS
+   PCM polarization energy = -0.00587995654003
+   @RHF iter  10:   -74.97145237163794    2.84217e-14   1.88304e-13 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240503     2A     -1.255176     3A     -0.591514  
+       4A     -0.461376     5A     -0.392021  
+
+    Virtual:                                                              
+
+       6A      0.595022     7A      0.704081  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145237163794
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9349673324328194
+    One-Electron Energy =                -121.9766191560015045
+    Two-Electron Energy =                  38.0760794084707825
+    PCM Polarization Energy =              -0.0058799565400268
+    Total Energy =                        -74.9714523716379375
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0532
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3401
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7131     Total:     0.7131
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8125     Total:     1.8125
+
+
+*** tstop() called on minazo at Wed May  2 19:41:52 2018
+Module time:
+	user time   =       2.31 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      62.80 seconds =       1.05 minutes
+	system time =       0.92 seconds =       0.02 minutes
+	total time  =         64 seconds =       1.07 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:52 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.758368033930     0.563650687468     1.007825032070
+           H          0.000000000000     0.758368033930     0.563650687447     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.37846  B =     14.54191  C =      8.96530 [cm^-1]
+  Rotational constants: A = 700868.55266  B = 435955.36029  C = 268772.84944 [MHz]
+  Nuclear repulsion =    8.910682175722268
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071030
+   2      H    1.4430   1.00     0.000000     -0.758368     0.563651
+   3      H    1.4430   1.00     0.000000     0.758368     0.563651
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6285000005E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00035719703900
+   @RHF iter   0:   -74.72230312996142   -7.47223e+01   2.00969e-01 
+   PCM polarization energy = -0.01355839227041
+   @RHF iter   1:   -74.93313971681626   -2.10837e-01   2.89765e-02 
+   PCM polarization energy = -0.00612048301359
+   @RHF iter   2:   -74.96934793741609   -3.62082e-02   5.41079e-03 DIIS
+   PCM polarization energy = -0.00604325393800
+   @RHF iter   3:   -74.97102169871737   -1.67376e-03   2.26989e-03 DIIS
+   PCM polarization energy = -0.00584007082307
+   @RHF iter   4:   -74.97144536175534   -4.23663e-04   2.39646e-04 DIIS
+   PCM polarization energy = -0.00585896310441
+   @RHF iter   5:   -74.97144938276435   -4.02101e-06   3.10916e-05 DIIS
+   PCM polarization energy = -0.00585336411683
+   @RHF iter   6:   -74.97144944190912   -5.91448e-08   1.25824e-05 DIIS
+   PCM polarization energy = -0.00585605324857
+   @RHF iter   7:   -74.97144944821586   -6.30675e-09   1.48808e-07 DIIS
+   PCM polarization energy = -0.00585604659896
+   @RHF iter   8:   -74.97144944821783   -1.96110e-12   1.46015e-08 DIIS
+   PCM polarization energy = -0.00585604360913
+   @RHF iter   9:   -74.97144944821781    1.42109e-14   6.06588e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240873     2A     -1.253942     3A     -0.590107  
+       4A     -0.461087     5A     -0.391902  
+
+    Virtual:                                                              
+
+       6A      0.592472     7A      0.700920  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144944821781
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9106821757222683
+    One-Electron Energy =                -121.9335938969570208
+    Two-Electron Energy =                  38.0573183166260662
+    PCM Polarization Energy =              -0.0058560436091261
+    Total Energy =                        -74.9714494482178111
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0565
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3446
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7119     Total:     0.7119
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8094     Total:     1.8094
+
+
+*** tstop() called on minazo at Wed May  2 19:41:54 2018
+Module time:
+	user time   =       1.81 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      64.65 seconds =       1.08 minutes
+	system time =       0.95 seconds =       0.02 minutes
+	total time  =         66 seconds =       1.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:54 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.754640740681     0.563650687468     1.007825032070
+           H          0.000000000000     0.754640740681     0.563650687447     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.37846  B =     14.68591  C =      9.01982 [cm^-1]
+  Rotational constants: A = 700868.55266  B = 440272.50430  C = 270407.54601 [MHz]
+  Nuclear repulsion =    8.937199022862725
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071030
+   2      H    1.4430   1.00     0.000000     -0.754641     0.563651
+   3      H    1.4430   1.00     0.000000     0.754641     0.563651
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6098554376E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00040223117789
+   @RHF iter   0:   -74.65046008084629   -7.46505e+01   2.01927e-01 
+   PCM polarization energy = -0.00911993862178
+   @RHF iter   1:   -74.96152485107945   -3.11065e-01   1.57121e-02 
+   PCM polarization energy = -0.00582620275350
+   @RHF iter   2:   -74.97084676829706   -9.32192e-03   2.80299e-03 DIIS
+   PCM polarization energy = -0.00589935763350
+   @RHF iter   3:   -74.97132202073104   -4.75252e-04   1.19018e-03 DIIS
+   PCM polarization energy = -0.00587242122673
+   @RHF iter   4:   -74.97144788533660   -1.25865e-04   1.78840e-04 DIIS
+   PCM polarization energy = -0.00588562891334
+   @RHF iter   5:   -74.97145045912281   -2.57379e-06   9.20457e-06 DIIS
+   PCM polarization energy = -0.00588475451958
+   @RHF iter   6:   -74.97145046428567   -5.16286e-09   2.63400e-06 DIIS
+   PCM polarization energy = -0.00588458906697
+   @RHF iter   7:   -74.97145046482213   -5.36460e-10   3.74476e-08 DIIS
+   PCM polarization energy = -0.00588458453960
+   @RHF iter   8:   -74.97145046482218   -5.68434e-14   7.96327e-10 DIIS
+   PCM polarization energy = -0.00588458439159
+   @RHF iter   9:   -74.97145046482220   -1.42109e-14   2.29564e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240807     2A     -1.255564     3A     -0.591027  
+       4A     -0.462102     5A     -0.392213  
+
+    Virtual:                                                              
+
+       6A      0.595669     7A      0.703463  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145046482220
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9371990228627247
+    One-Electron Energy =                -121.9787529734063867
+    Two-Electron Energy =                  38.0759880701130413
+    PCM Polarization Energy =              -0.0058845843915909
+    Total Energy =                        -74.9714504648222118
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0565
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3423
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7141     Total:     0.7141
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8151     Total:     1.8151
+
+
+*** tstop() called on minazo at Wed May  2 19:41:56 2018
+Module time:
+	user time   =       1.94 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      66.62 seconds =       1.11 minutes
+	system time =       0.98 seconds =       0.02 minutes
+	total time  =         68 seconds =       1.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:56 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071030235006    15.994914619560
+           H          0.000000000000    -0.756504387305     0.563650687468     1.007825032070
+           H          0.000000000000     0.756504387305     0.563650687447     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.37846  B =     14.61364  C =      8.99251 [cm^-1]
+  Rotational constants: A = 700868.55266  B = 438105.95586  C = 269588.72643 [MHz]
+  Nuclear repulsion =    8.923926860955445
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071030
+   2      H    1.4430   1.00     0.000000     -0.756504     0.563651
+   3      H    1.4430   1.00     0.000000     0.756504     0.563651
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6191717501E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00034770774282
+   @RHF iter   0:   -74.73746363626030   -7.47375e+01   2.01707e-01 
+   PCM polarization energy = -0.01443785707936
+   @RHF iter   1:   -74.92873105210916   -1.91267e-01   3.09567e-02 
+   PCM polarization energy = -0.00618869000548
+   @RHF iter   2:   -74.96958455088458   -4.08535e-02   5.37178e-03 DIIS
+   PCM polarization energy = -0.00608459450055
+   @RHF iter   3:   -74.97110162677755   -1.51708e-03   2.16263e-03 DIIS
+   PCM polarization energy = -0.00586209560926
+   @RHF iter   4:   -74.97145339964671   -3.51773e-04   2.06200e-04 DIIS
+   PCM polarization energy = -0.00587321001435
+   @RHF iter   5:   -74.97145590583818   -2.50619e-06   1.33389e-05 DIIS
+   PCM polarization energy = -0.00587023244314
+   @RHF iter   6:   -74.97145591276173   -6.92354e-09   3.59620e-07 DIIS
+   PCM polarization energy = -0.00587031253243
+   @RHF iter   7:   -74.97145591276754   -5.81224e-12   6.22603e-09 DIIS
+   PCM polarization energy = -0.00587031387707
+   @RHF iter   8:   -74.97145591276758   -4.26326e-14   3.67488e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240840     2A     -1.254751     3A     -0.590568  
+       4A     -0.461594     5A     -0.392057  
+
+    Virtual:                                                              
+
+       6A      0.594071     7A      0.702191  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145591276758
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9239268609554454
+    One-Electron Energy =                -121.9561614533526637
+    Two-Electron Energy =                  38.0666489935067034
+    PCM Polarization Energy =              -0.0058703138770687
+    Total Energy =                        -74.9714559127675813
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0565
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3435
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8122     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:41:59 2018
+Module time:
+	user time   =       2.12 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      68.79 seconds =       1.15 minutes
+	system time =       1.01 seconds =       0.02 minutes
+	total time  =         71 seconds =       1.18 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -74.9714559128
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -74.9714480048   -74.9714480048     0.0000000000
+	    1    -74.9714504095   -74.9714523716    -0.0001962149
+	    2    -74.9714494482   -74.9714504648    -0.0001016604
+
+	Gradient written.
+
+-------------------------------------------------------------
+  ## F-D gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000001790    -0.00026252269642
+    2     0.00000000000000    -0.00007216549681     0.00013126135572
+    3     0.00000000000000     0.00007216547892     0.00013126134070
+
+
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Internal coordinates to be generated automatically.
+	Detected frag 1 with atoms:  1 2 3
+	---Fragment 1 Bond Connectivity---
+	 1 : 2 3
+	 2 : 1
+	 3 : 1
+
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1342276913
+	 H           0.0000000000       -1.4295861103        1.0651454339
+	 H           0.0000000000        1.4295861103        1.0651454339
+	             0.0000000000        0.0000000000       -0.0002625227
+	             0.0000000000       -0.0000721655        0.0001312614
+	             0.0000000000        0.0000721655        0.0001312613
+
+	Previous optimization step data not found.  Starting new optimization.
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.866069	       0.987481
+	 R(1,3)           =         1.866069	       0.987481
+	 B(2,1,3)         =         1.745487	     100.009034
+
+	Current energy   :       -74.9714559128
+
+	Generating empirical Hessian (Schlegel '84) for each fragment.
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00075
+	Projected energy change by RFO approximation:        -0.0000001810
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.987481    -0.001151    -0.000148     0.987333
+	    2 R(1,3)          =      0.987481    -0.001151    -0.000148     0.987333
+	    3 B(2,1,3)        =    100.009034     0.000008     0.036202   100.045237
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  --------------------------------------------------------------------------------------------- ~
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp    ~
+  --------------------------------------------------------------------------------------------- ~
+    Convergence Criteria             o    1.50e-05 *    1.00e-05 *    6.00e-05 *    4.00e-05 *  ~
+  --------------------------------------------------------------------------------------------- ~
+      1     -74.97145591   -7.50e+01 o    1.40e-04      1.28e-04      6.32e-04      4.30e-04    ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000  -0.0000000000  -0.0708075231
+	    H     0.0000000000  -0.7565915088   0.5635393315
+	    H     0.0000000000   0.7565915088   0.5635393315
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.987333
+    H             1    0.987333      2  100.045237
+
+
+PCM analytic gradients are not implemented yet, re-routing to finite differences.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 7.
+	Translations projected? 1. Rotations projected? 1.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:41:59 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054508109208     0.045484949522     0.000000000000    15.994914619560
+           H          0.054508109208    -0.939916782625     0.000000000000     1.007825032070
+           H         -0.919591357898     0.218037626095     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.40393  B =     14.60986  C =      8.99484 [cm^-1]
+  Rotational constants: A = 701632.22815  B = 437992.55630  C = 269658.66080 [MHz]
+  Nuclear repulsion =    8.925203518215794
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:41 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054508     0.045485     0.000000
+   2      H    1.4430   1.00     0.054508     -0.939917     0.000000
+   3      H    1.4430   1.00     -0.919591     0.218038     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6179444206E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05721217901638
+   @RHF iter   0:   -74.48633267543316   -7.44863e+01   4.95967e-02 
+   PCM polarization energy = -0.01778285820428
+   @RHF iter   1:   -74.85755130075457   -3.71219e-01   4.68100e-02 
+   PCM polarization energy = -0.00626058184522
+   @RHF iter   2:   -74.96203499434083   -1.04484e-01   1.10255e-02 DIIS
+   PCM polarization energy = -0.00606916247597
+   @RHF iter   3:   -74.96982400322744   -7.78901e-03   4.43217e-03 DIIS
+   PCM polarization energy = -0.00584071547962
+   @RHF iter   4:   -74.97142617461273   -1.60217e-03   5.14954e-04 DIIS
+   PCM polarization energy = -0.00588919679226
+   @RHF iter   5:   -74.97144744916292   -2.12746e-05   1.00881e-04 DIIS
+   PCM polarization energy = -0.00587073297093
+   @RHF iter   6:   -74.97144801938775   -5.70225e-07   1.59656e-05 DIIS
+   PCM polarization energy = -0.00587294093247
+   @RHF iter   7:   -74.97144803145071   -1.20630e-08   2.90526e-06 DIIS
+   PCM polarization energy = -0.00587264036120
+   @RHF iter   8:   -74.97144803195067   -4.99966e-10   6.10040e-07 DIIS
+   PCM polarization energy = -0.00587268503538
+   @RHF iter   9:   -74.97144803197963   -2.89617e-11   5.40820e-08 DIIS
+   PCM polarization energy = -0.00587268960893
+   @RHF iter  10:   -74.97144803197986   -2.27374e-13   1.26257e-08 DIIS
+   PCM polarization energy = -0.00587268754598
+   @RHF iter  11:   -74.97144803197988   -1.42109e-14   1.36076e-09 DIIS
+   PCM polarization energy = -0.00587268742154
+   @RHF iter  12:   -74.97144803197985    2.84217e-14   1.71776e-10 DIIS
+   PCM polarization energy = -0.00587268744912
+   @RHF iter  13:   -74.97144803197989   -4.26326e-14   1.42255e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240776     2A     -1.254781     3A     -0.590699  
+       4A     -0.461526     5A     -0.392038  
+
+    Virtual:                                                              
+
+       6A      0.594131     7A      0.702499  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144803197989
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9252035182157936
+    One-Electron Energy =                -121.9586140642938688
+    Two-Electron Energy =                  38.0678352015473109
+    PCM Polarization Energy =              -0.0058726874491201
+    Total Energy =                        -74.9714480319798895
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8107      Y:    -0.6765      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2649      Y:     0.2178      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5458      Y:    -0.4587      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3874      Y:    -1.1659      Z:    -0.0000     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:01 2018
+Module time:
+	user time   =       1.97 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      70.82 seconds =       1.18 minutes
+	system time =       1.04 seconds =       0.02 minutes
+	total time  =         73 seconds =       1.22 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:01 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054295273593     0.045738800464     0.000000000000    15.994914619560
+           H          0.054295273593    -0.943525672761     0.000000000000     1.007825032070
+           H         -0.916000666622     0.217617717562     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.40393  B =     14.60986  C =      8.99484 [cm^-1]
+  Rotational constants: A = 701632.22815  B = 437992.55630  C = 269658.66080 [MHz]
+  Nuclear repulsion =    8.925203518215209
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054295     0.045739     0.000000
+   2      H    1.4430   1.00     0.054295     -0.943526     0.000000
+   3      H    1.4430   1.00     -0.916001     0.217618     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6179444206E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00587349652143
+   @RHF iter   0:   -74.97147589524340   -7.49715e+01   1.87179e-03 
+   PCM polarization energy = -0.00587262053117
+   @RHF iter   1:   -74.97144801227522    2.78830e-05   2.31989e-05 
+   PCM polarization energy = -0.00587269164994
+   @RHF iter   2:   -74.97144802963015   -1.73549e-08   5.98052e-06 DIIS
+   PCM polarization energy = -0.00587268630518
+   @RHF iter   3:   -74.97144803182933   -2.19917e-09   1.52754e-06 DIIS
+   PCM polarization energy = -0.00587268749171
+   @RHF iter   4:   -74.97144803197972   -1.50393e-10   8.58382e-08 DIIS
+   PCM polarization energy = -0.00587268732572
+   @RHF iter   5:   -74.97144803197997   -2.55795e-13   7.74470e-10 DIIS
+   PCM polarization energy = -0.00587268743302
+   @RHF iter   6:   -74.97144803197996    1.42109e-14   2.89671e-10 DIIS
+   PCM polarization energy = -0.00587268744199
+   @RHF iter   7:   -74.97144803197989    7.10543e-14   8.04924e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240776     2A     -1.254781     3A     -0.590699  
+       4A     -0.461526     5A     -0.392038  
+
+    Virtual:                                                              
+
+       6A      0.594131     7A      0.702499  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144803197989
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9252035182152092
+    One-Electron Energy =                -121.9586140636848057
+    Two-Electron Energy =                  38.0678352009316825
+    PCM Polarization Energy =              -0.0058726874419861
+    Total Energy =                        -74.9714480319799037
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8076      Y:    -0.6803      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2607      Y:     0.2228      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5469      Y:    -0.4575      Z:     0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3900      Y:    -1.1627      Z:     0.0000     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:02 2018
+Module time:
+	user time   =       1.40 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      72.25 seconds =       1.20 minutes
+	system time =       1.07 seconds =       0.02 minutes
+	total time  =         74 seconds =       1.23 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:02 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071214169589    15.994914619560
+           H          0.000000000000    -0.756591508821     0.565110275102     1.007825032070
+           H          0.000000000000     0.756591508821     0.565110275120     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.25785  B =     14.61028  C =      8.97334 [cm^-1]
+  Rotational constants: A = 697252.76991  B = 438005.06586  C = 269013.99469 [MHz]
+  Nuclear repulsion =    8.914139760096791
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071214
+   2      H    1.4430   1.00     0.000000     -0.756592     0.565110
+   3      H    1.4430   1.00     0.000000     0.756592     0.565110
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6265738267E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05705120872124
+   @RHF iter   0:   -74.48605599791118   -7.44861e+01   4.98487e-02 
+   PCM polarization energy = -0.01688953204920
+   @RHF iter   1:   -74.85854341709195   -3.72487e-01   4.60958e-02 
+   PCM polarization energy = -0.00619212352913
+   @RHF iter   2:   -74.96082018150553   -1.02277e-01   1.12064e-02 DIIS
+   PCM polarization energy = -0.00610607656293
+   @RHF iter   3:   -74.96927904189715   -8.45886e-03   4.97443e-03 DIIS
+   PCM polarization energy = -0.00580516776768
+   @RHF iter   4:   -74.97143697291745   -2.15793e-03   4.53667e-04 DIIS
+   PCM polarization energy = -0.00587772542334
+   @RHF iter   5:   -74.97145099745380   -1.40245e-05   1.21864e-04 DIIS
+   PCM polarization energy = -0.00585947963772
+   @RHF iter   6:   -74.97145168679397   -6.89340e-07   1.84018e-05 DIIS
+   PCM polarization energy = -0.00586169293033
+   @RHF iter   7:   -74.97145170871244   -2.19185e-08   3.50906e-06 DIIS
+   PCM polarization energy = -0.00586148781845
+   @RHF iter   8:   -74.97145170958066   -8.68226e-10   5.52487e-07 DIIS
+   PCM polarization energy = -0.00586153313619
+   @RHF iter   9:   -74.97145170960314   -2.24816e-11   7.95877e-08 DIIS
+   PCM polarization energy = -0.00586153419524
+   @RHF iter  10:   -74.97145170960377   -6.25278e-13   1.40124e-08 DIIS
+   PCM polarization energy = -0.00586153224660
+   @RHF iter  11:   -74.97145170960368    8.52651e-14   7.05517e-10 DIIS
+   PCM polarization energy = -0.00586153229672
+   @RHF iter  12:   -74.97145170960371   -2.84217e-14   1.37378e-10 DIIS
+   PCM polarization energy = -0.00586153231140
+   @RHF iter  13:   -74.97145170960368    2.84217e-14   2.13223e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241120     2A     -1.254360     3A     -0.589761  
+       4A     -0.461751     5A     -0.392079  
+
+    Virtual:                                                              
+
+       6A      0.593203     7A      0.700563  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145170960368
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9141397600967913
+    One-Electron Energy =                -121.9381110443727039
+    Two-Electron Energy =                  38.0583811069836315
+    PCM Polarization Energy =              -0.0058615323113961
+    Total Energy =                        -74.9714517096036843
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0592
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3463
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7129     Total:     0.7129
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     1.8119     Total:     1.8119
+
+
+*** tstop() called on minazo at Wed May  2 19:42:04 2018
+Module time:
+	user time   =       1.98 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      74.26 seconds =       1.24 minutes
+	system time =       1.09 seconds =       0.02 minutes
+	total time  =         76 seconds =       1.27 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:04 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070771526109    15.994914619560
+           H          0.000000000000    -0.756591508821     0.561597738479     1.007825032070
+           H          0.000000000000     0.756591508821     0.561597738497     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.54969  B =     14.61028  C =      9.01645 [cm^-1]
+  Rotational constants: A = 706002.03936  B = 438005.06586  C = 270306.42409 [MHz]
+  Nuclear repulsion =    8.936210773152688
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070772
+   2      H    1.4430   1.00     0.000000     -0.756592     0.561598
+   3      H    1.4430   1.00     0.000000     0.756592     0.561598
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6098358202E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00579560712706
+   @RHF iter   0:   -74.97386290074485   -7.49739e+01   9.48804e-04 
+   PCM polarization energy = -0.00587375368636
+   @RHF iter   1:   -74.97145042444532    2.41248e-03   9.81571e-05 
+   PCM polarization energy = -0.00587793316130
+   @RHF iter   2:   -74.97145102296993   -5.98525e-07   4.28292e-05 DIIS
+   PCM polarization energy = -0.00588079188674
+   @RHF iter   3:   -74.97145116577123   -1.42801e-07   9.67250e-07 DIIS
+   PCM polarization energy = -0.00588090503361
+   @RHF iter   4:   -74.97145116583424   -6.30109e-11   9.76661e-08 DIIS
+   PCM polarization energy = -0.00588091140749
+   @RHF iter   5:   -74.97145116583445   -2.13163e-13   1.02439e-08 DIIS
+   PCM polarization energy = -0.00588091272124
+   @RHF iter   6:   -74.97145116583452   -7.10543e-14   3.49274e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240448     2A     -1.255209     3A     -0.591652  
+       4A     -0.461315     5A     -0.392008  
+
+    Virtual:                                                              
+
+       6A      0.595108     7A      0.704341  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145116583452
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9362107731526876
+    One-Electron Energy =                -121.9790166857675615
+    Two-Electron Energy =                  38.0772356595015964
+    PCM Polarization Energy =              -0.0058809127212389
+    Total Energy =                        -74.9714511658345231
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0526
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3396
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     1.8124     Total:     1.8124
+
+
+*** tstop() called on minazo at Wed May  2 19:42:05 2018
+Module time:
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      75.61 seconds =       1.26 minutes
+	system time =       1.11 seconds =       0.02 minutes
+	total time  =         77 seconds =       1.28 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:05 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070992847849    15.994914619560
+           H          0.000000000000    -0.758455155446     0.563354006791     1.007825032070
+           H          0.000000000000     0.758455155446     0.563354006808     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.40309  B =     14.53856  C =      8.96765 [cm^-1]
+  Rotational constants: A = 701606.94767  B = 435855.21222  C = 268843.26869 [MHz]
+  Nuclear repulsion =    8.911919697362016
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070993
+   2      H    1.4430   1.00     0.000000     -0.758455     0.563354
+   3      H    1.4430   1.00     0.000000     0.758455     0.563354
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6275260232E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00593057457812
+   @RHF iter   0:   -74.96924079079733   -7.49692e+01   9.58549e-04 
+   PCM polarization energy = -0.00586216518437
+   @RHF iter   1:   -74.97144973138985   -2.20894e-03   4.80387e-05 
+   PCM polarization energy = -0.00585835139770
+   @RHF iter   2:   -74.97144987309434   -1.41704e-07   2.06070e-05 DIIS
+   PCM polarization energy = -0.00585724412936
+   @RHF iter   3:   -74.97144990578830   -3.26940e-08   2.08491e-06 DIIS
+   PCM polarization energy = -0.00585701467464
+   @RHF iter   4:   -74.97144990612851   -3.40208e-10   6.68825e-08 DIIS
+   PCM polarization energy = -0.00585701208186
+   @RHF iter   5:   -74.97144990612878   -2.70006e-13   1.24154e-08 DIIS
+   PCM polarization energy = -0.00585701092465
+   @RHF iter   6:   -74.97144990612878    0.00000e+00   7.90254e-13 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240818     2A     -1.253975     3A     -0.590244  
+       4A     -0.461027     5A     -0.391888  
+
+    Virtual:                                                              
+
+       6A      0.592557     7A      0.701179  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144990612878
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9119196973620163
+    One-Electron Energy =                -121.9359838772842437
+    Two-Electron Energy =                  38.0584712847180953
+    PCM Polarization Energy =              -0.0058570109246474
+    Total Energy =                        -74.9714499061287682
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0559
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.3441
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7118     Total:     0.7118
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     1.8093     Total:     1.8093
+
+
+*** tstop() called on minazo at Wed May  2 19:42:07 2018
+Module time:
+	user time   =       1.39 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      77.03 seconds =       1.28 minutes
+	system time =       1.14 seconds =       0.02 minutes
+	total time  =         79 seconds =       1.32 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:07 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070992847849    15.994914619560
+           H          0.000000000000    -0.754727862197     0.563354006791     1.007825032070
+           H          0.000000000000     0.754727862197     0.563354006808     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.40309  B =     14.68252  C =      9.02221 [cm^-1]
+  Rotational constants: A = 701606.94767  B = 440170.86503  C = 270479.01407 [MHz]
+  Nuclear repulsion =    8.938450149702614
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070993
+   2      H    1.4430   1.00     0.000000     -0.754728     0.563354
+   3      H    1.4430   1.00     0.000000     0.754728     0.563354
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6088728744E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00582648507189
+   @RHF iter   0:   -74.97349009081712   -7.49735e+01   9.85848e-04 
+   PCM polarization energy = -0.00588253621291
+   @RHF iter   1:   -74.97145008137345    2.04001e-03   2.07432e-05 
+   PCM polarization energy = -0.00588588308057
+   @RHF iter   2:   -74.97145009416668   -1.27932e-08   2.06667e-06 DIIS
+   PCM polarization energy = -0.00588562039660
+   @RHF iter   3:   -74.97145009441061   -2.43929e-10   8.32378e-07 DIIS
+   PCM polarization energy = -0.00588557350173
+   @RHF iter   4:   -74.97145009446265   -5.20401e-11   1.33567e-07 DIIS
+   PCM polarization energy = -0.00588556326717
+   @RHF iter   5:   -74.97145009446402   -1.36424e-12   2.51826e-09 DIIS
+   PCM polarization energy = -0.00588556347456
+   @RHF iter   6:   -74.97145009446405   -2.84217e-14   5.05679e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240752     2A     -1.255598     3A     -0.591166  
+       4A     -0.462042     5A     -0.392200  
+
+    Virtual:                                                              
+
+       6A      0.595756     7A      0.703723  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145009446405
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9384501497026143
+    One-Electron Energy =                -121.9811619096364410
+    Two-Electron Energy =                  38.0771472289443551
+    PCM Polarization Energy =              -0.0058855634745638
+    Total Energy =                        -74.9714500944640321
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0559
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.3418
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7141     Total:     0.7141
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     1.8150     Total:     1.8150
+
+
+*** tstop() called on minazo at Wed May  2 19:42:08 2018
+Module time:
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      78.41 seconds =       1.31 minutes
+	system time =       1.16 seconds =       0.02 minutes
+	total time  =         80 seconds =       1.33 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:08 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070992847849    15.994914619560
+           H          0.000000000000    -0.756591508821     0.563354006791     1.007825032070
+           H          0.000000000000     0.756591508821     0.563354006808     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.40309  B =     14.61028  C =      8.99488 [cm^-1]
+  Rotational constants: A = 701606.94767  B = 438005.06586  C = 269659.66809 [MHz]
+  Nuclear repulsion =    8.925171166449184
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070993
+   2      H    1.4430   1.00     0.000000     -0.756592     0.563354
+   3      H    1.4430   1.00     0.000000     0.756592     0.563354
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6181934859E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00590114447942
+   @RHF iter   0:   -74.97045022485187   -7.49705e+01   4.91899e-04 
+   PCM polarization energy = -0.00587275990369
+   @RHF iter   1:   -74.97145594806608   -1.00572e-03   1.02189e-05 
+   PCM polarization energy = -0.00587111741740
+   @RHF iter   2:   -74.97145595117527   -3.10919e-09   1.05040e-06 DIIS
+   PCM polarization energy = -0.00587124842904
+   @RHF iter   3:   -74.97145595123888   -6.36078e-11   4.26183e-07 DIIS
+   PCM polarization energy = -0.00587127230533
+   @RHF iter   4:   -74.97145595125259   -1.37135e-11   6.59408e-08 DIIS
+   PCM polarization energy = -0.00587127738998
+   @RHF iter   5:   -74.97145595125293   -3.41061e-13   1.05106e-09 DIIS
+   PCM polarization energy = -0.00587127730230
+   @RHF iter   6:   -74.97145595125299   -5.68434e-14   1.30198e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240784     2A     -1.254785     3A     -0.590706  
+       4A     -0.461534     5A     -0.392043  
+
+    Virtual:                                                              
+
+       6A      0.594157     7A      0.702451  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145595125299
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9251711664491840
+    One-Electron Energy =                -121.9585608344492300
+    Two-Electron Energy =                  38.0678049940493537
+    PCM Polarization Energy =              -0.0058712773023035
+    Total Energy =                        -74.9714559512529917
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0559
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.3430
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     1.8122     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:10 2018
+Module time:
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      79.80 seconds =       1.33 minutes
+	system time =       1.19 seconds =       0.02 minutes
+	total time  =         82 seconds =       1.37 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -74.9714559513
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -74.9714480320   -74.9714480320     0.0000000000
+	    1    -74.9714517096   -74.9714511658     0.0000543769
+	    2    -74.9714499061   -74.9714500945    -0.0000188335
+
+	Gradient written.
+
+-------------------------------------------------------------
+  ## F-D gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000     0.00007275275445
+    2     0.00000000000000    -0.00001336931689    -0.00003637637723
+    3     0.00000000000000     0.00001336931689    -0.00003637637723
+
+
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1341570398
+	 H           0.0000000000       -1.4297507461        1.0645847887
+	 H           0.0000000000        1.4297507461        1.0645847887
+	             0.0000000000        0.0000000000        0.0000727528
+	             0.0000000000       -0.0000133693       -0.0000363764
+	             0.0000000000        0.0000133693       -0.0000363764
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.865789	       0.987333
+	 R(1,3)           =         1.865789	       0.987333
+	 B(2,1,3)         =         1.746119	     100.045237
+
+	Current energy   :       -74.9714559513
+
+	Energy change for the previous step:
+		Projected    :        -0.0000001810
+		Actual       :        -0.0000000385
+	Energy ratio indicates iffy step: Trust radius decreased to 1.250e-01.
+
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Steps to be used in Hessian update: 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00029
+	Projected energy change by RFO approximation:        -0.0000000203
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.987333     0.000108     0.000004     0.987337
+	    2 R(1,3)          =      0.987333     0.000108     0.000004     0.987337
+	    3 B(2,1,3)        =    100.045237    -0.000005    -0.016349   100.028887
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria             o    1.50e-05 *    1.00e-05 *    6.00e-05 *    4.00e-05 *
+  ---------------------------------------------------------------------------------------------
+      2     -74.97145595   -3.85e-08 o    6.80e-05      4.07e-05      2.85e-04      1.65e-04    ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000  -0.0000000000  -0.0710663404
+	    H     0.0000000000  -0.7565037346   0.5633907531
+	    H     0.0000000000   0.7565037346   0.5633907531
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.987337
+    H             1    0.987337      2  100.028887
+
+
+PCM analytic gradients are not implemented yet, re-routing to finite differences.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 7.
+	Translations projected? 1. Rotations projected? 1.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:10 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054511058388     0.045500670217     0.000000000000    15.994914619560
+           H          0.054511058388    -0.939904653490     0.000000000000     1.007825032070
+           H         -0.919641112700     0.217775998119     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39580  B =     14.61325  C =      8.99493 [cm^-1]
+  Rotational constants: A = 701388.45510  B = 438094.18243  C = 269661.15295 [MHz]
+  Nuclear repulsion =    8.925213036625758
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054511     0.045501     0.000000
+   2      H    1.4430   1.00     0.054511     -0.939905     0.000000
+   3      H    1.4430   1.00     -0.919641     0.217776     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6179717963E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05725473535478
+   @RHF iter   0:   -74.48606323297653   -7.44861e+01   4.95964e-02 
+   PCM polarization energy = -0.01778565418386
+   @RHF iter   1:   -74.85756052284755   -3.71497e-01   4.68085e-02 
+   PCM polarization energy = -0.00626059806131
+   @RHF iter   2:   -74.96203721046385   -1.04477e-01   1.10250e-02 DIIS
+   PCM polarization energy = -0.00606930012886
+   @RHF iter   3:   -74.96982460219841   -7.78739e-03   4.43160e-03 DIIS
+   PCM polarization energy = -0.00584086815428
+   @RHF iter   4:   -74.97142618456481   -1.60158e-03   5.14951e-04 DIIS
+   PCM polarization energy = -0.00588932884580
+   @RHF iter   5:   -74.97144746083822   -2.12763e-05   1.00854e-04 DIIS
+   PCM polarization energy = -0.00587086923919
+   @RHF iter   6:   -74.97144803094251   -5.70104e-07   1.59604e-05 DIIS
+   PCM polarization energy = -0.00587307638009
+   @RHF iter   7:   -74.97144804299775   -1.20552e-08   2.90475e-06 DIIS
+   PCM polarization energy = -0.00587277582859
+   @RHF iter   8:   -74.97144804349770   -4.99952e-10   6.10002e-07 DIIS
+   PCM polarization energy = -0.00587282053262
+   @RHF iter   9:   -74.97144804352669   -2.89901e-11   5.40684e-08 DIIS
+   PCM polarization energy = -0.00587282510307
+   @RHF iter  10:   -74.97144804352688   -1.84741e-13   1.26276e-08 DIIS
+   PCM polarization energy = -0.00587282303881
+   @RHF iter  11:   -74.97144804352693   -5.68434e-14   1.35711e-09 DIIS
+   PCM polarization energy = -0.00587282291459
+   @RHF iter  12:   -74.97144804352691    2.84217e-14   1.71575e-10 DIIS
+   PCM polarization energy = -0.00587282294214
+   @RHF iter  13:   -74.97144804352693   -2.84217e-14   1.42208e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240793     2A     -1.254795     3A     -0.590668  
+       4A     -0.461562     5A     -0.392047  
+
+    Virtual:                                                              
+
+       6A      0.594153     7A      0.702453  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804352693
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9252130366257578
+    One-Electron Energy =                -121.9585377362134579
+    Two-Electron Energy =                  38.0677494790028987
+    PCM Polarization Energy =              -0.0058728229421368
+    Total Energy =                        -74.9714480435269337
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8108      Y:    -0.6768      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2650      Y:     0.2180      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5458      Y:    -0.4588      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3873      Y:    -1.1661      Z:    -0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:12 2018
+Module time:
+	user time   =       1.94 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      81.79 seconds =       1.36 minutes
+	system time =       1.21 seconds =       0.02 minutes
+	total time  =         84 seconds =       1.40 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:12 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054298213777     0.045754458333     0.000000000000    15.994914619560
+           H          0.054298213777    -0.943513574615     0.000000000000     1.007825032070
+           H         -0.916050269667     0.217357117677     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39580  B =     14.61325  C =      8.99493 [cm^-1]
+  Rotational constants: A = 701388.45510  B = 438094.18243  C = 269661.15295 [MHz]
+  Nuclear repulsion =    8.925213036625118
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054298     0.045754     0.000000
+   2      H    1.4430   1.00     0.054298     -0.943514     0.000000
+   3      H    1.4430   1.00     -0.916050     0.217357     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6179717963E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00587363203183
+   @RHF iter   0:   -74.97147590498905   -7.49715e+01   1.87180e-03 
+   PCM polarization energy = -0.00587275602378
+   @RHF iter   1:   -74.97144802381003    2.78812e-05   2.32007e-05 
+   PCM polarization energy = -0.00587282714516
+   @RHF iter   2:   -74.97144804117509   -1.73651e-08   5.98311e-06 DIIS
+   PCM polarization energy = -0.00587282179704
+   @RHF iter   3:   -74.97144804337627   -2.20118e-09   1.52785e-06 DIIS
+   PCM polarization energy = -0.00587282298464
+   @RHF iter   4:   -74.97144804352676   -1.50493e-10   8.56852e-08 DIIS
+   PCM polarization energy = -0.00587282281863
+   @RHF iter   5:   -74.97144804352706   -2.98428e-13   7.70625e-10 DIIS
+   PCM polarization energy = -0.00587282292602
+   @RHF iter   6:   -74.97144804352713   -7.10543e-14   2.88427e-10 DIIS
+   PCM polarization energy = -0.00587282293498
+   @RHF iter   7:   -74.97144804352706    7.10543e-14   8.07782e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240793     2A     -1.254795     3A     -0.590668  
+       4A     -0.461562     5A     -0.392047  
+
+    Virtual:                                                              
+
+       6A      0.594153     7A      0.702453  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804352706
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9252130366251183
+    One-Electron Energy =                -121.9585377356041391
+    Two-Electron Energy =                  38.0677494783869363
+    PCM Polarization Energy =              -0.0058728229349773
+    Total Energy =                        -74.9714480435270616
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8076      Y:    -0.6805      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2608      Y:     0.2230      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5468      Y:    -0.4576      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3899      Y:    -1.1630      Z:    -0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:13 2018
+Module time:
+	user time   =       1.40 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      83.22 seconds =       1.39 minutes
+	system time =       1.23 seconds =       0.02 minutes
+	total time  =         85 seconds =       1.42 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:13 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071226506950    15.994914619560
+           H          0.000000000000    -0.756503734630     0.565208176539     1.007825032070
+           H          0.000000000000     0.756503734630     0.565208176559     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.24979  B =     14.61367  C =      8.97342 [cm^-1]
+  Rotational constants: A = 697011.24425  B = 438106.71181  C = 269016.36317 [MHz]
+  Nuclear repulsion =    8.914147489017898
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071227
+   2      H    1.4430   1.00     0.000000     -0.756504     0.565208
+   3      H    1.4430   1.00     0.000000     0.756504     0.565208
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6266034940E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05707446249668
+   @RHF iter   0:   -74.48594239164346   -7.44859e+01   4.98515e-02 
+   PCM polarization energy = -0.01689422162988
+   @RHF iter   1:   -74.85851863893495   -3.72576e-01   4.61027e-02 
+   PCM polarization energy = -0.00619195845173
+   @RHF iter   2:   -74.96081975026894   -1.02301e-01   1.12067e-02 DIIS
+   PCM polarization energy = -0.00610621638309
+   @RHF iter   3:   -74.96927858239381   -8.45883e-03   4.97472e-03 DIIS
+   PCM polarization energy = -0.00580528338507
+   @RHF iter   4:   -74.97143674231461   -2.15816e-03   4.53739e-04 DIIS
+   PCM polarization energy = -0.00587785227153
+   @RHF iter   5:   -74.97145077195866   -1.40296e-05   1.21874e-04 DIIS
+   PCM polarization energy = -0.00585960374201
+   @RHF iter   6:   -74.97145146155817   -6.89600e-07   1.84035e-05 DIIS
+   PCM polarization energy = -0.00586181702113
+   @RHF iter   7:   -74.97145148348028   -2.19221e-08   3.50975e-06 DIIS
+   PCM polarization energy = -0.00586161195494
+   @RHF iter   8:   -74.97145148434905   -8.68766e-10   5.52663e-07 DIIS
+   PCM polarization energy = -0.00586165728567
+   @RHF iter   9:   -74.97145148437146   -2.24105e-11   7.96245e-08 DIIS
+   PCM polarization energy = -0.00586165834467
+   @RHF iter  10:   -74.97145148437208   -6.25278e-13   1.40141e-08 DIIS
+   PCM polarization energy = -0.00586165639391
+   @RHF iter  11:   -74.97145148437207    1.42109e-14   7.05508e-10 DIIS
+   PCM polarization energy = -0.00586165644428
+   @RHF iter  12:   -74.97145148437212   -5.68434e-14   1.36998e-10 DIIS
+   PCM polarization energy = -0.00586165645896
+   @RHF iter  13:   -74.97145148437214   -1.42109e-14   2.12969e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241137     2A     -1.254374     3A     -0.589730  
+       4A     -0.461787     5A     -0.392088  
+
+    Virtual:                                                              
+
+       6A      0.593225     7A      0.700518  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145148437214
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9141474890178980
+    One-Electron Energy =                -121.9380320838738783
+    Two-Electron Energy =                  38.0582947669428151
+    PCM Polarization Energy =              -0.0058616564589562
+    Total Energy =                        -74.9714514843721247
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0594
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3465
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7129     Total:     0.7129
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     1.8120     Total:     1.8120
+
+
+*** tstop() called on minazo at Wed May  2 19:42:15 2018
+Module time:
+	user time   =       1.97 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      85.23 seconds =       1.42 minutes
+	system time =       1.26 seconds =       0.02 minutes
+	total time  =         87 seconds =       1.45 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:15 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070783863470    15.994914619560
+           H          0.000000000000    -0.756503734630     0.561695639916     1.007825032070
+           H          0.000000000000     0.756503734630     0.561695639936     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.54148  B =     14.61367  C =      9.01654 [cm^-1]
+  Rotational constants: A = 705755.95381  B = 438106.71181  C = 270309.04107 [MHz]
+  Nuclear repulsion =    8.936222097844077
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070784
+   2      H    1.4430   1.00     0.000000     -0.756504     0.561696
+   3      H    1.4430   1.00     0.000000     0.756504     0.561696
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6098608773E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00579573241128
+   @RHF iter   0:   -74.97386359005641   -7.49739e+01   9.48982e-04 
+   PCM polarization energy = -0.00587389088084
+   @RHF iter   1:   -74.97145066168814    2.41293e-03   9.81617e-05 
+   PCM polarization energy = -0.00587807107205
+   @RHF iter   2:   -74.97145126024884   -5.98561e-07   4.28312e-05 DIIS
+   PCM polarization energy = -0.00588092905612
+   @RHF iter   3:   -74.97145140305821   -1.42809e-07   9.68387e-07 DIIS
+   PCM polarization energy = -0.00588104242657
+   @RHF iter   4:   -74.97145140312135   -6.31388e-11   9.79605e-08 DIIS
+   PCM polarization energy = -0.00588104881831
+   @RHF iter   5:   -74.97145140312163   -2.84217e-13   1.02767e-08 DIIS
+   PCM polarization energy = -0.00588105013663
+   @RHF iter   6:   -74.97145140312159    4.26326e-14   3.49213e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240465     2A     -1.255224     3A     -0.591621  
+       4A     -0.461351     5A     -0.392017  
+
+    Virtual:                                                              
+
+       6A      0.595130     7A      0.704296  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145140312159
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9362220978440767
+    One-Electron Energy =                -121.9789429451005560
+    Two-Electron Energy =                  38.0771504942714998
+    PCM Polarization Energy =              -0.0058810501366252
+    Total Energy =                        -74.9714514031215913
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0528
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.3397
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7131     Total:     0.7131
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     1.8125     Total:     1.8125
+
+
+*** tstop() called on minazo at Wed May  2 19:42:17 2018
+Module time:
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      86.54 seconds =       1.44 minutes
+	system time =       1.29 seconds =       0.02 minutes
+	total time  =         89 seconds =       1.48 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:17 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071005185210    15.994914619560
+           H          0.000000000000    -0.758367381254     0.563451908228     1.007825032070
+           H          0.000000000000     0.758367381254     0.563451908247     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39496  B =     14.54193  C =      8.96773 [cm^-1]
+  Rotational constants: A = 701363.15628  B = 435956.11068  C = 268845.84010 [MHz]
+  Nuclear repulsion =    8.911930584988554
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.758367     0.563452
+   3      H    1.4430   1.00     0.000000     0.758367     0.563452
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6275515982E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00593071119456
+   @RHF iter   0:   -74.96924114291497   -7.49692e+01   9.58597e-04 
+   PCM polarization energy = -0.00586229240524
+   @RHF iter   1:   -74.97144997814102   -2.20884e-03   4.80300e-05 
+   PCM polarization energy = -0.00585848258861
+   @RHF iter   2:   -74.97145011977950   -1.41638e-07   2.06031e-05 DIIS
+   PCM polarization energy = -0.00585737576019
+   @RHF iter   3:   -74.97145015246076   -3.26813e-08   2.08298e-06 DIIS
+   PCM polarization energy = -0.00585714646003
+   @RHF iter   4:   -74.97145015280043   -3.39668e-10   6.71108e-08 DIIS
+   PCM polarization energy = -0.00585714385294
+   @RHF iter   5:   -74.97145015280063   -1.98952e-13   1.24773e-08 DIIS
+   PCM polarization energy = -0.00585714268949
+   @RHF iter   6:   -74.97145015280063    0.00000e+00   7.88771e-13 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240835     2A     -1.253990     3A     -0.590214  
+       4A     -0.461063     5A     -0.391897  
+
+    Virtual:                                                              
+
+       6A      0.592580     7A      0.701134  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145015280063
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9119305849885535
+    One-Electron Energy =                -121.9359098710267233
+    Two-Electron Energy =                  38.0583862759270346
+    PCM Polarization Energy =              -0.0058571426894913
+    Total Energy =                        -74.9714501528006281
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3442
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7119     Total:     0.7119
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     1.8094     Total:     1.8094
+
+
+*** tstop() called on minazo at Wed May  2 19:42:18 2018
+Module time:
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      87.91 seconds =       1.47 minutes
+	system time =       1.32 seconds =       0.02 minutes
+	total time  =         90 seconds =       1.50 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:18 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071005185210    15.994914619560
+           H          0.000000000000    -0.754640088005     0.563451908228     1.007825032070
+           H          0.000000000000     0.754640088005     0.563451908247     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39496  B =     14.68594  C =      9.02229 [cm^-1]
+  Rotational constants: A = 701363.15628  B = 440273.26587  C = 270481.42595 [MHz]
+  Nuclear repulsion =    8.938458289624617
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.754640     0.563452
+   3      H    1.4430   1.00     0.000000     0.754640     0.563452
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6089020379E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00582661742278
+   @RHF iter   0:   -74.97348920376841   -7.49735e+01   9.85762e-04 
+   PCM polarization energy = -0.00588267525993
+   @RHF iter   1:   -74.97144984830489    2.03936e-03   2.07140e-05 
+   PCM polarization energy = -0.00588601347342
+   @RHF iter   2:   -74.97144986105981   -1.27549e-08   2.07384e-06 DIIS
+   PCM polarization energy = -0.00588575045976
+   @RHF iter   3:   -74.97144986130590   -2.46089e-10   8.36449e-07 DIIS
+   PCM polarization energy = -0.00588570321861
+   @RHF iter   4:   -74.97144986135838   -5.24807e-11   1.33222e-07 DIIS
+   PCM polarization energy = -0.00588569301162
+   @RHF iter   5:   -74.97144986135986   -1.47793e-12   2.57608e-09 DIIS
+   PCM polarization energy = -0.00588569322350
+   @RHF iter   6:   -74.97144986135983    2.84217e-14   5.27555e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240769     2A     -1.255613     3A     -0.591135  
+       4A     -0.462078     5A     -0.392209  
+
+    Virtual:                                                              
+
+       6A      0.595778     7A      0.703677  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144986135983
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9384582896246165
+    One-Electron Energy =                -121.9810831793440826
+    Two-Electron Energy =                  38.0770607215831234
+    PCM Polarization Energy =              -0.0058856932234951
+    Total Energy =                        -74.9714498613598295
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.3420
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7141     Total:     0.7141
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     1.8151     Total:     1.8151
+
+
+*** tstop() called on minazo at Wed May  2 19:42:20 2018
+Module time:
+	user time   =       1.50 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      89.46 seconds =       1.49 minutes
+	system time =       1.34 seconds =       0.02 minutes
+	total time  =         92 seconds =       1.53 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:20 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071005185210    15.994914619560
+           H          0.000000000000    -0.756503734630     0.563451908228     1.007825032070
+           H          0.000000000000     0.756503734630     0.563451908247     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39496  B =     14.61367  C =      8.99496 [cm^-1]
+  Rotational constants: A = 701363.15628  B = 438106.71181  C = 269662.16026 [MHz]
+  Nuclear repulsion =    8.925180686049908
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.756504     0.563452
+   3      H    1.4430   1.00     0.000000     0.756504     0.563452
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6182208501E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00590127781332
+   @RHF iter   0:   -74.97045056477111   -7.49705e+01   4.91856e-04 
+   PCM polarization energy = -0.00587289039670
+   @RHF iter   1:   -74.97145595901907   -1.00539e-03   1.02045e-05 
+   PCM polarization energy = -0.00587125226660
+   @RHF iter   2:   -74.97145596211912   -3.10006e-09   1.05408e-06 DIIS
+   PCM polarization energy = -0.00587138344794
+   @RHF iter   3:   -74.97145596218321   -6.40910e-11   4.28239e-07 DIIS
+   PCM polarization energy = -0.00587140750026
+   @RHF iter   4:   -74.97145596219704   -1.38272e-11   6.57554e-08 DIIS
+   PCM polarization energy = -0.00587141257040
+   @RHF iter   5:   -74.97145596219741   -3.69482e-13   1.08117e-09 DIIS
+   PCM polarization energy = -0.00587141248034
+   @RHF iter   6:   -74.97145596219738    2.84217e-14   1.44321e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240802     2A     -1.254799     3A     -0.590675  
+       4A     -0.461570     5A     -0.392053  
+
+    Virtual:                                                              
+
+       6A      0.594179     7A      0.702405  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145596219738
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9251806860499077
+    One-Electron Energy =                -121.9584845010017773
+    Two-Electron Energy =                  38.0677192652348282
+    PCM Polarization Energy =              -0.0058714124803385
+    Total Energy =                        -74.9714559621973677
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.3431
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     1.8123     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:21 2018
+Module time:
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      90.78 seconds =       1.51 minutes
+	system time =       1.37 seconds =       0.02 minutes
+	total time  =         93 seconds =       1.55 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -74.9714559622
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -74.9714480435   -74.9714480435    -0.0000000000
+	    1    -74.9714514844   -74.9714514031     0.0000081251
+	    2    -74.9714501528   -74.9714498614     0.0000291441
+
+	Gradient written.
+
+-------------------------------------------------------------
+  ## F-D gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000    -0.00000000001343     0.00001087079143
+    2     0.00000000000000     0.00002068845513    -0.00000543540135
+    3     0.00000000000000    -0.00002068844171    -0.00000543539009
+
+
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1341803541
+	 H           0.0000000000       -1.4295848770        1.0647697956
+	 H           0.0000000000        1.4295848770        1.0647697956
+	             0.0000000000       -0.0000000000        0.0000108708
+	             0.0000000000        0.0000206885       -0.0000054354
+	             0.0000000000       -0.0000206884       -0.0000054354
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.865796	       0.987337
+	 R(1,3)           =         1.865796	       0.987337
+	 B(2,1,3)         =         1.745833	     100.028887
+
+	Current energy   :       -74.9714559622
+
+	Energy change for the previous step:
+		Projected    :        -0.0000000203
+		Actual       :        -0.0000000109
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 2.
+	Steps to be used in Hessian update: 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00011
+	Projected energy change by RFO approximation:        -0.0000000033
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.987337     0.000159     0.000021     0.987357
+	    2 R(1,3)          =      0.987337     0.000159     0.000021     0.987357
+	    3 B(2,1,3)        =    100.028887     0.000001     0.005245   100.034133
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria             o    1.50e-05 *    1.00e-05 *    6.00e-05 *    4.00e-05 *
+  ---------------------------------------------------------------------------------------------
+      3     -74.97145596   -1.09e-08 o    1.93e-05      1.86e-05      9.15e-05      6.16e-05    ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0709909010
+	    H     0.0000000000  -0.7565485189   0.5634447661
+	    H     0.0000000000   0.7565485189   0.5634447661
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.987357
+    H             1    0.987357      2  100.034133
+
+
+PCM analytic gradients are not implemented yet, re-routing to finite differences.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 7.
+	Translations projected? 1. Rotations projected? 1.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:21 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054511308059     0.045496628969     0.000000000000    15.994914619560
+           H          0.054511308059    -0.939929236212     0.000000000000     1.007825032070
+           H         -0.919645324845     0.217864718385     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39738  B =     14.61152  C =      8.99451 [cm^-1]
+  Rotational constants: A = 701435.82111  B = 438042.32353  C = 269648.50386 [MHz]
+  Nuclear repulsion =    8.925013879343279
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054511     0.045497     0.000000
+   2      H    1.4430   1.00     0.054511     -0.939929     0.000000
+   3      H    1.4430   1.00     -0.919645     0.217865     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6181051905E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05724436570435
+   @RHF iter   0:   -74.48612678601162   -7.44861e+01   4.95936e-02 
+   PCM polarization energy = -0.01778519236069
+   @RHF iter   1:   -74.85755271610864   -3.71426e-01   4.68094e-02 
+   PCM polarization energy = -0.00626034263608
+   @RHF iter   2:   -74.96203589371153   -1.04483e-01   1.10253e-02 DIIS
+   PCM polarization energy = -0.00606908246777
+   @RHF iter   3:   -74.96982418511534   -7.78829e-03   4.43201e-03 DIIS
+   PCM polarization energy = -0.00584061873749
+   @RHF iter   4:   -74.97142618068163   -1.60200e-03   5.15002e-04 DIIS
+   PCM polarization energy = -0.00588909511337
+   @RHF iter   5:   -74.97144746123953   -2.12806e-05   1.00881e-04 DIIS
+   PCM polarization energy = -0.00587063001909
+   @RHF iter   6:   -74.97144803160100   -5.70361e-07   1.59645e-05 DIIS
+   PCM polarization energy = -0.00587283773889
+   @RHF iter   7:   -74.97144804366302   -1.20620e-08   2.90525e-06 DIIS
+   PCM polarization energy = -0.00587253721226
+   @RHF iter   8:   -74.97144804416310   -5.00080e-10   6.10129e-07 DIIS
+   PCM polarization energy = -0.00587258190721
+   @RHF iter   9:   -74.97144804419219   -2.90896e-11   5.40827e-08 DIIS
+   PCM polarization energy = -0.00587258647900
+   @RHF iter  10:   -74.97144804419230   -1.13687e-13   1.26290e-08 DIIS
+   PCM polarization energy = -0.00587258441498
+   @RHF iter  11:   -74.97144804419237   -7.10543e-14   1.35864e-09 DIIS
+   PCM polarization energy = -0.00587258429066
+   @RHF iter  12:   -74.97144804419239   -1.42109e-14   1.71680e-10 DIIS
+   PCM polarization energy = -0.00587258431822
+   @RHF iter  13:   -74.97144804419229    9.94760e-14   1.42282e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240790     2A     -1.254780     3A     -0.590668  
+       4A     -0.461547     5A     -0.392043  
+
+    Virtual:                                                              
+
+       6A      0.594125     7A      0.702443  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804419229
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9250138793432789
+    One-Electron Energy =                -121.9582165828341829
+    Two-Electron Energy =                  38.0676272436168333
+    PCM Polarization Energy =              -0.0058725843182242
+    Total Energy =                        -74.9714480441922859
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8108      Y:    -0.6767      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2650      Y:     0.2179      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5458      Y:    -0.4587      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3873      Y:    -1.1660      Z:    -0.0000     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:23 2018
+Module time:
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      92.77 seconds =       1.55 minutes
+	system time =       1.39 seconds =       0.02 minutes
+	total time  =         95 seconds =       1.58 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:23 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054298466333     0.045750437241     0.000000000000    15.994914619560
+           H          0.054298466333    -0.943538147395     0.000000000000     1.007825032070
+           H         -0.916054530467     0.217445508104     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39738  B =     14.61152  C =      8.99451 [cm^-1]
+  Rotational constants: A = 701435.82111  B = 438042.32353  C = 269648.50386 [MHz]
+  Nuclear repulsion =    8.925013879343547
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054298     0.045750     0.000000
+   2      H    1.4430   1.00     0.054298     -0.943538     0.000000
+   3      H    1.4430   1.00     -0.916055     0.217446     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6181051905E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00587339338563
+   @RHF iter   0:   -74.97147590489357   -7.49715e+01   1.87172e-03 
+   PCM polarization energy = -0.00587251739825
+   @RHF iter   1:   -74.97144802447755    2.78804e-05   2.32006e-05 
+   PCM polarization energy = -0.00587258852159
+   @RHF iter   2:   -74.97144804184066   -1.73631e-08   5.98253e-06 DIIS
+   PCM polarization energy = -0.00587258317326
+   @RHF iter   3:   -74.97144804404144   -2.20078e-09   1.52784e-06 DIIS
+   PCM polarization energy = -0.00587258436086
+   @RHF iter   4:   -74.97144804419196   -1.50521e-10   8.57353e-08 DIIS
+   PCM polarization energy = -0.00587258419474
+   @RHF iter   5:   -74.97144804419224   -2.84217e-13   7.72232e-10 DIIS
+   PCM polarization energy = -0.00587258430213
+   @RHF iter   6:   -74.97144804419223    1.42109e-14   2.88932e-10 DIIS
+   PCM polarization energy = -0.00587258431109
+   @RHF iter   7:   -74.97144804419230   -7.10543e-14   8.07073e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240790     2A     -1.254780     3A     -0.590668  
+       4A     -0.461547     5A     -0.392043  
+
+    Virtual:                                                              
+
+       6A      0.594125     7A      0.702443  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804419230
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9250138793435472
+    One-Electron Energy =                -121.9582165822263136
+    Two-Electron Energy =                  38.0676272430015388
+    PCM Polarization Energy =              -0.0058725843110912
+    Total Energy =                        -74.9714480441923143
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8076      Y:    -0.6805      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2608      Y:     0.2229      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5468      Y:    -0.4575      Z:     0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3899      Y:    -1.1629      Z:     0.0000     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:24 2018
+Module time:
+	user time   =       1.40 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      94.21 seconds =       1.57 minutes
+	system time =       1.41 seconds =       0.02 minutes
+	total time  =         96 seconds =       1.60 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:24 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071224109021    15.994914619560
+           H          0.000000000000    -0.756548518905     0.565189148117     1.007825032070
+           H          0.000000000000     0.756548518905     0.565189148109     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.25136  B =     14.61194  C =      8.97300 [cm^-1]
+  Rotational constants: A = 697058.17812  B = 438054.84544  C = 269003.79622 [MHz]
+  Nuclear repulsion =    8.913949392660978
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071224
+   2      H    1.4430   1.00     0.000000     -0.756549     0.565189
+   3      H    1.4430   1.00     0.000000     0.756549     0.565189
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6267361070E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05706575055860
+   @RHF iter   0:   -74.48597459301455   -7.44860e+01   4.98494e-02 
+   PCM polarization energy = -0.01689299159007
+   @RHF iter   1:   -74.85852016587491   -3.72546e-01   4.61009e-02 
+   PCM polarization energy = -0.00619175582595
+   @RHF iter   2:   -74.96081863385770   -1.02298e-01   1.12070e-02 DIIS
+   PCM polarization energy = -0.00610599653664
+   @RHF iter   3:   -74.96927825042448   -8.45962e-03   4.97494e-03 DIIS
+   PCM polarization energy = -0.00580503871836
+   @RHF iter   4:   -74.97143670058546   -2.15845e-03   4.53774e-04 DIIS
+   PCM polarization energy = -0.00587762100145
+   @RHF iter   5:   -74.97145073235943   -1.40318e-05   1.21897e-04 DIIS
+   PCM polarization energy = -0.00585936768660
+   @RHF iter   6:   -74.97145142214832   -6.89789e-07   1.84058e-05 DIIS
+   PCM polarization energy = -0.00586158107183
+   @RHF iter   7:   -74.97145144407712   -2.19288e-08   3.50991e-06 DIIS
+   PCM polarization energy = -0.00586137613658
+   @RHF iter   8:   -74.97145144494596   -8.68837e-10   5.52719e-07 DIIS
+   PCM polarization energy = -0.00586142146055
+   @RHF iter   9:   -74.97145144496855   -2.25953e-11   7.96293e-08 DIIS
+   PCM polarization energy = -0.00586142251887
+   @RHF iter  10:   -74.97145144496901   -4.54747e-13   1.40168e-08 DIIS
+   PCM polarization energy = -0.00586142056869
+   @RHF iter  11:   -74.97145144496901    0.00000e+00   7.05650e-10 DIIS
+   PCM polarization energy = -0.00586142061898
+   @RHF iter  12:   -74.97145144496905   -4.26326e-14   1.37156e-10 DIIS
+   PCM polarization energy = -0.00586142063366
+   @RHF iter  13:   -74.97145144496901    4.26326e-14   2.13116e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241134     2A     -1.254360     3A     -0.589729  
+       4A     -0.461773     5A     -0.392084  
+
+    Virtual:                                                              
+
+       6A      0.593197     7A      0.700508  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145144496901
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9139493926609781
+    One-Electron Energy =                -121.9377123734748238
+    Two-Electron Energy =                  38.0581729564785078
+    PCM Polarization Energy =              -0.0058614206336592
+    Total Energy =                        -74.9714514449690057
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0594
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3465
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7129     Total:     0.7129
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8120     Total:     1.8120
+
+
+*** tstop() called on minazo at Wed May  2 19:42:26 2018
+Module time:
+	user time   =       1.93 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      96.18 seconds =       1.60 minutes
+	system time =       1.44 seconds =       0.02 minutes
+	total time  =         98 seconds =       1.63 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:26 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070781465541    15.994914619560
+           H          0.000000000000    -0.756548518905     0.561676611494     1.007825032070
+           H          0.000000000000     0.756548518905     0.561676611485     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.54308  B =     14.61194  C =      9.01611 [cm^-1]
+  Rotational constants: A = 705803.77371  B = 438054.84544  C = 270296.30920 [MHz]
+  Nuclear repulsion =    8.936021877972948
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070781
+   2      H    1.4430   1.00     0.000000     -0.756549     0.561677
+   3      H    1.4430   1.00     0.000000     0.756549     0.561677
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6099950442E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00579550024082
+   @RHF iter   0:   -74.97386347192125   -7.49739e+01   9.48896e-04 
+   PCM polarization energy = -0.00587365171216
+   @RHF iter   1:   -74.97145070358386    2.41277e-03   9.81570e-05 
+   PCM polarization energy = -0.00587783155647
+   @RHF iter   2:   -74.97145130210927   -5.98525e-07   4.28299e-05 DIIS
+   PCM polarization energy = -0.00588068971634
+   @RHF iter   3:   -74.97145144491653   -1.42807e-07   9.68077e-07 DIIS
+   PCM polarization energy = -0.00588080302900
+   @RHF iter   4:   -74.97145144497952   -6.29967e-11   9.78728e-08 DIIS
+   PCM polarization energy = -0.00588080941431
+   @RHF iter   5:   -74.97145144497993   -4.12115e-13   1.02699e-08 DIIS
+   PCM polarization energy = -0.00588081073167
+   @RHF iter   6:   -74.97145144497989    4.26326e-14   3.49349e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240462     2A     -1.255209     3A     -0.591620  
+       4A     -0.461336     5A     -0.392013  
+
+    Virtual:                                                              
+
+       6A      0.595102     7A      0.704286  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145144497989
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9360218779729479
+    One-Electron Energy =                -121.9786203537600784
+    Two-Electron Energy =                  38.0770278415389001
+    PCM Polarization Energy =              -0.0058808107316671
+    Total Energy =                        -74.9714514449798912
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0528
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3397
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7131     Total:     0.7131
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8124     Total:     1.8124
+
+
+*** tstop() called on minazo at Wed May  2 19:42:28 2018
+Module time:
+	user time   =       1.52 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      97.74 seconds =       1.63 minutes
+	system time =       1.47 seconds =       0.02 minutes
+	total time  =        100 seconds =       1.67 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:28 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071002787281    15.994914619560
+           H          0.000000000000    -0.758412165530     0.563432879805     1.007825032070
+           H          0.000000000000     0.758412165530     0.563432879797     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39654  B =     14.54021  C =      8.96731 [cm^-1]
+  Rotational constants: A = 701410.53041  B = 435904.62574  C = 268833.21927 [MHz]
+  Nuclear repulsion =    8.911731572508691
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071003
+   2      H    1.4430   1.00     0.000000     -0.758412     0.563433
+   3      H    1.4430   1.00     0.000000     0.758412     0.563433
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6276855122E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00593046965907
+   @RHF iter   0:   -74.96924086255504   -7.49692e+01   9.58556e-04 
+   PCM polarization energy = -0.00586205662668
+   @RHF iter   1:   -74.97144975583871   -2.20889e-03   4.80310e-05 
+   PCM polarization energy = -0.00585824532240
+   @RHF iter   2:   -74.97144989749054   -1.41652e-07   2.06038e-05 DIIS
+   PCM polarization energy = -0.00585713847544
+   @RHF iter   3:   -74.97144993017503   -3.26845e-08   2.08403e-06 DIIS
+   PCM polarization energy = -0.00585690907078
+   @RHF iter   4:   -74.97144993051506   -3.40037e-10   6.70437e-08 DIIS
+   PCM polarization energy = -0.00585690646872
+   @RHF iter   5:   -74.97144993051523   -1.70530e-13   1.24575e-08 DIIS
+   PCM polarization energy = -0.00585690530728
+   @RHF iter   6:   -74.97144993051528   -4.26326e-14   7.89944e-13 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240832     2A     -1.253975     3A     -0.590213  
+       4A     -0.461048     5A     -0.391893  
+
+    Virtual:                                                              
+
+       6A      0.592551     7A      0.701124  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144993051528
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9117315725086907
+    One-Electron Energy =                -121.9355886253263606
+    Two-Electron Energy =                  38.0582640276096811
+    PCM Polarization Energy =              -0.0058569053072816
+    Total Energy =                        -74.9714499305152771
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3442
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7119     Total:     0.7119
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8093     Total:     1.8093
+
+
+*** tstop() called on minazo at Wed May  2 19:42:30 2018
+Module time:
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      99.38 seconds =       1.66 minutes
+	system time =       1.51 seconds =       0.03 minutes
+	total time  =        102 seconds =       1.70 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:30 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071002787281    15.994914619560
+           H          0.000000000000    -0.754684872281     0.563432879805     1.007825032070
+           H          0.000000000000     0.754684872281     0.563432879797     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39654  B =     14.68419  C =      9.02187 [cm^-1]
+  Rotational constants: A = 701410.53041  B = 440221.01430  C = 270468.74849 [MHz]
+  Nuclear repulsion =    8.938258992966473
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071003
+   2      H    1.4430   1.00     0.000000     -0.754685     0.563433
+   3      H    1.4430   1.00     0.000000     0.754685     0.563433
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6090348993E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00582638074557
+   @RHF iter   0:   -74.97348970126191   -7.49735e+01   9.85764e-04 
+   PCM polarization energy = -0.00588243393980
+   @RHF iter   1:   -74.97145007307520    2.03963e-03   2.07257e-05 
+   PCM polarization energy = -0.00588577548338
+   @RHF iter   2:   -74.97145008584610   -1.27709e-08   2.07205e-06 DIIS
+   PCM polarization energy = -0.00588551250253
+   @RHF iter   3:   -74.97145008609159   -2.45493e-10   8.35368e-07 DIIS
+   PCM polarization energy = -0.00588546536279
+   @RHF iter   4:   -74.97145008614407   -5.24807e-11   1.33352e-07 DIIS
+   PCM polarization energy = -0.00588545514521
+   @RHF iter   5:   -74.97145008614548   -1.40687e-12   2.55522e-09 DIIS
+   PCM polarization energy = -0.00588545535548
+   @RHF iter   6:   -74.97145008614544    4.26326e-14   5.14501e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240766     2A     -1.255598     3A     -0.591134  
+       4A     -0.462063     5A     -0.392205  
+
+    Virtual:                                                              
+
+       6A      0.595750     7A      0.703667  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145008614544
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9382589929664729
+    One-Electron Energy =                -121.9807621330064507
+    Two-Electron Energy =                  38.0769385092500201
+    PCM Polarization Energy =              -0.0058854553554803
+    Total Energy =                        -74.9714500861454525
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3420
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7141     Total:     0.7141
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8151     Total:     1.8151
+
+
+*** tstop() called on minazo at Wed May  2 19:42:31 2018
+Module time:
+	user time   =       1.39 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     100.81 seconds =       1.68 minutes
+	system time =       1.53 seconds =       0.03 minutes
+	total time  =        103 seconds =       1.72 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:31 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071002787281    15.994914619560
+           H          0.000000000000    -0.756548518905     0.563432879805     1.007825032070
+           H          0.000000000000     0.756548518905     0.563432879797     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39654  B =     14.61194  C =      8.99454 [cm^-1]
+  Rotational constants: A = 701410.53041  B = 438054.84544  C = 269649.51108 [MHz]
+  Nuclear repulsion =    8.924981530518185
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071003
+   2      H    1.4430   1.00     0.000000     -0.756549     0.563433
+   3      H    1.4430   1.00     0.000000     0.756549     0.563433
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6183542402E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00590103840520
+   @RHF iter   0:   -74.97045042614980   -7.49705e+01   4.91857e-04 
+   PCM polarization energy = -0.00587265309360
+   @RHF iter   1:   -74.97145595832416   -1.00553e-03   1.02103e-05 
+   PCM polarization energy = -0.00587101328765
+   @RHF iter   2:   -74.97145596142805   -3.10389e-09   1.05316e-06 DIIS
+   PCM polarization energy = -0.00587114445101
+   @RHF iter   3:   -74.97145596149205   -6.40057e-11   4.27692e-07 DIIS
+   PCM polarization energy = -0.00587116845168
+   @RHF iter   4:   -74.97145596150588   -1.38272e-11   6.58248e-08 DIIS
+   PCM polarization energy = -0.00587117352737
+   @RHF iter   5:   -74.97145596150621   -3.26850e-13   1.07034e-09 DIIS
+   PCM polarization energy = -0.00587117343816
+   @RHF iter   6:   -74.97145596150627   -5.68434e-14   1.34523e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240799     2A     -1.254784     3A     -0.590674  
+       4A     -0.461555     5A     -0.392049  
+
+    Virtual:                                                              
+
+       6A      0.594151     7A      0.702395  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145596150627
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9249815305181848
+    One-Electron Energy =                -121.9581633441849249
+    Two-Electron Energy =                  38.0675970255986442
+    PCM Polarization Energy =              -0.0058711734381635
+    Total Energy =                        -74.9714559615062655
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3431
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8122     Total:     1.8122
+
+
+*** tstop() called on minazo at Wed May  2 19:42:33 2018
+Module time:
+	user time   =       1.47 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     102.33 seconds =       1.71 minutes
+	system time =       1.56 seconds =       0.03 minutes
+	total time  =        105 seconds =       1.75 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -74.9714559615
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -74.9714480442   -74.9714480442    -0.0000000000
+	    1    -74.9714514450   -74.9714514450    -0.0000000011
+	    2    -74.9714499305   -74.9714500861    -0.0000155630
+
+	Gradient written.
+
+-------------------------------------------------------------
+  ## F-D gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000    -0.00000000000149    -0.00000000145641
+    2     0.00000000000000    -0.00001104768571     0.00000000072758
+    3     0.00000000000000     0.00001104768720     0.00000000072883
+
+
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1341758226
+	 H           0.0000000000       -1.4296695070        1.0647338371
+	 H           0.0000000000        1.4296695070        1.0647338371
+	             0.0000000000       -0.0000000000       -0.0000000015
+	             0.0000000000       -0.0000110477        0.0000000007
+	             0.0000000000        0.0000110477        0.0000000007
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.865835	       0.987357
+	 R(1,3)           =         1.865835	       0.987357
+	 B(2,1,3)         =         1.745925	     100.034133
+
+	Current energy   :       -74.9714559615
+
+	Energy change for the previous step:
+		Projected    :        -0.0000000033
+		Actual       :         0.0000000007
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 3.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 2.
+	Steps to be used in Hessian update: 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00007
+	Projected energy change by RFO approximation:        -0.0000000011
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.987357    -0.000070    -0.000011     0.987346
+	    2 R(1,3)          =      0.987357    -0.000070    -0.000011     0.987346
+	    3 B(2,1,3)        =    100.034133    -0.000001    -0.003595   100.030537
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria             o    1.50e-05 *    1.00e-05 *    6.00e-05 *    4.00e-05 *
+  ---------------------------------------------------------------------------------------------
+      4     -74.97145596    6.91e-10 o    1.32e-05 *    1.03e-05      6.28e-05      3.99e-05 *  ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0710140031
+	    H     0.0000000000  -0.7565203679   0.5634384877
+	    H     0.0000000000   0.7565203679   0.5634384877
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.987346
+    H             1    0.987346      2  100.030537
+
+
+PCM analytic gradients are not implemented yet, re-routing to finite differences.
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+-------------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients (fd_geoms_1_0).
+	Generating geometries for use with 3-point formula.
+	Displacement size will be 5.00e-03.
+	Number of atoms is 3.
+	Number of symmetric SALC's is 3.
+	Number of displacements (including reference) is 7.
+	Translations projected? 1. Rotations projected? 1.
+
+-------------------------------------------------------------
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:33 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054511320155     0.045499552769     0.000000000000    15.994914619560
+           H          0.054511320155    -0.939915556304     0.000000000000     1.007825032070
+           H         -0.919645528903     0.217804635645     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39614  B =     14.61261  C =      8.99473 [cm^-1]
+  Rotational constants: A = 701398.62839  B = 438074.92027  C = 269655.35845 [MHz]
+  Nuclear repulsion =    8.925120342929427
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054511     0.045500     0.000000
+   2      H    1.4430   1.00     0.054511     -0.939916     0.000000
+   3      H    1.4430   1.00     -0.919646     0.217805     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6180355412E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05724892289885
+   @RHF iter   0:   -74.48609967750545   -7.44861e+01   4.95958e-02 
+   PCM polarization energy = -0.01778579332917
+   @RHF iter   1:   -74.85755305036164   -3.71453e-01   4.68098e-02 
+   PCM polarization energy = -0.00626045675889
+   @RHF iter   2:   -74.96203637628662   -1.04483e-01   1.10252e-02 DIIS
+   PCM polarization energy = -0.00606920343144
+   @RHF iter   3:   -74.96982434287055   -7.78797e-03   4.43187e-03 DIIS
+   PCM polarization energy = -0.00584075596167
+   @RHF iter   4:   -74.97142618247706   -1.60184e-03   5.14988e-04 DIIS
+   PCM polarization energy = -0.00588922688594
+   @RHF iter   5:   -74.97144746174469   -2.12793e-05   1.00870e-04 DIIS
+   PCM polarization energy = -0.00587076391113
+   @RHF iter   6:   -74.97144803199980   -5.70255e-07   1.59627e-05 DIIS
+   PCM polarization energy = -0.00587297140940
+   @RHF iter   7:   -74.97144804405855   -1.20587e-08   2.90501e-06 DIIS
+   PCM polarization energy = -0.00587267087023
+   @RHF iter   8:   -74.97144804455850   -4.99952e-10   6.10081e-07 DIIS
+   PCM polarization energy = -0.00587271556776
+   @RHF iter   9:   -74.97144804458755   -2.90470e-11   5.40757e-08 DIIS
+   PCM polarization energy = -0.00587272013871
+   @RHF iter  10:   -74.97144804458772   -1.70530e-13   1.26287e-08 DIIS
+   PCM polarization energy = -0.00587271807439
+   @RHF iter  11:   -74.97144804458767    4.26326e-14   1.35757e-09 DIIS
+   PCM polarization energy = -0.00587271795012
+   @RHF iter  12:   -74.97144804458779   -1.13687e-13   1.71621e-10 DIIS
+   PCM polarization energy = -0.00587271797767
+   @RHF iter  13:   -74.97144804458775    4.26326e-14   1.42187e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240793     2A     -1.254789     3A     -0.590667  
+       4A     -0.461557     5A     -0.392045  
+
+    Virtual:                                                              
+
+       6A      0.594141     7A      0.702446  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804458775
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9251203429294268
+    One-Electron Energy =                -121.9583837554590247
+    Two-Electron Energy =                  38.0676880859195279
+    PCM Polarization Energy =              -0.0058727179776748
+    Total Energy =                        -74.9714480445877456
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8108      Y:    -0.6767      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2650      Y:     0.2180      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5458      Y:    -0.4588      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3873      Y:    -1.1661      Z:    -0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:35 2018
+Module time:
+	user time   =       2.03 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     104.43 seconds =       1.74 minutes
+	system time =       1.59 seconds =       0.03 minutes
+	total time  =        107 seconds =       1.78 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:35 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.054298476451     0.045753347225     0.000000000000    15.994914619560
+           H          0.054298476451    -0.943524474302     0.000000000000     1.007825032070
+           H         -0.916054701170     0.217385651458     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39614  B =     14.61261  C =      8.99473 [cm^-1]
+  Rotational constants: A = 701398.62839  B = 438074.92027  C = 269655.35845 [MHz]
+  Nuclear repulsion =    8.925120342929798
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.054298     0.045753     0.000000
+   2      H    1.4430   1.00     0.054298     -0.943524     0.000000
+   3      H    1.4430   1.00     -0.916055     0.217386     0.000000
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6180355412E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00587352705781
+   @RHF iter   0:   -74.97147590560537   -7.49715e+01   1.87176e-03 
+   PCM polarization energy = -0.00587265105855
+   @RHF iter   1:   -74.97144802487119    2.78807e-05   2.32007e-05 
+   PCM polarization energy = -0.00587272218098
+   @RHF iter   2:   -74.97144804223586   -1.73647e-08   5.98297e-06 DIIS
+   PCM polarization energy = -0.00587271683260
+   @RHF iter   3:   -74.97144804443694   -2.20108e-09   1.52786e-06 DIIS
+   PCM polarization energy = -0.00587271802025
+   @RHF iter   4:   -74.97144804458742   -1.50479e-10   8.57011e-08 DIIS
+   PCM polarization energy = -0.00587271785419
+   @RHF iter   5:   -74.97144804458776   -3.41061e-13   7.71187e-10 DIIS
+   PCM polarization energy = -0.00587271796158
+   @RHF iter   6:   -74.97144804458773    2.84217e-14   2.88602e-10 DIIS
+   PCM polarization energy = -0.00587271797054
+   @RHF iter   7:   -74.97144804458769    4.26326e-14   8.07587e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240793     2A     -1.254789     3A     -0.590667  
+       4A     -0.461557     5A     -0.392045  
+
+    Virtual:                                                              
+
+       6A      0.594141     7A      0.702446  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144804458769
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9251203429297981
+    One-Electron Energy =                -121.9583837548512548
+    Two-Electron Energy =                  38.0676880853043045
+    PCM Polarization Energy =              -0.0058727179705391
+    Total Energy =                        -74.9714480445876745
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.8076      Y:    -0.6805      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.2608      Y:     0.2230      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.5468      Y:    -0.4576      Z:    -0.0000     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -1.3899      Y:    -1.1630      Z:    -0.0000     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:36 2018
+Module time:
+	user time   =       1.37 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     105.83 seconds =       1.76 minutes
+	system time =       1.61 seconds =       0.03 minutes
+	total time  =        108 seconds =       1.80 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:36 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071225991843    15.994914619560
+           H          0.000000000000    -0.756520367884     0.565204088997     1.007825032070
+           H          0.000000000000     0.756520367884     0.565204088986     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.25013  B =     14.61302  C =      8.97323 [cm^-1]
+  Rotational constants: A = 697021.32586  B = 438087.44713  C = 269010.60102 [MHz]
+  Nuclear repulsion =    8.914055203629399
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071226
+   2      H    1.4430   1.00     0.000000     -0.756520     0.565204
+   3      H    1.4430   1.00     0.000000     0.756520     0.565204
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6266669862E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.05707153048131
+   @RHF iter   0:   -74.48595186952851   -7.44860e+01   4.98506e-02 
+   PCM polarization energy = -0.01689387682682
+   @RHF iter   1:   -74.85851813511927   -3.72566e-01   4.61022e-02 
+   PCM polarization energy = -0.00619185554324
+   @RHF iter   2:   -74.96081920703034   -1.02301e-01   1.12069e-02 DIIS
+   PCM polarization energy = -0.00610612041506
+   @RHF iter   3:   -74.96927840469972   -8.45920e-03   4.97484e-03 DIIS
+   PCM polarization energy = -0.00580517461741
+   @RHF iter   4:   -74.97143671163610   -2.15831e-03   4.53759e-04 DIIS
+   PCM polarization energy = -0.00587775032215
+   @RHF iter   5:   -74.97145074252767   -1.40309e-05   1.21885e-04 DIIS
+   PCM polarization energy = -0.00585949941946
+   @RHF iter   6:   -74.97145143222849   -6.89701e-07   1.84047e-05 DIIS
+   PCM polarization energy = -0.00586171274757
+   @RHF iter   7:   -74.97145145415395   -2.19255e-08   3.50986e-06 DIIS
+   PCM polarization energy = -0.00586150774486
+   @RHF iter   8:   -74.97145145502282   -8.68866e-10   5.52698e-07 DIIS
+   PCM polarization energy = -0.00586155307307
+   @RHF iter   9:   -74.97145145504523   -2.24105e-11   7.96286e-08 DIIS
+   PCM polarization energy = -0.00586155413175
+   @RHF iter  10:   -74.97145145504575   -5.25802e-13   1.40155e-08 DIIS
+   PCM polarization energy = -0.00586155218116
+   @RHF iter  11:   -74.97145145504581   -5.68434e-14   7.05574e-10 DIIS
+   PCM polarization energy = -0.00586155223150
+   @RHF iter  12:   -74.97145145504578    2.84217e-14   1.37053e-10 DIIS
+   PCM polarization energy = -0.00586155224618
+   @RHF iter  13:   -74.97145145504578    0.00000e+00   2.13030e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241137     2A     -1.254368     3A     -0.589728  
+       4A     -0.461782     5A     -0.392087  
+
+    Virtual:                                                              
+
+       6A      0.593213     7A      0.700511  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145145504578
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9140552036293990
+    One-Electron Energy =                -121.9378786487056203
+    Two-Electron Energy =                  38.0582335422766107
+    PCM Polarization Energy =              -0.0058615522461791
+    Total Energy =                        -74.9714514550457807
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0594
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3465
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7129     Total:     0.7129
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8120     Total:     1.8120
+
+
+*** tstop() called on minazo at Wed May  2 19:42:38 2018
+Module time:
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     107.82 seconds =       1.80 minutes
+	system time =       1.64 seconds =       0.03 minutes
+	total time  =        110 seconds =       1.83 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:38 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.070783348363    15.994914619560
+           H          0.000000000000    -0.756520367884     0.561691552374     1.007825032070
+           H          0.000000000000     0.756520367884     0.561691552362     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.54183  B =     14.61302  C =      9.01634 [cm^-1]
+  Rotational constants: A = 705766.22574  B = 438087.44713  C = 270303.21399 [MHz]
+  Nuclear repulsion =    8.936128995888083
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.070783
+   2      H    1.4430   1.00     0.000000     -0.756520     0.561692
+   3      H    1.4430   1.00     0.000000     0.756520     0.561692
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6099248697E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00579562996400
+   @RHF iter   0:   -74.97386356887093   -7.49739e+01   9.48951e-04 
+   PCM polarization energy = -0.00587378574538
+   @RHF iter   1:   -74.97145069313518    2.41288e-03   9.81597e-05 
+   PCM polarization energy = -0.00587796580953
+   @RHF iter   2:   -74.97145129168121   -5.98546e-07   4.28307e-05 DIIS
+   PCM polarization energy = -0.00588082383939
+   @RHF iter   3:   -74.97145143448988   -1.42809e-07   9.68298e-07 DIIS
+   PCM polarization energy = -0.00588093719380
+   @RHF iter   4:   -74.97145143455295   -6.30678e-11   9.79339e-08 DIIS
+   PCM polarization energy = -0.00588094358341
+   @RHF iter   5:   -74.97145143455334   -3.97904e-13   1.02752e-08 DIIS
+   PCM polarization energy = -0.00588094490150
+   @RHF iter   6:   -74.97145143455334    0.00000e+00   3.49276e-12 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240465     2A     -1.255218     3A     -0.591619  
+       4A     -0.461346     5A     -0.392016  
+
+    Virtual:                                                              
+
+       6A      0.595118     7A      0.704289  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145143455334
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9361289958880832
+    One-Electron Energy =                -121.9787884189009475
+    Two-Electron Energy =                  38.0770889333610114
+    PCM Polarization Energy =              -0.0058809449015013
+    Total Energy =                        -74.9714514345533587
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0528
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3397
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7131     Total:     0.7131
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8125     Total:     1.8125
+
+
+*** tstop() called on minazo at Wed May  2 19:42:40 2018
+Module time:
+	user time   =       1.30 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     109.15 seconds =       1.82 minutes
+	system time =       1.66 seconds =       0.03 minutes
+	total time  =        112 seconds =       1.87 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:40 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071004670103    15.994914619560
+           H          0.000000000000    -0.758384014509     0.563447820685     1.007825032070
+           H          0.000000000000     0.758384014509     0.563447820674     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39530  B =     14.54129  C =      8.96754 [cm^-1]
+  Rotational constants: A = 701373.33246  B = 435936.98768  C = 268840.06272 [MHz]
+  Nuclear repulsion =    8.911838026343915
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.758384     0.563448
+   3      H    1.4430   1.00     0.000000     0.758384     0.563448
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6276154978E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00593060492362
+   @RHF iter   0:   -74.96924102926060   -7.49692e+01   9.58580e-04 
+   PCM polarization energy = -0.00586218836539
+   @RHF iter   1:   -74.97144988646630   -2.20886e-03   4.80300e-05 
+   PCM polarization energy = -0.00585837804807
+   @RHF iter   2:   -74.97145002810775   -1.41641e-07   2.06032e-05 DIIS
+   PCM polarization energy = -0.00585727123260
+   @RHF iter   3:   -74.97145006078996   -3.26822e-08   2.08337e-06 DIIS
+   PCM polarization energy = -0.00585704189116
+   @RHF iter   4:   -74.97145006112970   -3.39739e-10   6.70906e-08 DIIS
+   PCM polarization energy = -0.00585703928572
+   @RHF iter   5:   -74.97145006112993   -2.27374e-13   1.24711e-08 DIIS
+   PCM polarization energy = -0.00585703812291
+   @RHF iter   6:   -74.97145006112986    7.10543e-14   7.89553e-13 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240835     2A     -1.253984     3A     -0.590212  
+       4A     -0.461058     5A     -0.391896  
+
+    Virtual:                                                              
+
+       6A      0.592568     7A      0.701127  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145006112986
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9118380263439150
+    One-Electron Energy =                -121.9357559612404032
+    Two-Electron Energy =                  38.0583249118895424
+    PCM Polarization Energy =              -0.0058570381229051
+    Total Energy =                        -74.9714500611298575
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3442
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7119     Total:     0.7119
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8094     Total:     1.8094
+
+
+*** tstop() called on minazo at Wed May  2 19:42:41 2018
+Module time:
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     110.46 seconds =       1.84 minutes
+	system time =       1.68 seconds =       0.03 minutes
+	total time  =        113 seconds =       1.88 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:41 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071004670103    15.994914619560
+           H          0.000000000000    -0.754656721260     0.563447820685     1.007825032070
+           H          0.000000000000     0.754656721260     0.563447820674     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39530  B =     14.68529  C =      9.02210 [cm^-1]
+  Rotational constants: A = 701373.33246  B = 440253.85811  C = 270475.61423 [MHz]
+  Nuclear repulsion =    8.938365462960045
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.754657     0.563448
+   3      H    1.4430   1.00     0.000000     0.754657     0.563448
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6089656215E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00582651321468
+   @RHF iter   0:   -74.97348939305868   -7.49735e+01   9.85758e-04 
+   PCM polarization energy = -0.00588256920920
+   @RHF iter   1:   -74.97144994217098    2.03945e-03   2.07180e-05 
+   PCM polarization energy = -0.00588590855493
+   @RHF iter   2:   -74.97144995493156   -1.27606e-08   2.07335e-06 DIIS
+   PCM polarization energy = -0.00588564554041
+   @RHF iter   3:   -74.97144995517735   -2.45791e-10   8.36143e-07 DIIS
+   PCM polarization energy = -0.00588559832967
+   @RHF iter   4:   -74.97144995522994   -5.25944e-11   1.33266e-07 DIIS
+   PCM polarization energy = -0.00588558811908
+   @RHF iter   5:   -74.97144995523128   -1.33582e-12   2.56917e-09 DIIS
+   PCM polarization energy = -0.00588558833043
+   @RHF iter   6:   -74.97144995523131   -2.84217e-14   5.24307e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240768     2A     -1.255606     3A     -0.591133  
+       4A     -0.462073     5A     -0.392208  
+
+    Virtual:                                                              
+
+       6A      0.595766     7A      0.703670  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97144995523131
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9383654629600446
+    One-Electron Energy =                -121.9809291305611083
+    Two-Electron Energy =                  38.0769993007001943
+    PCM Polarization Energy =              -0.0058855883304314
+    Total Energy =                        -74.9714499552312930
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3420
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7141     Total:     0.7141
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8151     Total:     1.8151
+
+
+*** tstop() called on minazo at Wed May  2 19:42:42 2018
+Module time:
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     111.80 seconds =       1.86 minutes
+	system time =       1.71 seconds =       0.03 minutes
+	total time  =        114 seconds =       1.90 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 7 of 7    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on minazo
+*** at Wed May  2 19:42:42 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/roberto/Workspace/robertodr/psi4/build_update-pcmsolver/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.071004670103    15.994914619560
+           H          0.000000000000    -0.756520367884     0.563447820685     1.007825032070
+           H          0.000000000000     0.756520367884     0.563447820674     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     23.39530  B =     14.61302  C =      8.99477 [cm^-1]
+  Rotational constants: A = 701373.33246  B = 438087.44713  C = 269656.36572 [MHz]
+  Nuclear repulsion =    8.925087993231385
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis function: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  **PSI4:PCMSOLVER Interface Active**
+
+-----------------------------------------------------------------------
+   PCMSolver: An Open Source API for the Polarizable Continuum Model
+                   PCMSolver 1.2.1+fa7c826
+
+           Git: Branch {HEAD}, Revision {fa7c826}
+
+ R. Di Remigio, A. H. Steindal, K. Mozgawa, V. Weijo, H. Cao, and
+ L. Frediani, Int. J. Quantum Chem., to be submitted
+
+ Source repository: https://github.com/PCMSolver/pcmsolver
+ Documentation: https://pcmsolver.readthedocs.io/
+ PCMSolver initialized on: Wednesday, 02 May 2018 07:42 PM
+-----------------------------------------------------------------------
+
+~~~~~~~~~~ PCMSolver ~~~~~~~~~~
+Using CODATA 2010 set of constants.
+Input parsing done API-side
+========== Cavity 
+Atomic radii set: 
+Cavity type: GePol
+Average tesserae area = 0.3 Ang^2
+Solvent probe radius = 1.385 Ang
+Number of spheres = 3 [initial = 3; added = 0]
+Number of finite elements = 188
+Number of irreducible finite elements = 188
+============ Spheres list (in Angstrom)
+ Sphere   on   Radius   Alpha       X            Y            Z     
+-------- ---- -------- ------- -----------  -----------  -----------
+   1      O    1.7500   1.00     0.000000     0.000000     -0.071005
+   2      H    1.4430   1.00     0.000000     -0.756520     0.563448
+   3      H    1.4430   1.00     0.000000     0.756520     0.563448
+========== Static solver 
+Solver Type: IEFPCM, isotropic
+PCM matrix hermitivitized
+============ Medium 
+Medium initialized from solvent built-in data.
+Solvent name:          Water
+Static  permittivity = 78.39
+Optical permittivity = 1.78
+Solvent radius =       1.39 Ang
+.... Inside 
+Green's function type: vacuum
+.... Outside 
+Green's function type: uniform dielectric
+Permittivity = 78.39
+
+  There are 188 tesserae, 188 of which irreducible.
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A          7       7       0       0       0       0
+   -------------------------------------------------------
+    Total       7       7       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:               5
+      Number of primitives:             15
+      Number of atomic orbitals:         7
+      Number of basis functions:         7
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 812 doubles for integral storage.
+  We computed 120 shell quartets total.
+  Whereas there are 120 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6182845925E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   PCM polarization energy = -0.00590117237609
+   @RHF iter   0:   -74.97045051681965   -7.49705e+01   4.91855e-04 
+   PCM polarization energy = -0.00587278580448
+   @RHF iter   1:   -74.97145595941460   -1.00544e-03   1.02065e-05 
+   PCM polarization energy = -0.00587114710464
+   @RHF iter   2:   -74.97145596251605   -3.10145e-09   1.05383e-06 DIIS
+   PCM polarization energy = -0.00587127828591
+   @RHF iter   3:   -74.97145596258014   -6.40910e-11   4.28084e-07 DIIS
+   PCM polarization energy = -0.00587130232272
+   @RHF iter   4:   -74.97145596259391   -1.37703e-11   6.57788e-08 DIIS
+   PCM polarization energy = -0.00587130739474
+   @RHF iter   5:   -74.97145596259426   -3.55271e-13   1.07759e-09 DIIS
+   PCM polarization energy = -0.00587130730497
+   @RHF iter   6:   -74.97145596259421    5.68434e-14   1.30601e-14 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.240801     2A     -1.254793     3A     -0.590673  
+       4A     -0.461565     5A     -0.392051  
+
+    Virtual:                                                              
+
+       6A      0.594167     7A      0.702398  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -74.97145596259421
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.9250879932313847
+    One-Electron Energy =                -121.9583305183783608
+    Two-Electron Energy =                  38.0676578698577330
+    PCM Polarization Energy =              -0.0058713073049659
+    Total Energy =                        -74.9714559625942059
+
+    Alert: EFP and PCM quantities not currently incorporated into SCF psivars.
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0561
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.3431
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7130     Total:     0.7130
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     1.8123     Total:     1.8123
+
+
+*** tstop() called on minazo at Wed May  2 19:42:44 2018
+Module time:
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     113.14 seconds =       1.89 minutes
+	system time =       1.73 seconds =       0.03 minutes
+	total time  =        116 seconds =       1.93 minutes
+
+-------------------------------------------------------------
+
+  Computing gradient from energies (fd_1_0).
+	Using 3-point formula.
+	Energy without displacement:  -74.9714559626
+	Check energies below for precision!
+	Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+	 Coord      Energy(-)        Energy(+)        Force
+	    0    -74.9714480446   -74.9714480446     0.0000000000
+	    1    -74.9714514550   -74.9714514346     0.0000020492
+	    2    -74.9714500611   -74.9714499552     0.0000105899
+
+	Gradient written.
+
+-------------------------------------------------------------
+  ## F-D gradient (Symmetry 0) ##
+  Irrep: 1 Size: 3 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000597     0.00000274175383
+    2     0.00000000000000     0.00000751739577    -0.00000137087441
+    3     0.00000000000000    -0.00000751740174    -0.00000137087942
+
+
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1341793807
+	 H           0.0000000000       -1.4296163093        1.0647620713
+	 H           0.0000000000        1.4296163093        1.0647620712
+	             0.0000000000        0.0000000000        0.0000027418
+	             0.0000000000        0.0000075174       -0.0000013709
+	             0.0000000000       -0.0000075174       -0.0000013709
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.865814	       0.987346
+	 R(1,3)           =         1.865814	       0.987346
+	 B(2,1,3)         =         1.745862	     100.030537
+
+	Current energy   :       -74.9714559626
+
+	Energy change for the previous step:
+		Projected    :        -0.0000000011
+		Actual       :        -0.0000000011
+	Energy ratio indicates good step: Trust radius increased to 3.750e-01.
+
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 4.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 3.
+	Denominators (dg)(dq) or (dq)(dq) are very small.
+	 Skipping Hessian update for step 2.
+	Steps to be used in Hessian update: 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00004
+	Projected energy change by RFO approximation:        -0.0000000005
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.987346     0.000055     0.000007     0.987354
+	    2 R(1,3)          =      0.987346     0.000055     0.000007     0.987354
+	    3 B(2,1,3)        =    100.030537     0.000001     0.002049   100.032586
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria             o    1.50e-05 *    1.00e-05 *    6.00e-05 *    4.00e-05 *
+  ---------------------------------------------------------------------------------------------
+      5     -74.97145596   -1.09e-09 o    7.05e-06 *    6.78e-06 *    3.58e-05 *    2.36e-05 *  ~
+  ---------------------------------------------------------------------------------------------
+
+
+  **** Optimization is complete! (in 5 steps) ****
+
+  ==> Optimization Summary <==
+
+  Measures of convergence in internal coordinates in au.
+  --------------------------------------------------------------------------------------------------------------- ~
+   Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp  ~
+  --------------------------------------------------------------------------------------------------------------- ~
+      1     -74.971455912768    -74.971455912768      0.00013965      0.00012810      0.00063185      0.00043031  ~
+      2     -74.971455951253     -0.000000038485      0.00006804      0.00004072      0.00028535      0.00016484  ~
+      3     -74.971455962197     -0.000000010944      0.00001934      0.00001861      0.00009155      0.00006163  ~
+      4     -74.971455961506      0.000000000691      0.00001324      0.00001031      0.00006275      0.00003985  ~
+      5     -74.971455962594     -0.000000001088      0.00000705      0.00000678      0.00003576      0.00002360  ~
+  --------------------------------------------------------------------------------------------------------------- ~
+
+	Writing optimization data to binary file.
+	Final energy is    -74.9714559625942
+	Final (previous) structure:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0710046701
+	    H     0.0000000000  -0.7565203679   0.5634478207
+	    H     0.0000000000   0.7565203679   0.5634478207
+	Saving final (previous) structure.
+	Removing binary optimization data file.
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Final optimized geometry and variables:
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.987346
+    H             1    0.987346      2  100.030537
+
+	Removing binary optimization data file.
+	Cleaning optimization helper files.
+	Nuclear repulsion energy..........................................PASSED
+	Reference energy..................................................PASSED
+
+    Psi4 stopped on: Wednesday, 02 May 2018 07:42PM
+    Psi4 wall time for execution: 0:01:55.63
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
The user needs not set `dertype='energy'` explicitly anymore when calling `optimize`. The test case has been extended accordingly.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **User-Facing for Release Notes**
  - [x] FInite difference gradient is always forced when using PCM 

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge