### PR TITLE
PSI_API for eigsort function in libciomr

### DIFF
--- a/psi4/src/psi4/libciomr/eigsort.cc
+++ b/psi4/src/psi4/libciomr/eigsort.cc
@@ -35,6 +35,8 @@
 
 #include <cstdlib>
 
+#include "psi4/pragma.h"
+
 namespace psi {
 
 /*!
@@ -53,7 +55,7 @@ namespace psi {
 **
 ** \ingroup CIOMR
 */
-void eigsort(double *d, double **v, int n)
+void PSI_API eigsort(double *d, double **v, int n)
 {
   int i,j,k;
   double p;


### PR DESCRIPTION
## Description
PSI_API for eigsort function in libciomr.

## Todos
Nothing notable... just fixes missing symbol in one of my plugins.

## Status
- [x] Ready for review
- [x] Ready for merge