### PR TITLE
Fix assignment bug in Prop::set_Ca.

### DIFF
--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -158,7 +158,7 @@ void Prop::set_Ca(SharedMatrix C)
 {
     Ca_so_ = C;
     if (same_orbs_) {
-        Ca_so_ = Ca_so_;
+        Cb_so_ = Ca_so_;
     }
 }
 void Prop::set_Cb(SharedMatrix C)


### PR DESCRIPTION
## Description
set_Ca treats Cb_so_ incorrectly in the same orbs case.
I did not trigger the bug actively, but it looks like a clear bug to me. The bug won't have triggered in any meaningful code, because every algorithm queries same orbs and therefore only uses Ca_so_ if(same_orbs). However it should be fixed regardless.

Please review carefully.

## Checklist
- [ ] Tests added for any new features
ctest -L quick ran through without errors.

## Status
- [X] Ready for review
- [ ] Ready for merge
