### PR TITLE
Adds PSI_API tag before the definition of F_DGEMV in ../fnocc/blas.cc

### DIFF
--- a/psi4/src/psi4/fnocc/blas.cc
+++ b/psi4/src/psi4/fnocc/blas.cc
@@ -44,7 +44,7 @@ long int Position(long int i,long int j){
 /**
  * fortran-ordered dgemv
  */
-void F_DGEMV(char trans,integer m,integer n,doublereal alpha,doublereal*A,integer lda,
+void PSI_API F_DGEMV(char trans,integer m,integer n,doublereal alpha,doublereal*A,integer lda,
             doublereal*X,integer incx,doublereal beta,doublereal*Y,integer incy){
     DGEMV(trans,m,n,alpha,A,lda,X,incx,beta,Y,incy);
 }


### PR DESCRIPTION
## Description
This change allows F_DGEMV to be called (when using plugins, for example) without modifying the source code in fnocc/blas.cc and recompiling Psi4.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Feature1
* **User-Facing for Release Notes**
  - [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
