### PR TITLE
OpenMP, take 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ if(ENABLE_gdma OR ENABLE_dkh OR ENABLE_erd OR ENABLE_PCMSolver)
 endif()
 
 if(ENABLE_erd)
+    message(FATAL_ERROR "The Psi4/ERD interface is broken, probably since spring 2017. We'll try to fix it (comment this line to try), but disabling for now.")
     message(WARNING "ERD will build, link, and run in Psi4 just fine. However, it has not been hooked into Psi4 in all roles, notably gradients, LRC DFT energies, and ESP. So upon activating through ``set integral_package erd``, known failures will be caught and halted, but perhaps other types not tested and identified will give *wrong* answers. Consider this your warning.")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #                 (default: search order MKL>OPENBLAS>ESSL>ATLAS>ACML>SYSTEM_NATIVE on Linux; MKL>Accelerate>... on Mac)"
 #    - LAPACK_LIBRARIES "Location of BLAS/LAPACK libraries as ";"-separated list of full paths, bypassing math detection"
 #    - LAPACK_INCLUDE_DIRS "Location of BLAS/LAPACK headers (only needed for MKL), bypassing math detection"
+#    - OpenMP_LIBRARY_DIRS "Location of OpenMP libraries (iomp5/gomp/omp) as ";"-separated list, hinting OpenMP detection"
 
 #  <<<  Install  >>>
 #
