### PR TITLE
Expose wavefunction and amplitudes to python

### DIFF
--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -187,6 +187,7 @@ void export_wavefunction(py::module& m) {
         .def("PCM_enabled", &Wavefunction::PCM_enabled, "Whether running a PCM calculation");
 
     py::class_<ccenergy::CCEnergyWavefunction, std::shared_ptr<ccenergy::CCEnergyWavefunction>, Wavefunction>(m, "CCEnergyWavefunction", "docstring");
+    py::class_<cclambda::CCLambdaWavefunction, std::shared_ptr<cclambda::CCLambdaWavefunction>, Wavefunction>(m, "CCLambdaWavefunction", "docstring");
 
     py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
         .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -96,10 +96,6 @@ void export_wavefunction(py::module& m) {
         .def("S", &Wavefunction::S, "Returns the overlap matrix.")
         .def("set_Ca", &Wavefunction::set_Ca, "Sets the Alpha Orbitals")
         .def("set_Cb", &Wavefunction::set_Cb, "Sets the Beta Orbitals.")
-        .def("set_T1", &Wavefunction::set_T1, "Sets the T1 amplitudes.")
-        .def("set_T2", &Wavefunction::set_T2, "Sets the T2 amplitudes.")
-        .def("set_L1", &Wavefunction::set_L1, "Sets the L1 amplitudes.")
-        .def("set_L2", &Wavefunction::set_L2, "Sets the L2 amplitudes.")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership,
@@ -190,8 +186,12 @@ void export_wavefunction(py::module& m) {
 #endif
         .def("PCM_enabled", &Wavefunction::PCM_enabled, "Whether running a PCM calculation");
 
-    py::class_<ccenergy::CCEnergyWavefunction, std::shared_ptr<ccenergy::CCEnergyWavefunction>, Wavefunction>(m, "CCEnergyWavefunction", "docstring");
-    py::class_<cclambda::CCLambdaWavefunction, std::shared_ptr<cclambda::CCLambdaWavefunction>, Wavefunction>(m, "CCLambdaWavefunction", "docstring");
+    py::class_<ccenergy::CCEnergyWavefunction, std::shared_ptr<ccenergy::CCEnergyWavefunction>, Wavefunction>(m, "CCEnergyWavefunction", "docstring")
+        .def("set_T1", &ccenergy::CCEnergyWavefunction::set_T1, "Sets the T1 amplitudes.")
+        .def("set_T2", &ccenergy::CCEnergyWavefunction::set_T2, "Sets the T2 amplitudes.");
+    py::class_<cclambda::CCLambdaWavefunction, std::shared_ptr<cclambda::CCLambdaWavefunction>, ccenergy::CCEnergyWavefunction, Wavefunction>(m, "CCLambdaWavefunction", "docstring")
+        .def("set_L1", &cclambda::CCLambdaWavefunction::set_L1, "Sets the L1 amplitudes.")
+        .def("set_L2", &cclambda::CCLambdaWavefunction::set_L2, "Sets the L2 amplitudes.");
 
     py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
         .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -98,6 +98,8 @@ void export_wavefunction(py::module& m) {
         .def("set_Cb", &Wavefunction::set_Cb, "Sets the Beta Orbitals.")
         .def("set_T1", &Wavefunction::set_T1, "Sets the T1 amplitudes.")
         .def("set_T2", &Wavefunction::set_T2, "Sets the T2 amplitudes.")
+        .def("set_L1", &Wavefunction::set_L1, "Sets the L1 amplitudes.")
+        .def("set_L2", &Wavefunction::set_L2, "Sets the L2 amplitudes.")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership,
@@ -116,6 +118,8 @@ void export_wavefunction(py::module& m) {
              "Returns the requested Beta Density subset.")
         .def("T1", &Wavefunction::T1, "Returns the T1 amplitudes.")
         .def("T2", &Wavefunction::T2, "Returns the T2 amplitudes.")
+        .def("L1", &Wavefunction::L1, "Returns the L1 amplitudes.")
+        .def("L2", &Wavefunction::L2, "Returns the L2 amplitudes.")
         .def("epsilon_a", &Wavefunction::epsilon_a, "Returns the Alpha Eigenvalues.")
         .def("epsilon_b", &Wavefunction::epsilon_b, "Returns the Beta Eigenvalues.")
         .def("epsilon_a_subset", &Wavefunction::epsilon_a_subset, "Returns the requested Alpha Eigenvalues subset.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -90,6 +90,9 @@ void export_wavefunction(py::module& m) {
         .def("nso", &Wavefunction::nso, "Number of symmetry orbitals.")
         .def("nmo", &Wavefunction::nmo, "Number of molecule orbitals.")
         .def("nirrep", &Wavefunction::nirrep, "Number of irreps in the system.")
+        .def("S", &Wavefunction::S, "Returns the overlap matrix.")
+        .def("set_Ca", &Wavefunction::set_Ca, "Sets the Alpha Orbitals")
+        .def("set_Cb", &Wavefunction::set_Cb, "Sets the Beta Orbitals.")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership,

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -38,6 +38,9 @@
 #include "psi4/libfock/jk.h"
 #include "psi4/libfock/soscf.h"
 
+#include "psi4/ccenergy/ccwave.h"
+#include "psi4/cclambda/cclambda.h"
+
 #include "psi4/detci/ciwave.h"
 #include "psi4/detci/civect.h"
 
@@ -93,6 +96,8 @@ void export_wavefunction(py::module& m) {
         .def("S", &Wavefunction::S, "Returns the overlap matrix.")
         .def("set_Ca", &Wavefunction::set_Ca, "Sets the Alpha Orbitals")
         .def("set_Cb", &Wavefunction::set_Cb, "Sets the Beta Orbitals.")
+        .def("set_T1", &Wavefunction::set_T1, "Sets the T1 amplitudes.")
+        .def("set_T2", &Wavefunction::set_T2, "Sets the T2 amplitudes.")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership,
@@ -109,6 +114,8 @@ void export_wavefunction(py::module& m) {
              "Returns the requested Alpha Density subset.")
         .def("Db_subset", &Wavefunction::Db_subset, py::return_value_policy::take_ownership,
              "Returns the requested Beta Density subset.")
+        .def("T1", &Wavefunction::T1, "Returns the T1 amplitudes.")
+        .def("T2", &Wavefunction::T2, "Returns the T2 amplitudes.")
         .def("epsilon_a", &Wavefunction::epsilon_a, "Returns the Alpha Eigenvalues.")
         .def("epsilon_b", &Wavefunction::epsilon_b, "Returns the Beta Eigenvalues.")
         .def("epsilon_a_subset", &Wavefunction::epsilon_a_subset, "Returns the requested Alpha Eigenvalues subset.")
@@ -178,6 +185,8 @@ void export_wavefunction(py::module& m) {
         .def("get_PCM", &Wavefunction::get_PCM, "Get the PCM object")
 #endif
         .def("PCM_enabled", &Wavefunction::PCM_enabled, "Whether running a PCM calculation");
+
+    py::class_<ccenergy::CCEnergyWavefunction, std::shared_ptr<ccenergy::CCEnergyWavefunction>, Wavefunction>(m, "CCEnergyWavefunction", "docstring");
 
     py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
         .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.")

--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -330,7 +330,7 @@ double CCEnergyWavefunction::compute_energy()
             outfile->Printf( "\n");
             amp_write();
 
-			// Get T amplitudes
+            // Get T amplitudes
             global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
             SharedMatrix new_t1 = SharedMatrix(new Matrix(&t1));
             set_T1(new_t1);

--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -96,8 +96,6 @@ double CCEnergyWavefunction::compute_energy()
     double **geom, *zvals, value;
     FILE *efile;
     int **cachelist, *cachefiles;
-    dpdfile2 t1;
-    dpdbuf4 t2;
     double *emp2_aa, *emp2_ab, *ecc_aa, *ecc_ab, tval;
 
     moinfo_.iter=0;
@@ -329,16 +327,6 @@ double CCEnergyWavefunction::compute_energy()
 
             outfile->Printf( "\n");
             amp_write();
-
-            // Get T amplitudes
-            global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
-            SharedMatrix new_t1 = SharedMatrix(new Matrix(&t1));
-            set_T1(new_t1);
-            global_dpd_->file2_close(&t1);
-            global_dpd_->buf4_init(&t2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-            SharedMatrix new_t2 = SharedMatrix(new Matrix(&t2));
-            set_T2(new_t2);
-            global_dpd_->buf4_close(&t2);
 
             if (params_.analyze != 0) analyze();
             break;
@@ -663,11 +651,21 @@ void CCEnergyWavefunction::one_step(void) {
     return;
 }
 
-SharedMatrix CCEnergyWavefunction::T1() const {
+SharedMatrix CCEnergyWavefunction::T1() {
+    dpdfile2 t1;
+    global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
+    SharedMatrix new_t1 = SharedMatrix(new Matrix(&t1));
+    T1_ = new_t1;
+    global_dpd_->file2_close(&t1);
     return T1_;
 }
 
-SharedMatrix CCEnergyWavefunction::T2() const {
+SharedMatrix CCEnergyWavefunction::T2() {
+    dpdbuf4 t2;
+    global_dpd_->buf4_init(&t2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
+    SharedMatrix new_t2 = SharedMatrix(new Matrix(&t2));
+    T2_ = new_t2;
+    global_dpd_->buf4_close(&t2);
     return T2_;
 }
 

--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -43,6 +43,7 @@
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/libmints/matrix.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -328,6 +329,17 @@ double CCEnergyWavefunction::compute_energy()
 
             outfile->Printf( "\n");
             amp_write();
+
+			// Get T amplitudes
+            global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
+            SharedMatrix new_t1 = SharedMatrix(new Matrix(&t1));
+            set_T1(new_t1);
+            global_dpd_->file2_close(&t1);
+            global_dpd_->buf4_init(&t2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
+            SharedMatrix new_t2 = SharedMatrix(new Matrix(&t2));
+            set_T2(new_t2);
+            global_dpd_->buf4_close(&t2);
+
             if (params_.analyze != 0) analyze();
             break;
         }
@@ -649,6 +661,22 @@ void CCEnergyWavefunction::one_step(void) {
         }
     }
     return;
+}
+
+SharedMatrix CCEnergyWavefunction::T1() const {
+    return T1_;
+}
+
+SharedMatrix CCEnergyWavefunction::T2() const {
+    return T2_;
+}
+
+void CCEnergyWavefunction::set_T1(SharedMatrix& T1_new) {
+    T1_ = T1_new;
+}
+
+void CCEnergyWavefunction::set_T2(SharedMatrix& T2_new) {
+    T2_ = T2_new;
 }
 
 }} // namespace psi::ccenergy

--- a/psi4/src/psi4/ccenergy/ccwave.h
+++ b/psi4/src/psi4/ccenergy/ccwave.h
@@ -52,6 +52,11 @@ public:
 
     double compute_energy();
 
+    virtual SharedMatrix T1() const;
+    virtual SharedMatrix T2() const;
+    virtual void set_T1(SharedMatrix& T1_new);
+    virtual void set_T2(SharedMatrix& T2_new);
+
 private:
 
     /* setup, info and teardown */

--- a/psi4/src/psi4/ccenergy/ccwave.h
+++ b/psi4/src/psi4/ccenergy/ccwave.h
@@ -52,8 +52,8 @@ public:
 
     double compute_energy();
 
-    virtual SharedMatrix T1() const;
-    virtual SharedMatrix T2() const;
+    virtual SharedMatrix T1();
+    virtual SharedMatrix T2();
     virtual void set_T1(SharedMatrix& T1_new);
     virtual void set_T2(SharedMatrix& T2_new);
 

--- a/psi4/src/psi4/cclambda/L2.cc
+++ b/psi4/src/psi4/cclambda/L2.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -57,9 +58,8 @@ void GmiL2(int L_irr);
 void dijabL2(int L_irr);
 
 void BL2_AO(int L_irr);
-void status(const char *, std::string);
 
-void L2_build(struct L_Params L_params) {
+void CCLambdaWavefunction::L2_build(struct L_Params L_params) {
   dpdbuf4 L2;
   int L_irr;
   L_irr = L_params.irrep;

--- a/psi4/src/psi4/cclambda/cache.cc
+++ b/psi4/src/psi4/cclambda/cache.cc
@@ -35,6 +35,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/cclambda/cclambda.h"
 
 namespace psi {
 extern FILE* outfile;
@@ -54,7 +55,7 @@ void cache_iajb_uhf(int **cachelist);
 void cache_ijka_uhf(int **cachelist);
 void cache_ijkl_uhf(int **cachelist);
 
-int **cacheprep_uhf(int level, int *cachefiles)
+int **CCLambdaWavefunction::cacheprep_uhf(int level, int *cachefiles)
 {
   int **cachelist;
 
@@ -120,7 +121,7 @@ int **cacheprep_uhf(int level, int *cachefiles)
    }
 }
 
-int **cacheprep_rhf(int level, int *cachefiles)
+int **CCLambdaWavefunction::cacheprep_rhf(int level, int *cachefiles)
 {
   int **cachelist;
 
@@ -745,12 +746,12 @@ void cache_ijkl_uhf(int **cachelist)
   cachelist[23][23] = 1;
 }
 
-void cachedone_uhf(int **cachelist)
+void CCLambdaWavefunction::cachedone_uhf(int **cachelist)
 {
   free_int_matrix(cachelist);
 }
 
-void cachedone_rhf(int **cachelist)
+void CCLambdaWavefunction::cachedone_rhf(int **cachelist)
 {
   free_int_matrix(cachelist);
 }

--- a/psi4/src/psi4/cclambda/cc2_L2.cc
+++ b/psi4/src/psi4/cclambda/cc2_L2.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -50,9 +51,8 @@ void L1FL2(int L_irr);
 void dijabL2(int L_irr);
 
 void BL2_AO(int L_irr);
-void status(const char *, std::string );
 
-void cc2_L2_build(struct L_Params L_params) {
+void CCLambdaWavefunction::cc2_L2_build(struct L_Params L_params) {
   int L_irr;
   L_irr = L_params.irrep;
 

--- a/psi4/src/psi4/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cclambda/cclambda.cc
@@ -122,8 +122,6 @@ double CCLambdaWavefunction::compute_energy()
     energy_ = 0.0;
     int done=0, i, root_L_irr;
     int **cachelist, *cachefiles;
-    dpdfile2 l1;
-    dpdbuf4 l2;
 
     init_io();
     title();
@@ -281,16 +279,6 @@ double CCLambdaWavefunction::compute_energy()
           }
           Lsave_index(pL_params[i]); /* save Ls with indices in LAMPS */
           Lamp_write(pL_params[i]); /* write out largest  Ls */
-          //TODO maybe also for all params.nstates
-          global_dpd_->file2_init(&l1, PSIF_CC_LAMBDA, pL_params[0].irrep, 0, 1, "LIA");
-          SharedMatrix new_l1 = SharedMatrix(new Matrix(&l1));
-          set_L1(new_l1);
-          global_dpd_->file2_close(&l1);
-
-          global_dpd_->buf4_init(&l2, PSIF_CC_LAMBDA, pL_params[0].irrep, 0, 5, 0, 5, 0, "LIjAb");
-          SharedMatrix new_l2 = SharedMatrix(new Matrix(&l2));
-          set_L2(new_l2);
-          global_dpd_->buf4_close(&l2);
 
       /* sort_amps(); to be done by later functions */
           outfile->Printf( "\n\tIterations converged.\n");
@@ -593,11 +581,21 @@ void zeta_norm(struct L_Params L_params) {
   return;
 }
 
-SharedMatrix CCLambdaWavefunction::L1() const {
+SharedMatrix CCLambdaWavefunction::L1() {
+    dpdfile2 l1;
+    global_dpd_->file2_init(&l1, PSIF_CC_LAMBDA, pL_params[0].irrep, 0, 1, "LIA");
+    SharedMatrix new_l1 = SharedMatrix(new Matrix(&l1));
+    L1_ = new_l1;
+    global_dpd_->file2_close(&l1);
     return L1_;
 }
 
-SharedMatrix CCLambdaWavefunction::L2() const {
+SharedMatrix CCLambdaWavefunction::L2() {
+    dpdbuf4 l2;
+    global_dpd_->buf4_init(&l2, PSIF_CC_LAMBDA, pL_params[0].irrep, 0, 5, 0, 5, 0, "LIjAb");
+    SharedMatrix new_l2 = SharedMatrix(new Matrix(&l2));
+    L2_ = new_l2;
+    global_dpd_->buf4_close(&l2);
     return L2_;
 }
 

--- a/psi4/src/psi4/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cclambda/cclambda.cc
@@ -119,9 +119,8 @@ namespace psi { namespace cclambda {
 
 CCLambdaWavefunction::CCLambdaWavefunction(std::shared_ptr<Wavefunction>
 reference_wavefunction, Options &options)
-    : Wavefunction(options)
+    : CCEnergyWavefunction(reference_wavefunction, options)
 {
-    set_reference_wavefunction(reference_wavefunction);
     psio_ = _default_psio_lib_;
     init();
 }

--- a/psi4/src/psi4/cclambda/cclambda.h
+++ b/psi4/src/psi4/cclambda/cclambda.h
@@ -48,9 +48,9 @@ public:
     double compute_energy();
 
     /// Returns the L1 amplitudes
-    virtual SharedMatrix L1() const;
+    virtual SharedMatrix L1();
     /// Returns the L2 amplitudes
-    virtual SharedMatrix L2() const;
+    virtual SharedMatrix L2();
     virtual void set_L1(SharedMatrix& L1_new);
     virtual void set_L2(SharedMatrix& L2_new);
 

--- a/psi4/src/psi4/cclambda/cclambda.h
+++ b/psi4/src/psi4/cclambda/cclambda.h
@@ -39,7 +39,7 @@ class Options;
 
 namespace psi { namespace cclambda {
 
-class CCLambdaWavefunction : public psi::ccenergy::CCEnergyWavefunction
+class CCLambdaWavefunction final : public psi::ccenergy::CCEnergyWavefunction
 {
 public:
     CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);

--- a/psi4/src/psi4/cclambda/cclambda.h
+++ b/psi4/src/psi4/cclambda/cclambda.h
@@ -30,6 +30,7 @@
 #define CCLAMBDA_H
 
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/ccenergy/ccwave.h"
 
 namespace psi {
 class Wavefunction;
@@ -38,7 +39,7 @@ class Options;
 
 namespace psi { namespace cclambda {
 
-class CCLambdaWavefunction : public Wavefunction
+class CCLambdaWavefunction : public psi::ccenergy::CCEnergyWavefunction
 {
 public:
     CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);

--- a/psi4/src/psi4/cclambda/cclambda.h
+++ b/psi4/src/psi4/cclambda/cclambda.h
@@ -47,8 +47,38 @@ public:
 
     double compute_energy();
 
+    /// Returns the L1 amplitudes
+    virtual SharedMatrix L1() const;
+    /// Returns the L2 amplitudes
+    virtual SharedMatrix L2() const;
+    virtual void set_L1(SharedMatrix& L1_new);
+    virtual void set_L2(SharedMatrix& L2_new);
+
 private:
     void init();
+    void init_io();
+    void init_amps(struct L_Params);
+    int **cacheprep_uhf(int level, int *cachefiles);
+    int **cacheprep_rhf(int level, int *cachefiles);
+    void cachedone_rhf(int **cachelist);
+    void cachedone_uhf(int **cachelist);
+    void cleanup();
+    void denom(struct L_Params);
+    void get_params(psi::Options&);
+    void local_init();
+    void local_done();
+    void exit_io();
+    void title();
+    void get_moinfo(std::shared_ptr<psi::Wavefunction> wfn);
+
+    int converged(int);
+    void diis(int, int);
+    void sort_amps(int);
+    void status(const char*, std::string);
+    void update();
+
+    void cc2_L2_build(struct L_Params);
+    void L2_build(struct L_Params);
 };
 
 }}

--- a/psi4/src/psi4/cclambda/converged.cc
+++ b/psi4/src/psi4/cclambda/converged.cc
@@ -34,6 +34,7 @@
 #include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -41,7 +42,7 @@
 
 namespace psi { namespace cclambda {
 
-int converged(int L_irr)
+int CCLambdaWavefunction::converged(int L_irr)
 {
   int row,col,h,nirreps;
   double rms=0.0;

--- a/psi4/src/psi4/cclambda/denom.cc
+++ b/psi4/src/psi4/cclambda/denom.cc
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cstring>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -44,7 +45,7 @@ void denom_rhf(struct L_Params);
 void denom_rohf(struct L_Params);
 void denom_uhf(struct L_Params);
 
-void denom(struct L_Params L_params) {
+void CCLambdaWavefunction::denom(struct L_Params L_params) {
   if(params.ref == 0) denom_rhf(L_params);
   else if(params.ref == 1) denom_rohf(L_params);
   else if(params.ref == 2) denom_uhf(L_params);

--- a/psi4/src/psi4/cclambda/diis.cc
+++ b/psi4/src/psi4/cclambda/diis.cc
@@ -38,6 +38,7 @@
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/cclambda/cclambda.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
@@ -60,7 +61,7 @@ namespace psi { namespace cclambda {
 ** -TDC  12/22/01
 */
 
-void diis(int iter, int L_irr)
+void CCLambdaWavefunction::diis(int iter, int L_irr)
 {
   int nvector=8;  /* Number of error vectors to keep */
   int h, nirreps;

--- a/psi4/src/psi4/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cclambda/get_moinfo.cc
@@ -38,6 +38,7 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/molecule.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -54,7 +55,7 @@ namespace psi { namespace cclambda {
 ** Modified for UHF references by TDC, June 2002.
 */
 
-void get_moinfo(std::shared_ptr<Wavefunction> wfn)
+void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn)
 {
     int i,j, h, p, q, errcod, nactive, nirreps, sym;
     double ***C, ***Ca, ***Cb;
@@ -241,7 +242,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn)
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
-void cleanup(void)
+void CCLambdaWavefunction::cleanup(void)
 {
     int i, h;
 

--- a/psi4/src/psi4/cclambda/get_params.cc
+++ b/psi4/src/psi4/cclambda/get_params.cc
@@ -42,6 +42,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/cclambda/cclambda.h"
 
 #include "MOInfo.h"
 #include "Params.h"
@@ -51,7 +52,7 @@
 
 namespace psi { namespace cclambda {
 
-void get_params(Options& options)
+void CCLambdaWavefunction::get_params(Options& options)
 {
   int errcod, iconv,i,j,k,l,prop_sym,prop_root, excited_method=0;
         int *states_per_irrep, prop_all, lambda_and_Ls = 0;

--- a/psi4/src/psi4/cclambda/init_amps.cc
+++ b/psi4/src/psi4/cclambda/init_amps.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -39,7 +40,7 @@
 
 namespace psi { namespace cclambda {
 
-void init_amps(struct L_Params L_params)
+void CCLambdaWavefunction::init_amps(struct L_Params L_params)
 {
   double norm;
   dpdfile2 T1, R1, LIA, Lia, dIA, dia, XIA, Xia;

--- a/psi4/src/psi4/cclambda/local.cc
+++ b/psi4/src/psi4/cclambda/local.cc
@@ -45,6 +45,7 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
+#include "psi4/cclambda/cclambda.h"
 #define EXTERN
 #include "globals.h"
 
@@ -64,7 +65,7 @@ namespace psi { namespace cclambda {
 ** TDC, Jan-June 2002
 */
 
-void local_init(void)
+void CCLambdaWavefunction::local_init(void)
 {
   local.nso = moinfo.nso;
   local.nocc = moinfo.occpi[0]; /* active doubly occupied orbitals */
@@ -74,7 +75,7 @@ void local_init(void)
 
 }
 
-void local_done(void)
+void CCLambdaWavefunction::local_done(void)
 {
   outfile->Printf( "\tLocal parameters free.\n");
 }

--- a/psi4/src/psi4/cclambda/sort_amps.cc
+++ b/psi4/src/psi4/cclambda/sort_amps.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -39,7 +40,7 @@
 
 namespace psi { namespace cclambda {
 
-void sort_amps(int L_irr)
+void CCLambdaWavefunction::sort_amps(int L_irr)
 {
   dpdbuf4 L2;
 

--- a/psi4/src/psi4/cclambda/status.cc
+++ b/psi4/src/psi4/cclambda/status.cc
@@ -33,9 +33,11 @@
 #include <cstdio>
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/cclambda/cclambda.h"
+
 namespace psi { namespace cclambda {
 
-void status(const char *s, std::string out)
+void CCLambdaWavefunction::status(const char *s, std::string out)
 {
    std::shared_ptr<psi::PsiOutStream> printer=(out=="outfile"?outfile:
            std::make_shared<PsiOutStream>(out));

--- a/psi4/src/psi4/cclambda/update.cc
+++ b/psi4/src/psi4/cclambda/update.cc
@@ -33,12 +33,13 @@
 #include <cstdio>
 #include "MOInfo.h"
 #include "Params.h"
+#include "psi4/cclambda/cclambda.h"
 #define EXTERN
 #include "globals.h"
 
 namespace psi { namespace cclambda {
 
-void update(void)
+void CCLambdaWavefunction::update(void)
 {
   outfile->Printf("\t%4d      %20.15f    %4.3e\n",moinfo.iter,moinfo.lcc,
 	  moinfo.conv);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -317,7 +317,7 @@ void Matrix::copy(const Matrix *cp) {
 #pragma omp parallel for
     for (int h = 0; h < nirrep_; ++h) {
         if (rowspi_[h] != 0 && colspi_[h ^ symmetry_] != 0)
-            memcpy(&(matrix_[h][0][0]), &(cp->matrix_[h][0][0]),
+            memmove(&(matrix_[h][0][0]), &(cp->matrix_[h][0][0]),
                    rowspi_[h] * (size_t)colspi_[h ^ symmetry_] * sizeof(double));
     }
 }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -242,7 +242,7 @@ Matrix::Matrix(dpdbuf4 *inBuf)
     : name_("None"), rowspi_(inBuf->params->nirreps), colspi_(inBuf->params->nirreps)
 {
     matrix_ = NULL;
-    symmetry_ = 0; //inBuf->my_irrep;
+    symmetry_ = inBuf->my_irrep;
     nirrep_ = inBuf->params->nirreps;
     for (int i=0; i<nirrep_; ++i) {
         rowspi_[i] = inBuf->params->rowtot[i];

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -41,6 +41,7 @@
 namespace psi {
 
 struct dpdfile2;
+struct dpdbuf4;
 
 class PSIO;
 class Vector;
@@ -161,6 +162,14 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param inFile dpdfile2 object to replicate (must already be initialized).
      */
     Matrix(dpdfile2* inFile);
+
+    /**
+     * Contructs a Matrix from a dpdbuf4
+     *
+     * @param inBuf dpdbuf4 object to replicate (must already be initialized).
+     */
+    Matrix(dpdbuf4 *inBuf);
+
 
     /**
      * Constructor using Dimension objects to define order and dimensionality.
@@ -1051,6 +1060,9 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
     /// Writes this to the dpdfile2 given
     void write_to_dpdfile2(dpdfile2* outFile);
+
+    /// Writes this to the dpdbuf4 given
+    void write_to_dpdbuf4(dpdbuf4 *outBuf);
 
     /// @{
     /// Checks matrix equality.

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -435,7 +435,7 @@ void Wavefunction::common_init() {
     // Make sure that the multiplicity is reasonable
     int multiplicity = molecule_->multiplicity();
     if (multiplicity - 1 > nelectron) {
-        char *str = new char[100];
+        char *str = new char[200];
         sprintf(str,
                 "There are not enough electrons for multiplicity = %d.\n"
                 "Please check your input",
@@ -444,7 +444,7 @@ void Wavefunction::common_init() {
         delete[] str;
     }
     if (multiplicity % 2 == nelectron % 2) {
-        char *str = new char[100];
+        char *str = new char[200];
         sprintf(str,
                 "A multiplicity of %d with %d electrons is impossible.\n"
                 "Please check your input",

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -145,6 +145,8 @@ void Wavefunction::shallow_copy(const Wavefunction *other) {
     Db_ = other->Db_;
     Fa_ = other->Fa_;
     Fb_ = other->Fb_;
+    T1_ = other->T1_;
+    T2_ = other->T2_;
     epsilon_a_ = other->epsilon_a_;
     epsilon_b_ = other->epsilon_b_;
 
@@ -225,6 +227,8 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     if (other->Db_) Db_ = other->Db_->clone();
     if (other->Fa_) Fa_ = other->Fa_->clone();
     if (other->Fb_) Fb_ = other->Fb_->clone();
+    if (other->T1_) T1_ = other->T1_->clone();
+    if (other->T2_) T2_ = other->T2_->clone();
     if (other->epsilon_a_) epsilon_a_ = SharedVector(other->epsilon_a_->clone());
     if (other->epsilon_b_) epsilon_b_ = SharedVector(other->epsilon_b_->clone());
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -147,6 +147,8 @@ void Wavefunction::shallow_copy(const Wavefunction *other) {
     Fb_ = other->Fb_;
     T1_ = other->T1_;
     T2_ = other->T2_;
+    L1_ = other->L1_;
+    L2_ = other->L2_;
     epsilon_a_ = other->epsilon_a_;
     epsilon_b_ = other->epsilon_b_;
 
@@ -229,6 +231,8 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     if (other->Fb_) Fb_ = other->Fb_->clone();
     if (other->T1_) T1_ = other->T1_->clone();
     if (other->T2_) T2_ = other->T2_->clone();
+    if (other->L1_) L1_ = other->L1_->clone();
+    if (other->L2_) L2_ = other->L2_->clone();
     if (other->epsilon_a_) epsilon_a_ = SharedVector(other->epsilon_a_->clone());
     if (other->epsilon_b_) epsilon_b_ = SharedVector(other->epsilon_b_->clone());
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -643,6 +643,25 @@ void Wavefunction::set_frzvpi(const Dimension &frzvpi) {
     }
 }
 
+void Wavefunction::set_Ca(SharedMatrix& Ca_new) {
+    if (Ca_)
+        Ca_ = Ca_new;
+    else if (reference_wavefunction_)
+        reference_wavefunction_->Ca_ = Ca_new;
+    else
+        throw PSIEXCEPTION("Wavefunction::set_Ca: Unable to set MO coefficients.");
+}
+
+void Wavefunction::set_Cb(SharedMatrix& Cb_new) {
+    if (Cb_)
+        Cb_ = Cb_new;
+    else if (reference_wavefunction_)
+        reference_wavefunction_->Cb_ = Cb_new;
+    else
+        throw PSIEXCEPTION("Wavefunction::set_Cb: Unable to set MO coefficients.");
+}
+
+
 SharedMatrix Wavefunction::Ca() const {
     if (!Ca_) {
         if (!reference_wavefunction_)

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -200,6 +200,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     SharedMatrix T1_;
     /// T2 amplitudes
     SharedMatrix T2_;
+    /// L1 amplitudes
+    SharedMatrix L1_;
+    /// L2 amplitudes
+    SharedMatrix L2_;
 
     /// Alpha orbital eneriges
     SharedVector epsilon_a_;
@@ -419,6 +423,11 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     virtual void set_T1(SharedMatrix& T1_new) { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
     /// Sets the T2 amplitudes
     virtual void set_T2(SharedMatrix& T2_new) { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
+    /// Sets the L1 amplitudes
+    virtual void set_L1(SharedMatrix& L1_new) { throw PSIEXCEPTION("There are no L1 amplitudes for this wavefunction."); };
+    /// Sets the L2 amplitudes
+    virtual void set_L2(SharedMatrix& L2_new) { throw PSIEXCEPTION("There are no L2 amplitudes for this wavefunction."); };
+
 
     /// Returns the alpha electrons MO coefficients
     SharedMatrix Ca() const;
@@ -432,6 +441,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     virtual SharedMatrix T1() const { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
     /// Returns the T2 amplitudes;
     virtual SharedMatrix T2() const { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
+    /// Returns the L1 amplitudes.
+    virtual SharedMatrix L1() const { throw PSIEXCEPTION("There are no L1 amplitudes for this wavefunction."); };
+    /// Returns the L2 amplitudes;
+    virtual SharedMatrix L2() const { throw PSIEXCEPTION("There are no L2 amplitudes for this wavefunction."); };
     /// Returns the alpha orbital energies
     SharedVector epsilon_a() const;
     /// Returns the beta orbital energies

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -196,6 +196,11 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Beta Fock matrix
     SharedMatrix Fb_;
 
+    /// T1 amplitudes
+    SharedMatrix T1_;
+    /// T2 amplitudes
+    SharedMatrix T2_;
+
     /// Alpha orbital eneriges
     SharedVector epsilon_a_;
     /// Beta orbital energies
@@ -410,6 +415,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     void set_Ca(SharedMatrix& Ca_new);
     /// Sets the beta electrons MO coefficients
     void set_Cb(SharedMatrix& Cb_new);
+    /// Sets the T1 amplitudes
+    virtual void set_T1(SharedMatrix& T1_new) { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
+    /// Sets the T2 amplitudes
+    virtual void set_T2(SharedMatrix& T2_new) { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
 
     /// Returns the alpha electrons MO coefficients
     SharedMatrix Ca() const;
@@ -419,6 +428,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     SharedMatrix Fa() const;
     /// Returns the (SO basis) beta Fock matrix
     SharedMatrix Fb() const;
+    /// Returns the T1 amplitudes.
+    virtual SharedMatrix T1() const { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
+    /// Returns the T2 amplitudes;
+    virtual SharedMatrix T2() const { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
     /// Returns the alpha orbital energies
     SharedVector epsilon_a() const;
     /// Returns the beta orbital energies

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -429,13 +429,13 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Returns the (SO basis) beta Fock matrix
     SharedMatrix Fb() const;
     /// Returns the T1 amplitudes.
-    virtual SharedMatrix T1() const { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
+    virtual SharedMatrix T1() { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
     /// Returns the T2 amplitudes;
-    virtual SharedMatrix T2() const { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
+    virtual SharedMatrix T2() { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
     /// Returns the L1 amplitudes.
-    virtual SharedMatrix L1() const { throw PSIEXCEPTION("There are no L1 amplitudes for this wavefunction."); };
+    virtual SharedMatrix L1() { throw PSIEXCEPTION("There are no L1 amplitudes for this wavefunction."); };
     /// Returns the L2 amplitudes;
-    virtual SharedMatrix L2() const { throw PSIEXCEPTION("There are no L2 amplitudes for this wavefunction."); };
+    virtual SharedMatrix L2() { throw PSIEXCEPTION("There are no L2 amplitudes for this wavefunction."); };
     /// Returns the alpha orbital energies
     SharedVector epsilon_a() const;
     /// Returns the beta orbital energies

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -419,15 +419,6 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     void set_Ca(SharedMatrix& Ca_new);
     /// Sets the beta electrons MO coefficients
     void set_Cb(SharedMatrix& Cb_new);
-    /// Sets the T1 amplitudes
-    virtual void set_T1(SharedMatrix& T1_new) { throw PSIEXCEPTION("There are no T1 amplitudes for this wavefunction."); };
-    /// Sets the T2 amplitudes
-    virtual void set_T2(SharedMatrix& T2_new) { throw PSIEXCEPTION("There are no T2 amplitudes for this wavefunction."); };
-    /// Sets the L1 amplitudes
-    virtual void set_L1(SharedMatrix& L1_new) { throw PSIEXCEPTION("There are no L1 amplitudes for this wavefunction."); };
-    /// Sets the L2 amplitudes
-    virtual void set_L2(SharedMatrix& L2_new) { throw PSIEXCEPTION("There are no L2 amplitudes for this wavefunction."); };
-
 
     /// Returns the alpha electrons MO coefficients
     SharedMatrix Ca() const;

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -406,6 +406,11 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Returns the core Hamiltonian matrix
     SharedMatrix H() const { return H_; }
 
+    /// Sets the alpha electrons MO coefficients
+    void set_Ca(SharedMatrix& Ca_new);
+    /// Sets the beta electrons MO coefficients
+    void set_Cb(SharedMatrix& Cb_new);
+
     /// Returns the alpha electrons MO coefficients
     SharedMatrix Ca() const;
     /// Returns the beta electrons MO coefficients

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2073,7 +2073,7 @@ int read_options(const std::string &name, Options & options, bool suppress_print
     options.add_bool("CANONICALIZE_INACTIVE_FAVG",false);
     /*- Do consider internal rotations? -*/
     options.add_bool("INTERNAL_ROTATIONS",true);
-    /*- Do attempt to force a two configruation solution by starting with CI coefficents of $\pm \sqrt{\frac{1}{2}}$ ? -*/
+    /*- Do attempt to force a two configuration solution by starting with CI coefficents of $\pm \sqrt{\frac{1}{2}}$ ? -*/
     options.add_bool("FORCE_TWOCON",false);
     /*- The number of singly occupied orbitals, per irrep -*/
     options.add("SOCC", new ArrayType());


### PR DESCRIPTION
## Description
The purpose of this PR is to expose the wavefunction as well as access to all amplitudes from CC to the python side. This has the advantage to sort out the relationship of Wavefunction, CCEnergyWavefunction and CCLambdaWavefunction in a more natural C++ way through inheritance.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] CCLambdaWavefunction inherits from CCEnergyWavefunction to facilitate better runtime access from the python side.
  - [x] Setter and getter for all T & L amplitudes are included in the python interface to enable more sophisticated methods in the future, e.g. in the broker from #1057.
* **User-Facing for Release Notes**
  - [x] Setter and getter for all T & L amplitudes are included in the python interface to enable more sophisticated methods in the future, e.g. in the broker from #1057.

## Questions
- [ ] Does the more technical details from above (inheritance change and exposing of the amplitudes to python) require more text for the release notes?
- [ ] The python documentation should be automatically built, is there more documentation for this part required?

## Checklist
- [x] Tests added for any new features (not required as no new functionality added)
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
