### PR TITLE
DFH: suppress DFH memory messages during SAD guess

### DIFF
--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -233,16 +233,22 @@ void DFHelper::AO_core() {
 
     // a fraction of memory to use, do we want it as an option?
     double fraction_of_memory = 0.8;
-    
-    outfile->Printf("  DFHelper Memory: AOs need %.3f [GiB]; user supplied %.3f [GiB]. ",
-                   (required / fraction_of_memory * 8 / (1024 * 1024 * 1024.0)),
-                   (memory_ * 8 / (1024 * 1024 * 1024.0)));
+
     if (memory_ * fraction_of_memory < required) {
         AO_core_ = false;
+        outfile->Printf("  DFHelper Memory: AOs need %.3f [GiB]; user supplied %.3f [GiB]. ",
+                        (required / fraction_of_memory * 8 / (1024 * 1024 * 1024.0)),
+                        (memory_ * 8 / (1024 * 1024 * 1024.0)));
         outfile->Printf("Turning off in-core AOs.\n\n");
     } else {
-        outfile->Printf("Using in-core AOs.\n\n");
+        if (print_lvl_ > 0) {
+            outfile->Printf("  DFHelper Memory: AOs need %.3f [GiB]; user supplied %.3f [GiB]. ",
+                            (required / fraction_of_memory * 8 / (1024 * 1024 * 1024.0)),
+                            (memory_ * 8 / (1024 * 1024 * 1024.0)));
+            outfile->Printf("Using in-core AOs.\n\n");
+        }
     }
+
 }
 void DFHelper::print_header() {
     outfile->Printf("  ==> DFHelper <==\n");

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -233,22 +233,14 @@ void DFHelper::AO_core() {
 
     // a fraction of memory to use, do we want it as an option?
     double fraction_of_memory = 0.8;
+    if (memory_ * fraction_of_memory < required) AO_core_ = false;
 
-    if (memory_ * fraction_of_memory < required) {
-        AO_core_ = false;
+    if (print_lvl_ > 0) {
         outfile->Printf("  DFHelper Memory: AOs need %.3f [GiB]; user supplied %.3f [GiB]. ",
                         (required / fraction_of_memory * 8 / (1024 * 1024 * 1024.0)),
                         (memory_ * 8 / (1024 * 1024 * 1024.0)));
-        outfile->Printf("Turning off in-core AOs.\n\n");
-    } else {
-        if (print_lvl_ > 0) {
-            outfile->Printf("  DFHelper Memory: AOs need %.3f [GiB]; user supplied %.3f [GiB]. ",
-                            (required / fraction_of_memory * 8 / (1024 * 1024 * 1024.0)),
-                            (memory_ * 8 / (1024 * 1024 * 1024.0)));
-            outfile->Printf("Using in-core AOs.\n\n");
-        }
+        outfile->Printf("%s in-core AOs.\n\n", (memory_ * fraction_of_memory < required) ? "Turning off" : "Using");
     }
-
 }
 void DFHelper::print_header() {
     outfile->Printf("  ==> DFHelper <==\n");

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -141,6 +141,12 @@ class PSI_API DFHelper {
     void set_omega(double omega) { omega_ = omega; }
     size_t get_omega() { return omega_; }
 
+    ///
+    /// set the printing verbosity parameter
+    /// @param print_lvl indicating verbosity
+    ///
+    void set_print_lvl(int print_lvl) { print_lvl_ = print_lvl; }
+
     /// Initialize the object
     void initialize();
 
@@ -291,6 +297,7 @@ class PSI_API DFHelper {
     bool do_wK_ = false;
     double omega_;
     bool debug_ = false;
+    int print_lvl_ = 1;
 
     // => in-core machinery <=
     void AO_core();

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1025,6 +1025,11 @@ class MemDFJK : public JK {
     * type on output file
     */
     virtual void print_header() const;
+
+    /**
+     * Returns the DFHelper object
+     */
+    std::shared_ptr<DFHelper> dfh() { return dfh_; }
 };
 }
 #endif

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -57,6 +57,7 @@
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/libdiis/diisentry.h"
 #include "psi4/libfock/jk.h"
+#include "psi4/lib3index/dfhelper.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/liboptions/liboptions.h"
@@ -451,6 +452,7 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
         MemDFJK* dfjk = new MemDFJK(bas, fit);
         if (options_["DF_INTS_NUM_THREADS"].has_changed())
             dfjk->set_df_ints_num_threads(options_.get_int("DF_INTS_NUM_THREADS"));
+        dfjk->dfh()->set_print_lvl(0);
         jk = std::unique_ptr<JK>(dfjk);
     } else if (options_.get_str("SAD_SCF_TYPE") == "DIRECT") {
         DirectJK* directjk(new DirectJK(bas));


### PR DESCRIPTION
## Description
How many PRs does it take to correctly and conveniently print JK memory? This is the fourth.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] SAD guess was printing a dfh memory announcement for every atom type of the SAD guess ever since we starting printing for both sufficient and insufficient AO in-core memory in #1097. This adds a `print_lvl` to DFHelper and sets it to 0 for SAD

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
