### PR TITLE
Port libciomr to Windows

### DIFF
--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -35,11 +35,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <strings.h>
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
-#include <unistd.h>
 #ifdef _POSIX_MEMLOCK
 #include <sys/mman.h>
 #endif
@@ -75,7 +73,7 @@ namespace psi {
 ** \ingroup CIOMR
 */
 
-double ** PSI_API block_matrix(size_t n, size_t m, bool memlock)
+PSI_API double ** block_matrix(size_t n, size_t m, bool memlock)
 {
     double **A=nullptr;
     double *B=nullptr;

--- a/psi4/src/psi4/libciomr/init_array.cc
+++ b/psi4/src/psi4/libciomr/init_array.cc
@@ -35,7 +35,6 @@
 #include "psi4/psifiles.h"
 #include <cstdio>
 #include <cstdlib>
-#include <strings.h>
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
@@ -61,7 +60,7 @@ double * init_array(size_t size)
     outfile->Printf("size = %ld\n",size);
     exit(PSI_RETURN_FAILURE);
   }
-  bzero(array,size*(size_t)sizeof(double));
+  memset(array,0,size*(size_t)sizeof(double));
   return(array);
 }
 

--- a/psi4/src/psi4/libciomr/init_matrix.cc
+++ b/psi4/src/psi4/libciomr/init_matrix.cc
@@ -40,7 +40,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <strings.h>
 
 namespace psi {
 

--- a/psi4/src/psi4/libciomr/int_array.cc
+++ b/psi4/src/psi4/libciomr/int_array.cc
@@ -39,7 +39,7 @@
 #include "psi4/psifiles.h"
 #include <cstdio>
 #include <cstdlib>
-#include <strings.h>
+#include <cstring>
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {
@@ -59,7 +59,7 @@ namespace psi {
 ** C. David Sherrill
 ** \ingroup CIOMR
 */
-int * PSI_API init_int_array(int size)
+PSI_API int * init_int_array(int size)
 {
   int *array;
 
@@ -68,7 +68,7 @@ int * PSI_API init_int_array(int size)
     outfile->Printf("size = %d\n",size);
     exit(PSI_RETURN_FAILURE);
   }
-  bzero(array,sizeof(int)*size);
+  memset(array, 0, sizeof(int)*size);
   return(array);
 }
 
@@ -86,7 +86,7 @@ int * PSI_API init_int_array(int size)
 */
 void zero_int_array(int *a, int size)
 {
-   bzero(a,sizeof(int)*size);
+   memset(a, 0, sizeof(int)*size);
 }
 
 
@@ -103,7 +103,7 @@ void zero_int_array(int *a, int size)
 **
 ** \ingroup CIOMR
 */
-int ** PSI_API init_int_matrix(int rows, int cols)
+PSI_API int ** init_int_matrix(int rows, int cols)
 {
    int **array=nullptr;
    int i;
@@ -122,7 +122,7 @@ int ** PSI_API init_int_matrix(int rows, int cols)
    for (i=1; i<rows; i++) {
      array[i] = array[i-1] + cols;
    }
-   bzero(array[0], sizeof(int)*cols*rows);
+   memset(array[0], 0, sizeof(int)*cols*rows);
 
    return array;
 }

--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -95,9 +95,9 @@ void zero_arr(double *a, int size) ;
 void zero_mat(double **a, int rows, int cols) ;
 
 /* Functions in int_array.c */
-int * init_int_array(int size) ;
+PSI_API int * init_int_array(int size) ;
 void zero_int_array(int *a, int size);
-int **init_int_matrix(int rows, int cols);
+PSI_API int ** init_int_matrix(int rows, int cols);
 void free_int_matrix(int **array);
 void zero_int_matrix(int **array, int rows, int cols);
 void print_int_mat(int **a, int m, int n, std::string out);
@@ -111,7 +111,7 @@ void zero_long_int_matrix(long int **array, int rows, int cols);
 void print_long_int_mat(long int **a, int m, int n, std::string out);
 
 /* Functions in block_matrix.c */
-double ** block_matrix(size_t n, size_t m, bool mlock = false);
+PSI_API double ** block_matrix(size_t n, size_t m, bool mlock = false);
 void free_block(double **array);
 
 /* Functions in fndcor */

--- a/psi4/src/psi4/libciomr/long_int_array.cc
+++ b/psi4/src/psi4/libciomr/long_int_array.cc
@@ -43,7 +43,7 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <strings.h>
+#include <cstring>
 
 namespace psi {
 
@@ -67,7 +67,7 @@ long int * init_long_int_array(int size)
     outfile->Printf("size = %d\n",size);
     exit(PSI_RETURN_FAILURE);
   }
-  bzero(array,sizeof(long int)*size);
+  memset(array, 0, sizeof(long int)*size);
   return(array);
 }
 

--- a/psi4/src/psi4/libciomr/tstart.cc
+++ b/psi4/src/psi4/libciomr/tstart.cc
@@ -36,17 +36,38 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <sys/times.h>
 #include <cstdio>
 #include <cstdlib>
-#include <unistd.h>
 #include <cstring>
-#include <string>
 #include <ctime>
+#include <string>
+
+#ifdef _MSC_VER
+// Fake Windows implementation of the system/user timer
+struct tms {
+    double tms_stime;
+    double tms_utime;
+};
+static void times(struct tms *time) {
+    time->tms_stime = 0;
+    time->tms_utime = 0;
+}
+#define _SC_CLK_TCK 0
+static long sysconf(int name) {
+    return (long)name;
+}
+#else
+#include <sys/times.h>
+#endif
+
+#ifdef _MSC_VER
+#include <Winsock2.h>
+#include <winsock.h>
+#else
+#include <unistd.h>
+#endif
 
 namespace psi {
-
-
 
 time_t time_start, time_end;
 time_t time_start_overall;

--- a/psi4/src/psi4/libciomr/zero.cc
+++ b/psi4/src/psi4/libciomr/zero.cc
@@ -32,7 +32,7 @@
 ** \ingroup CIOMR
 */
 
-#include <strings.h>
+#include <cstring>
 
 namespace psi {
 
@@ -48,7 +48,7 @@ namespace psi {
 */
 void zero_arr(double *a, int size)
 {
-  bzero(a,sizeof(double)*size);
+  memset(a, 0, sizeof(double)*size);
 }
 
 /*!
@@ -65,7 +65,7 @@ void zero_mat(double **a, int n, int m)
   int i;
 
   for (i=0; i < n; i++) {
-    bzero(a[i],sizeof(double)*m);
+    memset(a[i], 0, sizeof(double)*m);
   }
 }
 


### PR DESCRIPTION
## Description
This is part of Psi4 porting to Windows (#933).

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x]  Add missing and remove unnecessary headers
  - [x] Fix `PSI_API` usage
  - [x] Replace `bzero` with `memset`
  - [x] Disable system/user timer

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
