### PR TITLE
wavefunction.build auto-zeros DF basis

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -115,6 +115,9 @@ def pybuild_wavefunction(mol, basis=None):
         basis = core.BasisSet.build(mol, "ORBITAL", basis)
 
     wfn = core.Wavefunction(mol, basis)
+    # Set basis for density-fitted calculations to the zero basis...
+    # ...until the user explicitly provides a DF basis.
+    wfn.set_basisset("DF_BASIS_SCF", core.BasisSet.zero_ao_basis_set())
     return wfn
 
 


### PR DESCRIPTION
## Description
As a side effect of #961, all wavefunctions had to have a density-fitted basis set when doing any energy computations, even if not density-fitted. Any scripts calling `psi4.core.Wavefunction.build` would have to manually set the DF basis to zero.

`psi4.core.Wavefunction.build` now automatically sets the DF basis to zero - one less upgrade problem for users to worry about.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] `psi4.core.Wavefunction.build` have zero DF basis by default

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
