### PR TITLE
fix PSI_API in libciomr

### DIFF
--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -35,6 +35,7 @@ if pymod.startswith(os.path.sep + os.path.sep):
     pymod = pymod[1:]
 pymod_dir_step = os.path.sep.join(['..'] * pymod.count(os.path.sep))
 data_dir = os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_DATADIR@', 'psi4'])
+executable = os.path.abspath(os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_BINDIR@', 'psi4']))
 
 # from . import config
 # data_dir = config.psidatadir
@@ -69,6 +70,7 @@ if "PSI_SCRATCH" in os.environ.keys():
     core.IOManager.shared_object().set_default_path(envvar_scratch)
 
 core.set_datadir(data_dir)
+del psi4_module_loc, pymod, pymod_dir_step, data_dir
 
 # Cleanup core at exit
 import atexit

--- a/psi4/psi4Config.cmake.in
+++ b/psi4/psi4Config.cmake.in
@@ -71,6 +71,7 @@ set(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
 
 # location of psi4/core.so
 set(${PN}_LIBRARY "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@@PYMOD_INSTALL_LIBDIR@/psi4/@PYTHON_MODULE_PREFIX@core.so")
+set(${PN}_SYS_PATH "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@@PYMOD_INSTALL_LIBDIR@")
 
 # presence of external addons
 macro(psi4_component name on)
@@ -101,9 +102,10 @@ endforeach()
 check_required_components(${PN})
 
 if(NOT CMAKE_REQUIRED_QUIET)
-    message(STATUS "Psi4 script:  ${${PN}_EXECUTABLE}")
-    message(STATUS "Psi4 headers: ${${PN}_INCLUDE_DIR}")
-    message(STATUS "Psi4 library: ${${PN}_LIBRARY}")
+    message(STATUS "Psi4 script:   ${${PN}_EXECUTABLE}")
+    message(STATUS "Psi4 headers:  ${${PN}_INCLUDE_DIR}")
+    message(STATUS "Psi4 library:  ${${PN}_LIBRARY}")
+    message(STATUS "Psi4 sys.path: ${${PN}_SYS_PATH}")
     message(STATUS "Psi4 components: ${${PN}_FOUND_COMPONENTS}")
     message(STATUS "Python executable: @PYTHON_EXECUTABLE@")
 endif()

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -75,7 +75,7 @@ namespace psi {
 ** \ingroup CIOMR
 */
 
-double ** PSI_API block_matrix(size_t n, size_t m, bool memlock)
+PSI_API double ** block_matrix(size_t n, size_t m, bool memlock)
 {
     double **A=nullptr;
     double *B=nullptr;

--- a/psi4/src/psi4/libciomr/int_array.cc
+++ b/psi4/src/psi4/libciomr/int_array.cc
@@ -59,7 +59,7 @@ namespace psi {
 ** C. David Sherrill
 ** \ingroup CIOMR
 */
-int * PSI_API init_int_array(int size)
+PSI_API int * init_int_array(int size)
 {
   int *array;
 
@@ -103,7 +103,7 @@ void zero_int_array(int *a, int size)
 **
 ** \ingroup CIOMR
 */
-int ** PSI_API init_int_matrix(int rows, int cols)
+PSI_API int ** init_int_matrix(int rows, int cols)
 {
    int **array=nullptr;
    int i;


### PR DESCRIPTION
- [x] PSI_API doesn't work for gnu compiler and pointer returning fns whe not at start of decl. Affects `v2rdm_casscf/tests/v2rdm6/input.dat`
- [x] Adds to python module, `psi4.executable` returning the psithon script/binary/executable. Also cleaned up main psi4 namespace by deleting some intermediate strings.
- [x] To the `psi4Config.cmake` consumed by downstream, defines `psi4_SYS_PATH` which is the full path needed to be added to `sys.path` in order to `import psi4`.

## Status
- [x] Ready for review
- [x] Ready for merge
