### PR TITLE
Port psimrcc to Windows

### DIFF
--- a/psi4/src/psi4/psimrcc/main.cc
+++ b/psi4/src/psi4/psimrcc/main.cc
@@ -109,7 +109,7 @@ psimrcc(SharedWavefunction ref_wfn, Options &options)
 
   int nactmo = moinfo->get_nactv();
   int nactel = moinfo->get_nactive_ael() + moinfo->get_nactive_bel();
-  if(nactel > 2 and nactmo > 2){
+  if(nactel > 2 && nactmo > 2){
       outfile->Printf("\n   WARNING: PSIMRCC detected that you are not using a CAS(2,n) or CAS(m,2) active space");
       outfile->Printf("\n            You requested a CAS(%d,%d) space.  In this case the program will run",nactel,nactmo);
       outfile->Printf("\n            but will negled matrix elements of the effective Hamiltonian between");
@@ -125,7 +125,7 @@ psimrcc(SharedWavefunction ref_wfn, Options &options)
     mrpt2(ref_wfn, options);
   }else{
     mrccsd(ref_wfn, options);
-    if(nactel > 2 and nactmo > 2){
+    if(nactel > 2 && nactmo > 2){
         outfile->Printf("\n   WARNING: PSIMRCC detected that you are not using a CAS(2,n) or CAS(m,2) active space");
         outfile->Printf("\n            You requested a CAS(%d,%d) space.  In this case the program will run",nactel,nactmo);
         outfile->Printf("\n            but will negled matrix elements of the effective Hamiltonian between");

--- a/psi4/src/psi4/psimrcc/mrccsd_t_compute.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_compute.cc
@@ -99,7 +99,7 @@ void MRCCSD_T::compute()
     }
   }
 
-  if(not options_.get_bool("DIAGONALIZE_HEFF")){
+  if(!options_.get_bool("DIAGONALIZE_HEFF")){
     double Heff_E = 0.0;
     for(int mu = 0; mu < nrefs; ++mu){
       for(int nu = 0; nu < nrefs; ++nu){

--- a/psi4/src/psi4/psimrcc/mrccsd_t_compute_restricted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_compute_restricted.cc
@@ -63,7 +63,7 @@ void MRCCSD_T::compute_restricted()
 
   compute_ooo_triples_restricted();
   compute_ooO_triples_restricted();
-  if(not closed_shell_case){
+  if(!closed_shell_case){
     compute_oOO_triples_restricted();
     compute_OOO_triples_restricted();
   }
@@ -107,7 +107,7 @@ void MRCCSD_T::compute_restricted()
     }
   }
 
-  if(not options_.get_bool("DIAGONALIZE_HEFF")){
+  if(!options_.get_bool("DIAGONALIZE_HEFF")){
     double Heff_E = 0.0;
     for(int mu = 0; mu < nrefs; ++mu){
       for(int nu = 0; nu < nrefs; ++nu){
@@ -156,7 +156,7 @@ void MRCCSD_T::compute_ooo_triples_restricted()
     size_t j_abs = o->get_tuple_abs_index(ijk.ind_abs<1>());
     size_t k_abs = o->get_tuple_abs_index(ijk.ind_abs<2>());
 
-    if((i_abs < j_abs) and (j_abs < k_abs)){
+    if((i_abs < j_abs) && (j_abs < k_abs)){
 
       int i_sym    = o->get_tuple_irrep(ijk.ind_abs<0>());
       int j_sym    = o->get_tuple_irrep(ijk.ind_abs<1>());
@@ -310,7 +310,7 @@ void MRCCSD_T::compute_OOO_triples_restricted()
     size_t j_abs = o->get_tuple_abs_index(ijk.ind_abs<1>());
     size_t k_abs = o->get_tuple_abs_index(ijk.ind_abs<2>());
 
-    if((i_abs < j_abs) and (j_abs < k_abs)){
+    if((i_abs < j_abs) && (j_abs < k_abs)){
 
       int i_sym    = o->get_tuple_irrep(ijk.ind_abs<0>());
       int j_sym    = o->get_tuple_irrep(ijk.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_compute_spin_adapted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_compute_spin_adapted.cc
@@ -120,7 +120,7 @@ void MRCCSD_T::compute_ooO_triples_spin_adapted()
     size_t j_abs = o->get_tuple_abs_index(ijk.ind_abs<1>());
     size_t k_abs = o->get_tuple_abs_index(ijk.ind_abs<2>());
 
-    if((i_abs <= j_abs) and (j_abs <= k_abs)){
+    if((i_abs <= j_abs) && (j_abs <= k_abs)){
       int i_sym     = o->get_tuple_irrep(ijk.ind_abs<0>());
       int j_sym     = o->get_tuple_irrep(ijk.ind_abs<1>());
       int k_sym     = o->get_tuple_irrep(ijk.ind_abs<2>());
@@ -269,7 +269,7 @@ void MRCCSD_T::compute_ooO_triples_spin_adapted()
       //////////////
       // IJK CASE //
       //////////////
-      if((i_abs < j_abs) and (j_abs <= k_abs)){
+      if((i_abs < j_abs) && (j_abs <= k_abs)){
         for(int mu = 0; mu < nrefs; ++mu){
           T[mu][ijk_sym]->zero();
         }
@@ -375,7 +375,7 @@ void MRCCSD_T::compute_ooO_triples_spin_adapted()
       //////////////
       // IKJ CASE //
       //////////////
-      if((i_abs <= j_abs) and (j_abs < k_abs)){
+      if((i_abs <= j_abs) && (j_abs < k_abs)){
 
         for(int mu = 0; mu < nrefs; ++mu){
           T[mu][ijk_sym]->zero();
@@ -482,7 +482,7 @@ void MRCCSD_T::compute_ooO_triples_spin_adapted()
       //////////////
       // JKI CASE //
       //////////////
-      if((i_abs < j_abs) and (j_abs < k_abs)){
+      if((i_abs < j_abs) && (j_abs < k_abs)){
 
         for(int mu = 0; mu < nrefs; ++mu){
           T[mu][ijk_sym]->zero();
@@ -589,7 +589,7 @@ void MRCCSD_T::compute_ooO_triples_spin_adapted()
       //////////////
       // AAA CASE //
       //////////////
-      if((i_abs < j_abs) and (j_abs < k_abs)){
+      if((i_abs < j_abs) && (j_abs < k_abs)){
 
         for(int mu = 0; mu < nrefs; ++mu){
           T[mu][ijk_sym]->zero();

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff.cc
@@ -43,7 +43,7 @@ void MRCCSD_T::compute_ooo_contribution_to_Heff(int i,int j,int k,int mu,BlockMa
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_ooo_contribution_to_Heff(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
     }
@@ -60,15 +60,15 @@ void MRCCSD_T::compute_ooO_contribution_to_Heff(int i,int j,int k,int mu,BlockMa
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_ooO_contribution_to_Heff(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_ooO_contribution_to_Heff(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (alpha,beta)->(alpha,beta) double excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_AB_ooO_contribution_to_Heff(alpha_internal_excitation[0].first, beta_internal_excitation[0].first,
                                                                alpha_internal_excitation[0].second,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
@@ -86,15 +86,15 @@ void MRCCSD_T::compute_oOO_contribution_to_Heff(int i,int j,int k,int mu,BlockMa
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_oOO_contribution_to_Heff(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_oOO_contribution_to_Heff(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (alpha,beta)->(alpha,beta) double excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_AB_oOO_contribution_to_Heff(alpha_internal_excitation[0].first, beta_internal_excitation[0].first,
                                                                alpha_internal_excitation[0].second,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
@@ -112,7 +112,7 @@ void MRCCSD_T::compute_OOO_contribution_to_Heff(int i,int j,int k,int mu,BlockMa
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_OOO_contribution_to_Heff(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
     }

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_a.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_a.cc
@@ -39,7 +39,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  jk_sym  = oo->get_tuple_irrep(j_abs,k_abs);
@@ -48,7 +48,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -66,7 +66,7 @@ double MRCCSD_T::compute_A_ooO_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  jk_sym  = oo->get_tuple_irrep(j_abs,k_abs);
@@ -75,7 +75,7 @@ double MRCCSD_T::compute_A_ooO_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -93,7 +93,7 @@ double MRCCSD_T::compute_A_oOO_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  jk_sym  = oo->get_tuple_irrep(j_abs,k_abs);
@@ -102,7 +102,7 @@ double MRCCSD_T::compute_A_oOO_contribution_to_Heff(int u_abs,int x_abs,int i_ab
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_a_restricted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_a_restricted.cc
@@ -39,7 +39,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff_restricted(int u_abs,int x_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -52,7 +52,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff_restricted(int u_abs,int x_a
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -62,7 +62,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff_restricted(int u_abs,int x_a
     }
   }
   if(j_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -72,7 +72,7 @@ double MRCCSD_T::compute_A_ooo_contribution_to_Heff_restricted(int u_abs,int x_a
     }
   }
   if(k_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -90,7 +90,7 @@ double MRCCSD_T::compute_A_ooO_contribution_to_Heff_restricted(int u_abs,int x_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  ik_sym  = oo->get_tuple_irrep(i_abs,k_abs);
@@ -101,7 +101,7 @@ double MRCCSD_T::compute_A_ooO_contribution_to_Heff_restricted(int u_abs,int x_a
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -111,7 +111,7 @@ double MRCCSD_T::compute_A_ooO_contribution_to_Heff_restricted(int u_abs,int x_a
     }
   }
   if(j_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -129,7 +129,7 @@ double MRCCSD_T::compute_A_oOO_contribution_to_Heff_restricted(int u_abs,int x_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(x_abs);
   int  jk_sym  = oo->get_tuple_irrep(j_abs,k_abs);
@@ -138,7 +138,7 @@ double MRCCSD_T::compute_A_oOO_contribution_to_Heff_restricted(int u_abs,int x_a
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(i_abs == u_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int    ef_sym  = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_ab.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_ab.cc
@@ -40,7 +40,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
   int    j_sym  = o->get_tuple_irrep(j_abs);
   int    k_sym  = o->get_tuple_irrep(k_abs);
 
-  int  ijk_sym  = i_sym xor j_sym xor k_sym;
+  int  ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   size_t i_rel  = o->get_tuple_rel_index(i_abs);
 
@@ -58,7 +58,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
   size_t kj_rel = oo->get_tuple_rel_index(k_abs,j_abs);
   size_t xy_rel = vv->get_tuple_rel_index(x_abs,Y_abs);
 
-  if((j_abs == u_abs) and (k_abs == V_abs)){
+  if((j_abs == u_abs) && (k_abs == V_abs)){
     CCIndexIterator  e("[v]",i_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
@@ -70,7 +70,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
     }
   }
   if(i_abs == u_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
       size_t e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -82,7 +82,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
     }
   }
   if(k_abs == V_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
       size_t e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -93,8 +93,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
       }
     }
   }
-  if((j_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((j_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   ief_sym  = ovv->get_tuple_irrep(i_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t fe_rel  = vv->get_tuple_rel_index(ef.ind_abs<1>(),ef.ind_abs<0>());
@@ -105,8 +105,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff(int u_abs,int V_abs,int x_a
       }
     }
   }
-  if((j_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((j_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int    ief_sym = ovv->get_tuple_irrep(i_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -129,7 +129,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
   int    j_sym  = o->get_tuple_irrep(j_abs);
   int    k_sym  = o->get_tuple_irrep(k_abs);
 
-  int  ijk_sym  = i_sym xor j_sym xor k_sym;
+  int  ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   size_t k_rel  = o->get_tuple_rel_index(k_abs);
 
@@ -147,7 +147,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
   size_t ij_rel = oo->get_tuple_rel_index(i_abs,j_abs);
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
-  if((i_abs == u_abs) and (j_abs == V_abs)){
+  if((i_abs == u_abs) && (j_abs == V_abs)){
     CCIndexIterator  e("[v]",k_sym);
     for(e.first(); !e.end(); e.next()){
       size_t  e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -158,7 +158,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
     }
   }
   if(i_abs == u_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    ve_sym = ov->get_tuple_irrep(V_abs,e.ind_abs<0>());
       size_t ve_rel = ov->get_tuple_rel_index(V_abs,e.ind_abs<0>());
@@ -169,7 +169,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
     }
   }
   if(k_abs == V_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    ue_sym = ov->get_tuple_irrep(u_abs,e.ind_abs<0>());
       size_t ue_rel = ov->get_tuple_rel_index(u_abs,e.ind_abs<0>());
@@ -179,8 +179,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
       }
     }
   }
-  if((i_abs == u_abs) and (j_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((i_abs == u_abs) && (j_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   kef_sym  = ovv->get_tuple_irrep(k_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -190,8 +190,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff(int u_abs,int V_abs,int x_a
       }
     }
   }
-  if((i_abs == u_abs) and (j_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((i_abs == u_abs) && (j_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int   kef_sym  = ovv->get_tuple_irrep(k_abs,ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_ab_restricted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_ab_restricted.cc
@@ -41,7 +41,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
   int    j_sym  = o->get_tuple_irrep(j_abs);
   int    k_sym  = o->get_tuple_irrep(k_abs);
 
-  int  ijk_sym  = i_sym xor j_sym xor k_sym;
+  int  ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   size_t i_rel  = o->get_tuple_rel_index(i_abs);
   size_t j_rel  = o->get_tuple_rel_index(j_abs);
@@ -62,7 +62,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
   size_t kj_rel = oo->get_tuple_rel_index(k_abs,j_abs);
   size_t xy_rel = vv->get_tuple_rel_index(x_abs,Y_abs);
 
-  if((j_abs == u_abs) and (k_abs == V_abs)){
+  if((j_abs == u_abs) && (k_abs == V_abs)){
     CCIndexIterator  e("[v]",i_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
@@ -72,7 +72,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
+  if((i_abs == u_abs) && (k_abs == V_abs)){
     CCIndexIterator  e("[v]",j_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
@@ -84,7 +84,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
   }
 
   if(i_abs == u_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
       size_t e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -96,7 +96,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
     }
   }
   if(j_abs == u_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
       size_t e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -110,7 +110,7 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
 
 
   if(k_abs == V_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    e_sym  = v->get_tuple_irrep(e.ind_abs<0>());
       size_t e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -121,8 +121,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((j_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((j_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   ief_sym  = ovv->get_tuple_irrep(i_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t fe_rel  = vv->get_tuple_rel_index(ef.ind_abs<1>(),ef.ind_abs<0>());
@@ -133,8 +133,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((i_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   jef_sym  = ovv->get_tuple_irrep(j_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t fe_rel  = vv->get_tuple_rel_index(ef.ind_abs<1>(),ef.ind_abs<0>());
@@ -147,8 +147,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
   }
 
 
-  if((j_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((j_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int    ief_sym = ovv->get_tuple_irrep(i_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -161,8 +161,8 @@ double MRCCSD_T::compute_AB_ooO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((i_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int    jef_sym = ovv->get_tuple_irrep(j_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -185,7 +185,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
   int    j_sym  = o->get_tuple_irrep(j_abs);
   int    k_sym  = o->get_tuple_irrep(k_abs);
 
-  int  ijk_sym  = i_sym xor j_sym xor k_sym;
+  int  ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   size_t j_rel  = o->get_tuple_rel_index(j_abs);
   size_t k_rel  = o->get_tuple_rel_index(k_abs);
@@ -206,7 +206,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
   size_t ik_rel = oo->get_tuple_rel_index(i_abs,k_abs);
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
-  if((i_abs == u_abs) and (j_abs == V_abs)){
+  if((i_abs == u_abs) && (j_abs == V_abs)){
     CCIndexIterator  e("[v]",k_sym);
     for(e.first(); !e.end(); e.next()){
       size_t  e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -216,7 +216,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
+  if((i_abs == u_abs) && (k_abs == V_abs)){
     CCIndexIterator  e("[v]",j_sym);
     for(e.first(); !e.end(); e.next()){
       size_t  e_rel  = v->get_tuple_rel_index(e.ind_abs<0>());
@@ -228,7 +228,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
   }
 
   if(i_abs == u_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    ve_sym = ov->get_tuple_irrep(V_abs,e.ind_abs<0>());
       size_t ve_rel = ov->get_tuple_rel_index(V_abs,e.ind_abs<0>());
@@ -240,7 +240,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
   }
 
   if(k_abs == V_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    ue_sym = ov->get_tuple_irrep(u_abs,e.ind_abs<0>());
       size_t ue_rel = ov->get_tuple_rel_index(u_abs,e.ind_abs<0>());
@@ -251,7 +251,7 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
     }
   }
   if(j_abs == V_abs){
-    CCIndexIterator  e("[v]",ijk_sym xor xy_sym);
+    CCIndexIterator  e("[v]",ijk_sym ^ xy_sym);
     for(e.first(); !e.end(); e.next()){
       int    ue_sym = ov->get_tuple_irrep(u_abs,e.ind_abs<0>());
       size_t ue_rel = ov->get_tuple_rel_index(u_abs,e.ind_abs<0>());
@@ -262,8 +262,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
     }
   }
 
-  if((i_abs == u_abs) and (j_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((i_abs == u_abs) && (j_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   kef_sym  = ovv->get_tuple_irrep(k_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -273,8 +273,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+  if((i_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int   jef_sym  = ovv->get_tuple_irrep(j_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
       size_t ef_rel  = vv->get_tuple_rel_index(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -285,8 +285,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
     }
   }
 
-  if((i_abs == u_abs) and (j_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((i_abs == u_abs) && (j_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int   kef_sym  = ovv->get_tuple_irrep(k_abs,ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -299,8 +299,8 @@ double MRCCSD_T::compute_AB_oOO_contribution_to_Heff_restricted(int u_abs,int V_
       }
     }
   }
-  if((i_abs == u_abs) and (k_abs == V_abs)){
-    CCIndexIterator  ef("[vv]",ijk_sym xor y_sym);
+  if((i_abs == u_abs) && (k_abs == V_abs)){
+    CCIndexIterator  ef("[vv]",ijk_sym ^ y_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int      e_sym =   v->get_tuple_irrep(ef.ind_abs<0>());
       int   jef_sym  = ovv->get_tuple_irrep(j_abs,ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_b.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_b.cc
@@ -39,7 +39,7 @@ double MRCCSD_T::compute_B_ooO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -47,7 +47,7 @@ double MRCCSD_T::compute_B_ooO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   size_t ij_rel = oo->get_tuple_rel_index(i_abs,j_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -68,7 +68,7 @@ double MRCCSD_T::compute_B_oOO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -76,7 +76,7 @@ double MRCCSD_T::compute_B_oOO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   size_t ij_rel = oo->get_tuple_rel_index(i_abs,j_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -97,7 +97,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -105,7 +105,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff(int U_abs,int X_abs,int i_ab
   size_t ij_rel = oo->get_tuple_rel_index(i_abs,j_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_b_restricted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_b_restricted.cc
@@ -39,7 +39,7 @@ double MRCCSD_T::compute_B_ooO_contribution_to_Heff_restricted(int U_abs,int X_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -47,7 +47,7 @@ double MRCCSD_T::compute_B_ooO_contribution_to_Heff_restricted(int U_abs,int X_a
   size_t ij_rel = oo->get_tuple_rel_index(i_abs,j_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -68,7 +68,7 @@ double MRCCSD_T::compute_B_oOO_contribution_to_Heff_restricted(int U_abs,int X_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -78,7 +78,7 @@ double MRCCSD_T::compute_B_oOO_contribution_to_Heff_restricted(int U_abs,int X_a
   size_t ik_rel = oo->get_tuple_rel_index(i_abs,k_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -91,7 +91,7 @@ double MRCCSD_T::compute_B_oOO_contribution_to_Heff_restricted(int U_abs,int X_a
     }
   }
   if(j_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -112,7 +112,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff_restricted(int U_abs,int X_a
   int   i_sym  = o->get_tuple_irrep(i_abs);
   int   j_sym  = o->get_tuple_irrep(j_abs);
   int   k_sym  = o->get_tuple_irrep(k_abs);
-  int ijk_sym  = i_sym xor j_sym xor k_sym;
+  int ijk_sym  = i_sym ^ j_sym ^ k_sym;
 
   int   x_sym  = v->get_tuple_irrep(X_abs);
   int  ij_sym  = oo->get_tuple_irrep(i_abs,j_abs);
@@ -124,7 +124,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff_restricted(int U_abs,int X_a
   size_t jk_rel = oo->get_tuple_rel_index(j_abs,k_abs);
 
   if(k_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -137,7 +137,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff_restricted(int U_abs,int X_a
     }
   }
   if(j_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());
@@ -150,7 +150,7 @@ double MRCCSD_T::compute_B_OOO_contribution_to_Heff_restricted(int U_abs,int X_a
     }
   }
   if(i_abs == U_abs){
-    CCIndexIterator  ef("[vv]",ijk_sym xor x_sym);
+    CCIndexIterator  ef("[vv]",ijk_sym ^ x_sym);
     for(ef.first(); !ef.end(); ef.next()){
       int     e_sym = v->get_tuple_irrep(ef.ind_abs<0>());
       int    ef_sym = vv->get_tuple_irrep(ef.ind_abs<0>(),ef.ind_abs<1>());

--- a/psi4/src/psi4/psimrcc/mrccsd_t_heff_restricted.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_heff_restricted.cc
@@ -43,7 +43,7 @@ void MRCCSD_T::compute_ooo_contribution_to_Heff_restricted(int i,int j,int k,int
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_ooo_contribution_to_Heff_restricted(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
     }
@@ -60,15 +60,15 @@ void MRCCSD_T::compute_ooO_contribution_to_Heff_restricted(int i,int j,int k,int
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_ooO_contribution_to_Heff_restricted(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_ooO_contribution_to_Heff_restricted(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (alpha,beta)->(alpha,beta) double excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_AB_ooO_contribution_to_Heff_restricted(alpha_internal_excitation[0].first, beta_internal_excitation[0].first,
                                                                alpha_internal_excitation[0].second,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
@@ -86,15 +86,15 @@ void MRCCSD_T::compute_oOO_contribution_to_Heff_restricted(int i,int j,int k,int
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (alpha)->(alpha) single excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 0)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 0)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_A_oOO_contribution_to_Heff_restricted(alpha_internal_excitation[0].first,alpha_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_oOO_contribution_to_Heff_restricted(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
       // Set (alpha,beta)->(alpha,beta) double excitations
-      if((alpha_internal_excitation.size() == 1) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 1) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_AB_oOO_contribution_to_Heff_restricted(alpha_internal_excitation[0].first, beta_internal_excitation[0].first,
                                                                alpha_internal_excitation[0].second,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
@@ -112,7 +112,7 @@ void MRCCSD_T::compute_OOO_contribution_to_Heff_restricted(int i,int j,int k,int
       double                   sign_internal_excitation = moinfo->get_sign_internal_excitation(mu,nu);
 
       // Set (beta)->(beta) single excitations
-      if((alpha_internal_excitation.size() == 0) and (beta_internal_excitation.size() == 1)){
+      if((alpha_internal_excitation.size() == 0) && (beta_internal_excitation.size() == 1)){
         d_h_eff[nu][mu] += sign_internal_excitation * compute_B_OOO_contribution_to_Heff_restricted(beta_internal_excitation[0].first,beta_internal_excitation[0].second,i,j,k,mu,T3);
       }
     }

--- a/psi4/src/psi4/psimrcc/mrccsd_t_setup.cc
+++ b/psi4/src/psi4/psimrcc/mrccsd_t_setup.cc
@@ -343,7 +343,7 @@ void MRCCSD_T::startup()
   }
 
   // Allocate W
-  if((triples_algorithm == UnrestrictedTriples) or (triples_algorithm == RestrictedTriples)){
+  if((triples_algorithm == UnrestrictedTriples) || (triples_algorithm == RestrictedTriples)){
     allocate2(BlockMatrix**,W,nrefs,nirreps);
     for(int mu = 0; mu < nrefs; ++mu){
       for(int h = 0; h < nirreps; ++h){
@@ -416,9 +416,9 @@ void MRCCSD_T::check_intruders()
         size_t c_abs = v->get_tuple_abs_index(abc.ind_abs<2>());
 
         // AAA Case
-        if(is_aocc[mu][i_abs] and is_aocc[mu][j_abs] and is_aocc[mu][k_abs]){
-          if(is_avir[mu][a_abs] and is_avir[mu][b_abs] and is_avir[mu][c_abs]){
-            if((i_abs < j_abs) and (j_abs < k_abs) and (a_abs < b_abs) and (b_abs < c_abs)){
+        if(is_aocc[mu][i_abs] && is_aocc[mu][j_abs] && is_aocc[mu][k_abs]){
+          if(is_avir[mu][a_abs] && is_avir[mu][b_abs] && is_avir[mu][c_abs]){
+            if((i_abs < j_abs) && (j_abs < k_abs) && (a_abs < b_abs) && (b_abs < c_abs)){
               double D_ijk = e_oo[mu][i_abs] + e_oo[mu][j_abs] + e_oo[mu][k_abs];
               double D_abc = e_vv[mu][a_abs] + e_vv[mu][b_abs] + e_vv[mu][c_abs];
               double denominator = D_ijk - D_abc;
@@ -437,9 +437,9 @@ void MRCCSD_T::check_intruders()
         }
 
         // AAB Case
-        if(is_aocc[mu][i_abs] and is_aocc[mu][j_abs] and is_bocc[mu][k_abs]){
-          if(is_avir[mu][a_abs] and is_avir[mu][b_abs] and is_bvir[mu][c_abs]){
-            if((i_abs < j_abs) and (a_abs < b_abs)){
+        if(is_aocc[mu][i_abs] && is_aocc[mu][j_abs] && is_bocc[mu][k_abs]){
+          if(is_avir[mu][a_abs] && is_avir[mu][b_abs] && is_bvir[mu][c_abs]){
+            if((i_abs < j_abs) && (a_abs < b_abs)){
               double D_ijk = e_oo[mu][i_abs] + e_oo[mu][j_abs] + e_OO[mu][k_abs];
               double D_abc = e_vv[mu][a_abs] + e_vv[mu][b_abs] + e_VV[mu][c_abs];
               double denominator = D_ijk - D_abc;
@@ -664,7 +664,7 @@ void MRCCSD_T::cleanup()
   release2(Z);
 
   // Deallocate W
-  if((triples_algorithm == UnrestrictedTriples) or (triples_algorithm == RestrictedTriples)){
+  if((triples_algorithm == UnrestrictedTriples) || (triples_algorithm == RestrictedTriples)){
     for(int mu = 0; mu < nrefs; ++mu){
       for(int h = 0; h < nirreps; ++h){
         delete W[mu][h];

--- a/psi4/src/psi4/psimrcc/special_matrices.cc
+++ b/psi4/src/psi4/psimrcc/special_matrices.cc
@@ -105,7 +105,7 @@ void MatrixBase::add(MatrixBase* A, double alpha, double beta)
 void MatrixBase::contract(MatrixBase* A, MatrixBase* B, double const alpha, double const beta)
 {
   size_t max_r = A->get_ncols();
-  if((max_r != 0) and (nrows != 0) and (ncols != 0))
+  if((max_r != 0) && (nrows != 0) && (ncols != 0))
     C_DGEMM('n','t',nrows,ncols,max_r,alpha,&(A->get_matrix()[0][0]),max_r,&(B->get_matrix()[0][0]),max_r,beta,&(matrix[0][0]),ncols);
   else if(std::fabs(beta) < 1.0e-9)
     zero();

--- a/psi4/src/psi4/psimrcc/updater_mk.cc
+++ b/psi4/src/psi4/psimrcc/updater_mk.cc
@@ -157,7 +157,7 @@ void MkUpdater::update(int cycle,Hamiltonian* heff)
         }
 
         // Update t1 for reference i
-        if(not options_.get_bool("NO_SINGLES")){
+        if(!options_.get_bool("NO_SINGLES")){
             blas->solve("t1_delta[o][v]{" + i_str + "}  =   t1_eqns[o][v]{" + i_str + "} / d'1[o][v]{" + i_str + "} - t1[o][v]{" + i_str + "}");
             blas->solve("t1_delta[O][V]{" + i_str + "}  =   t1_eqns[O][V]{" + i_str + "} / d'1[O][V]{" + i_str + "} - t1[O][V]{" + i_str + "}");
 


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to *Windows* (https://github.com/psi4/psi4/issues/933).

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] MSVC does not support non-standard `not`, `and`, `or`, `xor` operators, which are replaced with `!`, `&&`, `||`, `^`, respectively.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
