### PR TITLE
CI: stop testing py27. insufficient conda pkgs to add py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
         - gfortran-4.9
     env:
       - CXX_COMPILER='g++-4.9'
-      - PYTHON_VER='2.7'
+      - PYTHON_VER='3.6'
       - C_COMPILER='gcc-4.9'
       - Fortran_COMPILER='gfortran-4.9'
       - BUILD_TYPE='release'


### PR DESCRIPTION
## Description
I don't want to fix py27 bug in #1098, so this evades testing it.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] CI: stop testing py27. insufficient conda pkgs to add py37

## Status
- [x] Ready for review
- [x] Ready for merge