@@ -239,6 +240,7 @@ ExternalProject_Add(psi4-core
               -DLIBC_INTERJECT=${LIBC_INTERJECT}
               -DRESTRICT_KEYWORD=${RESTRICT_KEYWORD}
               -DFC_SYMBOL=${FC_SYMBOL}
+              -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
               -DDESTDIR=${CMAKE_BINARY_DIR}/stage
    CMAKE_CACHE_ARGS -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
    BUILD_ALWAYS 1

--- a/doc/sphinxman/source/freq.rst
+++ b/doc/sphinxman/source/freq.rst
@@ -55,6 +55,52 @@ thermochemical analysis.
 
 .. autofunction:: psi4.hessian(name [, molecule, return_wfn, func, dertype, irrep])
 
+It's handy to collect the wavefunction after a frequency
+calculation through ``e, wfn = psi4.frequency(...,
+return_wfn=True)`` as the frequencies can be accessed through
+:py:func:`psi4.core.Wavefunction.frequencies()`, the Hessian through
+:py:func:`psi4.core.Wavefunction.hessian()`, and much other computation
+info through ``psi4.core.Wavefunction.frequency_analysis``
+(note no parentheses). Examples of using this data
+structure can be found :srcsample:`fd-freq-gradient` and
+:srcsample:`python/vibanalysis`. Formatted printing of vibrational
+results is available through :py:func:`qcdb.vib.print_vibs`.
+
+.. _`table:frequency_analysis`:
+
+.. table:: Results accessible through ``psi4.core.Wavefunction.frequency_analysis``
+
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | key           | description (lbl & comment)                | units     | data (real/imaginary modes)                          |
+    +===============+============================================+===========+======================================================+
+    | omega         | frequency                                  | cm^-1     | nd.array(ndof) complex (real/imag)                   |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | q             | normal mode, normalized mass-weighted      | a0 u^1/2  | ndarray(ndof, ndof) float                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | w             | normal mode, un-mass-weighted              | a0        | ndarray(ndof, ndof) float                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | x             | normal mode, normalized un-mass-weighted   | a0        | ndarray(ndof, ndof) float                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | degeneracy    | degree of degeneracy                       |           | ndarray(ndof) int                                    |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | TRV           | translation/rotation/vibration             |           | ndarray(ndof) str 'TR' or 'V' or '-' for partial     |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | gamma         | irreducible representation                 |           | ndarray(ndof) str irrep or None if unclassifiable    |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | mu            | reduced mass                               | u         | ndarray(ndof) float (+/+)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | k             | force constant                             | mDyne/A   | ndarray(ndof) float (+/-)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | DQ0           | RMS deviation v=0                          | a0 u^1/2  | ndarray(ndof) float (+/0)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | Qtp0          | Turning point v=0                          | a0 u^1/2  | ndarray(ndof) float (+/0)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | Xtp0          | Turning point v=0                          | a0        | ndarray(ndof) float (+/0)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+    | theta_vib     | char temp                                  | K         | ndarray(ndof) float (+/0)                            |
+    +---------------+--------------------------------------------+-----------+------------------------------------------------------+
+
+
 Visualization of Normal Modes
 -----------------------------
 

--- a/doc/sphinxman/source/thermo.rst
+++ b/doc/sphinxman/source/thermo.rst
@@ -36,8 +36,8 @@
 Vibrational and Thermochemical Analysis
 =======================================
 
-.. codeauthor:: Rollin A. King
-.. comment.. sectionauthor:: Rollin A. King and Lori A. Burns
+.. codeauthor:: Rollin A. King and Lori A. Burns
+.. sectionauthor:: Lori A. Burns
 
 *Module:* :ref:`Keywords <apdx:thermo>`, :ref:`PSI Variables <apdx:thermo_psivar>`, :source:`THERMO <psi4/src/psi4/thermo>`
 
@@ -69,6 +69,21 @@ Keywords
 
 Examples
 ^^^^^^^^
+
+A thermochemical analysis is performed after any full (not just specific
+symmetry subgroups). If the wavefunction is retained, it may be reused
+at a different temperature, pressure, rotational symmetry number, or
+isotopic substitution through the function :py:func:`qcdb.vib.thermo`
+as is shown in :srcsample:`freq-isotope2`.
+
+A few summary psivars are set: "ZPVE", "THERMAL ENERGY CORRECTION",
+"ENTHALPY CORRECTION", "GIBBS FREE ENERGY CORRECTION", "ZERO K
+ENTHALPHY", "THERMAL ENERGY", "ENTHALPY", "GIBBS FREE ENERGY".
+But additionally, every valid combination of {S, Cv, Cp, ZPE, E, H, G}
+with {elec, trans, rot, vib, corr, tot} (e.g., vibrational entropy,
+S_vib, and enthalpy correction, H_corr) is returned by dictionary
+from the ``thermo`` function. See :srcsample:`python/vibanalysis`
+(near the end) for an example.
 
 
 .. index::

--- a/external/common/lapack/CMakeLists.txt
+++ b/external/common/lapack/CMakeLists.txt
@@ -34,11 +34,12 @@ endforeach()
 # <<  Detect OpenMP and modify for BLAS/LAPACK  >>
 if(NOT TARGET tgt::MathOpenMP)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+    set(TargetOpenMP_FIND_COMPONENTS "CXX")
     find_package(MathOpenMP)
 endif()
 
 include(CMakePrintHelpers)
-cmake_print_properties(TARGETS OpenMP::OpenMP_CXX tgt::MathOpenMP blas lapk lapack
+cmake_print_properties(TARGETS OpenMP::OpenMP_C OpenMP::OpenMP_CXX OpenMP::OpenMP_Fortran OpenMP::OpenMP tgt::MathOpenMP lapack
                        PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_INCLUDE_DIRS INTERFACE_LINK_LIBRARIES)
 
 get_property(_ill TARGET lapk PROPERTY INTERFACE_LINK_LIBRARIES)

--- a/external/common/lapack/FindMathOpenMP.cmake
+++ b/external/common/lapack/FindMathOpenMP.cmake
@@ -74,7 +74,11 @@ if (${isMKL} MATCHES "MKL")
     if ((CMAKE_C_COMPILER_ID STREQUAL GNU) OR
         (CMAKE_CXX_COMPILER_ID STREQUAL GNU) OR
         (CMAKE_Fortran_COMPILER_ID STREQUAL GNU))
-        set(_MathOpenMP_LIB_NAMES "iomp5;-Wl,--as-needed")
+        if (APPLE)
+            set(_MathOpenMP_LIB_NAMES "iomp5")
+        else()
+            set(_MathOpenMP_LIB_NAMES "iomp5;-Wl,--as-needed")
+        endif()
         find_omp_libs("MathOpenMP" ${_MathOpenMP_LIB_NAMES})
         set_property(TARGET tgt::MathOpenMP PROPERTY INTERFACE_LINK_LIBRARIES "${MathOpenMP_LIBRARIES}")
     endif()

--- a/external/common/lapack/FindMathOpenMP.cmake
+++ b/external/common/lapack/FindMathOpenMP.cmake
@@ -12,7 +12,7 @@
 #
 # * this is a hack until we update min cmake (to 3.10?)
 # * it is specific to Psi4 in that:
-#   * we only care about C++ OpenMP
+#   * we only care about C++ OpenMP. updated for C/CXX/Fortran
 #   * minimum Intel in 2017, so no need to add logic for lower
 #   * we never use OPENMP_FOUND
 # * this is run by the TargetLAPACK module and tgt::lapack is supplemented by
@@ -22,7 +22,7 @@
 #
 #   tgt::MathOpenMP - always defined, though it may be a dummy target
 #                     if OpenMP disabled or compiler incapable. If OpenMP
-#                     enabled and found, linked to OpenMP::OpenMP_CXX as
+#                     enabled and found, linked to OpenMP::OpenMP as
 #                     well as carries any additional flags or libraries
 #                     needed by BLAS/LAPACK.
 #
@@ -41,8 +41,7 @@ macro(find_omp_libs _service)
         find_library(_lib
                      NAMES ${_l}
                      HINTS ${_fullspec}
-                           ${OpenMP_CXX_LIBRARY_DIRS}
-                           ${OpenMP_ROOT}
+                           ${OpenMP_LIBRARY_DIRS}
                      DOC "Path to the ${_l} library for OpenMP"
                      NO_DEFAULT_PATH)
         #message("${_service} ${_l} A ${_lib}")
@@ -72,12 +71,19 @@ endmacro()
 add_library(tgt::MathOpenMP INTERFACE IMPORTED)
 
 if (${isMKL} MATCHES "MKL")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    if ((CMAKE_C_COMPILER_ID STREQUAL GNU) OR
+        (CMAKE_CXX_COMPILER_ID STREQUAL GNU) OR
+        (CMAKE_Fortran_COMPILER_ID STREQUAL GNU))
         set(_MathOpenMP_LIB_NAMES "iomp5;-Wl,--as-needed")
         find_omp_libs("MathOpenMP" ${_MathOpenMP_LIB_NAMES})
         set_property(TARGET tgt::MathOpenMP PROPERTY INTERFACE_LINK_LIBRARIES "${MathOpenMP_LIBRARIES}")
     endif()
 
+    if (CMAKE_C_COMPILER_ID STREQUAL Clang)
+        if (NOT DEFINED OpenMP_C_FLAG)
+            set (OpenMP_C_FLAG "-fopenmp=libiomp5")
+        endif()
+    endif()
     if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         if (NOT DEFINED OpenMP_CXX_FLAG)
             set (OpenMP_CXX_FLAG "-fopenmp=libiomp5")
@@ -86,7 +92,7 @@ if (${isMKL} MATCHES "MKL")
 endif()
 
 if (ENABLE_OPENMP)
-    find_package(TargetOpenMP)
+    find_package(TargetOpenMP REQUIRED COMPONENTS ${TargetOpenMP_FIND_COMPONENTS})
 endif()
 
 set(PN MathOpenMP)
@@ -96,10 +102,6 @@ set (${PN}_MESSAGE "Found MathOpenMP: ${_ill}")
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args (${PN} DEFAULT_MSG ${PN}_MESSAGE)
 
-if (TARGET OpenMP::OpenMP_CXX)
-    set_property(TARGET tgt::MathOpenMP APPEND PROPERTY INTERFACE_LINK_LIBRARIES "OpenMP::OpenMP_CXX")
+if (TARGET OpenMP::OpenMP)
+    set_property(TARGET tgt::MathOpenMP APPEND PROPERTY INTERFACE_LINK_LIBRARIES "OpenMP::OpenMP")
 endif()
-
-#include(CMakePrintHelpers)
-#cmake_print_properties(TARGETS tgt::MathOpenMP
-#                       PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_INCLUDE_DIRS INTERFACE_LINK_LIBRARIES)

--- a/external/common/lapack/FindMathOpenMP.cmake
+++ b/external/common/lapack/FindMathOpenMP.cmake
@@ -92,7 +92,8 @@ if (${isMKL} MATCHES "MKL")
 endif()
 
 if (ENABLE_OPENMP)
-    find_package(TargetOpenMP REQUIRED COMPONENTS ${TargetOpenMP_FIND_COMPONENTS})
+    # *not* REQUIRED b/c some compilers don't support OpenMP and -DENABLE_OPENMP isn't a build-or-die-trying
+    find_package(TargetOpenMP COMPONENTS ${TargetOpenMP_FIND_COMPONENTS})
 endif()
 
 set(PN MathOpenMP)

--- a/external/common/lapack/FindTargetOpenMP.cmake
+++ b/external/common/lapack/FindTargetOpenMP.cmake
@@ -8,7 +8,8 @@
 #
 #   TargetOpenMP_FOUND - true if OpenMP found on the system
 #   TargetOpenMP_MESSAGE - status message with OpenMP library path list
-#   OpenMP_CXX_LIB_NAMES - ";"-separated list of CXX libraries for OpenMP (no paths)
+#   OpenMP_<lang>_LIB_NAMES - ";"-separated list of <lang> libraries for OpenMP (no paths)
+#                              not present if bypassed by OpenMP_FLAGS & OpenMP_LIBRARIES
 #
 # * this is a hack until we update min cmake (to 3.10?)
 # * it is specific to Psi4 in that:
@@ -20,71 +21,108 @@
 #
 # This module defines the following imported targets ::
 #
-#   OpenMP::OpenMP_CXX - if enabled and available for compiler for C++.
-#                        may be found by newer FindOpenMP or constructed here.
+#   OpenMP::OpenMP_<lang> - if enabled and available for compiler for <lang>.
+#                           may be found by newer FindOpenMP or constructed here.
 #
+#   OpenMP::OpenMP - concatenation of requested language targets.
+#
+# Inputs ::
+#
+#   TargetOpenMP_FIND_COMPONENTS - set to languages (C, CXX, Fortran) to find OpenMP,
+#                                  default is all enabled.
+#   OpenMP_LIBRARY_DIRS - list of directories where OpenMP libraries may be found,
+#                         in preference to DEFAULT_PATHS
+#
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)  # support IN_LISTS
+
 
 set(PN TargetOpenMP)
 
+separate_arguments(${PN}_FIND_COMPONENTS)
+if(NOT ${PN}_FIND_COMPONENTS)
+    set(${PN}_FINDLIST C CXX Fortran)
+else()
+    set(${PN}_FINDLIST ${${PN}_FIND_COMPONENTS})
+endif()
+separate_arguments(${PN}_FINDLIST)
+
 if (NOT ${PN}_FIND_QUIETLY)
-    message(STATUS "Detecting MathOpenMP -- ?OpenMP=${ENABLE_OPENMP}, ?MKL=${isMKL}, CXX=${CMAKE_CXX_COMPILER_ID}")
+    message(STATUS "Detecting MathOpenMP -- ?OpenMP=${ENABLE_OPENMP}, ?MKL=${isMKL}, LANG=${${PN}_FINDLIST}, C/CXX/Fortran=${CMAKE_C_COMPILER_ID}/${CMAKE_CXX_COMPILER_ID}/${CMAKE_Fortran_COMPILER_ID}")
 endif()
 
 # 1st precedence - libraries passed in through -DOpenMP_LIBRARIES
-if (OpenMP_LIBRARIES AND OpenMP_FLAGS AND OpenMP_CXX_LIB_NAMES)
+if (OpenMP_LIBRARIES AND OpenMP_FLAGS)
     if (NOT ${PN}_FIND_QUIETLY)
         message (STATUS "OpenMP detection suppressed.")
     endif()
 
-    add_library (OpenMP::OpenMP_CXX INTERFACE IMPORTED)
-    set_property (TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_FLAGS})
-    set_property (TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_LIBRARIES})
+    add_library (OpenMP::OpenMP INTERFACE IMPORTED)
+    set_property (TARGET OpenMP::OpenMP PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_FLAGS})
+    set_property (TARGET OpenMP::OpenMP PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_LIBRARIES})
 else()
     # 2nd precedence - target from modern FindOpenMP.cmake
