### PR TITLE
Stop RHF/ROHF stability_analysis from silently skipping a "FOLLOW"

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -667,6 +667,9 @@ if the instability still exists. For more attempts, set |scf__max_attempts|;
 the default value of 1 is recommended. In case the SCF ends up in the same minimum, modification
 of |scf__follow_step_scale| is recommended over increasing |scf__max_attempts|.
 
+.. note:: Setting the option |scf__stability_analysis| to ``FOLLOW`` is only avalible for UHF. When using 
+   RHF and ROHF instabilities can be checked, but not followed. If you want to attempt to find a lower energy solution
+   you should re-run the calculation with |scf__reference| set to ``UHF``.
 
 The main algorithm available in |PSIfour| is the Direct Inversion algorithm. It can *only*
 work with |scf__scf_type| ``PK``, and it explicitly builds the full electronic Hessian
@@ -684,15 +687,15 @@ analysis. The capabilities of both algorithms are summarized below:
 
 .. table:: Stability analysis methods available in |PSIfour|
 
-    +------------------+------------------+----------------------------------------------+-----------------+
-    |     Algorithm    | |scf__reference| |     Stability checked                        | |scf__scf_type| |
-    +==================+==================+==============================================+=================+
-    |                  |       RHF        | Internal, External (:math:`\rightarrow` UHF) | PK only         |
-    +                  +------------------+----------------------------------------------+-----------------+
-    | Direct Inversion |       ROHF       | Internal                                     | PK only         |
-    +------------------+------------------+----------------------------------------------+-----------------+
-    |   Davidson       |       UHF        | Internal                                     |   Anything      |
-    +------------------+------------------+----------------------------------------------+-----------------+
+    +------------------+------------------+----------------------------------------------+---------------------------+-----------------+
+    |     Algorithm    | |scf__reference| |     Stability checked                        | |scf__stability_analysis| | |scf__scf_type| |
+    +==================+==================+==============================================+===========================+=================+
+    |                  |       RHF        | Internal, External (:math:`\rightarrow` UHF) | ``CHECK``                 |   PK only       |
+    +                  +------------------+----------------------------------------------+---------------------------+-----------------+
+    | Direct Inversion |       ROHF       | Internal                                     | ``CHECK``                 |   PK only       |
+    +------------------+------------------+----------------------------------------------+---------------------------+-----------------+
+    |   Davidson       |       UHF        | Internal                                     | ``CHECK`` or ``FOLLOW``   |   Anything      |
+    +------------------+------------------+----------------------------------------------+---------------------------+-----------------+
 
 The best algorithm is automatically selected, *i.e.* Davidson for UHF :math:`\rightarrow` UHF and Direct Inversion otherwise.
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1022,7 +1022,7 @@ def scf_wavefunction_factory(name, ref_wfn, reference):
                 disp_type[0], disp_type[1], tuple_params=modified_disp_params)
         wfn._disp_functor.print_out()
         if (disp_type["type"] == 'nl'):
-             del wfn._disp_functor 
+            del wfn._disp_functor
 
     # Set the DF basis sets
     if ("DF" in core.get_option("SCF", "SCF_TYPE")) or \
@@ -1194,6 +1194,9 @@ def scf_helper(name, post_scf=True, **kwargs):
     if cast and do_broken:
         raise ValidationError("""Detected options to both cast and perform a broken symmetry computation""")
 
+    if (core.get_option('SCF', 'STABILITY_ANALYSIS') == 'FOLLOW') and (core.get_option('SCF', 'REFERENCE') != 'UHF'):
+        raise ValidationError("""Stability analysis root following is only available for UHF""")
+
     # broken set-up
     if do_broken:
         raise ValidationError("""Broken symmetry computations are not currently enabled.""")
@@ -1353,7 +1356,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         scf_wfn.basisset().print_detail_out()
 
     # Compute dftd3
-    if "_disp_functor" in dir(scf_wfn): 
+    if "_disp_functor" in dir(scf_wfn):
         disp_energy = scf_wfn._disp_functor.compute_energy(scf_wfn.molecule())
         scf_wfn.set_variable("-D Energy", disp_energy)
 
@@ -2099,7 +2102,7 @@ def run_scf_gradient(name, **kwargs):
     if core.get_option('SCF', 'REFERENCE') in ['ROHF', 'CUHF']:
         ref_wfn.semicanonicalize()
 
-    if "_disp_functor" in dir(ref_wfn): 
+    if "_disp_functor" in dir(ref_wfn):
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
         ref_wfn.set_array("-D Gradient", disp_grad)
 
@@ -2167,7 +2170,7 @@ def run_scf_hessian(name, **kwargs):
     if badref or badint:
         raise ValidationError("Only RHF Hessians are currently implemented. SCF_TYPE either CD or OUT_OF_CORE not supported")
 
-    if "_disp_functor" in dir(ref_wfn): 
+    if "_disp_functor" in dir(ref_wfn):
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
         ref_wfn.set_array("-D Hessian", disp_hess)
 


### PR DESCRIPTION
## Description
closes #973 

## Todos
* **User-Facing for Release Notes**
  - [x] setting `stability_analysis = "FOLLOW"` will cause a `ValidationError` when used with `REFERENCE` that is not `UHF`
  - [x] SCF docs have been updated to include a note that follow is only implemented for UHF, and the stability analysis methods table has been expanded to include a column showing valid `STABILITY_ANALYSIS` values for each reference.

#973 Contained the report that RHF stability analysis = follow would silently check for instabilities and then continue on doing nothing about them, and a request to implement FOLLOW for RHF/ROHF. This PR fixes the first part, The feature request has been added under a separate issue (#1005)


## Status
- [x] Ready for review
- [x] Ready for merge
