### PR TITLE
Do not freeze electrons on ghost atoms.

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -175,12 +175,14 @@ std::shared_ptr<BasisSet> construct_basisset_from_pydict(const std::shared_ptr<M
     // Modify the nuclear charges, to account for the ECP.
     if (totalncore) {
         for (int atom = 0; atom < mol->natom(); ++atom) {
-            const std::string& basis = mol->basis_on_atom(atom);
-            const std::string& label = mol->label(atom);
-            int ncore = basis_atom_ncore[basis][label];
-            int Z = mol->true_atomic_number(atom) - ncore;
-            mol->set_nuclear_charge(atom, Z);
-            basisset->set_n_ecp_core(label, ncore);
+            if (mol->Z(atom) > 0) {
+                const std::string& basis = mol->basis_on_atom(atom);
+                const std::string& label = mol->label(atom);
+                int ncore = basis_atom_ncore[basis][label];
+                int Z = mol->true_atomic_number(atom) - ncore;
+                mol->set_nuclear_charge(atom, Z);
+                basisset->set_n_ecp_core(label, ncore);
+            }
         }
     }
 

--- a/psi4/src/psi4/libcubeprop/csg.cc
+++ b/psi4/src/psi4/libcubeprop/csg.cc
@@ -286,7 +286,7 @@ void CubicScalarGrid::write_cube_file(double* v, const std::string& name, const 
 
     // Atoms of molecule (Z, Q?, x, y, z)
     for (int A = 0; A < mol_->natom(); A++) {
-        fprintf(fh, "%3d %10.6f %10.6f %10.6f %10.6f\n", (int)mol_->Z(A), 0.0, mol_->x(A), mol_->y(A), mol_->z(A));
+        fprintf(fh, "%3d %10.6f %10.6f %10.6f %10.6f\n", (int)mol_->true_atomic_number(A), 0.0, mol_->x(A), mol_->y(A), mol_->z(A));
     }
 
     // Data, striped (x, y, z)

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -189,19 +189,22 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
         // have one valence electron in this scheme.
         for (int A = 0; A < mymol->natom(); A++) {
             double Z   = mymol->Z(A);
-            // Add ECPs to Z, the number of electrons less ECP-treated electrons
-            double ECP = n_ecp_core(mymol->label(A));
-            if (Z + ECP > 2) nfzc += 1;
-            if (Z + ECP > 10) nfzc += 4;
-            if (Z + ECP > 18) nfzc += 4;
-            if (Z + ECP > 36) nfzc += 9;
-            if (Z + ECP > 54) nfzc += 9;
-            if (Z + ECP > 86) nfzc += 16;
-            if (Z + ECP > 108) {
-                throw PSIEXCEPTION("Invalid atomic number");
+            // Exclude ghosted atoms from core-freezing
+            if (Z > 0) {
+                // Add ECPs to Z, the number of electrons less ECP-treated electrons
+                double ECP = n_ecp_core(mymol->label(A));
+                if (Z + ECP > 2) nfzc += 1;
+                if (Z + ECP > 10) nfzc += 4;
+                if (Z + ECP > 18) nfzc += 4;
+                if (Z + ECP > 36) nfzc += 9;
+                if (Z + ECP > 54) nfzc += 9;
+                if (Z + ECP > 86) nfzc += 16;
+                if (Z + ECP > 108) {
+                    throw PSIEXCEPTION("Invalid atomic number");
+                }
+                // If this center has an ECP, some pairs are already frozen
+                if (ECP > 0) nfzc -= ECP/2;
             }
-            // If this center has an ECP, some pairs are already frozen
-            if (ECP > 0) nfzc -= ECP/2;
         }
         return nfzc;
     } else {

--- a/psi4/src/psi4/optking/geom_gradients_io.cc
+++ b/psi4/src/psi4/optking/geom_gradients_io.cc
@@ -118,7 +118,7 @@ void MOLECULE::read_geom_grad(void) {
       double **grad = fragments[f]->g_grad_pointer();
 
       for (int i=0; i<fragments[f]->g_natom(); ++i) {
-          Z[i] = mol->Z(atom);
+          Z[i] = mol->true_atomic_number(atom);
 
           geom[i][0] = geometry(atom, 0);
           geom[i][1] = geometry(atom, 1);

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -1,13 +1,17 @@
-#! He-Ne dimer MP2 energies with ECP, Ne electrons correlated then frozen.
+#! Ne-Xe dimer MP2 energies with ECP, with electrons correlated then frozen.
 
 refnuc =   45.86202474447                                                                #TEST
 refall = -457.47320868249                                                                #TEST
 reffzc = -457.38127218548                                                                #TEST
 reffHe = -457.47130951838                                                                #TEST
+refEin =    0.00468169972                                                                #TEST
 
 molecule dimer {
-    Ne
-    Xe 1 3.0
+    0 1
+    Ne 0.0 0.0 0.0 
+    --
+    0 1
+    Xe 0.0 0.0 3.0
 }
 
 set {
@@ -21,10 +25,13 @@ compare_values(refnuc, dimer.nuclear_repulsion_energy(), 8, "Nuclear repulsion e
 compare_values(refall, Eall, 8, "MP2 energy with all-electron Ne and ECP on Xe")         #TEST
 
 set freeze_core true
-set guess read
+set guess sad
 # [He] electrons on Ne frozen, [Kr] electrons on Xe frozen
 Efzc = energy('mp2')
 compare_values(reffzc, Efzc, 8, "MP2 energy with frozen [He] and [Kr]")                  #TEST
+Eint = energy('mp2',bsse_type=['cp'])
+compare_values(refEin, Eint, 8, "MP2 CP interaction energy frozen [He] and [Kr]")        #TEST
+
 
 set freeze_core false
 set num_frozen_docc 1

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -8,7 +8,7 @@ refEin =    0.00468169972                                                       
 
 molecule dimer {
     0 1
-    Ne 0.0 0.0 0.0 
+    Ne 0.0 0.0 0.0
     --
     0 1
     Xe 0.0 0.0 3.0
@@ -21,7 +21,7 @@ set {
 
 # All electrons on Ne correlated, all non-ECP electrons on Xe correlated
 Eall = energy('mp2')
-compare_values(refnuc, dimer.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy")  #TEST 
+compare_values(refnuc, dimer.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy")  #TEST
 compare_values(refall, Eall, 8, "MP2 energy with all-electron Ne and ECP on Xe")         #TEST
 
 set freeze_core true
@@ -39,3 +39,27 @@ set guess read
 # [He] electrons on Ne frozen,  only ECP electrons on Xe frozen
 EfHe = energy('mp2')
 compare_values(reffHe, EfHe, 8, "MP2 energy with frozen [He] and ECP")                   #TEST
+
+molecule ghne {
+    0 1
+    @Ne 0.0 0.0 0.0
+    --
+    0 1
+    Xe 0.0 0.0 3.0
+}
+
+molecule ghxe {
+    0 1
+    Ne 0.0 0.0 0.0
+    --
+    0 1
+    Gh(Xe) 0.0 0.0 3.0
+}
+
+set freeze_core true
+set num_frozen_docc 0
+set guess sad
+
+Eghne = energy('mp2', molecule=ghne)
+Eghxe = energy('mp2', molecule=ghxe)
+compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy frozen [He] and [Kr] by hand")  #TEST


### PR DESCRIPTION
## Description
Fix for #1102. We were subtracting ECP's, as (Z + ECP) was > 0 (usually around 10), even when the atom was ghosted (Z == 0).

## Questions
- [x] Should this be applied against master or against #953?

## Checklist
- [x] [All or relevant fraction of full tests run.](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests) Test `dfmp2-ecp` modified to check for correct behaviour.
- [x] Fix #843.

## Status
- [x] Ready for review
- [x] Ready for merge
