### PR TITLE
Move nbody_gufunc call up in driver.

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -424,7 +424,11 @@ def energy(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
-
+    
+    # Bounce to CP if bsse kwarg
+    if kwargs.get('bsse_type', None) is not None:
+        return driver_nbody.nbody_gufunc(energy, name, ptype='energy', **kwargs)
+    
     # Bounce if name is function
     if hasattr(name, '__call__'):
         return name(energy, kwargs.pop('label', 'custom function'), ptype='energy', **kwargs)
@@ -434,10 +438,6 @@ def energy(name, **kwargs):
     lowername, level = driver_util.parse_arbitrary_order(lowername)
     if level:
         kwargs['level'] = level
-
-    # Bounce to CP if bsse kwarg
-    if kwargs.get('bsse_type', None) is not None:
-        return driver_nbody.nbody_gufunc(energy, name, ptype='energy', **kwargs)
 
     # Bounce to CBS if "method/basis" name
     if "/" in lowername:


### PR DESCRIPTION
This fixes #977 .

## Description
Make `energy(cbs, ..., bsse_type=[...])` calls work the expected way - calculating and returning overall interaction energies. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Fix for #977

## Questions
- [ ] Do we need a test for this?

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
