### PR TITLE
Reactivate cc46

### DIFF
--- a/tests/cc46/CMakeLists.txt
+++ b/tests/cc46/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-#add_regression_test(cc46 "psi;cc;autotest")
+add_regression_test(cc46 "psi;cc;autotest")


### PR DESCRIPTION
## Description
Test case cc46 was removed after it was noticed to be failing (#1002 ), it was determined that the failure was not indicating a bug, so it was temporarily removed so pre-release pakages wouldn't be reporting a failure. This PR reactivates the test with modifications so that it is passing again. 




* **Developer Interest**
   - cc46 checks GS and excited state Dipole/Quadrupole components against reference values generated by psi. 
   -  Was failing because calling `properties=['oscillator_strength']` prior to #995 was the only way to force ccdensity to make a call to OEProp for each excited state.  Post #995 this does not compute one electron properties for excited states so the computed values were all zero.
   - Correcting the driver call `properties=['dipole','quadrupole']` is not enough
     - The test values were generated using  `oscillator_strength` which triggers EOM/Lambda convergence thresholds to be reduced.
      - The computed values are 'too good' and comparison with the older reference values fails in the 4th decimal place for some quadrupole components of excited states.
  - *Final Solution*
    - I dropped the convergence thresholds manually in the test-input to what the were set to by the driver at the time that the reference data was generated. 

Side Note:
- Personally I don't think the savings achieved by this over ride of the convergence thresholds are significant enough to justify potentially confusing situations. 
- If a user sets those values manually and requested `oscilator_strength` and/or `rotational_strength` the user-set values are overridden.
- Commenting out the [relevant lines](https://github.com/psi4/psi4/blob/72c30b536201a25171fa6426c8f319e2abdbb1cb/psi4/driver/procrouting/proc.py#L2637-L2652) all cc tests still pass. Including this one (with my changes).


## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
