### PR TITLE
Port ccdensity, ccenergy, cceom, ccresponse, and cctriples to Windows

### DIFF
--- a/psi4/src/psi4/ccdensity/Gciab.cc
+++ b/psi4/src/psi4/ccdensity/Gciab.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccdensity/Gijab_UHF.cc
+++ b/psi4/src/psi4/ccdensity/Gijab_UHF.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccdensity/Gijka.cc
+++ b/psi4/src/psi4/ccdensity/Gijka.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccdensity/deanti_UHF.cc
+++ b/psi4/src/psi4/ccdensity/deanti_UHF.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"

--- a/psi4/src/psi4/ccdensity/energy_UHF.cc
+++ b/psi4/src/psi4/ccdensity/energy_UHF.cc
@@ -32,7 +32,6 @@
     coresponding one- and two-particle density matrices.
 */
 #include <stdio.h>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccdensity/fold_UHF.cc
+++ b/psi4/src/psi4/ccdensity/fold_UHF.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccdensity/onepdm.cc
+++ b/psi4/src/psi4/ccdensity/onepdm.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <strings.h>
 #include <string.h>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -54,9 +54,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/types.h>
 
 namespace psi { namespace ccenergy {
 

--- a/psi4/src/psi4/cceom/diagSS.cc
+++ b/psi4/src/psi4/cceom/diagSS.cc
@@ -57,7 +57,7 @@ void restart_SS(double **alpha, int L, int num, int C_irr);
 void dgeev_eom(int L, double **G, double *evals, double **alpha);
 double norm_C1(dpdfile2 *C1A, dpdfile2 *C1B);
 double norm_C1_rhf(dpdfile2 *C1A);
-double scm_C1(dpdfile2 *C1A, dpdfile2 *C1B, double a);
+void scm_C1(dpdfile2 *C1A, dpdfile2 *C1B, double a);
 
 void diagSS(int C_irr) {
   dpdfile2 Fmi, FMI, Fae, FAE, Fme, FME;

--- a/psi4/src/psi4/cceom/overlap.cc
+++ b/psi4/src/psi4/cceom/overlap.cc
@@ -46,7 +46,7 @@
 
 namespace psi { namespace cceom {
 
-int overlap(int C_irr, int current) {
+void overlap(int C_irr, int current) {
   dpdfile2 R1, R1A, R1B;
   dpdfile2 R1_old, R1A_old, R1B_old;
   dpdbuf4 R2, R2AA, R2BB, R2AB;
@@ -164,8 +164,6 @@ int overlap(int C_irr, int current) {
     global_dpd_->buf4_close(&R2BB);
     global_dpd_->buf4_close(&R2AB);
   }
-
-  return 1;
 }
 
 void overlap_stash(int C_irr)

--- a/psi4/src/psi4/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/ccresponse/ccresponse.cc
@@ -45,6 +45,7 @@
 #include "psi4/physconst.h"
 #include "psi4/psifiles.h"
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/psi4-dec.h"
 #include "Params.h"
 #include "MOInfo.h"
 #include "Local.h"
@@ -81,7 +82,7 @@ void roa(void);
 
 void preppert(std::shared_ptr<BasisSet> primary);
 
-int ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
+PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 {
   int **cachelist, *cachefiles;
 
@@ -151,7 +152,8 @@ int ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
   timer_off("ccresponse");
 
   exit_io();
-  return 0;
+
+  return PsiReturnType::Success;
 }
 
 void init_io(void)

--- a/psi4/src/psi4/cctriples/ET_RHF.cc
+++ b/psi4/src/psi4/cctriples/ET_RHF.cc
@@ -957,6 +957,8 @@ void* ET_RHF_thread(void* thread_data_in)
         } /* i */
 
   pthread_exit(nullptr);
+
+  return nullptr;
 }
 
 }} // namespace psi::CCTRIPLES

--- a/psi4/src/psi4/cctriples/EaT_RHF.cc
+++ b/psi4/src/psi4/cctriples/EaT_RHF.cc
@@ -932,6 +932,8 @@ void* EaT_RHF_thread(void* thread_data_in)
   } /* i */
 
   pthread_exit(nullptr);
+
+  return nullptr;
 }
 
 }} // namespace psi::CCTRIPLES


### PR DESCRIPTION
## Description
This is part of Psi4 porting to Windows (#933).

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Remove unnecessary headers
  - [x] Match function signatures
  - [x] Add and remove `return`

## Checklist
- [ ] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
