### PR TITLE
gau2grid: ensure we get the right bf ordering

### DIFF
--- a/external/upstream/gau2grid/CMakeLists.txt
+++ b/external/upstream/gau2grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(gau2grid 1.0 CONFIG QUIET)
+find_package(gau2grid 1.0 CONFIG QUIET COMPONENTS gaussian)
 
 if(${gau2grid_FOUND})
     get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
@@ -26,6 +26,8 @@ else()
                    -DENABLE_XHOST=${ENABLE_XHOST}
                    -DBUILD_FPIC=${BUILD_FPIC}
                    -DMAX_AM=${MAX_AM_ERI}
+                   -DCARTESIAN_ORDER=row
+                   -DSPHERICAL_ORDER=gaussian
                    -DENABLE_GENERIC=${ENABLE_GENERIC}
                    -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
         CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}

--- a/external/upstream/gau2grid/CMakeLists.txt
+++ b/external/upstream/gau2grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(gau2grid 1.0 CONFIG QUIET COMPONENTS gaussian)
+find_package(gau2grid 1.1 CONFIG QUIET COMPONENTS gaussian)
 
 if(${gau2grid_FOUND})
     get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
@@ -14,7 +14,7 @@ else()
     ExternalProject_Add(gau2grid_external
         DEPENDS pybind11_external
         GIT_REPOSITORY https://github.com/dgasmith/gau2grid
-        GIT_TAG v1.0.1
+        GIT_TAG v1.1.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
     message(STATUS "Disabled erd")
 endif()
 
-find_package(gau2grid 1.0 CONFIG REQUIRED COMPONENTS gaussian)
+find_package(gau2grid 1.1 CONFIG REQUIRED COMPONENTS gaussian)
 get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using gau2grid${ColourReset}: ${_loc} (version ${gau2grid_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
     message(STATUS "Disabled erd")
 endif()
 
-find_package(gau2grid 1.0 CONFIG REQUIRED)
+find_package(gau2grid 1.0 CONFIG REQUIRED COMPONENTS gaussian)
 get_property(_loc TARGET gau2grid::gg PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using gau2grid${ColourReset}: ${_loc} (version ${gau2grid_VERSION})")


### PR DESCRIPTION
## Description
gau2grid now provides spherical basis sets in `gaussian` _or_ `cca` ordering. let's make sure we get the right one!

~**This won't work until a PR comes into g2g and versions/git tags get bumped here.**~

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] detect/build the gaussian g2g
  - [x] bump min g2g version so the components are there

## Checklist
- [x] ran quicktests against g2g dgasmith/gau2grid#11
- [x] full tests pass locally

## Status
- [x] Ready for review
- [x] Ready for merge
