### PR TITLE
fix local options for plugins

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -547,13 +547,11 @@ void py_psi_clean_options() {
     Process::environment.options.clear();
     Process::environment.options.set_read_globals(true);
     read_options("", Process::environment.options, true);
-    Process::environment.options.set_read_globals(false);
     for (std::map<std::string, plugin_info>::iterator it=plugins.begin(); it!=plugins.end(); ++it) {
         // Get the plugin options back into the global space
-        Process::environment.options.set_read_globals(true);
         it->second.read_options(it->second.name, Process::environment.options);
-        Process::environment.options.set_read_globals(false);
     }
+    Process::environment.options.set_read_globals(false);
 }
 
 void py_psi_print_out(std::string s) { (*outfile->stream()) << s; }

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -548,6 +548,12 @@ void py_psi_clean_options() {
     Process::environment.options.set_read_globals(true);
     read_options("", Process::environment.options, true);
     Process::environment.options.set_read_globals(false);
+    for (std::map<std::string, plugin_info>::iterator it=plugins.begin(); it!=plugins.end(); ++it) {
+        // Get the plugin options back into the global space
+        Process::environment.options.set_read_globals(true);
+        it->second.read_options(it->second.name, Process::environment.options);
+        Process::environment.options.set_read_globals(false);
+    }
 }
 
 void py_psi_print_out(std::string s) { (*outfile->stream()) << s; }

--- a/tests/pytest/test_addons.py
+++ b/tests/pytest/test_addons.py
@@ -726,14 +726,13 @@ def test_v2rdm_casscf():
       'restricted_docc': [ 2, 0, 0, 0, 0, 2, 0, 0 ],
       'active': [ 1, 0, 1, 1, 0, 1, 1, 1 ],
     })
-    ##psi4.set_module_options('v2rdm_casscf', {
-    psi4.set_options({
-    #  'positivity': 'dqg',
+    psi4.set_module_options('v2rdm_casscf', {
+      'positivity': 'dqg',
       'r_convergence': 1e-5,
       'e_convergence': 1e-6,
       'maxiter': 20000,
-    #  #'orbopt_frequency': 1000,
-    #  #'mu_update_frequency': 1000,
+      #'orbopt_frequency': 1000,
+      #'mu_update_frequency': 1000,
     })
 
     psi4.activate(n2)


### PR DESCRIPTION
## Description
So `psi4.clean_options()` is a mainstay of psiapi mode because it allows you to do two calculations after another both starting from a clean slate of options. Likewise, it is important for testing b/c we do one behind the scenes (in pytest) between each test so that your MP2 doesn't get PCM solvation, etc. For plugins, this has been broken since the `clean_options()` command was invented, in that as soon as you tried to set an option unique to the plugin (as opposed to one that another module in read_options.cc defined) _after_ a options cleanse, it would complain about an invalid option. This PR reloads the plugin options after a cleanse.

## Status
- [x] Ready for review
- [x] Ready for merge