-    find_package (OpenMP QUIET MODULE COMPONENTS CXX)
+    find_package (OpenMP QUIET MODULE COMPONENTS ${${PN}_FINDLIST})
 
-    if (NOT TARGET OpenMP::OpenMP_CXX)
-        # 3rd precedence - construct a target
+    foreach(_lang ${${PN}_FINDLIST})
+        if (NOT TARGET OpenMP::OpenMP_${_lang})
+            # 3rd precedence - construct a target
 
-        if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-            set(OpenMP_CXX_FLAGS "-fopenmp")
-            set(OpenMP_CXX_LIB_NAMES "gomp;pthread")
-        elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)
-            set(OpenMP_CXX_FLAGS "-qopenmp")
-            set(OpenMP_CXX_LIB_NAMES "iomp5;pthread")
-        elseif (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-            if (OpenMP_CXX_FLAG MATCHES "-fopenmp=libiomp5")
-                set(OpenMP_CXX_FLAGS "-fopenmp=libiomp5")
-                set(OpenMP_CXX_LIB_NAMES "iomp5")
-            elseif (OpenMP_CXX_FLAG MATCHES "-fopenmp=libgomp")
-                set(OpenMP_CXX_FLAGS "-fopenmp=libgomp")
-                set(OpenMP_CXX_LIB_NAMES "gomp")
-            else()
-                set(OpenMP_CXX_FLAGS "-fopenmp=libomp")
-                set(OpenMP_CXX_LIB_NAMES "omp")
+            if (CMAKE_${_lang}_COMPILER_ID MATCHES GNU)
+                set(OpenMP_${_lang}_FLAGS "-fopenmp")
+                set(OpenMP_${_lang}_LIB_NAMES "gomp;pthread")
+
+            elseif (CMAKE_${_lang}_COMPILER_ID MATCHES Intel)
+                set(OpenMP_${_lang}_FLAGS "-qopenmp")
+                set(OpenMP_${_lang}_LIB_NAMES "iomp5;pthread")
+
+            elseif (CMAKE_${_lang}_COMPILER_ID STREQUAL Clang)
+                if (OpenMP_${_lang}_FLAG MATCHES "-fopenmp=libiomp5")
+                    set(OpenMP_${_lang}_FLAGS "-fopenmp=libiomp5")
+                    set(OpenMP_${_lang}_LIB_NAMES "iomp5")
+                elseif (OpenMP_${_lang}_FLAG MATCHES "-fopenmp=libgomp")
+                    set(OpenMP_${_lang}_FLAGS "-fopenmp=libgomp")
+                    set(OpenMP_${_lang}_LIB_NAMES "gomp")
+                else()
+                    set(OpenMP_${_lang}_FLAGS "-fopenmp=libomp")
+                    set(OpenMP_${_lang}_LIB_NAMES "omp")
+                endif()
+
+            endif()
+
+            find_omp_libs("TargetOpenMP_${_lang}" ${OpenMP_${_lang}_LIB_NAMES})
+            if (TargetOpenMP_${_lang}_LIBRARIES)
+                add_library(OpenMP::OpenMP_${_lang} INTERFACE IMPORTED)
+                set_property (TARGET OpenMP::OpenMP_${_lang} PROPERTY INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:${_lang}>:${OpenMP_${_lang}_FLAGS}>")
+                set_property (TARGET OpenMP::OpenMP_${_lang} PROPERTY INTERFACE_LINK_LIBRARIES "${TargetOpenMP_${_lang}_LIBRARIES}")
+                if (NOT ${PN}_FIND_QUIETLY)
+                    message (STATUS "OpenMP_${_lang} target constructed.")
+                endif()
             endif()
         endif()
+    endforeach()
+endif()
 
-        find_omp_libs("TargetOpenMP" ${OpenMP_CXX_LIB_NAMES})
-        if (TargetOpenMP_LIBRARIES)
-            add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
-            set_property (TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>")
-            set_property (TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES "${TargetOpenMP_LIBRARIES}")
-            if (NOT ${PN}_FIND_QUIETLY)
-                message (STATUS "OpenMP target constructed.")
-            endif()
+unset(_omp_target_for_sought_langs)
+add_library (OpenMP::OpenMP INTERFACE IMPORTED)
+foreach(_lang IN ITEMS C CXX Fortran)
+    if((NOT ${PN}_FIND_COMPONENTS AND CMAKE_${_lang}_COMPILER_LOADED) OR _lang IN_LIST ${PN}_FIND_COMPONENTS)
+        if (TARGET OpenMP::OpenMP_${_lang})
+            set(${PN}_${_lang}_FOUND 1)
+            set_property(TARGET OpenMP::OpenMP APPEND PROPERTY INTERFACE_LINK_LIBRARIES "OpenMP::OpenMP_${_lang}")
         endif()
+        list(APPEND _omp_target_for_sought_langs "${PN}_${_lang}_FOUND")
+        set (${PN}_MESSAGE "Found TargetOpenMP ${${PN}_FINDLIST}: ${_ill}")  # only last lang
     endif()
-endif()
-
-if (TARGET OpenMP::OpenMP_CXX)
-    get_property (_ill TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES)
-    set (${PN}_MESSAGE "Found TargetOpenMP: ${_ill}")
-endif()
-
-#include(CMakePrintHelpers)
-#cmake_print_properties(TARGETS OpenMP::OpenMP_CXX
-#                       PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_INCLUDE_DIRS INTERFACE_LINK_LIBRARIES)
+endforeach()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args (${PN} DEFAULT_MSG ${PN}_MESSAGE)
+find_package_handle_standard_args(${PN}
+                                  REQUIRED_VARS ${_omp_target_for_sought_langs}
+                                  HANDLE_COMPONENTS)
+
+#include(CMakePrintHelpers)
+#message("Targets after find_package(TargetOpenMP)")
+#cmake_print_properties(TARGETS OpenMP::OpenMP_C OpenMP::OpenMP_CXX OpenMP::OpenMP_Fortran OpenMP::OpenMP
+#                       PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_INCLUDE_DIRS INTERFACE_LINK_LIBRARIES)
+cmake_policy(POP)

--- a/external/common/lapack/TargetLAPACKConfig.cmake.in
+++ b/external/common/lapack/TargetLAPACKConfig.cmake.in
@@ -23,4 +23,8 @@ if(NOT TARGET tgt::lapack)
     get_property(_ill TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES)
     get_property(_illl TARGET tgt::lapk PROPERTY INTERFACE_LINK_LIBRARIES)
     get_property(_illb TARGET tgt::blas PROPERTY INTERFACE_LINK_LIBRARIES)
+
+    include(CMakePrintHelpers)
+    cmake_print_properties(TARGETS OpenMP::OpenMP_C OpenMP::OpenMP_CXX OpenMP::OpenMP_Fortran OpenMP::OpenMP tgt::MathOpenMP tgt::lapack
+                           PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_INCLUDE_DIRS INTERFACE_LINK_LIBRARIES)
 endif()

--- a/external/downstream/gpu_dfcc/CMakeLists.txt
+++ b/external/downstream/gpu_dfcc/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_gpu_dfcc})
-    find_package(gpu_dfcc 0.2 CONFIG QUIET)  # TODO change when final
+    find_package(gpu_dfcc 0.3 CONFIG QUIET)
     if(${gpu_dfcc_FOUND})
         get_property(_loc TARGET gpu_dfcc::gpu_dfcc PROPERTY LOCATION)
         message(STATUS "${Cyan}Found gpu_dfcc${ColourReset}: ${_loc} (found version ${gpu_dfcc_VERSION})")
@@ -16,7 +16,7 @@ if(${ENABLE_gpu_dfcc})
         ExternalProject_Add(gpu_dfcc_external
             DEPENDS psi4-core
             GIT_REPOSITORY https://github.com/edeprince3/gpu_dfcc
-            GIT_TAG fd1dd94  # v0.2 + 2  # TODO change when final
+            GIT_TAG v0.3  # 16606bf
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_v2rdm_casscf})
-    find_package(v2rdm_casscf 0.6 CONFIG QUIET)
+    find_package(v2rdm_casscf 0.8 CONFIG QUIET)
 
     if(${v2rdm_casscf_FOUND})
         get_property(_loc TARGET v2rdm_casscf::v2rdm_casscf PROPERTY LOCATION)
