### PR TITLE
Remove warning due to PKWorker class

### DIFF
--- a/psi4/src/psi4/libfock/PK_workers.h
+++ b/psi4/src/psi4/libfock/PK_workers.h
@@ -255,8 +255,8 @@ private:
     bool is_shell_relevant();
 
     // This class should never be copied
-    PKWorker(const PKWorker &other) {}
-    PKWorker & operator = (PKWorker &other) {}
+    PKWorker(const PKWorker &other) = delete;
+    PKWorker & operator = (PKWorker &other) = delete;
 
 protected:
     /// Setter function for nbuf_


### PR DESCRIPTION
## Description
Eliminates a compilation warning due to the way the copy constructor and = operator were disabled in the PKWorker class.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Use C++11 `delete` syntax 

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge