### PR TITLE
Make Density Fitting Compatible with Frequencies (#1093 Fix)

### DIFF
--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -369,6 +369,8 @@ class ZMatrixEntry : public CoordEntry {
                                                   atoms[ato_->entry_number()], aval_->clone(map),
                                                   atoms[dto_->entry_number()], dval_->clone(map));
         }
+        if (computed_)
+            temp->set_coordinates(coordinates_[0], coordinates_[1], coordinates_[2]);
         return temp;
     }
 };

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -219,13 +219,15 @@ Molecule &Molecule::operator=(const Molecule &other) {
 
     // Deep copy the map of variables
     full_atoms_.clear();
+    atoms_.clear();
+    std::shared_ptr<CoordEntry> new_atom;
     std::vector<std::shared_ptr<CoordEntry> >::const_iterator iter = other.full_atoms_.begin();
     for (; iter != other.full_atoms_.end(); ++iter) {
-        full_atoms_.push_back((*iter)->clone(full_atoms_, geometry_variables_));
-    }
-    atoms_.clear();
-    for (iter = other.atoms_.begin(); iter != other.atoms_.end(); ++iter) {
-        atoms_.push_back((*iter)->clone(atoms_, geometry_variables_));
+        new_atom = (*iter)->clone(full_atoms_, geometry_variables_);
+        full_atoms_.push_back(new_atom);
+        // To guarantee every atom is identically a full_atom, add the needed full_atom into atoms
+        // If we lose any atoms this way, we have a bigger problem.
+        if (new_atom->symbol() != "X") atoms_.push_back(new_atom);
     }
 
     // This is called here, so that the atoms list is populated

--- a/tests/dfmp2-freq1/CMakeLists.txt
+++ b/tests/dfmp2-freq1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dfmp2-freq1 "psi;quicktests;df;dfmp2;freq")

--- a/tests/dfmp2-freq1/input.dat
+++ b/tests/dfmp2-freq1/input.dat
@@ -1,0 +1,25 @@
+#! DF-MP2 frequency by difference of energies for H2O
+
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+}
+
+set {
+  basis cc-pvdz
+  df_basis_scf cc-pvdz-jkfit
+  df_basis_cc cc-pvdz-ri
+  scf_type df
+  guess sad
+  freeze_core true
+  cc_type df
+  qc_module occ
+}
+
+e, wfn = frequencies('mp2', dertype=0, return_wfn=True)
+fd_freqs = wfn.frequencies().to_array() # TEST
+compare_arrays([1635.3, 3933.1, 4071.9], fd_freqs, 1, # TEST
+               "Frequencies vs. reference frequencies 07/2018") # TEST

--- a/tests/dfmp2-freq2/CMakeLists.txt
+++ b/tests/dfmp2-freq2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dfmp2-freq1 "psi;quicktests;df;dfmp2;freq")

--- a/tests/dfmp2-freq2/input.dat
+++ b/tests/dfmp2-freq2/input.dat
@@ -1,0 +1,26 @@
+#! DF-MP2 frequency by difference of energies for H2O
+
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+}
+
+set {
+  basis cc-pvdz
+  df_basis_scf cc-pvdz-jkfit
+  df_basis_cc cc-pvdz-ri
+  scf_type df
+  guess sad
+  freeze_core true
+  cc_type df
+  qc_module occ
+}
+
+e, wfn = frequencies('mp2', dertype=1, return_wfn=True)
+fd_freqs = wfn.frequencies().to_array() # TEST
+compare_arrays([1635.3, 3933.1, 4071.9], fd_freqs, 1, # TEST
+               "Frequencies vs. reference frequencies 07/2018") # TEST
+


### PR DESCRIPTION
## Description
Fixes issue #1093, where the use of density fitting caused a crash when computing frequencies.

As for why these fixes are necessary:

Previously, the clone function would have separate memory addresses for elements of the two lists, which would be fixed by update_geometry assuming that coordinate reinterpretation was allowed. This is precisely what the driver does not allow when getting a findif hessian. The basis set setting code assumed that the memory addresses were the same. This assumption failing led to the originally reported error with setting basis sets. As this seems a rather sane assumption to me, it is Now enforced.

This uncovered a second error when ZMAT coordinates were used: energies at displacements would be off by ~4 hartrees. When the molecule is cloned in the process of getting a c1 wavefunction, I found that the coordinates of the cloned molecules differed from those of the original molecule, right before the basis sets were set. Telling the basis sets that the atoms are not what they actually are seems like the kind of thing that would lead to garbage energies, though I didn't get a detailed mechanism for this. To get the geometries consistent, I had to change the atom cloning procedure.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Molecule clone now guarantees that each elements of the atom_ list is identical to some element of the full_atom_ list.
  - [x] Atom clone now guarantees that ZMATs with computed coordinates carry the computed coordinates over to the clone.
* **User-Facing for Release Notes**
  - [x] Fixed a bug where using density fitting for a frequency computation would cause an error unless the symmetry was explicitly set to c1.

## Questions
- [x] Symmetry is used for the purposes of generating displacements, but not for labeling normal modes. Even if we can't take advantage of symmetry for the energetics, we should be able to use symmetry for displacements and normal modes. My hunch is that this is a problem with changing the symmetry of the molecule between the two findif calls, but I'd like Py-side findif to be accepted before looking into this, just in case. Sound good?

## Checklist
- [x] Tests added for any newly functional features
- [x] [All of full tests run, modulo DFT benchmarks and plugins](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge (as soon as the last review is in)