@@ -16,10 +16,8 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            GIT_REPOSITORY https://github.com/loriab/v2rdm_casscf
-            #GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
-            #GIT_TAG e4145f5  # v0.6 + 13
-            GIT_TAG verfix4
+            GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
+            GIT_TAG 976d8af  # v0.8 + 1 (internal version bump)
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,8 +16,10 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
-            GIT_TAG e4145f5  # v0.6 + 13
+            GIT_REPOSITORY https://github.com/loriab/v2rdm_casscf
+            #GIT_REPOSITORY https://github.com/edeprince3/v2rdm_casscf
+            #GIT_TAG e4145f5  # v0.6 + 13
+            GIT_TAG verfix4
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/chemps2/CMakeLists.txt
+++ b/external/upstream/chemps2/CMakeLists.txt
@@ -47,10 +47,12 @@ if(${ENABLE_CheMPS2})
                        -DCMAKE_AR=${CMAKE_AR}
                        -DCMAKE_NM=${CMAKE_NM}
                        -DENABLE_TESTS=OFF
+                       -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
                        -DTargetLAPACK_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetLAPACK
                        -DTargetHDF5_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+                             -DTargetOpenMP_FIND_COMPONENTS:STRING=C;CXX
             INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(CheMPS2_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/CheMPS2 CACHE PATH "path to internally built CheMPS2Config.cmake" FORCE)

