### PR TITLE
add PSI_API to class OperatorSymmetry

### DIFF
--- a/psi4/src/psi4/libmints/multipolesymmetry.h
+++ b/psi4/src/psi4/libmints/multipolesymmetry.h
@@ -30,6 +30,7 @@
 #define MULTIPOLESYMMETRY_H
 
 #include "psi4/libmints/typedefs.h"
+#include "psi4/pragma.h"
 
 #include <vector>
 #include <string>
@@ -41,7 +42,7 @@ class Molecule;
 class IntegralFactory;
 class MatrixFactory;
 
-class OperatorSymmetry
+class PSI_API OperatorSymmetry
 {
     // The order of the multipole (dipole=1, quadrupole=2, etc...)
     int order_;


### PR DESCRIPTION
## Description
Add PSI_API to libmints/multipolesymmetry.h, so that it can support a version of v2rdm_casscf plugin.

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [ ] Feature1
* **User-Facing for Release Notes**
  - [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
