### PR TITLE
Expose class Slice as PSI_API.

### DIFF
--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -122,7 +122,7 @@ class PSI_API Dimension {
  *      SharedVector v;
  *      v->get_block({begin,end}); // same as v->get_block(slice);
  */
-class Slice {
+class PSI_API Slice {
     Dimension begin_;
     Dimension end_;
 


### PR DESCRIPTION
## Description
`Slice` class is used in Forte. However, recent modifications blinds `Slice` from plugins.
This PR expose `Slice` class as `PSI_API` to be called in plugins.

## Modification
  - [x] Added `PSI_API` flag for class `Slice`.

## Status
- [x] Ready for review
- [x] Ready for merge