--- a/external/upstream/libefp/CMakeLists.txt
+++ b/external/upstream/libefp/CMakeLists.txt
@@ -33,8 +33,10 @@ if(${ENABLE_libefp})
                        -DINSTALL_DEVEL_HEADERS=ON
                        -DFRAGLIB_UNDERSCORE_L=OFF
                        -DFRAGLIB_DEEP=OFF
+                       -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
                        -DTargetLAPACK_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetLAPACK
             CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                             -DTargetOpenMP_FIND_COMPONENTS:STRING=C
             INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install)
 
         set(libefp_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/libefp CACHE PATH "path to internally built libefpConfig.cmake" FORCE)

--- a/external/upstream/libefp/CMakeLists.txt
+++ b/external/upstream/libefp/CMakeLists.txt
@@ -15,7 +15,7 @@ if(${ENABLE_libefp})
         ExternalProject_Add(libefp_external
             DEPENDS lapack_external
             GIT_REPOSITORY https://github.com/ilyak/libefp
-            GIT_TAG 1.5.0  # 4cbc84c
+            GIT_TAG 15cd7ce  # v1.5.0 + 10 (docs and a cmake lapack patch)
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKECONFIG_INSTALL_DIR "share/cmake/psi4")
 # <<<  Marshal Dependencies & Add-ons  >>>
 
 set(_addons)
+set(TargetOpenMP_FIND_COMPONENTS "CXX")
 find_package(TargetLAPACK CONFIG REQUIRED)
 get_property(_ill TARGET tgt::lapk PROPERTY INTERFACE_LINK_LIBRARIES)
 list(GET _ill 0 _ill0)

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1524,7 +1524,7 @@ def run_dfocc(name, **kwargs):
 
     def set_cholesky_from(mtd_type):
         type_val = core.get_global_option(mtd_type)
-        if type_val == 'DF':
+        if type_val in ['DISK_DF', 'DF']:
             core.set_local_option('DFOCC', 'CHOLESKY', 'FALSE')
             proc_util.check_disk_df(name.upper(), optstash)
 
@@ -3129,7 +3129,7 @@ def run_dfep2(name, **kwargs):
         ref_wfn = scf_helper(name, **kwargs)  # C1 certified
 
     if core.get_global_option('REFERENCE') != "RHF":
-        raise ValidationError("DF-EP2 is not availabel for %s references.",
+        raise ValidationError("DF-EP2 is not available for %s references.",
                               core.get_global_option('REFERENCE'))
 
 
@@ -3852,7 +3852,7 @@ def run_fnodfcc(name, **kwargs):
                 core.set_global_option('SCF_TYPE', 'CD')
                 core.print_out("""    SCF Algorithm Type (re)set to CD.\n""")
 
-        elif type_val == 'DF':
+        elif type_val in ['DISK_DF', 'DF']:
             if core.get_option('FNOCC', 'DF_BASIS_CC') == 'CHOLESKY':
                 core.set_local_option('FNOCC', 'DF_BASIS_CC', '')
 

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -134,8 +134,6 @@ def test_plugin_dfmp2(args):
     inputdat = """
 import %s
 
-memory 2 gb
-
 molecule {
 0 1
 C     0.0000000    0.0000000    1.0590353

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -126,7 +126,7 @@ def run_psithon_inputs(args, tfn, label):
     print("   Psi4@n%d : Psi4@n%d ratio (want ~%d): %.2f" % (threads[0], threads[-1], threads[-1], rat1))
     if args.passfail:
         #assert math.isclose(rat1, threads[-1], rel_tol=0.6), 'Psithon speedup {} !~= {}'.format(rat1, threads[-1])
-        assert rat1 > 1.3, '{} Psithon speedup {} !~= {}'.format(label, rat1, threads[-1])
+        assert rat1 > 1.25, '{} Psithon speedup {} !~= {}'.format(label, rat1, threads[-1])
 
 
 def test_plugin_dfmp2(args):

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -30,6 +30,9 @@ add_library(core SHARED ${sources_list})
 
 get_property(psi4_binmodules GLOBAL PROPERTY BINLIST)
 target_link_libraries(core PRIVATE ${PRE_LIBRARY_OPTION} dpd qt ${POST_LIBRARY_OPTION})
+if(TARGET ambit::ambit)
+    target_link_libraries(core PRIVATE ${PRE_LIBRARY_OPTION} ambit_interface ${POST_LIBRARY_OPTION})
+endif()
 
 if(TARGET dkh::dkh)
     target_compile_definitions(core PRIVATE $<TARGET_PROPERTY:dkh::dkh,INTERFACE_COMPILE_DEFINITIONS>)

--- a/psi4/src/psi4/ambit_interface/convert.cc
+++ b/psi4/src/psi4/ambit_interface/convert.cc
@@ -43,7 +43,7 @@ namespace helpers
 namespace psi4
 {
 
-void convert(const psi::Matrix &matrix, ambit::Tensor *target)
+void PSI_API convert(const psi::Matrix &matrix, ambit::Tensor *target)
 {
     if (target->rank() != 2)
         throw std::runtime_error(
@@ -77,7 +77,7 @@ void convert(const psi::Matrix &matrix, ambit::Tensor *target)
     (*target)() = local_tensor();
 }
 
-void convert(const psi::Vector &vector, ambit::Tensor *target)
+void PSI_API convert(const psi::Vector &vector, ambit::Tensor *target)
 {
     if (target->rank() != 1)
         throw std::runtime_error(

--- a/psi4/src/psi4/ambit_interface/integrals.cc
+++ b/psi4/src/psi4/ambit_interface/integrals.cc
@@ -45,7 +45,7 @@ namespace helpers {
 
 namespace psi4 {
 
-void integrals(psi::OneBodyAOInt &integral, ambit::Tensor *target) {
+void PSI_API integrals(psi::OneBodyAOInt &integral, ambit::Tensor *target) {
     // One-electron integrals are generally small enough to compute
     // on a single core and broadcast them out.
 
@@ -77,7 +77,7 @@ void integrals(psi::OneBodyAOInt &integral, ambit::Tensor *target) {
     }
 }
 
-void integrals(psi::TwoBodyAOInt &integral, Tensor *target) {
+void PSI_API integrals(psi::TwoBodyAOInt &integral, Tensor *target) {
     if (target->type() != CoreTensor)
         throw std::runtime_error(
             "integrals(TwoBodyAOInt, Tensor) is only "

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -3001,7 +3001,8 @@ int read_options(const std::string &name, Options & options, bool suppress_print
       point group (e.g., C2v for methane). Default takes into account symmetry
       reduction through asymmetric isotopic substitution and is unaffected by
       user-set symmetry on molecule, so this option is the sole way to influence
-      the symmetry-dependent aspects of the thermodynamic analysis. -*/
+      the symmetry-dependent aspects of the thermodynamic analysis.
+      Note that this factor is handled differently among quantum chemistry software. -*/
       options.add_int("ROTATIONAL_SYMMETRY_NUMBER", 1);
   }
   if (name == "CFOUR"|| options.read_globals()) {

--- a/tests/cc-module/CMakeLists.txt
+++ b/tests/cc-module/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc-module, "psi;quicktests;cc")
+add_regression_test(cc-module "psi;quicktests;cc")


### PR DESCRIPTION
## Description
Fixes up the OpenMP problems. This still needs some tidying, but you can start to take a look.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Mostly this polishes the new OpenMP/Math interface/detection by expanding it to C/CXX/Fortran (thanks, v2rdm, for playing your persistent role of complicating things) and making sure vars are propagated among the externalprojects. Key cmake option is `OpenMP_LIBRARY_DIRS` which is a `;`-sep PATH-like var to search for omp libs if not naturally found. closes #1041 
  - [x] fix a few DISK_DF in driver and add some long-awaited (really, look at the milestone history for that ticket) freq docs in #350 
  - [x] fatal_error's ERD
  - [x] bump various upstream/downstream
  - [x] get ambit back (can't readily test it except by building plugin)

## Questions
- [x] Roberto and Radovan should look over the CMake

## Status
- [x] Ready for review
- [x] Ready for merge
