### PR TITLE
Split of Prop and OEProp to allow I/O less computation of Properties without globals.

### DIFF
--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -35,8 +35,8 @@
 using namespace psi;
 
 void export_oeprop(py::module &m) {
-    py::class_<Prop, std::shared_ptr<Prop> >(m, "Prop", "docstring")
-        .def("set_title", &OEProp::set_title, "docstring");
+    py::class_<TaskListComputer, std::shared_ptr<TaskListComputer> >(m, "TaskListComputer", "docstring")
+        .def("set_title", &TaskListComputer::set_title, "docstring");
 
     //     def(init<std::shared_ptr<Wavefunction> >()).
     //     def("print_header", pure_virtual(&Prop::print_header)).
@@ -48,7 +48,7 @@ void export_oeprop(py::module &m) {
     //     def("set_Da_mo", &Prop::set_Da_mo, "docstring").
     //     def("set_Db_mo", &Prop::set_Db_mo, "docstring");
 
-    py::class_<OEProp, std::shared_ptr<OEProp>, Prop>(m, "OEProp", "docstring")
+    py::class_<OEProp, std::shared_ptr<OEProp>, Prop, TaskListComputer>(m, "OEProp", "docstring")
         .
         // TODO had no_init but init member present
         def(py::init<std::shared_ptr<Wavefunction> >())

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -35,6 +35,8 @@
 using namespace psi;
 
 void export_oeprop(py::module &m) {
+    py::class_<Prop, std::shared_ptr<Prop> >(m, "Prop", "docstring");
+
     py::class_<TaskListComputer, std::shared_ptr<TaskListComputer> >(m, "TaskListComputer", "docstring")
         .def("set_title", &TaskListComputer::set_title, "docstring");
 

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -30,6 +30,7 @@
 
 #include "psi4/libmints/oeprop.h"
 #include "psi4/libmints/matrix.h"
+#include "psi4/libmints/vector.h"
 #include "psi4/libmints/wavefunction.h"
 
 using namespace psi;
@@ -49,6 +50,16 @@ void export_oeprop(py::module &m) {
     //     def("set_Db_so", &Prop::set_Db_so, "docstring").
     //     def("set_Da_mo", &Prop::set_Da_mo, "docstring").
     //     def("set_Db_mo", &Prop::set_Db_mo, "docstring");
+
+    py::class_<ESPPropCalc, std::shared_ptr<ESPPropCalc>, Prop>(
+            m,
+            "ESPPropCalc",
+            "ESPPropCalc gives access to routines calculating the ESP on a grid")
+        .def(
+                "compute_esp_over_grid_in_memory",
+                &ESPPropCalc::compute_esp_over_grid_in_memory,
+                "Computes ESP on specified grid Nx3 (as SharedMatrix)"
+                );
 
     py::class_<OEProp, std::shared_ptr<OEProp>, Prop, TaskListComputer>(m, "OEProp", "docstring")
         .

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -57,7 +57,7 @@ void export_oeprop(py::module &m) {
         .def("compute_esp_over_grid_in_memory", &ESPPropCalc::compute_esp_over_grid_in_memory,
              "Computes ESP on specified grid Nx3 (as SharedMatrix)");
 
-    py::class_<OEProp, std::shared_ptr<OEProp>, Prop, TaskListComputer>(m, "OEProp", "docstring")
+    py::class_<OEProp, std::shared_ptr<OEProp>, TaskListComputer>(m, "OEProp", "docstring")
         .
         // TODO had no_init but init member present
         def(py::init<std::shared_ptr<Wavefunction> >())

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -55,6 +55,7 @@ void export_oeprop(py::module &m) {
             m,
             "ESPPropCalc",
             "ESPPropCalc gives access to routines calculating the ESP on a grid")
+        .def(py::init<std::shared_ptr<Wavefunction> >())
         .def(
                 "compute_esp_over_grid_in_memory",
                 &ESPPropCalc::compute_esp_over_grid_in_memory,

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -52,15 +52,10 @@ void export_oeprop(py::module &m) {
     //     def("set_Db_mo", &Prop::set_Db_mo, "docstring");
 
     py::class_<ESPPropCalc, std::shared_ptr<ESPPropCalc>, Prop>(
-            m,
-            "ESPPropCalc",
-            "ESPPropCalc gives access to routines calculating the ESP on a grid")
+        m, "ESPPropCalc", "ESPPropCalc gives access to routines calculating the ESP on a grid")
         .def(py::init<std::shared_ptr<Wavefunction> >())
-        .def(
-                "compute_esp_over_grid_in_memory",
-                &ESPPropCalc::compute_esp_over_grid_in_memory,
-                "Computes ESP on specified grid Nx3 (as SharedMatrix)"
-                );
+        .def("compute_esp_over_grid_in_memory", &ESPPropCalc::compute_esp_over_grid_in_memory,
+             "Computes ESP on specified grid Nx3 (as SharedMatrix)");
 
     py::class_<OEProp, std::shared_ptr<OEProp>, Prop, TaskListComputer>(m, "OEProp", "docstring")
         .
@@ -80,8 +75,7 @@ void export_oeprop(py::module &m) {
         .def("Vvals", &OEProp::Vvals, "The electrostatic potential (in a.u.) at each grid point")
         .def("Exvals", &OEProp::Exvals, "The x component of the field (in a.u.) at each grid point")
         .def("Eyvals", &OEProp::Eyvals, "The y component of the field (in a.u.) at each grid point")
-        .def("Ezvals", &OEProp::Ezvals,
-             "The z component of the field (in a.u.) at each grid point");
+        .def("Ezvals", &OEProp::Ezvals, "The z component of the field (in a.u.) at each grid point");
 
     // class_<GridProp, std::shared_ptr<GridProp> >("GridProp", "docstring").
     //    def("add", &GridProp::gridpy_add, "docstring").

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2152,12 +2152,13 @@ PopulationAnalysisCalc::compute_wiberg_lowdin_indices(bool print_output) {
 }
 
 void OEProp::compute_no_occupations() {
-    std::vector<std::vector<std::tuple<double, int, int>>> metrics;
-    pac_.compute_no_occupations(metrics, max_noon_, true);
-    wfn_->set_no_occupations(metrics);
+    auto metrics_ptr = pac_.compute_no_occupations(max_noon_, true);
+    wfn_->set_no_occupations(*metrics_ptr);
 }
-void PopulationAnalysisCalc::compute_no_occupations(
-    std::vector<std::vector<std::tuple<double, int, int>>>& output_metrics, int max_noon, bool print_output) {
+std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> PopulationAnalysisCalc::compute_no_occupations(
+    int max_noon, bool print_output) {
+    std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> output_metrics_ptr =
+        std::make_shared<std::vector<std::vector<std::tuple<double, int, int>>>>();
     std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
 
     if (print_output) {
@@ -2165,7 +2166,7 @@ void PopulationAnalysisCalc::compute_no_occupations(
     }
 
     // Terminally, it will be [metric_a , metric_b, metric] or [metric] depending on same_dens
-    std::vector<std::vector<std::tuple<double, int, int>>>& metrics = output_metrics;
+    std::vector<std::vector<std::tuple<double, int, int>>>& metrics = *output_metrics_ptr;
 
     if (!same_dens_) {
         SharedVector Oa;
@@ -2279,7 +2280,7 @@ void PopulationAnalysisCalc::compute_no_occupations(
         }
         outfile->Printf("\n");
     }
-
+    return output_metrics_ptr;
     //for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
 
 }

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -729,8 +729,10 @@ SharedMatrix Prop::overlap_so()
     return S;
 }
 
-Vector3 Prop::compute_center(const double* property) const {
-    std::shared_ptr<Molecule> mol = basisset_->molecule();
+std::string Prop::Da_name() const { return Da_so_->name(); }
+
+Vector3 OEProp::compute_center(const double* property) const {
+    std::shared_ptr<Molecule> mol = wfn_->molecule();
     int natoms = mol->natom();
     double x = 0.0;
     double y = 0.0;
@@ -751,7 +753,8 @@ Vector3 Prop::compute_center(const double* property) const {
 }
 
 OEProp::OEProp(std::shared_ptr<Wavefunction> wfn)
-    : Prop(wfn), mpc_(wfn, get_origin_from_environment()), pac_(wfn), epc_(wfn) {
+    : wfn_(wfn), mpc_(wfn, get_origin_from_environment()), pac_(wfn), epc_(wfn) {
+    if (wfn_.get() == nullptr) throw PSIEXCEPTION("Prop: Wavefunction is null");
     common_init();
 }
 OEProp::~OEProp() {}
@@ -811,7 +814,7 @@ Vector3 OEProp::get_origin_from_environment() const {
     Options& options = Process::environment.options;
     Vector3 origin(0.0, 0.0, 0.0);
 
-    std::shared_ptr<Molecule> mol = basisset_->molecule();
+    std::shared_ptr<Molecule> mol = wfn_->molecule();
     int natoms = mol->natom();
     if(options["PROPERTIES_ORIGIN"].has_changed()){
         int size = options["PROPERTIES_ORIGIN"].size();
@@ -872,7 +875,8 @@ void OEProp::compute()
 
     
     if (title_ == "") {
-        outfile->Printf("OEProp: No title given, name of density matrix used for the following properties is '%s'\n", Da_so_->name().c_str());
+        outfile->Printf("OEProp: No title given, name of density matrix used for the following properties is '%s'\n",
+                        mpc_.Da_name().c_str());
     } else {
         outfile->Printf( "\nProperties computed using the %s density matrix\n\n", title_.c_str());
     }

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1993,7 +1993,7 @@ void OEProp::compute_mayer_indices()
 {
     SharedMatrix MBI_total,MBI_alpha,MBI_beta;
     SharedVector MBI_valence;
-    std::tie(MBI_total,MBI_alpha,MBI_beta,MBI_valence) = pac.compute_mayer_indices();
+    std::tie(MBI_total,MBI_alpha,MBI_beta,MBI_valence) = pac.compute_mayer_indices(true);
 
     wfn_->set_array("MAYER_INDICES", MBI_total);
 }
@@ -2120,7 +2120,7 @@ void OEProp::compute_wiberg_lowdin_indices()
 {
     SharedMatrix WBI_total,WBI_alpha,WBI_beta;
     SharedVector WBI_valence;
-    std::tie(WBI_total,WBI_alpha,WBI_beta,WBI_valence) = pac.compute_wiberg_lowdin_indices();
+    std::tie(WBI_total,WBI_alpha,WBI_beta,WBI_valence) = pac.compute_wiberg_lowdin_indices(true);
     wfn_->set_array("WIBERG_LOWDIN_INDICES", WBI_total);
 }
 
@@ -2246,7 +2246,7 @@ std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector>  PopulationAnaly
 void OEProp::compute_no_occupations()
 {
     std::vector<std::vector<std::tuple<double, int, int> >> metrics;
-    pac.compute_no_occupations(metrics,max_noon_,true);
+    pac.compute_no_occupations(metrics, max_noon_,true);
     wfn_->set_no_occupations(metrics);
 }
 void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int> > > & output_metrics, int max_noon, bool print_output)

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -280,27 +280,19 @@ void Prop::set_Db_mo(SharedMatrix D)
     }
     delete[] temp;
 }
-TaskListComputer::TaskListComputer()
-{
+TaskListComputer::TaskListComputer() {
     title_ = "";
     print_ = 1;
     debug_ = 0;
     tasks_.clear();
 }
-void TaskListComputer::add(const std::string& prop)
-{
-    tasks_.insert(prop);
-}
-void TaskListComputer::add(std::vector<std::string> props)
-{
+void TaskListComputer::add(const std::string& prop) { tasks_.insert(prop); }
+void TaskListComputer::add(std::vector<std::string> props) {
     for (int i = 0; i < (int)props.size(); i++) {
         tasks_.insert(props[i]);
     }
 }
-void TaskListComputer::clear()
-{
-    tasks_.clear();
-}
+void TaskListComputer::clear() { tasks_.clear(); }
 SharedVector Prop::epsilon_a()
 {
     return SharedVector(epsilon_a_->clone());
@@ -737,8 +729,7 @@ SharedMatrix Prop::overlap_so()
     return S;
 }
 
-Vector3 Prop::compute_center(const double *property) const
-{
+Vector3 Prop::compute_center(const double* property) const {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     int natoms = mol->natom();
     double x = 0.0;
@@ -759,14 +750,11 @@ Vector3 Prop::compute_center(const double *property) const
     return Vector3(x, y, z);
 }
 
-
-OEProp::OEProp(std::shared_ptr<Wavefunction> wfn) : Prop(wfn), mpc(wfn,get_origin_from_environment()), pac(wfn), epc(wfn)
-{
+OEProp::OEProp(std::shared_ptr<Wavefunction> wfn)
+    : Prop(wfn), mpc(wfn, get_origin_from_environment()), pac(wfn), epc(wfn) {
     common_init();
 }
-OEProp::~OEProp()
-{
-}
+OEProp::~OEProp() {}
 
 void OEProp::common_init()
 {
@@ -774,13 +762,14 @@ void OEProp::common_init()
     print_ = options.get_int("PRINT");
 
     // Determine number of NOONs to print; default is 3
-    if(options.get_str("PRINT_NOONS") == "ALL") max_noon_ = wfn_->nmo();
-        else max_noon_ = to_integer(options.get_str("PRINT_NOONS"));
+    if (options.get_str("PRINT_NOONS") == "ALL")
+        max_noon_ = wfn_->nmo();
+    else
+        max_noon_ = to_integer(options.get_str("PRINT_NOONS"));
 }
 
-
-MultipolePropCalc::MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const & origin) : Prop(wfn), origin_(origin)
-{
+MultipolePropCalc::MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin)
+    : Prop(wfn), origin_(origin) {
     typedef MultipolePropCalc MPC;
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
@@ -803,27 +792,25 @@ MultipolePropCalc::MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 
             // rr(xyz, xyz) tells us how the orbitals transform in this
             // symmetry operation, then we multiply by the character in
             // the irrep
-            for (int xyz = 0; xyz < 3; ++xyz)
-                t[xyz] += origin_[xyz]*rr(xyz, xyz) * gamma.character(G) / nirrep;
+            for (int xyz = 0; xyz < 3; ++xyz) t[xyz] += origin_[xyz] * rr(xyz, xyz) * gamma.character(G) / nirrep;
         }
 
         for (int xyz = 0; xyz < 3; ++xyz) {
-            if(std::fabs(t[xyz]) > 1.0E-8){
-                outfile->Printf( "The origin chosen breaks symmetry; multipoles will be computed without symmetry.\n");
+            if (std::fabs(t[xyz]) > 1.0E-8) {
+                outfile->Printf("The origin chosen breaks symmetry; multipoles will be computed without symmetry.\n");
                 origin_preserves_symmetry_ = false;
             }
         }
     }
 }
 
-Vector3 OEProp::get_origin_from_environment() const
-{
+Vector3 OEProp::get_origin_from_environment() const {
     // This function gets called early in the constructor of OEProp.
     // Take care not to use or initialize members, which are only initialized later.
     // The only member used here is basisset, which is initialized in the base class.
     // See if the user specified the origin
-    Options &options = Process::environment.options;
-    Vector3 origin(0.0,0.0,0.0);
+    Options& options = Process::environment.options;
+    Vector3 origin(0.0, 0.0, 0.0);
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     int natoms = mol->natom();
@@ -859,8 +846,8 @@ Vector3 OEProp::get_origin_from_environment() const
             throw PSIEXCEPTION("Invalid specification of PROPERTIES_ORIGIN.  Please consult the manual.");
         }
     }
-    outfile->Printf( "\n\nProperties will be evaluated at %10.6f, %10.6f, %10.6f [a0]\n",
-            origin[0], origin[1], origin[2]);
+    outfile->Printf("\n\nProperties will be evaluated at %10.6f, %10.6f, %10.6f [a0]\n", origin[0], origin[1],
+                    origin[2]);
 
     return origin;
 }
@@ -937,10 +924,9 @@ void OEProp::compute()
 void OEProp::compute_multipoles(int order, bool transition)
 {
     typedef MultipolePropCalc::MultipoleOutputType OutType;
-    MultipolePropCalc::MultipoleOutputType_ptr out = mpc.compute_multipoles(order,transition,true,print_ > 4);
-    MultipolePropCalc::MultipoleOutputType & mpoles = *out;
-    for (OutType::iterator it = mpoles.begin(); it != mpoles.end(); ++it)
-    {
+    MultipolePropCalc::MultipoleOutputType_ptr out = mpc.compute_multipoles(order, transition, true, print_ > 4);
+    MultipolePropCalc::MultipoleOutputType& mpoles = *out;
+    for (OutType::iterator it = mpoles.begin(); it != mpoles.end(); ++it) {
         std::string name;
         double total_mpole = 0.0;
         // unpack the multipole, which is: name, nuc, elec, total, ignore nuc and elec:
@@ -953,10 +939,10 @@ void OEProp::compute_multipoles(int order, bool transition)
     }
 }
 
-MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles(int order, bool transition, bool print_output, bool verbose)
-{
+MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles(int order, bool transition,
+                                                                                 bool print_output, bool verbose) {
     MultipolePropCalc::MultipoleOutputType_ptr mot_ptr = std::make_shared<MultipolePropCalc::MultipoleOutputType>();
-    MultipolePropCalc::MultipoleOutputType & mot = *mot_ptr;
+    MultipolePropCalc::MultipoleOutputType& mot = *mot_ptr;
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     SharedMatrix Da;
@@ -995,8 +981,7 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
         }
     }
 
-    if (verbose)
-    {
+    if (verbose) {
         std::vector<SharedMatrix>::iterator iter;
         for(iter = mp_ints.begin(); iter != mp_ints.end(); ++iter)
             iter->get()->print();
@@ -1004,12 +989,11 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
 
     SharedVector nuclear_contributions = MultipoleInt::nuclear_contribution(mol, order, origin_);
 
-    if (print_output)
-    {
+    if (print_output) {
         outfile->Printf("\n%s Multipole Moments:\n", transition ? "Transition" : "");
-        outfile->Printf( "\n ------------------------------------------------------------------------------------\n");
-        outfile->Printf( "     Multipole             Electric (a.u.)       Nuclear  (a.u.)        Total (a.u.)\n");
-        outfile->Printf( " ------------------------------------------------------------------------------------\n\n");
+        outfile->Printf("\n ------------------------------------------------------------------------------------\n");
+        outfile->Printf("     Multipole             Electric (a.u.)       Nuclear  (a.u.)        Total (a.u.)\n");
+        outfile->Printf(" ------------------------------------------------------------------------------------\n\n");
     }
     double convfac = pc_dipmom_au2debye;
     int address = 0;
@@ -1021,9 +1005,8 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
         if(l > 2)
             ss << "^" << l-1;
         std::string exp = ss.str();
-        if (print_output)
-        {
-            outfile->Printf( " L = %d.  Multiply by %.10f to convert to Debye%s\n", l, convfac, exp.c_str());
+        if (print_output) {
+            outfile->Printf(" L = %d.  Multiply by %.10f to convert to Debye%s\n", l, convfac, exp.c_str());
         }
         for(int component = 0; component < ncomponents; ++component){
             SharedMatrix mpmat = mp_ints[address];
@@ -1031,24 +1014,20 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
             double nuc = transition ? 0.0 : nuclear_contributions->get(address);
             double elec = Da->vector_dot(mpmat) + Db->vector_dot(mpmat);
             double tot = nuc + elec;
-            if (print_output)
-            {
-                outfile->Printf( " %-20s: %18.7f   %18.7f   %18.7f\n",
-                        name.c_str(), elec, nuc, tot);
+            if (print_output) {
+                outfile->Printf(" %-20s: %18.7f   %18.7f   %18.7f\n", name.c_str(), elec, nuc, tot);
             }
             std::string upper_name = to_upper_copy(name);
-            mot.push_back(std::make_tuple(upper_name,nuc,elec,tot));
+            mot.push_back(std::make_tuple(upper_name, nuc, elec, tot));
             ++address;
         }
-        if (print_output)
-        {
-            outfile->Printf( "\n");
+        if (print_output) {
+            outfile->Printf("\n");
         }
         convfac *= pc_bohr2angstroms;
     }
-    if (print_output)
-    {
-        outfile->Printf( " --------------------------------------------------------------------------------\n");
+    if (print_output) {
+        outfile->Printf(" --------------------------------------------------------------------------------\n");
     }
 
     return mot_ptr;
@@ -1105,28 +1084,19 @@ public:
     }
 };
 
-ESPPropCalc::ESPPropCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn)
-{
-}
+ESPPropCalc::ESPPropCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn) {}
 
-ESPPropCalc::~ESPPropCalc()
-{
-}
+ESPPropCalc::~ESPPropCalc() {}
 
-void OEProp::compute_esp_over_grid()
-{
-    epc.compute_esp_over_grid(true);
-}
+void OEProp::compute_esp_over_grid() { epc.compute_esp_over_grid(true); }
 
-void ESPPropCalc::compute_esp_over_grid(bool print_output)
-{
+void ESPPropCalc::compute_esp_over_grid(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
 
-    if (print_output)
-    {
-        outfile->Printf( "\n Electrostatic potential computed on the grid and written to grid_esp.dat\n");
+    if (print_output) {
+        outfile->Printf("\n Electrostatic potential computed on the grid and written to grid_esp.dat\n");
     }
 
     SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
@@ -1165,21 +1135,18 @@ void ESPPropCalc::compute_esp_over_grid(bool print_output)
     fclose(gridout);
 }
 
-SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_grid) const
-{
+SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_grid) const {
     // We only want a plain matrix to work with here:
-    if (input_grid->nirrep() != 1)
-    {
+    if (input_grid->nirrep() != 1) {
         throw PSIEXCEPTION("ESPPropCalc only allows \"plain\" input matrices with, i.e. nirrep == 1.");
     }
-    if (input_grid->coldim() != 3)
-    {
+    if (input_grid->coldim() != 3) {
         throw PSIEXCEPTION("ESPPropCalc only allows \"plain\" input matrices with a dimension of N (rows) x 3 (cols)");
     }
 
     int number_of_grid_points = input_grid->rowdim();
     SharedVector output_ptr = std::make_shared<Vector>(number_of_grid_points);
-    Vector & output = *output_ptr;
+    Vector& output = *output_ptr;
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
@@ -1187,31 +1154,28 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
     SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
         Dtot->scale(2.0);
-    }else{
+    } else {
         Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
     int const nbf = basisset_->nbf();
 
-
     bool convert = mol->units() == Molecule::Angstrom;
 
-    #pragma openmp parallel for
-    for(int i = 0; i < number_of_grid_points; ++i){
-        Vector3 origin(input_grid->get(i,0),input_grid->get(i,1),input_grid->get(i,2));
-        if(convert)
-            origin /= pc_bohr2angstroms;
+#pragma openmp parallel for
+    for (int i = 0; i < number_of_grid_points; ++i) {
+        Vector3 origin(input_grid->get(i, 0), input_grid->get(i, 1), input_grid->get(i, 2));
+        if (convert) origin /= pc_bohr2angstroms;
         auto ints = std::make_shared<Matrix>(nbf, nbf);
         ints->zero();
         epot->compute(ints, origin);
         double Velec = Dtot->vector_dot(ints);
         double Vnuc = 0.0;
         int natom = mol->natom();
-        for(int i=0; i < natom; i++) {
+        for (int i = 0; i < natom; i++) {
             Vector3 dR = origin - mol->xyz(i);
             double r = dR.norm();
-            if(r > 1.0E-8)
-                Vnuc += mol->Z(i)/r;
+            if (r > 1.0E-8) Vnuc += mol->Z(i) / r;
         }
         double Vtot = Velec + Vnuc;
         output[i] = Vtot;
@@ -1219,20 +1183,15 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
     return output_ptr;
 }
 
-void OEProp::compute_field_over_grid()
-{
-    epc.compute_field_over_grid(true);
-}
+void OEProp::compute_field_over_grid() { epc.compute_field_over_grid(true); }
 
-void ESPPropCalc::compute_field_over_grid(bool print_output)
-{
+void ESPPropCalc::compute_field_over_grid(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
 
-    if (print_output)
-    {
-        outfile->Printf( "\n Field computed on the grid and written to grid_field.dat\n");
+    if (print_output) {
+        outfile->Printf("\n Field computed on the grid and written to grid_field.dat\n");
     }
 
     SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
@@ -1278,20 +1237,18 @@ void ESPPropCalc::compute_field_over_grid(bool print_output)
     fclose(gridout);
 }
 
-void OEProp::compute_esp_at_nuclei()
-{
+void OEProp::compute_esp_at_nuclei() {
     std::shared_ptr<std::vector<double>> nesps = epc.compute_esp_at_nuclei(true, print_ > 2);
-    for(int atom1 = 0; atom1 < nesps->size(); ++atom1){
+    for (int atom1 = 0; atom1 < nesps->size(); ++atom1) {
         std::stringstream s;
-        s << "ESP AT CENTER " << atom1+1;
+        s << "ESP AT CENTER " << atom1 + 1;
         /*- Process::environment.globals["ESP AT CENTER n"] -*/
         Process::environment.globals[s.str()] = (*nesps)[atom1];
     }
     wfn_->set_esp_at_nuclei(nesps);
 }
 
-std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool print_output, bool verbose)
-{
+std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool print_output, bool verbose) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     std::shared_ptr<std::vector<double>> nesps(new std::vector<double>(mol->natom()));
@@ -1308,20 +1265,18 @@ std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool pri
     }
 
     Matrix dist = mol->distance_matrix();
-    if (print_output)
-    {
-        outfile->Printf( "\n Electrostatic potentials at the nuclear coordinates:\n");
-        outfile->Printf( " ---------------------------------------------\n");
-        outfile->Printf( "   Center     Electrostatic Potential (a.u.)\n");
-        outfile->Printf( " ---------------------------------------------\n");
+    if (print_output) {
+        outfile->Printf("\n Electrostatic potentials at the nuclear coordinates:\n");
+        outfile->Printf(" ---------------------------------------------\n");
+        outfile->Printf("   Center     Electrostatic Potential (a.u.)\n");
+        outfile->Printf(" ---------------------------------------------\n");
     }
     for(int atom1 = 0; atom1 < natoms; ++atom1){
         std::stringstream s;
         s << "ESP AT CENTER " << atom1+1;
         auto ints = std::make_shared<Matrix>(s.str(), nbf, nbf);
         epot->compute(ints, mol->xyz(atom1));
-        if (verbose)
-        {
+        if (verbose) {
             ints->print();
         }
         double elec = Dtot->vector_dot(ints);
@@ -1331,23 +1286,19 @@ std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool pri
                 continue;
             nuc += mol->Z(atom2) / dist[0][atom1][atom2];
         }
-        if (print_output)
-        {
-            outfile->Printf( "  %3d %2s           %16.12f\n",
-                    atom1+1, mol->label(atom1).c_str(), nuc+elec);
+        if (print_output) {
+            outfile->Printf("  %3d %2s           %16.12f\n", atom1 + 1, mol->label(atom1).c_str(), nuc + elec);
         }
         (*nesps)[atom1] = nuc+elec;
     }
-    if (print_output)
-    {
-        outfile->Printf( " ---------------------------------------------\n");
+    if (print_output) {
+        outfile->Printf(" ---------------------------------------------\n");
     }
     return nesps;
 }
 
-void OEProp::compute_dipole(bool transition)
-{
-    SharedVector dipole = mpc.compute_dipole(transition,true,print_ > 4);
+void OEProp::compute_dipole(bool transition) {
+    SharedVector dipole = mpc.compute_dipole(transition, true, print_ > 4);
     // Dipole components in Debye
     std::stringstream s;
     s << title_ << " DIPOLE X";
@@ -1360,8 +1311,7 @@ void OEProp::compute_dipole(bool transition)
     Process::environment.globals[s.str()] = dipole->get(2);
 }
 
-SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_output, bool verbose)
-{
+SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_output, bool verbose) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     Vector3 de;
@@ -1402,7 +1352,7 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
         }
     }
 
-    if (verbose){
+    if (verbose) {
         for (int n = 0; n < 3; ++n) dipole_ints[n]->print();
     }
 
@@ -1413,16 +1363,14 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
     SharedVector ndip = DipoleInt::nuclear_contribution(mol, origin_);
 
     if (!transition) {
-        if (print_output)
-        {
-            outfile->Printf( "  Nuclear Dipole Moment: [e a0]\n");
-            outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf\n",
-                    ndip->get(0), ndip->get(1), ndip->get(2));
-            outfile->Printf( "\n");
-            outfile->Printf( "  Electronic Dipole Moment: [e a0]\n");
-            outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf\n",
-                    de[0], de[1], de[2]);
-            outfile->Printf( "\n");
+        if (print_output) {
+            outfile->Printf("  Nuclear Dipole Moment: [e a0]\n");
+            outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf\n", ndip->get(0), ndip->get(1),
+                            ndip->get(2));
+            outfile->Printf("\n");
+            outfile->Printf("  Electronic Dipole Moment: [e a0]\n");
+            outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf\n", de[0], de[1], de[2]);
+            outfile->Printf("\n");
         }
 
         de[0] += ndip->get(0, 0);
@@ -1430,62 +1378,58 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
         de[2] += ndip->get(0, 2);
     }
 
-    if (print_output)
-    {
+    if (print_output) {
         outfile->Printf("  %sDipole Moment: [e a0]\n", (transition ? "Transition " : ""));
-        outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf     Total: %10.4lf\n",
-           de[0], de[1], de[2], de.norm());
-        outfile->Printf( "\n");
+        outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf     Total: %10.4lf\n", de[0], de[1], de[2],
+                        de.norm());
+        outfile->Printf("\n");
     }
 
     double dfac = pc_dipmom_au2debye;
-    if (print_output)
-    {
+    if (print_output) {
         outfile->Printf("  %sDipole Moment: [D]\n", (transition ? "Transition " : ""));
-        outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf     Total: %10.4lf\n",
-           de[0]*dfac, de[1]*dfac, de[2]*dfac, de.norm()*dfac);
-        outfile->Printf( "\n");
+        outfile->Printf("     X: %10.4lf      Y: %10.4lf      Z: %10.4lf     Total: %10.4lf\n", de[0] * dfac,
+                        de[1] * dfac, de[2] * dfac, de.norm() * dfac);
+        outfile->Printf("\n");
     }
 
     // Dipole components in Debye
-    double dipole_x = de[0]*dfac;
-    double dipole_y = de[1]*dfac;
-    double dipole_z = de[2]*dfac;
+    double dipole_x = de[0] * dfac;
+    double dipole_y = de[1] * dfac;
+    double dipole_z = de[2] * dfac;
 
     auto output = std::make_shared<Vector>(3);
-    output->set(0,dipole_x);
-    output->set(1,dipole_y);
-    output->set(2,dipole_z);
+    output->set(0, dipole_x);
+    output->set(1, dipole_y);
+    output->set(2, dipole_z);
 
     return output;
 }
 
-void OEProp::compute_quadrupole(bool transition)
-{
+void OEProp::compute_quadrupole(bool transition) {
     SharedMatrix quadrupole_ptr = mpc.compute_quadrupole(transition, true, print_ > 4);
-    Matrix & quadrupole = *quadrupole_ptr;
+    Matrix& quadrupole = *quadrupole_ptr;
     std::stringstream s;
     s << title_ << " QUADRUPOLE XX";
-    Process::environment.globals[s.str()] = quadrupole.get(0,0);
+    Process::environment.globals[s.str()] = quadrupole.get(0, 0);
     s.str(std::string());
     s << title_ << " QUADRUPOLE YY";
-    Process::environment.globals[s.str()] = quadrupole.get(1,1);
+    Process::environment.globals[s.str()] = quadrupole.get(1, 1);
     s.str(std::string());
     s << title_ << " QUADRUPOLE ZZ";
-    Process::environment.globals[s.str()] = quadrupole.get(2,2);
+    Process::environment.globals[s.str()] = quadrupole.get(2, 2);
     s.str(std::string());
     s << title_ << " QUADRUPOLE XY";
-    Process::environment.globals[s.str()] = quadrupole.get(0,1);
+    Process::environment.globals[s.str()] = quadrupole.get(0, 1);
     s.str(std::string());
     s << title_ << " QUADRUPOLE XZ";
-    Process::environment.globals[s.str()] = quadrupole.get(0,2);
+    Process::environment.globals[s.str()] = quadrupole.get(0, 2);
     s.str(std::string());
     s << title_ << " QUADRUPOLE YZ";
-    Process::environment.globals[s.str()] = quadrupole.get(1,2);
+    Process::environment.globals[s.str()] = quadrupole.get(1, 2);
 }
 
-SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_output, bool verbose)
-{
+SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_output, bool verbose) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     SharedMatrix Da;
     SharedMatrix Db;
@@ -1523,7 +1467,7 @@ SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_o
         }
     }
 
-    if(verbose)
+    if (verbose)
         for(int n = 0; n < 6; ++n)
             qpole_ints[n]->print();
 
@@ -1549,61 +1493,54 @@ SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_o
 
     // Print multipole components
     double dfac = pc_dipmom_au2debye * pc_bohr2angstroms;
-    if (print_output)
-    {
-        outfile->Printf( "  %sQuadrupole Moment: [D A]\n", (transition ? "Transition " : ""));
-        outfile->Printf( "    XX: %10.4lf     YY: %10.4lf     ZZ: %10.4lf\n", \
-           qe[0]*dfac, qe[3]*dfac, qe[5]*dfac);
-        outfile->Printf( "    XY: %10.4lf     XZ: %10.4lf     YZ: %10.4lf\n", \
-           qe[1]*dfac, qe[2]*dfac, qe[4]*dfac);
-        outfile->Printf( "\n");
+    if (print_output) {
+        outfile->Printf("  %sQuadrupole Moment: [D A]\n", (transition ? "Transition " : ""));
+        outfile->Printf("    XX: %10.4lf     YY: %10.4lf     ZZ: %10.4lf\n", qe[0] * dfac, qe[3] * dfac, qe[5] * dfac);
+        outfile->Printf("    XY: %10.4lf     XZ: %10.4lf     YZ: %10.4lf\n", qe[1] * dfac, qe[2] * dfac, qe[4] * dfac);
+        outfile->Printf("\n");
     }
 
     double dtrace = (1.0 / 3.0) * (qe[0] + qe[3] + qe[5]);
-    if (print_output)
-    {
-        outfile->Printf( "  Traceless %sQuadrupole Moment: [D A]\n", (transition ? "Transition " : ""));
-        outfile->Printf( "    XX: %10.4lf     YY: %10.4lf     ZZ: %10.4lf\n", \
-           (qe[0]-dtrace)*dfac, (qe[3]-dtrace)*dfac, (qe[5]-dtrace)*dfac);
-        outfile->Printf( "    XY: %10.4lf     XZ: %10.4lf     YZ: %10.4lf\n", \
-           qe[1]*dfac, qe[2]*dfac, qe[4]*dfac);
-        outfile->Printf( "\n");
+    if (print_output) {
+        outfile->Printf("  Traceless %sQuadrupole Moment: [D A]\n", (transition ? "Transition " : ""));
+        outfile->Printf("    XX: %10.4lf     YY: %10.4lf     ZZ: %10.4lf\n", (qe[0] - dtrace) * dfac,
+                        (qe[3] - dtrace) * dfac, (qe[5] - dtrace) * dfac);
+        outfile->Printf("    XY: %10.4lf     XZ: %10.4lf     YZ: %10.4lf\n", qe[1] * dfac, qe[2] * dfac, qe[4] * dfac);
+        outfile->Printf("\n");
     }
 
     // Quadrupole components in Debye Ang
-    double xx = qe[0]*dfac;
-    double yy = qe[3]*dfac;
-    double zz = qe[5]*dfac;
-    double xy = qe[1]*dfac;
-    double xz = qe[2]*dfac;
-    double yz = qe[4]*dfac;
+    double xx = qe[0] * dfac;
+    double yy = qe[3] * dfac;
+    double zz = qe[5] * dfac;
+    double xy = qe[1] * dfac;
+    double xz = qe[2] * dfac;
+    double yz = qe[4] * dfac;
 
-    auto output = std::make_shared<Matrix>(3,3);
-    Matrix & outmat = *output;
-    outmat.set(0,0,xx);
-    outmat.set(1,1,yy);
-    outmat.set(2,2,zz);
+    auto output = std::make_shared<Matrix>(3, 3);
+    Matrix& outmat = *output;
+    outmat.set(0, 0, xx);
+    outmat.set(1, 1, yy);
+    outmat.set(2, 2, zz);
 
-    outmat.set(0,1,xy);
-    outmat.set(1,0,xy);
+    outmat.set(0, 1, xy);
+    outmat.set(1, 0, xy);
 
-    outmat.set(1,2,yz);
-    outmat.set(2,1,yz);
+    outmat.set(1, 2, yz);
+    outmat.set(2, 1, yz);
 
-    outmat.set(0,2,xz);
-    outmat.set(2,0,xz);
+    outmat.set(0, 2, xz);
+    outmat.set(2, 0, xz);
 
     return output;
 }
 
-void OEProp::compute_mo_extents()
-{
+void OEProp::compute_mo_extents() {
     std::vector<SharedVector> mo_es = mpc.compute_mo_extents(true);
     wfn_->set_mo_extents(mo_es);
 }
 
-std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_output)
-{
+std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     SharedMatrix Ca;
     SharedMatrix Cb;
@@ -1720,10 +1657,9 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
             }
         }
         std::sort(metric.begin(),metric.end());
-        if (print_output)
-        {
-            outfile->Printf( "\n  Orbital extents (a.u.):\n");
-            outfile->Printf( "    %10s%15s%15s%15s%15s\n", "MO", "<x^2>", "<y^2>", "<z^2>", "<r^2>");
+        if (print_output) {
+            outfile->Printf("\n  Orbital extents (a.u.):\n");
+            outfile->Printf("    %10s%15s%15s%15s%15s\n", "MO", "<x^2>", "<y^2>", "<z^2>", "<r^2>");
         }
 
         for (int i = 0; i < nmo; i++) {
@@ -1733,25 +1669,18 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
             double xx = quadrupole[0]->get(0, i),
                    yy = quadrupole[1]->get(0, i),
                    zz = quadrupole[2]->get(0, i);
-            if (print_output)
-            {
-                outfile->Printf( "    %4d%3s%3d%15.10f%15.10f%15.10f%15.10f\n",
-                        i,
-                        labels[h].c_str(),
-                        n,
-                        std::fabs(quadrupole[0]->get(0, i)),
-                        std::fabs(quadrupole[1]->get(0, i)),
-                        std::fabs(quadrupole[2]->get(0, i)),
-                        std::fabs(xx + yy + zz));
+            if (print_output) {
+                outfile->Printf("    %4d%3s%3d%15.10f%15.10f%15.10f%15.10f\n", i, labels[h].c_str(), n,
+                                std::fabs(quadrupole[0]->get(0, i)), std::fabs(quadrupole[1]->get(0, i)),
+                                std::fabs(quadrupole[2]->get(0, i)), std::fabs(xx + yy + zz));
             }
-                    mo_es[0]->set(0,i,quadrupole[0]->get(0, i));
-                    mo_es[1]->set(0,i,quadrupole[1]->get(0, i));
-                    mo_es[2]->set(0,i,quadrupole[2]->get(0, i));
-                    mo_es[3]->set(0,i,fabs(xx + yy + zz));
+            mo_es[0]->set(0, i, quadrupole[0]->get(0, i));
+            mo_es[1]->set(0, i, quadrupole[1]->get(0, i));
+            mo_es[2]->set(0, i, quadrupole[2]->get(0, i));
+            mo_es[3]->set(0, i, fabs(xx + yy + zz));
         }
-        if (print_output)
-        {
-            outfile->Printf( "\n");
+        if (print_output) {
+            outfile->Printf("\n");
         }
 
     } else {
@@ -1763,41 +1692,36 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
 }
 
 typedef PopulationAnalysisCalc PAC;
-PopulationAnalysisCalc::PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn)
-{
-    //No internal state. num_noon is now an argument.
+PopulationAnalysisCalc::PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn) {
+    // No internal state. num_noon is now an argument.
 }
 
-PopulationAnalysisCalc::~PopulationAnalysisCalc()
-{
-
-}
+PopulationAnalysisCalc::~PopulationAnalysisCalc() {}
 
 void OEProp::compute_mulliken_charges()
 {
-    PAC::SharedStdVector Qa_ptr,Qb_ptr,apcs ;
-    std::tie(Qa_ptr,Qb_ptr,apcs) = pac.compute_mulliken_charges(true);
+    PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
+    std::tie(Qa_ptr, Qb_ptr, apcs) = pac.compute_mulliken_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Mulliken Charges: (a.u.)", 1, apcs->size());
-    for (size_t i = 0; i < apcs->size(); i++){
+    for (size_t i = 0; i < apcs->size(); i++) {
         vec_apcs->set(0, i, (*apcs)[i]);
     }
     wfn_->set_array("MULLIKEN_CHARGES", vec_apcs);
 }
 
-std::tuple<PAC::SharedStdVector,PAC::SharedStdVector,PAC::SharedStdVector>  PopulationAnalysisCalc::compute_mulliken_charges(bool print_output)
-{
-    if (print_output)
-    {
-        outfile->Printf( "  Mulliken Charges: (a.u.)\n");
+std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
+PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
+    if (print_output) {
+        outfile->Printf("  Mulliken Charges: (a.u.)\n");
     }
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     auto Qa_ptr = std::make_shared<std::vector<double>>(mol->natom());
     auto Qb_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    std::vector<double> & Qa = *Qa_ptr;
-    std::vector<double> & Qb = *Qb_ptr;
+    std::vector<double>& Qa = *Qa_ptr;
+    std::vector<double>& Qb = *Qb_ptr;
 
     auto apcs = std::make_shared<std::vector<double>>(mol->natom());
     double* PSa = new double[basisset_->nbf()];
@@ -1848,66 +1772,58 @@ std::tuple<PAC::SharedStdVector,PAC::SharedStdVector,PAC::SharedStdVector>  Popu
     }
 
 //    Print out the Mulliken populations and charges
-    if (print_output)
-    {
-        outfile->Printf( "   Center  Symbol    Alpha    Beta     Spin     Total\n");
+    if (print_output) {
+        outfile->Printf("   Center  Symbol    Alpha    Beta     Spin     Total\n");
     }
     double nuc = 0.0;
     for (int A = 0; A < mol->natom(); A++) {
         double Qs = Qa[A] - Qb[A];
         double Qt = mol->Z(A) - (Qa[A] + Qb[A]);
         (*apcs)[A]=Qt;
-        if (print_output)
-        {
-            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A+1,mol->label(A).c_str(), \
-                Qa[A], Qb[A], Qs, Qt);
+        if (print_output) {
+            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), Qa[A], Qb[A],
+                            Qs, Qt);
         }
         nuc += (double) mol->Z(A);
    }
 
-    if (print_output)
-    {
-        outfile->Printf( "\n   Total alpha = %8.5f, Total beta = %8.5f, Total charge = %8.5f\n", \
-                suma, sumb, nuc - suma - sumb);
+   if (print_output) {
+       outfile->Printf("\n   Total alpha = %8.5f, Total beta = %8.5f, Total charge = %8.5f\n", suma, sumb,
+                       nuc - suma - sumb);
     }
-
 
 //    Free memory
     delete[] PSa;
     delete[] PSb;
 
-    if (print_output)
-        outfile->Printf( "\n");
+    if (print_output) outfile->Printf("\n");
 
-    return std::make_tuple(Qa_ptr,Qb_ptr,apcs);
-
+    return std::make_tuple(Qa_ptr, Qb_ptr, apcs);
 }
 void OEProp::compute_lowdin_charges()
 {
-    PAC::SharedStdVector Qa_ptr,Qb_ptr,apcs ;
-    std::tie(Qa_ptr,Qb_ptr,apcs) = pac.compute_lowdin_charges(true);
+    PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
+    std::tie(Qa_ptr, Qb_ptr, apcs) = pac.compute_lowdin_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Lowdin Charges: (a.u.)", 1, apcs->size());
-    for (size_t i = 0; i < apcs->size(); i++){
+    for (size_t i = 0; i < apcs->size(); i++) {
         vec_apcs->set(0, i, (*apcs)[i]);
     }
     wfn_->set_array("LOWDIN_CHARGES", vec_apcs);
 }
 
-std::tuple<PAC::SharedStdVector,PAC::SharedStdVector,PAC::SharedStdVector> PopulationAnalysisCalc::compute_lowdin_charges(bool print_output)
-{
-    if (print_output)
-    {
-        outfile->Printf( "  Lowdin Charges: (a.u.)\n");
+std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
+PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
+    if (print_output) {
+        outfile->Printf("  Lowdin Charges: (a.u.)\n");
     }
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     auto Qa_ptr = std::make_shared<std::vector<double>>(mol->natom());
     auto Qb_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    std::vector<double> & Qa = *Qa_ptr;
-    std::vector<double> & Qb = *Qb_ptr;
-
+    std::vector<double>& Qa = *Qa_ptr;
+    std::vector<double>& Qb = *Qb_ptr;
 
     auto apcs = std::make_shared<std::vector<double>>(mol->natom());
 
@@ -1964,44 +1880,40 @@ std::tuple<PAC::SharedStdVector,PAC::SharedStdVector,PAC::SharedStdVector> Popul
 
 //    Print out the populations and charges
 
-    if (print_output)
-    {
-        outfile->Printf( "   Center  Symbol    Alpha    Beta     Spin     Total\n");
+    if (print_output) {
+        outfile->Printf("   Center  Symbol    Alpha    Beta     Spin     Total\n");
     }
     double nuc = 0.0;
     for (int A = 0; A < mol->natom(); A++) {
         double Qs = Qa[A] - Qb[A];
         double Qt = mol->Z(A) - (Qa[A] + Qb[A]);
         (*apcs)[A]=Qt;
-        if (print_output)
-        {
-            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A+1,mol->label(A).c_str(), \
-                Qa[A], Qb[A], Qs, Qt);
+        if (print_output) {
+            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), Qa[A], Qb[A],
+                            Qs, Qt);
         }
         nuc += (double) mol->Z(A);
     }
-    if (print_output)
-    {
-        outfile->Printf( "\n  Total alpha = %8.5f, Total beta = %8.5f, Total charge = %8.5f\n", \
-            suma, sumb, nuc - suma - sumb);
+    if (print_output) {
+        outfile->Printf("\n  Total alpha = %8.5f, Total beta = %8.5f, Total charge = %8.5f\n", suma, sumb,
+                        nuc - suma - sumb);
     }
 
-    return std::make_tuple(Qa_ptr,Qb_ptr,apcs);
+    return std::make_tuple(Qa_ptr, Qb_ptr, apcs);
 }
 void OEProp::compute_mayer_indices()
 {
-    SharedMatrix MBI_total,MBI_alpha,MBI_beta;
+    SharedMatrix MBI_total, MBI_alpha, MBI_beta;
     SharedVector MBI_valence;
-    std::tie(MBI_total,MBI_alpha,MBI_beta,MBI_valence) = pac.compute_mayer_indices(true);
+    std::tie(MBI_total, MBI_alpha, MBI_beta, MBI_valence) = pac.compute_mayer_indices(true);
 
     wfn_->set_array("MAYER_INDICES", MBI_total);
 }
 
-std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector> PopulationAnalysisCalc::compute_mayer_indices(bool print_output)
-{
-    if (print_output)
-    {
-        outfile->Printf( "\n\n  Mayer Bond Indices:\n\n");
+std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> PopulationAnalysisCalc::compute_mayer_indices(
+    bool print_output) {
+    if (print_output) {
+        outfile->Printf("\n\n  Mayer Bond Indices:\n\n");
     }
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
@@ -2093,44 +2005,40 @@ std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector> PopulationAnalys
 
 //    A nicer output is needed ...
 
-    if (print_output)
-    {
+    if (print_output) {
         if (same_dens_) {
             MBI_total->print();
-            outfile->Printf( "  Atomic Valences: \n");
+            outfile->Printf("  Atomic Valences: \n");
             MBI_valence->print();
-        }
-        else {
-            outfile->Printf( "  Total Bond Index: \n");
+        } else {
+            outfile->Printf("  Total Bond Index: \n");
             MBI_total->print();
-            outfile->Printf( "  Alpha Contribution: \n");
+            outfile->Printf("  Alpha Contribution: \n");
             MBI_alpha->print();
-            outfile->Printf( "  Beta Contribution: \n");
+            outfile->Printf("  Beta Contribution: \n");
             MBI_beta->print();
-            outfile->Printf( "  Atomic Valences: \n");
+            outfile->Printf("  Atomic Valences: \n");
             MBI_valence->print();
         }
     }
 
-    return std::make_tuple(MBI_total,MBI_alpha,MBI_beta,MBI_valence);
-
+    return std::make_tuple(MBI_total, MBI_alpha, MBI_beta, MBI_valence);
 }
 void OEProp::compute_wiberg_lowdin_indices()
 {
-    SharedMatrix WBI_total,WBI_alpha,WBI_beta;
+    SharedMatrix WBI_total, WBI_alpha, WBI_beta;
     SharedVector WBI_valence;
-    std::tie(WBI_total,WBI_alpha,WBI_beta,WBI_valence) = pac.compute_wiberg_lowdin_indices(true);
+    std::tie(WBI_total, WBI_alpha, WBI_beta, WBI_valence) = pac.compute_wiberg_lowdin_indices(true);
     wfn_->set_array("WIBERG_LOWDIN_INDICES", WBI_total);
 }
 
-std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector>  PopulationAnalysisCalc::compute_wiberg_lowdin_indices(bool print_output)
-{
-    if (print_output)
-    {
-        outfile->Printf( "\n\n  Wiberg Bond Indices using Orthogonal Lowdin Orbitals:\n\n");
+std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector>
+PopulationAnalysisCalc::compute_wiberg_lowdin_indices(bool print_output) {
+    if (print_output) {
+        outfile->Printf("\n\n  Wiberg Bond Indices using Orthogonal Lowdin Orbitals:\n\n");
     }
 
-//    We may wanna get rid of these if we have NAOs...
+    //    We may wanna get rid of these if we have NAOs...
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
@@ -2210,59 +2118,53 @@ std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector>  PopulationAnaly
 
 //    Compute valences
 
-        auto WBI_valence = std::make_shared<Vector>(natom);
+    auto WBI_valence = std::make_shared<Vector>(natom);
 
-        for (int iat = 0; iat < natom; iat++) {
-            for (int jat = 0; jat < natom; jat++) {
-                double valence = WBI_valence->get(0, iat);
-                WBI_valence->set(0, iat, valence + WBI_total->get(0, iat, jat));
-            }
+    for (int iat = 0; iat < natom; iat++) {
+        for (int jat = 0; jat < natom; jat++) {
+            double valence = WBI_valence->get(0, iat);
+            WBI_valence->set(0, iat, valence + WBI_total->get(0, iat, jat));
         }
+    }
 
 //    Print out the bond index matrix
 //    A nicer output is needed ...
-    if (print_output)
-    {
+    if (print_output) {
         if (same_dens_) {
             WBI_total->print();
-            outfile->Printf( "  Atomic Valences: \n");
+            outfile->Printf("  Atomic Valences: \n");
             WBI_valence->print();
-        }
-        else {
-            outfile->Printf( "  Total Bond Index: \n");
+        } else {
+            outfile->Printf("  Total Bond Index: \n");
             WBI_total->print();
-            outfile->Printf( "  Alpha Contribution: \n");
+            outfile->Printf("  Alpha Contribution: \n");
             WBI_alpha->print();
-            outfile->Printf( "  Beta Contribution: \n");
+            outfile->Printf("  Beta Contribution: \n");
             WBI_beta->print();
-            outfile->Printf( "  Atomic Valences: \n");
+            outfile->Printf("  Atomic Valences: \n");
             WBI_valence->print();
         }
     }
-    return std::make_tuple(WBI_total,WBI_alpha,WBI_beta,WBI_valence);
+    return std::make_tuple(WBI_total, WBI_alpha, WBI_beta, WBI_valence);
 }
 
-void OEProp::compute_no_occupations()
-{
-    std::vector<std::vector<std::tuple<double, int, int> >> metrics;
-    pac.compute_no_occupations(metrics, max_noon_,true);
+void OEProp::compute_no_occupations() {
+    std::vector<std::vector<std::tuple<double, int, int>>> metrics;
+    pac.compute_no_occupations(metrics, max_noon_, true);
     wfn_->set_no_occupations(metrics);
 }
-void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int> > > & output_metrics, int max_noon, bool print_output)
-{
+void PopulationAnalysisCalc::compute_no_occupations(
+    std::vector<std::vector<std::tuple<double, int, int>>>& output_metrics, int max_noon, bool print_output) {
     std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
 
-    if (print_output)
-    {
-        outfile->Printf( "  Natural Orbital Occupations:\n\n");
+    if (print_output) {
+        outfile->Printf("  Natural Orbital Occupations:\n\n");
     }
 
     // Terminally, it will be [metric_a , metric_b, metric] or [metric] depending on same_dens
-    std::vector<std::vector<std::tuple<double, int, int> >> & metrics = output_metrics;
+    std::vector<std::vector<std::tuple<double, int, int>>>& metrics = output_metrics;
 
     if (!same_dens_) {
-
-
         SharedVector Oa;
         SharedVector Ob;
         if (same_dens_) {
@@ -2291,22 +2193,20 @@ void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std:
         int stop_vir_a = offset_a + max_noon + 1;
         stop_vir_a = (int)((size_t)stop_vir_a >= metric_a.size() ? metric_a.size()  : stop_vir_a);
 
-        if (print_output)
-        {
-            outfile->Printf( "  Alpha Occupations:\n");
+        if (print_output) {
+            outfile->Printf("  Alpha Occupations:\n");
 
             for (int index = start_occ_a; index < stop_vir_a; index++) {
                 if (index < offset_a) {
-                    outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset_a - index - 1,
-                    std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])].c_str(),
-                    std::get<0>(metric_a[index]));
+                    outfile->Printf("  HONO-%-2d: %4d%3s %8.3f\n", offset_a - index - 1,
+                                    std::get<1>(metric_a[index]) + 1, labels[std::get<2>(metric_a[index])].c_str(),
+                                    std::get<0>(metric_a[index]));
                 } else {
-                    outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_a,
-                    std::get<1>(metric_a[index])+1,labels[std::get<2>(metric_a[index])].c_str(),
-                    std::get<0>(metric_a[index]));
+                    outfile->Printf("  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_a, std::get<1>(metric_a[index]) + 1,
+                                    labels[std::get<2>(metric_a[index])].c_str(), std::get<0>(metric_a[index]));
                 }
             }
-            outfile->Printf( "\n");
+            outfile->Printf("\n");
         }
 
         std::vector<std::tuple<double, int, int> > metric_b;
@@ -2326,21 +2226,19 @@ void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std:
         int stop_vir_b = offset_b + max_noon + 1;
         stop_vir_b = (int)((size_t)stop_vir_b >= metric_b.size() ? metric_b.size()  : stop_vir_b);
 
-        if (print_output)
-        {
-            outfile->Printf( "  Beta Occupations:\n");
+        if (print_output) {
+            outfile->Printf("  Beta Occupations:\n");
             for (int index = start_occ_b; index < stop_vir_b; index++) {
                 if (index < offset_b) {
-                    outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset_b - index - 1,
-                    std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])].c_str(),
-                    std::get<0>(metric_b[index]));
+                    outfile->Printf("  HONO-%-2d: %4d%3s %8.3f\n", offset_b - index - 1,
+                                    std::get<1>(metric_b[index]) + 1, labels[std::get<2>(metric_b[index])].c_str(),
+                                    std::get<0>(metric_b[index]));
                 } else {
-                    outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_b,
-                    std::get<1>(metric_b[index])+1,labels[std::get<2>(metric_b[index])].c_str(),
-                    std::get<0>(metric_b[index]));
+                    outfile->Printf("  LUNO+%-2d: %4d%3s %8.3f\n", index - offset_b, std::get<1>(metric_b[index]) + 1,
+                                    labels[std::get<2>(metric_b[index])].c_str(), std::get<0>(metric_b[index]));
                 }
             }
-            outfile->Printf( "\n");
+            outfile->Printf("\n");
         }
 
     }
@@ -2365,111 +2263,95 @@ void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std:
     int stop_vir = offset + max_noon + 1;
     stop_vir = (int)((size_t)stop_vir >= metric.size() ? metric.size()  : stop_vir);
 
-    if (print_output)
-    {
-        outfile->Printf( "  Total Occupations:\n");
+    if (print_output) {
+        outfile->Printf("  Total Occupations:\n");
         for (int index = start_occ; index < stop_vir; index++) {
             if (index < offset) {
-                outfile->Printf( "  HONO-%-2d: %4d%3s %8.3f\n", offset - index - 1,
-                std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])].c_str(),
-                std::get<0>(metric[index]));
+                outfile->Printf("  HONO-%-2d: %4d%3s %8.3f\n", offset - index - 1, std::get<1>(metric[index]) + 1,
+                                labels[std::get<2>(metric[index])].c_str(), std::get<0>(metric[index]));
             } else {
-                outfile->Printf( "  LUNO+%-2d: %4d%3s %8.3f\n", index - offset,
-                std::get<1>(metric[index])+1,labels[std::get<2>(metric[index])].c_str(),
-                std::get<0>(metric[index]));
+                outfile->Printf("  LUNO+%-2d: %4d%3s %8.3f\n", index - offset, std::get<1>(metric[index]) + 1,
+                                labels[std::get<2>(metric[index])].c_str(), std::get<0>(metric[index]));
             }
         }
-        outfile->Printf( "\n");
+        outfile->Printf("\n");
     }
 
     //for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
 
 }
 
-void OEProp::set_wavefunction(std::shared_ptr<Wavefunction> wfn)
-{
+void OEProp::set_wavefunction(std::shared_ptr<Wavefunction> wfn) {
     mpc.set_wavefunction(wfn);
     pac.set_wavefunction(wfn);
     epc.set_wavefunction(wfn);
 }
 
-void OEProp::set_restricted(bool restricted)
-{
+void OEProp::set_restricted(bool restricted) {
     mpc.set_restricted(restricted);
     pac.set_restricted(restricted);
     epc.set_restricted(restricted);
 }
 
-void OEProp::set_epsilon_a(SharedVector epsilon_a)
-{
+void OEProp::set_epsilon_a(SharedVector epsilon_a) {
     mpc.set_epsilon_a(epsilon_a);
     pac.set_epsilon_a(epsilon_a);
     epc.set_epsilon_a(epsilon_a);
 }
 
-void OEProp::set_epsilon_b(SharedVector epsilon_b)
-{
+void OEProp::set_epsilon_b(SharedVector epsilon_b) {
     mpc.set_epsilon_b(epsilon_b);
     pac.set_epsilon_b(epsilon_b);
     epc.set_epsilon_b(epsilon_b);
 }
 
-void OEProp::set_Ca(SharedMatrix Ca)
-{
+void OEProp::set_Ca(SharedMatrix Ca) {
     mpc.set_Ca(Ca);
     pac.set_Ca(Ca);
     epc.set_Ca(Ca);
 }
 
-void OEProp::set_Cb(SharedMatrix Cb)
-{
+void OEProp::set_Cb(SharedMatrix Cb) {
     mpc.set_Cb(Cb);
     pac.set_Cb(Cb);
     epc.set_Cb(Cb);
 }
 
-void OEProp::set_Da_ao(SharedMatrix Da, int symmetry)
-{
-    mpc.set_Da_ao(Da,symmetry);
-    pac.set_Da_ao(Da,symmetry);
-    epc.set_Da_ao(Da,symmetry);
+void OEProp::set_Da_ao(SharedMatrix Da, int symmetry) {
+    mpc.set_Da_ao(Da, symmetry);
+    pac.set_Da_ao(Da, symmetry);
+    epc.set_Da_ao(Da, symmetry);
 }
 
-void OEProp::set_Db_ao(SharedMatrix Db, int symmetry)
-{
-    mpc.set_Db_ao(Db,symmetry);
-    pac.set_Db_ao(Db,symmetry);
-    epc.set_Db_ao(Db,symmetry);
+void OEProp::set_Db_ao(SharedMatrix Db, int symmetry) {
+    mpc.set_Db_ao(Db, symmetry);
+    pac.set_Db_ao(Db, symmetry);
+    epc.set_Db_ao(Db, symmetry);
 }
 
-void OEProp::set_Da_so(SharedMatrix Da)
-{
+void OEProp::set_Da_so(SharedMatrix Da) {
     mpc.set_Da_so(Da);
     pac.set_Da_so(Da);
     epc.set_Da_so(Da);
 }
 
-void OEProp::set_Db_so(SharedMatrix Db)
-{
+void OEProp::set_Db_so(SharedMatrix Db) {
     mpc.set_Db_so(Db);
     pac.set_Db_so(Db);
     epc.set_Db_so(Db);
 }
 
-void OEProp::set_Da_mo(SharedMatrix Da)
-{
+void OEProp::set_Da_mo(SharedMatrix Da) {
     mpc.set_Da_mo(Da);
     pac.set_Da_mo(Da);
     epc.set_Da_mo(Da);
 }
 
-void OEProp::set_Db_mo(SharedMatrix Db)
-{
+void OEProp::set_Db_mo(SharedMatrix Db) {
     mpc.set_Db_mo(Db);
     pac.set_Db_mo(Db);
     epc.set_Db_mo(Db);
 }
-
 
 //GridProp::GridProp(std::shared_ptr<Wavefunction> wfn) : filename_("out.grid"), Prop(wfn)
 //{

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -79,10 +79,6 @@ Prop::~Prop()
 }
 void Prop::common_init()
 {
-    title_ = "";
-    print_ = 1;
-    debug_ = 0;
-    tasks_.clear();
     set_wavefunction(wfn_);
 }
 void Prop::set_wavefunction(std::shared_ptr<Wavefunction> wfn)
@@ -284,17 +280,24 @@ void Prop::set_Db_mo(SharedMatrix D)
     }
     delete[] temp;
 }
-void Prop::add(const std::string& prop)
+TaskListComputer::TaskListComputer()
+{
+    title_ = "";
+    print_ = 1;
+    debug_ = 0;
+    tasks_.clear();
+}
+void TaskListComputer::add(const std::string& prop)
 {
     tasks_.insert(prop);
 }
-void Prop::add(std::vector<std::string> props)
+void TaskListComputer::add(std::vector<std::string> props)
 {
     for (int i = 0; i < (int)props.size(); i++) {
         tasks_.insert(props[i]);
     }
 }
-void Prop::clear()
+void TaskListComputer::clear()
 {
     tasks_.clear();
 }
@@ -734,15 +737,7 @@ SharedMatrix Prop::overlap_so()
     return S;
 }
 
-OEProp::OEProp(std::shared_ptr<Wavefunction> wfn) : Prop(wfn)
-{
-    common_init();
-}
-OEProp::~OEProp()
-{
-}
-
-Vector3 OEProp::compute_center(const double *property) const
+Vector3 Prop::compute_center(const double *property) const
 {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     int natoms = mol->natom();
@@ -762,6 +757,15 @@ Vector3 OEProp::compute_center(const double *property) const
     y /= sum;
     z /= sum;
     return Vector3(x, y, z);
+}
+
+
+OEProp::OEProp(std::shared_ptr<Wavefunction> wfn) : Prop(wfn)
+{
+    common_init();
+}
+OEProp::~OEProp()
+{
 }
 
 void OEProp::common_init()

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -770,7 +770,6 @@ void OEProp::common_init()
 
 MultipolePropCalc::MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin)
     : Prop(wfn), origin_(origin) {
-    typedef MultipolePropCalc MPC;
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     /*

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -167,8 +167,8 @@ void Prop::set_Cb(SharedMatrix C)
 void Prop::set_Da_ao(SharedMatrix D, int symm)
 {
     Da_so_ = std::make_shared<Matrix>("Da_so", Ca_so_->rowspi(),Ca_so_->rowspi(),symm);
-
-    double* temp = new double[AO2USO_->max_ncol() * AO2USO_->max_nrow()];
+    std::vector<double> temp(AO2USO_->max_ncol() * AO2USO_->max_nrow());
+    double* temp_ptr = temp.data();
     for (int h = 0; h < AO2USO_->nirrep(); ++h) {
         int nao = AO2USO_->rowspi()[0];
         int nsol = AO2USO_->colspi()[h];
@@ -180,10 +180,9 @@ void Prop::set_Da_ao(SharedMatrix D, int symm)
         double** Urp = AO2USO_->pointer(h^symm);
         double** DAOp = D->pointer();
         double** DSOp = Da_so_->pointer(h);
-        C_DGEMM('N','N',nao,nsor,nao,1.0,DAOp[0],nao,Urp[0],nsor,0.0,temp,nsor);
-        C_DGEMM('T','N',nsol,nsor,nao,1.0,Ulp[0],nsol,temp,nsor,0.0,DSOp[0],nsor);
+        C_DGEMM('N', 'N', nao, nsor, nao, 1.0, DAOp[0], nao, Urp[0], nsor, 0.0, temp_ptr, nsor);
+        C_DGEMM('T', 'N', nsol, nsor, nao, 1.0, Ulp[0], nsol, temp_ptr, nsor, 0.0, DSOp[0], nsor);
     }
-    delete[] temp;
 
     if (same_dens_) {
         Db_so_ = Da_so_;
@@ -196,7 +195,8 @@ void Prop::set_Db_ao(SharedMatrix D, int symm)
 
     Db_so_ = std::make_shared<Matrix>("Db_so", Cb_so_->rowspi(),Cb_so_->rowspi(),symm);
 
-    double* temp = new double[AO2USO_->max_ncol() * AO2USO_->max_nrow()];
+    std::vector<double> temp(AO2USO_->max_ncol() * AO2USO_->max_nrow());
+    double* temp_ptr = temp.data();
     for (int h = 0; h < AO2USO_->nirrep(); ++h) {
         int nao = AO2USO_->rowspi()[0];
         int nsol = AO2USO_->colspi()[h];
@@ -208,10 +208,9 @@ void Prop::set_Db_ao(SharedMatrix D, int symm)
         double** Urp = AO2USO_->pointer(h^symm);
         double** DAOp = D->pointer();
         double** DSOp = Db_so_->pointer(h);
-        C_DGEMM('N','N',nao,nsor,nao,1.0,DAOp[0],nao,Urp[0],nsor,0.0,temp,nsor);
-        C_DGEMM('T','N',nsol,nsor,nao,1.0,Ulp[0],nsol,temp,nsor,0.0,DSOp[0],nsor);
+        C_DGEMM('N', 'N', nao, nsor, nao, 1.0, DAOp[0], nao, Urp[0], nsor, 0.0, temp_ptr, nsor);
+        C_DGEMM('T', 'N', nsol, nsor, nao, 1.0, Ulp[0], nsol, temp_ptr, nsor, 0.0, DSOp[0], nsor);
     }
-    delete[] temp;
 }
 void Prop::set_Da_so(SharedMatrix D)
 {
@@ -234,7 +233,8 @@ void Prop::set_Da_mo(SharedMatrix D)
     int symm = D->symmetry();
     int nirrep = D->nirrep();
 
-    double* temp = new double[Ca_so_->max_ncol() * Ca_so_->max_nrow()];
+    std::vector<double> temp(Ca_so_->max_ncol() * Ca_so_->max_nrow());
+    double* temp_ptr = temp.data();
     for (int h = 0; h < nirrep; h++) {
         int nmol = Ca_so_->colspi()[h];
         int nmor = Ca_so_->colspi()[h^symm];
@@ -245,10 +245,9 @@ void Prop::set_Da_mo(SharedMatrix D)
         double** Crp = Ca_so_->pointer(h^symm);
         double** Dmop = D->pointer(h^symm);
         double** Dsop = Da_so_->pointer(h^symm);
-        C_DGEMM('N','T',nmol,nsor,nmor,1.0,Dmop[0],nmor,Crp[0],nmor,0.0,temp,nsor);
-        C_DGEMM('N','N',nsol,nsor,nmol,1.0,Clp[0],nmol,temp,nsor,0.0,Dsop[0],nsor);
+        C_DGEMM('N', 'T', nmol, nsor, nmor, 1.0, Dmop[0], nmor, Crp[0], nmor, 0.0, temp_ptr, nsor);
+        C_DGEMM('N', 'N', nsol, nsor, nmol, 1.0, Clp[0], nmol, temp_ptr, nsor, 0.0, Dsop[0], nsor);
     }
-    delete[] temp;
 
     if (same_dens_) {
         Db_so_ = Da_so_;
@@ -264,7 +263,8 @@ void Prop::set_Db_mo(SharedMatrix D)
     int symm = D->symmetry();
     int nirrep = D->nirrep();
 
-    double* temp = new double[Cb_so_->max_ncol() * Cb_so_->max_nrow()];
+    std::vector<double> temp(Cb_so_->max_ncol() * Cb_so_->max_nrow());
+    double* temp_ptr = temp.data();
     for (int h = 0; h < nirrep; h++) {
         int nmol = Cb_so_->colspi()[h];
         int nmor = Cb_so_->colspi()[h^symm];
@@ -275,10 +275,9 @@ void Prop::set_Db_mo(SharedMatrix D)
         double** Crp = Cb_so_->pointer(h^symm);
         double** Dmop = D->pointer(h^symm);
         double** Dsop = Db_so_->pointer(h^symm);
-        C_DGEMM('N','T',nmol,nsor,nmor,1.0,Dmop[0],nmor,Crp[0],nmor,0.0,temp,nsor);
-        C_DGEMM('N','N',nsol,nsor,nmol,1.0,Clp[0],nmol,temp,nsor,0.0,Dsop[0],nsor);
+        C_DGEMM('N', 'T', nmol, nsor, nmor, 1.0, Dmop[0], nmor, Crp[0], nmor, 0.0, temp_ptr, nsor);
+        C_DGEMM('N', 'N', nsol, nsor, nmol, 1.0, Clp[0], nmol, temp_ptr, nsor, 0.0, Dsop[0], nsor);
     }
-    delete[] temp;
 }
 TaskListComputer::TaskListComputer() {
     title_ = "";
@@ -303,7 +302,8 @@ SharedVector Prop::epsilon_b()
 }
 SharedMatrix Prop::Da_ao()
 {
-    double* temp = new double[AO2USO_->max_ncol() * AO2USO_->max_nrow()];
+    std::vector<double> temp(AO2USO_->max_ncol() * AO2USO_->max_nrow());
+    double* temp_ptr = temp.data();
     auto D = std::make_shared<Matrix>("Da (AO basis)", basisset_->nbf(), basisset_->nbf());
     int symm = Da_so_->symmetry();
     for (int h = 0; h < AO2USO_->nirrep(); ++h) {
@@ -315,10 +315,9 @@ SharedMatrix Prop::Da_ao()
         double** Urp = AO2USO_->pointer(h^symm);
         double** DSOp = Da_so_->pointer(h^symm);
         double** DAOp = D->pointer();
-        C_DGEMM('N','T',nsol,nao,nsor,1.0,DSOp[0],nsor,Urp[0],nsor,0.0,temp,nao);
-        C_DGEMM('N','N',nao,nao,nsol,1.0,Ulp[0],nsol,temp,nao,1.0,DAOp[0],nao);
+        C_DGEMM('N', 'T', nsol, nao, nsor, 1.0, DSOp[0], nsor, Urp[0], nsor, 0.0, temp_ptr, nao);
+        C_DGEMM('N', 'N', nao, nao, nsol, 1.0, Ulp[0], nsol, temp_ptr, nao, 1.0, DAOp[0], nao);
     }
-    delete[] temp;
     return D;
 }
 SharedMatrix Prop::Db_ao()
@@ -326,7 +325,8 @@ SharedMatrix Prop::Db_ao()
     if (same_dens_)
         throw PSIEXCEPTION("Wavefunction is restricted, asking for Db makes no sense");
 
-    double* temp = new double[AO2USO_->max_ncol() * AO2USO_->max_nrow()];
+    std::vector<double> temp(AO2USO_->max_ncol() * AO2USO_->max_nrow());
+    double* temp_ptr;
     auto D = std::make_shared<Matrix>("Db (AO basis)", basisset_->nbf(), basisset_->nbf());
     int symm = Db_so_->symmetry();
     for (int h = 0; h < AO2USO_->nirrep(); ++h) {
@@ -338,10 +338,9 @@ SharedMatrix Prop::Db_ao()
         double** Urp = AO2USO_->pointer(h^symm);
         double** DSOp = Db_so_->pointer(h^symm);
         double** DAOp = D->pointer();
-        C_DGEMM('N','T',nsol,nao,nsor,1.0,DSOp[0],nsor,Urp[0],nsor,0.0,temp,nao);
-        C_DGEMM('N','N',nao,nao,nsol,1.0,Ulp[0],nsol,temp,nao,1.0,DAOp[0],nao);
+        C_DGEMM('N', 'T', nsol, nao, nsor, 1.0, DSOp[0], nsor, Urp[0], nsor, 0.0, temp_ptr, nao);
+        C_DGEMM('N', 'N', nao, nao, nsol, 1.0, Ulp[0], nsol, temp_ptr, nao, 1.0, DAOp[0], nao);
     }
-    delete[] temp;
     return D;
 }
 SharedMatrix Prop::Ca_so()
@@ -377,8 +376,10 @@ SharedMatrix Prop::Da_mo()
 
     SharedMatrix S = overlap_so();
 
-    double* SC = new double[Ca_so_->max_ncol() * Ca_so_->max_nrow()];
-    double* temp = new double[Ca_so_->max_ncol() * Ca_so_->max_nrow()];
+    std::vector<double> SC(Ca_so_->max_ncol() * Ca_so_->max_nrow());
+    std::vector<double> temp(Ca_so_->max_ncol() * Ca_so_->max_nrow());
+    double* SC_ptr = SC.data();
+    double* temp_ptr = temp.data();
     for (int h = 0; h < nirrep; h++) {
         int nmol = Ca_so_->colspi()[h];
         int nmor = Ca_so_->colspi()[h^symm];
@@ -392,13 +393,11 @@ SharedMatrix Prop::Da_mo()
         double** Dmop = D->pointer(h);
         double** Dsop = Da_so_->pointer(h);
 
-        C_DGEMM('N','N',nsor,nmor,nsor,1.0,Srp[0],nsor,Crp[0],nmor,0.0,SC,nmor);
-        C_DGEMM('N','N',nsol,nmor,nsor,1.0,Dsop[0],nsor,SC,nmor,0.0,temp,nmor);
-        C_DGEMM('N','N',nsol,nmol,nsol,1.0,Slp[0],nsol,Clp[0],nmol,0.0,SC,nmol);
-        C_DGEMM('T','N',nmol,nmor,nsol,1.0,SC,nmol,temp,nmor,0.0,Dmop[0],nmor);
+        C_DGEMM('N', 'N', nsor, nmor, nsor, 1.0, Srp[0], nsor, Crp[0], nmor, 0.0, SC_ptr, nmor);
+        C_DGEMM('N', 'N', nsol, nmor, nsor, 1.0, Dsop[0], nsor, SC_ptr, nmor, 0.0, temp_ptr, nmor);
+        C_DGEMM('N', 'N', nsol, nmol, nsol, 1.0, Slp[0], nsol, Clp[0], nmol, 0.0, SC_ptr, nmol);
+        C_DGEMM('T', 'N', nmol, nmor, nsol, 1.0, SC_ptr, nmol, temp_ptr, nmor, 0.0, Dmop[0], nmor);
     }
-    delete[] temp;
-    delete[] SC;
     return D;
 }
 SharedMatrix Prop::Db_mo()
@@ -413,8 +412,11 @@ SharedMatrix Prop::Db_mo()
 
     SharedMatrix S = overlap_so();
 
-    double* SC = new double[Cb_so_->max_ncol() * Cb_so_->max_nrow()];
-    double* temp = new double[Cb_so_->max_ncol() * Cb_so_->max_nrow()];
+    std::vector<double> SC(Cb_so_->max_ncol() * Cb_so_->max_nrow());
+    std::vector<double> temp(Cb_so_->max_ncol() * Cb_so_->max_nrow());
+
+    double* SC_ptr = SC.data();
+    double* temp_ptr = temp.data();
     for (int h = 0; h < nirrep; h++) {
         int nmol = Cb_so_->colspi()[h];
         int nmor = Cb_so_->colspi()[h^symm];
@@ -428,13 +430,11 @@ SharedMatrix Prop::Db_mo()
         double** Dmop = D->pointer(h);
         double** Dsop = Db_so_->pointer(h);
 
-        C_DGEMM('N','N',nsor,nmor,nsor,1.0,Srp[0],nsor,Crp[0],nmor,0.0,SC,nmor);
-        C_DGEMM('N','N',nsol,nmor,nsor,1.0,Dsop[0],nsor,SC,nmor,0.0,temp,nmor);
-        C_DGEMM('N','N',nsol,nmol,nsol,1.0,Slp[0],nsol,Clp[0],nmol,0.0,SC,nmol);
-        C_DGEMM('T','N',nmol,nmor,nsol,1.0,SC,nmol,temp,nmor,0.0,Dmop[0],nmor);
+        C_DGEMM('N', 'N', nsor, nmor, nsor, 1.0, Srp[0], nsor, Crp[0], nmor, 0.0, SC_ptr, nmor);
+        C_DGEMM('N', 'N', nsol, nmor, nsor, 1.0, Dsop[0], nsor, SC_ptr, nmor, 0.0, temp_ptr, nmor);
+        C_DGEMM('N', 'N', nsol, nmol, nsol, 1.0, Slp[0], nsol, Clp[0], nmol, 0.0, SC_ptr, nmol);
+        C_DGEMM('T', 'N', nmol, nmor, nsol, 1.0, SC_ptr, nmol, temp_ptr, nmor, 0.0, Dmop[0], nmor);
     }
-    delete[] temp;
-    delete[] SC;
     return D;
 }
 SharedMatrix Prop::Dt_so(bool total)
@@ -820,7 +820,7 @@ Vector3 OEProp::get_origin_from_environment() const {
         int size = options["PROPERTIES_ORIGIN"].size();
 
         if(size == 1){
-            double *property = new double[natoms];
+            std::vector<double> property(natoms);
             std::string str = options["PROPERTIES_ORIGIN"][0].to_string();
             if(str == "COM"){
                 for(int atom = 0; atom < natoms; ++atom)
@@ -831,8 +831,7 @@ Vector3 OEProp::get_origin_from_environment() const {
             }else{
                 throw PSIEXCEPTION("Invalid specification of PROPERTIES_ORIGIN.  Please consult the manual.");
             }
-            origin = compute_center(property);
-            delete [] property;
+            origin = compute_center(property.data());
         }else if(size == 3){
             double x = options["PROPERTIES_ORIGIN"][0].to_double();
             double y = options["PROPERTIES_ORIGIN"][1].to_double();
@@ -926,10 +925,8 @@ void OEProp::compute()
 
 void OEProp::compute_multipoles(int order, bool transition)
 {
-    typedef MultipolePropCalc::MultipoleOutputType OutType;
-    MultipolePropCalc::MultipoleOutputType_ptr out = mpc_.compute_multipoles(order, transition, true, print_ > 4);
-    MultipolePropCalc::MultipoleOutputType& mpoles = *out;
-    for (OutType::iterator it = mpoles.begin(); it != mpoles.end(); ++it) {
+    MultipolePropCalc::MultipoleOutputType mpoles = mpc_.compute_multipoles(order, transition, true, print_ > 4);
+    for (auto it = mpoles->begin(); it != mpoles->end(); ++it) {
         std::string name;
         double total_mpole = 0.0;
         // unpack the multipole, which is: name, nuc, elec, total, ignore nuc and elec:
@@ -942,10 +939,9 @@ void OEProp::compute_multipoles(int order, bool transition)
     }
 }
 
-MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles(int order, bool transition,
-                                                                                 bool print_output, bool verbose) {
-    MultipolePropCalc::MultipoleOutputType_ptr mot_ptr = std::make_shared<MultipolePropCalc::MultipoleOutputType>();
-    MultipolePropCalc::MultipoleOutputType& mot = *mot_ptr;
+MultipolePropCalc::MultipoleOutputType MultipolePropCalc::compute_multipoles(int order, bool transition,
+                                                                             bool print_output, bool verbose) {
+    MultipolePropCalc::MultipoleOutputType mot = std::make_shared<MultipolePropCalc::MultipoleOutputTypeBase>();
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     SharedMatrix Da;
@@ -1021,7 +1017,7 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
                 outfile->Printf(" %-20s: %18.7f   %18.7f   %18.7f\n", name.c_str(), elec, nuc, tot);
             }
             std::string upper_name = to_upper_copy(name);
-            mot.push_back(std::make_tuple(upper_name, nuc, elec, tot));
+            mot->push_back(std::make_tuple(upper_name, nuc, elec, tot));
             ++address;
         }
         if (print_output) {
@@ -1033,7 +1029,7 @@ MultipolePropCalc::MultipoleOutputType_ptr MultipolePropCalc::compute_multipoles
         outfile->Printf(" --------------------------------------------------------------------------------\n");
     }
 
-    return mot_ptr;
+    return mot;
 }
 
 
@@ -1148,8 +1144,7 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
     }
 
     int number_of_grid_points = input_grid->rowdim();
-    SharedVector output_ptr = std::make_shared<Vector>(number_of_grid_points);
-    Vector& output = *output_ptr;
+    SharedVector output = std::make_shared<Vector>(number_of_grid_points);
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
@@ -1181,9 +1176,9 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
             if (r > 1.0E-8) Vnuc += mol->Z(i) / r;
         }
         double Vtot = Velec + Vnuc;
-        output[i] = Vtot;
+        (*output)[i] = Vtot;
     }
-    return output_ptr;
+    return output;
 }
 
 void OEProp::compute_field_over_grid() { epc_.compute_field_over_grid(true); }
@@ -1410,26 +1405,25 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
 }
 
 void OEProp::compute_quadrupole(bool transition) {
-    SharedMatrix quadrupole_ptr = mpc_.compute_quadrupole(transition, true, print_ > 4);
-    Matrix& quadrupole = *quadrupole_ptr;
+    SharedMatrix quadrupole = mpc_.compute_quadrupole(transition, true, print_ > 4);
     std::stringstream s;
     s << title_ << " QUADRUPOLE XX";
-    Process::environment.globals[s.str()] = quadrupole.get(0, 0);
+    Process::environment.globals[s.str()] = quadrupole->get(0, 0);
     s.str(std::string());
     s << title_ << " QUADRUPOLE YY";
-    Process::environment.globals[s.str()] = quadrupole.get(1, 1);
+    Process::environment.globals[s.str()] = quadrupole->get(1, 1);
     s.str(std::string());
     s << title_ << " QUADRUPOLE ZZ";
-    Process::environment.globals[s.str()] = quadrupole.get(2, 2);
+    Process::environment.globals[s.str()] = quadrupole->get(2, 2);
     s.str(std::string());
     s << title_ << " QUADRUPOLE XY";
-    Process::environment.globals[s.str()] = quadrupole.get(0, 1);
+    Process::environment.globals[s.str()] = quadrupole->get(0, 1);
     s.str(std::string());
     s << title_ << " QUADRUPOLE XZ";
-    Process::environment.globals[s.str()] = quadrupole.get(0, 2);
+    Process::environment.globals[s.str()] = quadrupole->get(0, 2);
     s.str(std::string());
     s << title_ << " QUADRUPOLE YZ";
-    Process::environment.globals[s.str()] = quadrupole.get(1, 2);
+    Process::environment.globals[s.str()] = quadrupole->get(1, 2);
 }
 
 SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_output, bool verbose) {
@@ -1521,19 +1515,19 @@ SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_o
     double yz = qe[4] * dfac;
 
     auto output = std::make_shared<Matrix>(3, 3);
-    Matrix& outmat = *output;
-    outmat.set(0, 0, xx);
-    outmat.set(1, 1, yy);
-    outmat.set(2, 2, zz);
 
-    outmat.set(0, 1, xy);
-    outmat.set(1, 0, xy);
+    output->set(0, 0, xx);
+    output->set(1, 1, yy);
+    output->set(2, 2, zz);
 
-    outmat.set(1, 2, yz);
-    outmat.set(2, 1, yz);
+    output->set(0, 1, xy);
+    output->set(1, 0, xy);
 
-    outmat.set(0, 2, xz);
-    outmat.set(2, 0, xz);
+    output->set(1, 2, yz);
+    output->set(2, 1, yz);
+
+    output->set(0, 2, xz);
+    output->set(2, 0, xz);
 
     return output;
 }
@@ -1703,8 +1697,8 @@ PopulationAnalysisCalc::~PopulationAnalysisCalc() {}
 
 void OEProp::compute_mulliken_charges()
 {
-    PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
-    std::tie(Qa_ptr, Qb_ptr, apcs) = pac_.compute_mulliken_charges(true);
+    PAC::SharedStdVector Qa, Qb, apcs;
+    std::tie(Qa, Qb, apcs) = pac_.compute_mulliken_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Mulliken Charges: (a.u.)", 1, apcs->size());
@@ -1721,16 +1715,14 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
     }
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
-    auto Qa_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    auto Qb_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    std::vector<double>& Qa = *Qa_ptr;
-    std::vector<double>& Qb = *Qb_ptr;
+    auto Qa = std::make_shared<std::vector<double>>(mol->natom());
+    auto Qb = std::make_shared<std::vector<double>>(mol->natom());
 
     auto apcs = std::make_shared<std::vector<double>>(mol->natom());
-    double* PSa = new double[basisset_->nbf()];
+    std::vector<double> PSa(basisset_->nbf());
     double suma = 0.0;
 
-    double* PSb = new double[basisset_->nbf()];
+    std::vector<double> PSb(basisset_->nbf());
     double sumb = 0.0;
 
     SharedMatrix Da;
@@ -1767,8 +1759,8 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
         int shell = basisset_->function_to_shell(mu);
         int A = basisset_->shell_to_center(shell);
 
-        Qa[A] += PSa[mu];
-        Qb[A] += PSb[mu];
+        (*Qa)[A] += PSa[mu];
+        (*Qb)[A] += PSb[mu];
 
         suma += PSa[mu];
         sumb += PSb[mu];
@@ -1780,12 +1772,12 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
     }
     double nuc = 0.0;
     for (int A = 0; A < mol->natom(); A++) {
-        double Qs = Qa[A] - Qb[A];
-        double Qt = mol->Z(A) - (Qa[A] + Qb[A]);
+        double Qs = (*Qa)[A] - (*Qb)[A];
+        double Qt = mol->Z(A) - ((*Qa)[A] + (*Qb)[A]);
         (*apcs)[A]=Qt;
         if (print_output) {
-            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), Qa[A], Qb[A],
-                            Qs, Qt);
+            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), (*Qa)[A],
+                            (*Qb)[A], Qs, Qt);
         }
         nuc += (double) mol->Z(A);
    }
@@ -1795,18 +1787,14 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
                        nuc - suma - sumb);
     }
 
-//    Free memory
-    delete[] PSa;
-    delete[] PSb;
-
     if (print_output) outfile->Printf("\n");
 
-    return std::make_tuple(Qa_ptr, Qb_ptr, apcs);
+    return std::make_tuple(Qa, Qb, apcs);
 }
 void OEProp::compute_lowdin_charges()
 {
-    PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
-    std::tie(Qa_ptr, Qb_ptr, apcs) = pac_.compute_lowdin_charges(true);
+    PAC::SharedStdVector Qa, Qb, apcs;
+    std::tie(Qa, Qb, apcs) = pac_.compute_lowdin_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Lowdin Charges: (a.u.)", 1, apcs->size());
@@ -1823,10 +1811,8 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
     }
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
-    auto Qa_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    auto Qb_ptr = std::make_shared<std::vector<double>>(mol->natom());
-    std::vector<double>& Qa = *Qa_ptr;
-    std::vector<double>& Qb = *Qb_ptr;
+    auto Qa = std::make_shared<std::vector<double>>(mol->natom());
+    auto Qb = std::make_shared<std::vector<double>>(mol->natom());
 
     auto apcs = std::make_shared<std::vector<double>>(mol->natom());
 
@@ -1874,8 +1860,8 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
         int shell = basisset_->function_to_shell(mu);
         int A = basisset_->shell_to_center(shell);
 
-        Qa[A] += SDSa->get(0,mu,mu);
-        Qb[A] += SDSb->get(0,mu,mu);
+        (*Qa)[A] += SDSa->get(0, mu, mu);
+        (*Qb)[A] += SDSb->get(0, mu, mu);
 
         suma += SDSa->get(0,mu,mu);
         sumb += SDSb->get(0,mu,mu);
@@ -1888,12 +1874,12 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
     }
     double nuc = 0.0;
     for (int A = 0; A < mol->natom(); A++) {
-        double Qs = Qa[A] - Qb[A];
-        double Qt = mol->Z(A) - (Qa[A] + Qb[A]);
+        double Qs = (*Qa)[A] - (*Qb)[A];
+        double Qt = mol->Z(A) - ((*Qa)[A] + (*Qb)[A]);
         (*apcs)[A]=Qt;
         if (print_output) {
-            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), Qa[A], Qb[A],
-                            Qs, Qt);
+            outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), (*Qa)[A],
+                            (*Qb)[A], Qs, Qt);
         }
         nuc += (double) mol->Z(A);
     }
@@ -1902,7 +1888,7 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
                         nuc - suma - sumb);
     }
 
-    return std::make_tuple(Qa_ptr, Qb_ptr, apcs);
+    return std::make_tuple(Qa, Qb, apcs);
 }
 void OEProp::compute_mayer_indices()
 {
@@ -2152,12 +2138,12 @@ PopulationAnalysisCalc::compute_wiberg_lowdin_indices(bool print_output) {
 }
 
 void OEProp::compute_no_occupations() {
-    auto metrics_ptr = pac_.compute_no_occupations(max_noon_, true);
-    wfn_->set_no_occupations(*metrics_ptr);
+    auto metrics = pac_.compute_no_occupations(max_noon_, true);
+    wfn_->set_no_occupations(*metrics);
 }
 std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> PopulationAnalysisCalc::compute_no_occupations(
     int max_noon, bool print_output) {
-    std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> output_metrics_ptr =
+    std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> metrics =
         std::make_shared<std::vector<std::vector<std::tuple<double, int, int>>>>();
     std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
 
@@ -2166,7 +2152,6 @@ std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> Populati
     }
 
     // Terminally, it will be [metric_a , metric_b, metric] or [metric] depending on same_dens
-    std::vector<std::vector<std::tuple<double, int, int>>>& metrics = *output_metrics_ptr;
 
     if (!same_dens_) {
         SharedVector Oa;
@@ -2188,7 +2173,7 @@ std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> Populati
             }
         }
 
-        metrics.push_back(metric_a);
+        metrics->push_back(metric_a);
 
         std::sort(metric_a.begin(), metric_a.end(), std::greater<std::tuple<double,int,int> >());
         int offset_a = wfn_->nalpha();
@@ -2220,7 +2205,7 @@ std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> Populati
             }
         }
 
-        metrics.push_back(metric_b);
+        metrics->push_back(metric_b);
 
         std::sort(metric_b.begin(), metric_b.end(), std::greater<std::tuple<double,int,int> >());
 
@@ -2257,7 +2242,7 @@ std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> Populati
         }
     }
 
-    metrics.push_back(metric);
+    metrics->push_back(metric);
 
     std::sort(metric.begin(), metric.end(), std::greater<std::tuple<double,int,int> >());
 
@@ -2280,7 +2265,7 @@ std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> Populati
         }
         outfile->Printf("\n");
     }
-    return output_metrics_ptr;
+    return metrics;
     //for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
 
 }

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -751,7 +751,7 @@ Vector3 Prop::compute_center(const double* property) const {
 }
 
 OEProp::OEProp(std::shared_ptr<Wavefunction> wfn)
-    : Prop(wfn), mpc(wfn, get_origin_from_environment()), pac(wfn), epc(wfn) {
+    : Prop(wfn), mpc_(wfn, get_origin_from_environment()), pac_(wfn), epc_(wfn) {
     common_init();
 }
 OEProp::~OEProp() {}
@@ -923,7 +923,7 @@ void OEProp::compute()
 void OEProp::compute_multipoles(int order, bool transition)
 {
     typedef MultipolePropCalc::MultipoleOutputType OutType;
-    MultipolePropCalc::MultipoleOutputType_ptr out = mpc.compute_multipoles(order, transition, true, print_ > 4);
+    MultipolePropCalc::MultipoleOutputType_ptr out = mpc_.compute_multipoles(order, transition, true, print_ > 4);
     MultipolePropCalc::MultipoleOutputType& mpoles = *out;
     for (OutType::iterator it = mpoles.begin(); it != mpoles.end(); ++it) {
         std::string name;
@@ -1087,7 +1087,7 @@ ESPPropCalc::ESPPropCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn) {}
 
 ESPPropCalc::~ESPPropCalc() {}
 
-void OEProp::compute_esp_over_grid() { epc.compute_esp_over_grid(true); }
+void OEProp::compute_esp_over_grid() { epc_.compute_esp_over_grid(true); }
 
 void ESPPropCalc::compute_esp_over_grid(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
@@ -1182,7 +1182,7 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
     return output_ptr;
 }
 
-void OEProp::compute_field_over_grid() { epc.compute_field_over_grid(true); }
+void OEProp::compute_field_over_grid() { epc_.compute_field_over_grid(true); }
 
 void ESPPropCalc::compute_field_over_grid(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
@@ -1237,7 +1237,7 @@ void ESPPropCalc::compute_field_over_grid(bool print_output) {
 }
 
 void OEProp::compute_esp_at_nuclei() {
-    std::shared_ptr<std::vector<double>> nesps = epc.compute_esp_at_nuclei(true, print_ > 2);
+    std::shared_ptr<std::vector<double>> nesps = epc_.compute_esp_at_nuclei(true, print_ > 2);
     for (int atom1 = 0; atom1 < nesps->size(); ++atom1) {
         std::stringstream s;
         s << "ESP AT CENTER " << atom1 + 1;
@@ -1297,7 +1297,7 @@ std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool pri
 }
 
 void OEProp::compute_dipole(bool transition) {
-    SharedVector dipole = mpc.compute_dipole(transition, true, print_ > 4);
+    SharedVector dipole = mpc_.compute_dipole(transition, true, print_ > 4);
     // Dipole components in Debye
     std::stringstream s;
     s << title_ << " DIPOLE X";
@@ -1406,7 +1406,7 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
 }
 
 void OEProp::compute_quadrupole(bool transition) {
-    SharedMatrix quadrupole_ptr = mpc.compute_quadrupole(transition, true, print_ > 4);
+    SharedMatrix quadrupole_ptr = mpc_.compute_quadrupole(transition, true, print_ > 4);
     Matrix& quadrupole = *quadrupole_ptr;
     std::stringstream s;
     s << title_ << " QUADRUPOLE XX";
@@ -1535,7 +1535,7 @@ SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_o
 }
 
 void OEProp::compute_mo_extents() {
-    std::vector<SharedVector> mo_es = mpc.compute_mo_extents(true);
+    std::vector<SharedVector> mo_es = mpc_.compute_mo_extents(true);
     wfn_->set_mo_extents(mo_es);
 }
 
@@ -1700,7 +1700,7 @@ PopulationAnalysisCalc::~PopulationAnalysisCalc() {}
 void OEProp::compute_mulliken_charges()
 {
     PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
-    std::tie(Qa_ptr, Qb_ptr, apcs) = pac.compute_mulliken_charges(true);
+    std::tie(Qa_ptr, Qb_ptr, apcs) = pac_.compute_mulliken_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Mulliken Charges: (a.u.)", 1, apcs->size());
@@ -1802,7 +1802,7 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
 void OEProp::compute_lowdin_charges()
 {
     PAC::SharedStdVector Qa_ptr, Qb_ptr, apcs;
-    std::tie(Qa_ptr, Qb_ptr, apcs) = pac.compute_lowdin_charges(true);
+    std::tie(Qa_ptr, Qb_ptr, apcs) = pac_.compute_lowdin_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Lowdin Charges: (a.u.)", 1, apcs->size());
@@ -1904,7 +1904,7 @@ void OEProp::compute_mayer_indices()
 {
     SharedMatrix MBI_total, MBI_alpha, MBI_beta;
     SharedVector MBI_valence;
-    std::tie(MBI_total, MBI_alpha, MBI_beta, MBI_valence) = pac.compute_mayer_indices(true);
+    std::tie(MBI_total, MBI_alpha, MBI_beta, MBI_valence) = pac_.compute_mayer_indices(true);
 
     wfn_->set_array("MAYER_INDICES", MBI_total);
 }
@@ -2027,7 +2027,7 @@ void OEProp::compute_wiberg_lowdin_indices()
 {
     SharedMatrix WBI_total, WBI_alpha, WBI_beta;
     SharedVector WBI_valence;
-    std::tie(WBI_total, WBI_alpha, WBI_beta, WBI_valence) = pac.compute_wiberg_lowdin_indices(true);
+    std::tie(WBI_total, WBI_alpha, WBI_beta, WBI_valence) = pac_.compute_wiberg_lowdin_indices(true);
     wfn_->set_array("WIBERG_LOWDIN_INDICES", WBI_total);
 }
 
@@ -2149,7 +2149,7 @@ PopulationAnalysisCalc::compute_wiberg_lowdin_indices(bool print_output) {
 
 void OEProp::compute_no_occupations() {
     std::vector<std::vector<std::tuple<double, int, int>>> metrics;
-    pac.compute_no_occupations(metrics, max_noon_, true);
+    pac_.compute_no_occupations(metrics, max_noon_, true);
     wfn_->set_no_occupations(metrics);
 }
 void PopulationAnalysisCalc::compute_no_occupations(
@@ -2281,75 +2281,75 @@ void PopulationAnalysisCalc::compute_no_occupations(
 }
 
 void OEProp::set_wavefunction(std::shared_ptr<Wavefunction> wfn) {
-    mpc.set_wavefunction(wfn);
-    pac.set_wavefunction(wfn);
-    epc.set_wavefunction(wfn);
+    mpc_.set_wavefunction(wfn);
+    pac_.set_wavefunction(wfn);
+    epc_.set_wavefunction(wfn);
 }
 
 void OEProp::set_restricted(bool restricted) {
-    mpc.set_restricted(restricted);
-    pac.set_restricted(restricted);
-    epc.set_restricted(restricted);
+    mpc_.set_restricted(restricted);
+    pac_.set_restricted(restricted);
+    epc_.set_restricted(restricted);
 }
 
 void OEProp::set_epsilon_a(SharedVector epsilon_a) {
-    mpc.set_epsilon_a(epsilon_a);
-    pac.set_epsilon_a(epsilon_a);
-    epc.set_epsilon_a(epsilon_a);
+    mpc_.set_epsilon_a(epsilon_a);
+    pac_.set_epsilon_a(epsilon_a);
+    epc_.set_epsilon_a(epsilon_a);
 }
 
 void OEProp::set_epsilon_b(SharedVector epsilon_b) {
-    mpc.set_epsilon_b(epsilon_b);
-    pac.set_epsilon_b(epsilon_b);
-    epc.set_epsilon_b(epsilon_b);
+    mpc_.set_epsilon_b(epsilon_b);
+    pac_.set_epsilon_b(epsilon_b);
+    epc_.set_epsilon_b(epsilon_b);
 }
 
 void OEProp::set_Ca(SharedMatrix Ca) {
-    mpc.set_Ca(Ca);
-    pac.set_Ca(Ca);
-    epc.set_Ca(Ca);
+    mpc_.set_Ca(Ca);
+    pac_.set_Ca(Ca);
+    epc_.set_Ca(Ca);
 }
 
 void OEProp::set_Cb(SharedMatrix Cb) {
-    mpc.set_Cb(Cb);
-    pac.set_Cb(Cb);
-    epc.set_Cb(Cb);
+    mpc_.set_Cb(Cb);
+    pac_.set_Cb(Cb);
+    epc_.set_Cb(Cb);
 }
 
 void OEProp::set_Da_ao(SharedMatrix Da, int symmetry) {
-    mpc.set_Da_ao(Da, symmetry);
-    pac.set_Da_ao(Da, symmetry);
-    epc.set_Da_ao(Da, symmetry);
+    mpc_.set_Da_ao(Da, symmetry);
+    pac_.set_Da_ao(Da, symmetry);
+    epc_.set_Da_ao(Da, symmetry);
 }
 
 void OEProp::set_Db_ao(SharedMatrix Db, int symmetry) {
-    mpc.set_Db_ao(Db, symmetry);
-    pac.set_Db_ao(Db, symmetry);
-    epc.set_Db_ao(Db, symmetry);
+    mpc_.set_Db_ao(Db, symmetry);
+    pac_.set_Db_ao(Db, symmetry);
+    epc_.set_Db_ao(Db, symmetry);
 }
 
 void OEProp::set_Da_so(SharedMatrix Da) {
-    mpc.set_Da_so(Da);
-    pac.set_Da_so(Da);
-    epc.set_Da_so(Da);
+    mpc_.set_Da_so(Da);
+    pac_.set_Da_so(Da);
+    epc_.set_Da_so(Da);
 }
 
 void OEProp::set_Db_so(SharedMatrix Db) {
-    mpc.set_Db_so(Db);
-    pac.set_Db_so(Db);
-    epc.set_Db_so(Db);
+    mpc_.set_Db_so(Db);
+    pac_.set_Db_so(Db);
+    epc_.set_Db_so(Db);
 }
 
 void OEProp::set_Da_mo(SharedMatrix Da) {
-    mpc.set_Da_mo(Da);
-    pac.set_Da_mo(Da);
-    epc.set_Da_mo(Da);
+    mpc_.set_Da_mo(Da);
+    pac_.set_Da_mo(Da);
+    epc_.set_Da_mo(Da);
 }
 
 void OEProp::set_Db_mo(SharedMatrix Db) {
-    mpc.set_Db_mo(Db);
-    pac.set_Db_mo(Db);
-    epc.set_Db_mo(Db);
+    mpc_.set_Db_mo(Db);
+    pac_.set_Db_mo(Db);
+    epc_.set_Db_mo(Db);
 }
 
 //GridProp::GridProp(std::shared_ptr<Wavefunction> wfn) : filename_("out.grid"), Prop(wfn)

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1656,6 +1656,15 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
 }
 
 typedef PopulationAnalysisCalc PAC;
+PopulationAnalysisCalc::PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn) : Prop(wfn)
+{
+    //No internal state. num_noon is now an argument.
+}
+
+PopulationAnalysisCalc::~PopulationAnalysisCalc()
+{
+
+}
 
 void OEProp::compute_mulliken_charges()
 {

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -782,7 +782,6 @@ void OEProp::common_init()
 MultipolePropCalc::MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const & origin) : Prop(wfn), origin_(origin)
 {
     typedef MultipolePropCalc MPC;
-
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     /*
@@ -824,7 +823,7 @@ Vector3 OEProp::get_origin_from_environment() const
     // The only member used here is basisset, which is initialized in the base class.
     // See if the user specified the origin
     Options &options = Process::environment.options;
-    Vector3 origin;
+    Vector3 origin(0.0,0.0,0.0);
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
     int natoms = mol->natom();
@@ -2386,6 +2385,91 @@ void PopulationAnalysisCalc::compute_no_occupations(std::vector<std::vector<std:
     //for(int h = 0; h < epsilon_a_->nirrep(); h++) free(labels[h]); free(labels);
 
 }
+
+void OEProp::set_wavefunction(std::shared_ptr<Wavefunction> wfn)
+{
+    mpc.set_wavefunction(wfn);
+    pac.set_wavefunction(wfn);
+    epc.set_wavefunction(wfn);
+}
+
+void OEProp::set_restricted(bool restricted)
+{
+    mpc.set_restricted(restricted);
+    pac.set_restricted(restricted);
+    epc.set_restricted(restricted);
+}
+
+void OEProp::set_epsilon_a(SharedVector epsilon_a)
+{
+    mpc.set_epsilon_a(epsilon_a);
+    pac.set_epsilon_a(epsilon_a);
+    epc.set_epsilon_a(epsilon_a);
+}
+
+void OEProp::set_epsilon_b(SharedVector epsilon_b)
+{
+    mpc.set_epsilon_b(epsilon_b);
+    pac.set_epsilon_b(epsilon_b);
+    epc.set_epsilon_b(epsilon_b);
+}
+
+void OEProp::set_Ca(SharedMatrix Ca)
+{
+    mpc.set_Ca(Ca);
+    pac.set_Ca(Ca);
+    epc.set_Ca(Ca);
+}
+
+void OEProp::set_Cb(SharedMatrix Cb)
+{
+    mpc.set_Cb(Cb);
+    pac.set_Cb(Cb);
+    epc.set_Cb(Cb);
+}
+
+void OEProp::set_Da_ao(SharedMatrix Da, int symmetry)
+{
+    mpc.set_Da_ao(Da,symmetry);
+    pac.set_Da_ao(Da,symmetry);
+    epc.set_Da_ao(Da,symmetry);
+}
+
+void OEProp::set_Db_ao(SharedMatrix Db, int symmetry)
+{
+    mpc.set_Db_ao(Db,symmetry);
+    pac.set_Db_ao(Db,symmetry);
+    epc.set_Db_ao(Db,symmetry);
+}
+
+void OEProp::set_Da_so(SharedMatrix Da)
+{
+    mpc.set_Da_so(Da);
+    pac.set_Da_so(Da);
+    epc.set_Da_so(Da);
+}
+
+void OEProp::set_Db_so(SharedMatrix Db)
+{
+    mpc.set_Db_so(Db);
+    pac.set_Db_so(Db);
+    epc.set_Db_so(Db);
+}
+
+void OEProp::set_Da_mo(SharedMatrix Da)
+{
+    mpc.set_Da_mo(Da);
+    pac.set_Da_mo(Da);
+    epc.set_Da_mo(Da);
+}
+
+void OEProp::set_Db_mo(SharedMatrix Db)
+{
+    mpc.set_Db_mo(Db);
+    pac.set_Db_mo(Db);
+    epc.set_Db_mo(Db);
+}
+
 
 //GridProp::GridProp(std::shared_ptr<Wavefunction> wfn) : filename_("out.grid"), Prop(wfn)
 //{

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -281,11 +281,11 @@ class MultipolePropCalc : public Prop {
     /// Common initialization
     MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin);
     // Output Type of multipole function, name, elec, nuc, tot
-    typedef std::vector<std::tuple<std::string, double, double, double>> MultipoleOutputType;
-    typedef std::shared_ptr<MultipoleOutputType> MultipoleOutputType_ptr;
+    typedef std::vector<std::tuple<std::string, double, double, double>> MultipoleOutputTypeBase;
+    typedef std::shared_ptr<MultipoleOutputTypeBase> MultipoleOutputType;
     /// Compute arbitrary-order multipoles up to (and including) l=order. returns name, elec, nuc and tot as vector_ptr
-    MultipoleOutputType_ptr compute_multipoles(int order, bool transition = false, bool print_output = false,
-                                               bool verbose = false);
+    MultipoleOutputType compute_multipoles(int order, bool transition = false, bool print_output = false,
+                                           bool verbose = false);
     /// Compute dipole
     SharedVector compute_dipole(bool transition = false, bool print_output = false, bool verbose = false);
     /// Compute quadrupole

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -189,30 +189,28 @@ public:
     SharedMatrix overlap_so();
 
     /// Computes the center for a given property, for the current molecule. Weighted center of geometry function
-    Vector3 compute_center(const double *property) const;
-
+    Vector3 compute_center(const double* property) const;
 };
 
 /**
-* The TaskListComputer, a utility base class to add, remove tasks to a tasklist.
-*
-* Historically this class was part of Prop. As Prop provides lots of meaningful
-* functionality without the need to actually compute everything asap in a task loop,
-* it was split off here.
-*
-* Recommendations:
-*   - This class should be removed in the future. A clear API with directly exposed
-*     functions (using SharedPointer return values) without writing into global
-*     environments is the way to go.
-*
-*   - Before using this as a base in a new class, it should be investigated, whether a direct
-*     API would be a better approach with a "PropFactory" for use in the interactive
-*     interpreter.
-*/
+ * The TaskListComputer, a utility base class to add, remove tasks to a tasklist.
+ *
+ * Historically this class was part of Prop. As Prop provides lots of meaningful
+ * functionality without the need to actually compute everything asap in a task loop,
+ * it was split off here.
+ *
+ * Recommendations:
+ *   - This class should be removed in the future. A clear API with directly exposed
+ *     functions (using SharedPointer return values) without writing into global
+ *     environments is the way to go.
+ *
+ *   - Before using this as a base in a new class, it should be investigated, whether a direct
+ *     API would be a better approach with a "PropFactory" for use in the interactive
+ *     interpreter.
+ */
 
-class TaskListComputer
-{
-protected:
+class TaskListComputer {
+   protected:
     /// Print flag
     int print_;
     /// Debug flag
@@ -224,7 +222,7 @@ protected:
     /// The set of tasks to complete
     std::set<std::string> tasks_;
 
-public:
+   public:
     /// Print header
     virtual void print_header() = 0;
     // => Queue/Compute Routines <= //
@@ -253,45 +251,40 @@ public:
 };
 
 /**
-* MultipolePropCalc
-*
-* Class, which calculates multipoles and mo_extents.
-*
-* Historically this class was part of OEProp.
-*
-* It is initialized with a wavefunction and an origin vector. If the origin breaks symmetry,
-* a warning is generated. Apart from this, this class does not have output, it also does
-* not export any values into the environment.
-*
-* If you are looking for previous OEProp functionality (i.e. output and environment exports)
-* OEProp still contains all that.
-*
-*/
+ * MultipolePropCalc
+ *
+ * Class, which calculates multipoles and mo_extents.
+ *
+ * Historically this class was part of OEProp.
+ *
+ * It is initialized with a wavefunction and an origin vector. If the origin breaks symmetry,
+ * a warning is generated. Apart from this, this class does not have output, it also does
+ * not export any values into the environment.
+ *
+ * If you are looking for previous OEProp functionality (i.e. output and environment exports)
+ * OEProp still contains all that.
+ *
+ */
 
-class MultipolePropCalc : public Prop
-{
-private:
+class MultipolePropCalc : public Prop {
+   private:
     MultipolePropCalc();
-protected:
+
+   protected:
     /// The center about which properties are computed
     Vector3 origin_;
     /// Whether the origin is on a symmetry axis or not
     bool origin_preserves_symmetry_;
-public:
+
+   public:
     /// Common initialization
-    MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const & origin);
-    //Output Type of multipole function, name, elec, nuc, tot
-    typedef std::vector<
-            std::tuple<
-            std::string,
-            double,
-            double,
-            double
-            >
-    > MultipoleOutputType;
+    MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin);
+    // Output Type of multipole function, name, elec, nuc, tot
+    typedef std::vector<std::tuple<std::string, double, double, double>> MultipoleOutputType;
     typedef std::shared_ptr<MultipoleOutputType> MultipoleOutputType_ptr;
     /// Compute arbitrary-order multipoles up to (and including) l=order. returns name, elec, nuc and tot as vector_ptr
-    MultipoleOutputType_ptr compute_multipoles(int order, bool transition = false, bool print_output = false, bool verbose = false);
+    MultipoleOutputType_ptr compute_multipoles(int order, bool transition = false, bool print_output = false,
+                                               bool verbose = false);
     /// Compute dipole
     SharedVector compute_dipole(bool transition = false, bool print_output = false, bool verbose = false);
     /// Compute quadrupole
@@ -301,63 +294,64 @@ public:
 };
 
 /**
-* PopulationAnalysisCalc
-*
-* Class, which carries out popular population analysis, such as Mulliken or Loewdin.
-*
-* Historically this class was part of OEProp.
-*
-* It is initialized with a wavefunction. It does not generate any output or populate any
-* environment variables.
-*
-* If you are looking for previous OEProp functionality (i.e. output and environment exports)
-* OEProp still contains all that.
-*
-*/
+ * PopulationAnalysisCalc
+ *
+ * Class, which carries out popular population analysis, such as Mulliken or Loewdin.
+ *
+ * Historically this class was part of OEProp.
+ *
+ * It is initialized with a wavefunction. It does not generate any output or populate any
+ * environment variables.
+ *
+ * If you are looking for previous OEProp functionality (i.e. output and environment exports)
+ * OEProp still contains all that.
+ *
+ */
 
-class PopulationAnalysisCalc : public Prop
-{
-private:
+class PopulationAnalysisCalc : public Prop {
+   private:
     PopulationAnalysisCalc();
-public:
-    typedef std::shared_ptr<std::vector<double> > SharedStdVector;
+
+   public:
+    typedef std::shared_ptr<std::vector<double>> SharedStdVector;
     PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn);
     virtual ~PopulationAnalysisCalc();
     /// Compute Mulliken Charges
-    std::tuple<SharedStdVector,SharedStdVector,SharedStdVector>  compute_mulliken_charges(bool print_output = false);
+    std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_mulliken_charges(bool print_output = false);
     /// Compute Lowdin Charges
-    std::tuple<SharedStdVector,SharedStdVector,SharedStdVector> compute_lowdin_charges(bool print_output = false);
+    std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_lowdin_charges(bool print_output = false);
     /// Compute Mayer Bond Indices (non-orthogoal basis)
-    std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector> compute_mayer_indices(bool print_output = false);
+    std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> compute_mayer_indices(bool print_output = false);
     /// Compute Wiberg Bond Indices using Lowdin Orbitals (symmetrically orthogonal basis)
-    std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector>  compute_wiberg_lowdin_indices(bool print_output = false);
+    std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> compute_wiberg_lowdin_indices(
+        bool print_output = false);
     /// Compute/display natural orbital occupations around the bandgap. Displays max_num above and below the bandgap
-    void compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int> > > & output_metrics, int max_noon = 3, bool print_output = false);
+    void compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int>>>& output_metrics,
+                                int max_noon = 3, bool print_output = false);
 };
 
-
 /**
-* ESPPropCalc
-*
-* Class, which calculates multiple potentials based on a grid.
-*
-* Historically this class was part of OEProp.
-*
-* It is initialized with a wavefunction.
-* environment variables. Most functions currently require a file "grid.dat" to be present.
-* The functions generate their output on disk in files such as grid-esp.dat.
-* No environment variables are populated.
-*
-* If you are looking for previous OEProp functionality (i.e. output and environment exports)
-* OEProp still contains all that.
-*
-*/
+ * ESPPropCalc
+ *
+ * Class, which calculates multiple potentials based on a grid.
+ *
+ * Historically this class was part of OEProp.
+ *
+ * It is initialized with a wavefunction.
+ * environment variables. Most functions currently require a file "grid.dat" to be present.
+ * The functions generate their output on disk in files such as grid-esp.dat.
+ * No environment variables are populated.
+ *
+ * If you are looking for previous OEProp functionality (i.e. output and environment exports)
+ * OEProp still contains all that.
+ *
+ */
 class ESPPropCalc : public Prop {
-private:
-    //Constructing without wavefunction is forbidden:
+   private:
+    // Constructing without wavefunction is forbidden:
     ESPPropCalc();
 
-protected:
+   protected:
     /// The ESP in a.u., computed at each grid point
     std::vector<double> Vvals_;
     /// The field components in a.u. computed at each grid point
@@ -365,16 +359,16 @@ protected:
     std::vector<double> Eyvals_;
     std::vector<double> Ezvals_;
 
-public:
+   public:
     /// Constructor
     ESPPropCalc(std::shared_ptr<Wavefunction> wfn);
     /// Destructor
     virtual ~ESPPropCalc();
 
-    std::vector<double> const & Vvals() const { return Vvals_; }
-    std::vector<double> const & Exvals() const { return Exvals_; }
-    std::vector<double> const & Eyvals() const { return Eyvals_; }
-    std::vector<double> const & Ezvals() const { return Ezvals_; }
+    std::vector<double> const& Vvals() const { return Vvals_; }
+    std::vector<double> const& Exvals() const { return Exvals_; }
+    std::vector<double> const& Eyvals() const { return Eyvals_; }
+    std::vector<double> const& Ezvals() const { return Ezvals_; }
 
     /// This function is missing, it should be removed until it is implemented.
     void compute_electric_field_and_gradients();
@@ -393,10 +387,11 @@ public:
 * analyses (typically vectors)
 **/
 class OEProp : public Prop, public TaskListComputer {
-private:
+   private:
     /// Constructor, uses globals and Process::environment::reference wavefunction, Implementation does not exist.
     OEProp();
-protected:
+
+   protected:
     /// Common initialization
     void common_init();
     /// Print header and information
@@ -421,7 +416,8 @@ protected:
     void compute_wiberg_lowdin_indices();
     /// Compute/display natural orbital occupations around the bandgap. Displays max_num above and below the bandgap
     void compute_no_occupations();
-    /// Compute electric field and electric field gradients, this function is missing, the declaration should be removed.
+    /// Compute electric field and electric field gradients, this function is missing, the declaration should be
+    /// removed.
     void compute_electric_field_and_gradients();
     /// Compute electrostatic potentials at the nuclei
     void compute_esp_at_nuclei();
@@ -439,7 +435,7 @@ protected:
     // retrieves the Origin vector from the environment.
     Vector3 get_origin_from_environment() const;
 
-public:
+   public:
     /// Constructor, uses globals
     OEProp(std::shared_ptr<Wavefunction> wfn);
     /// Destructor
@@ -453,10 +449,10 @@ public:
     /// Compute and print/save the properties
     void compute();
 
-    std::vector<double> const & Vvals() const { return epc.Vvals(); }
-    std::vector<double> const & Exvals() const { return epc.Exvals(); }
-    std::vector<double> const & Eyvals() const { return epc.Eyvals(); }
-    std::vector<double> const & Ezvals() const { return epc.Ezvals(); }
+    std::vector<double> const& Vvals() const { return epc.Vvals(); }
+    std::vector<double> const& Exvals() const { return epc.Exvals(); }
+    std::vector<double> const& Eyvals() const { return epc.Eyvals(); }
+    std::vector<double> const& Ezvals() const { return epc.Ezvals(); }
 
     // These functions need to be overridden to pass on to the feature classes:
 
@@ -473,7 +469,8 @@ public:
     // Set beta C matrix, SO/MO pitzer order basis. Throws if restricted
     void set_Cb(SharedMatrix Cb);
 
-    // => Set OPDM/TDM/DDM (often called). These need not be totally symmetric. Note, you are setting Da and/or Db, I do the adding to Dt  <= //
+    // => Set OPDM/TDM/DDM (often called). These need not be totally symmetric. Note, you are setting Da and/or Db, I do
+    // the adding to Dt  <= //
 
     // TODO Add symmetry is irrep number
     void set_Da_ao(SharedMatrix Da, int symmetry = 0);

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -384,6 +384,8 @@ public:
     void compute_esp_over_grid(bool print_output = false);
     /// Compute field at specified grid points
     void compute_field_over_grid(bool print_output = false);
+    /// Compute electrostatic potential at grid points based on input grid, OpenMP version. input_grid is Nx3
+    SharedVector compute_esp_over_grid_in_memory(SharedMatrix input_grid) const;
 };
 
 /**

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -263,7 +263,7 @@ protected:
     bool origin_preserves_symmetry_;
 public:
     /// Common initialization
-    MultipolePropCalc(std::shared_ptr<Wavefunction> wfn);
+    MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const & origin);
     //Output Type of multipole function, name, elec, nuc, tot
     typedef std::vector<
             std::tuple<
@@ -304,6 +304,41 @@ public:
     void compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int> > > & output_metrics, int max_noon = 3, bool print_output = false);
 };
 
+
+class ESPPropCalc : public Prop {
+private:
+    //Constructing without wavefunction is forbidden:
+    ESPPropCalc();
+
+protected:
+    /// The ESP in a.u., computed at each grid point
+    std::vector<double> Vvals_;
+    /// The field components in a.u. computed at each grid point
+    std::vector<double> Exvals_;
+    std::vector<double> Eyvals_;
+    std::vector<double> Ezvals_;
+
+public:
+    /// Constructor
+    ESPPropCalc(std::shared_ptr<Wavefunction> wfn);
+    /// Destructor
+    virtual ~ESPPropCalc();
+
+    std::vector<double> const & Vvals() const { return Vvals_; }
+    std::vector<double> const & Exvals() const { return Exvals_; }
+    std::vector<double> const & Eyvals() const { return Eyvals_; }
+    std::vector<double> const & Ezvals() const { return Ezvals_; }
+
+    /// This function is missing, it should be removed until it is implemented.
+    void compute_electric_field_and_gradients();
+    /// Compute electrostatic potentials at the nuclei
+    std::shared_ptr<std::vector<double>> compute_esp_at_nuclei(bool print_output = false, bool verbose = false);
+    /// Compute electrostatic potential at specified grid points
+    void compute_esp_over_grid(bool print_output = false);
+    /// Compute field at specified grid points
+    void compute_field_over_grid(bool print_output = false);
+};
+
 /**
 * The OEProp object, computes arbitrary expectation values (scalars)
 * analyses (typically vectors)
@@ -337,7 +372,7 @@ protected:
     void compute_wiberg_lowdin_indices();
     /// Compute/display natural orbital occupations around the bandgap. Displays max_num above and below the bandgap
     void compute_no_occupations();
-    /// Compute electric field and electric field gradients
+    /// Compute electric field and electric field gradients, this function is missing, the declaration should be removed.
     void compute_electric_field_and_gradients();
     /// Compute electrostatic potentials at the nuclei
     void compute_esp_at_nuclei();
@@ -348,17 +383,12 @@ protected:
 
     MultipolePropCalc mpc;
     PopulationAnalysisCalc pac;
+    ESPPropCalc epc;
+
     int max_noon_ = 3;
 
-    /// The ESP in a.u., computed at each grid point
-    std::vector<double> Vvals_;
-    /// The field components in a.u. computed at each grid point
-    std::vector<double> Exvals_;
-    std::vector<double> Eyvals_;
-    std::vector<double> Ezvals_;
+    Vector3 get_origin_from_environment() const;
 
-    /// Computes the center for a given property, for the current molecule
-    Vector3 compute_center(const double *property) const;
 public:
     /// Constructor, uses globals
     OEProp(std::shared_ptr<Wavefunction> wfn);
@@ -373,10 +403,10 @@ public:
     /// Compute and print/save the properties
     void compute();
 
-    std::vector<double> Vvals() const { return Vvals_; }
-    std::vector<double> Exvals() const { return Exvals_; }
-    std::vector<double> Eyvals() const { return Eyvals_; }
-    std::vector<double> Ezvals() const { return Ezvals_; }
+    std::vector<double> const & Vvals() const { return epc.Vvals(); }
+    std::vector<double> const & Exvals() const { return epc.Exvals(); }
+    std::vector<double> const & Eyvals() const { return epc.Eyvals(); }
+    std::vector<double> const & Ezvals() const { return epc.Ezvals(); }
 };
 
 /**

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -185,11 +185,12 @@ public:
     /// The total natural orbital occupations and orbitals in the AO basis
     std::pair<SharedMatrix, SharedVector> Nt_ao();
 
+    /// Density Matrix title, used for fallback naming of OEProp compute jobs
+    std::string Da_name() const;
+
     // => Some integral helpers <= //
     SharedMatrix overlap_so();
 
-    /// Computes the center for a given property, for the current molecule. Weighted center of geometry function
-    Vector3 compute_center(const double* property) const;
 };
 
 /**
@@ -386,12 +387,14 @@ class ESPPropCalc : public Prop {
 * The OEProp object, computes arbitrary expectation values (scalars)
 * analyses (typically vectors)
 **/
-class OEProp : public Prop, public TaskListComputer {
+class OEProp : public TaskListComputer {
    private:
     /// Constructor, uses globals and Process::environment::reference wavefunction, Implementation does not exist.
     OEProp();
 
    protected:
+    /// The wavefunction object this Prop is built around
+    std::shared_ptr<Wavefunction> wfn_;
     /// Common initialization
     void common_init();
     /// Print header and information
@@ -434,6 +437,8 @@ class OEProp : public Prop, public TaskListComputer {
 
     // retrieves the Origin vector from the environment.
     Vector3 get_origin_from_environment() const;
+    /// Computes the center for a given property, for the current molecule. Weighted center of geometry function
+    Vector3 compute_center(const double* property) const;
 
    public:
     /// Constructor, uses globals

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -327,8 +327,8 @@ class PopulationAnalysisCalc : public Prop {
     std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> compute_wiberg_lowdin_indices(
         bool print_output = false);
     /// Compute/display natural orbital occupations around the bandgap. Displays max_num above and below the bandgap
-    void compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int>>>& output_metrics,
-                                int max_noon = 3, bool print_output = false);
+    std::shared_ptr<std::vector<std::vector<std::tuple<double, int, int>>>> compute_no_occupations(
+        int max_noon = 3, bool print_output = false);
 };
 
 /**

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -252,6 +252,22 @@ public:
     virtual ~TaskListComputer() {}
 };
 
+/**
+* MultipolePropCalc
+*
+* Class, which calculates multipoles and mo_extents.
+*
+* Historically this class was part of OEProp.
+*
+* It is initialized with a wavefunction and an origin vector. If the origin breaks symmetry,
+* a warning is generated. Apart from this, this class does not have output, it also does
+* not export any values into the environment.
+*
+* If you are looking for previous OEProp functionality (i.e. output and environment exports)
+* OEProp still contains all that.
+*
+*/
+
 class MultipolePropCalc : public Prop
 {
 private:
@@ -284,6 +300,21 @@ public:
     std::vector<SharedVector> compute_mo_extents(bool print_output = false);
 };
 
+/**
+* PopulationAnalysisCalc
+*
+* Class, which carries out popular population analysis, such as Mulliken or Loewdin.
+*
+* Historically this class was part of OEProp.
+*
+* It is initialized with a wavefunction. It does not generate any output or populate any
+* environment variables.
+*
+* If you are looking for previous OEProp functionality (i.e. output and environment exports)
+* OEProp still contains all that.
+*
+*/
+
 class PopulationAnalysisCalc : public Prop
 {
 private:
@@ -305,6 +336,22 @@ public:
 };
 
 
+/**
+* ESPPropCalc
+*
+* Class, which calculates multiple potentials based on a grid.
+*
+* Historically this class was part of OEProp.
+*
+* It is initialized with a wavefunction.
+* environment variables. Most functions currently require a file "grid.dat" to be present.
+* The functions generate their output on disk in files such as grid-esp.dat.
+* No environment variables are populated.
+*
+* If you are looking for previous OEProp functionality (i.e. output and environment exports)
+* OEProp still contains all that.
+*
+*/
 class ESPPropCalc : public Prop {
 private:
     //Constructing without wavefunction is forbidden:

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -436,6 +436,7 @@ protected:
 
     int max_noon_ = 3;
 
+    // retrieves the Origin vector from the environment.
     Vector3 get_origin_from_environment() const;
 
 public:

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -456,6 +456,31 @@ public:
     std::vector<double> const & Exvals() const { return epc.Exvals(); }
     std::vector<double> const & Eyvals() const { return epc.Eyvals(); }
     std::vector<double> const & Ezvals() const { return epc.Ezvals(); }
+
+    // These functions need to be overridden to pass on to the feature classes:
+
+    // Change restricted flag. Resets C/D/epsilon matrices from wfn
+    void set_wavefunction(std::shared_ptr<Wavefunction> wfn);
+    // Change restricted flag. Resets C/D/epsilon matrices from wfn
+    void set_restricted(bool restricted);
+    // Set alpha eigenvalues, MO pitzer order basis
+    void set_epsilon_a(SharedVector epsilon_a);
+    // Set beta eigenvalues, MO pitzer order basis. Throws if restricted
+    void set_epsilon_b(SharedVector epsilon_a);
+    // Set alpha C matrix, SO/MO pitzer order basis.
+    void set_Ca(SharedMatrix Ca);
+    // Set beta C matrix, SO/MO pitzer order basis. Throws if restricted
+    void set_Cb(SharedMatrix Cb);
+
+    // => Set OPDM/TDM/DDM (often called). These need not be totally symmetric. Note, you are setting Da and/or Db, I do the adding to Dt  <= //
+
+    // TODO Add symmetry is irrep number
+    void set_Da_ao(SharedMatrix Da, int symmetry = 0);
+    void set_Db_ao(SharedMatrix Db, int symmetry = 0);
+    void set_Da_so(SharedMatrix Da);
+    void set_Db_so(SharedMatrix Db);
+    void set_Da_mo(SharedMatrix Da);
+    void set_Db_mo(SharedMatrix Db);
 };
 
 /**

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -426,9 +426,9 @@ class OEProp : public Prop, public TaskListComputer {
     /// Compute field at specified grid points
     void compute_field_over_grid();
 
-    MultipolePropCalc mpc;
-    PopulationAnalysisCalc pac;
-    ESPPropCalc epc;
+    MultipolePropCalc mpc_;
+    PopulationAnalysisCalc pac_;
+    ESPPropCalc epc_;
 
     int max_noon_ = 3;
 
@@ -449,10 +449,10 @@ class OEProp : public Prop, public TaskListComputer {
     /// Compute and print/save the properties
     void compute();
 
-    std::vector<double> const& Vvals() const { return epc.Vvals(); }
-    std::vector<double> const& Exvals() const { return epc.Exvals(); }
-    std::vector<double> const& Eyvals() const { return epc.Eyvals(); }
-    std::vector<double> const& Ezvals() const { return epc.Ezvals(); }
+    std::vector<double> const& Vvals() const { return epc_.Vvals(); }
+    std::vector<double> const& Exvals() const { return epc_.Exvals(); }
+    std::vector<double> const& Eyvals() const { return epc_.Eyvals(); }
+    std::vector<double> const& Ezvals() const { return epc_.Ezvals(); }
 
     // These functions need to be overridden to pass on to the feature classes:
 

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -284,6 +284,25 @@ public:
     std::vector<SharedVector> compute_mo_extents(bool print_output = false);
 };
 
+class PopulationAnalysisCalc : public Prop
+{
+private:
+    PopulationAnalysisCalc();
+public:
+    typedef std::shared_ptr<std::vector<double> > SharedStdVector;
+    PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn);
+    virtual ~PopulationAnalysisCalc();
+    /// Compute Mulliken Charges
+    std::tuple<SharedStdVector,SharedStdVector,SharedStdVector>  compute_mulliken_charges(bool print_output = false);
+    /// Compute Lowdin Charges
+    std::tuple<SharedStdVector,SharedStdVector,SharedStdVector> compute_lowdin_charges(bool print_output = false);
+    /// Compute Mayer Bond Indices (non-orthogoal basis)
+    std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector> compute_mayer_indices(bool print_output = false);
+    /// Compute Wiberg Bond Indices using Lowdin Orbitals (symmetrically orthogonal basis)
+    std::tuple<SharedMatrix,SharedMatrix,SharedMatrix,SharedVector>  compute_wiberg_lowdin_indices(bool print_output = false);
+    /// Compute/display natural orbital occupations around the bandgap. Displays max_num above and below the bandgap
+    void compute_no_occupations(std::vector<std::vector<std::tuple<double, int, int> > > & output_metrics, int max_noon = 3, bool print_output = false);
+};
 
 /**
 * The OEProp object, computes arbitrary expectation values (scalars)
@@ -328,7 +347,7 @@ protected:
     void compute_field_over_grid();
 
     MultipolePropCalc mpc;
-
+    PopulationAnalysisCalc pac;
     int max_noon_ = 3;
 
     /// The ESP in a.u., computed at each grid point

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -196,7 +196,7 @@ public:
 /**
 * The TaskListComputer, a utility base class to add, remove tasks to a tasklist.
 *
-* Historically this class was part of Prop. As prop provides lots of meaningful
+* Historically this class was part of Prop. As Prop provides lots of meaningful
 * functionality without the need to actually compute everything asap in a task loop,
 * it was split off here.
 *
@@ -246,9 +246,42 @@ public:
     void set_print(int print) { print_ = print; }
     void set_debug(int debug) { debug_ = debug; }
 
-
+    // Constructor, sets defaults for print and debug
     TaskListComputer();
+    // Destructor
     virtual ~TaskListComputer() {}
+};
+
+class MultipolePropCalc : public Prop
+{
+private:
+    MultipolePropCalc();
+protected:
+    /// The center about which properties are computed
+    Vector3 origin_;
+    /// Whether the origin is on a symmetry axis or not
+    bool origin_preserves_symmetry_;
+public:
+    /// Common initialization
+    MultipolePropCalc(std::shared_ptr<Wavefunction> wfn);
+    //Output Type of multipole function, name, elec, nuc, tot
+    typedef std::vector<
+            std::tuple<
+            std::string,
+            double,
+            double,
+            double
+            >
+    > MultipoleOutputType;
+    typedef std::shared_ptr<MultipoleOutputType> MultipoleOutputType_ptr;
+    /// Compute arbitrary-order multipoles up to (and including) l=order. returns name, elec, nuc and tot as vector_ptr
+    MultipoleOutputType_ptr compute_multipoles(int order, bool transition = false, bool print_output = false, bool verbose = false);
+    /// Compute dipole
+    SharedVector compute_dipole(bool transition = false, bool print_output = false, bool verbose = false);
+    /// Compute quadrupole
+    SharedMatrix compute_quadrupole(bool transition = false, bool print_output = false, bool verbose = false);
+    /// Compute mo extents
+    std::vector<SharedVector> compute_mo_extents(bool print_output = false);
 };
 
 
@@ -257,7 +290,9 @@ public:
 * analyses (typically vectors)
 **/
 class OEProp : public Prop, public TaskListComputer {
-
+private:
+    /// Constructor, uses globals and Process::environment::reference wavefunction, Implementation does not exist.
+    OEProp();
 protected:
     /// Common initialization
     void common_init();
@@ -292,11 +327,9 @@ protected:
     /// Compute field at specified grid points
     void compute_field_over_grid();
 
+    MultipolePropCalc mpc;
+
     int max_noon_ = 3;
-    /// The center about which properties are computed
-    Vector3 origin_;
-    /// Whether the origin is on a symmetry axis or not
-    bool origin_preserves_symmetry_;
 
     /// The ESP in a.u., computed at each grid point
     std::vector<double> Vvals_;
@@ -310,8 +343,6 @@ protected:
 public:
     /// Constructor, uses globals
     OEProp(std::shared_ptr<Wavefunction> wfn);
-    /// Constructor, uses globals and Process::environment::reference wavefunction
-    OEProp();
     /// Destructor
     virtual ~OEProp();
 


### PR DESCRIPTION
## Description
This pull request adresses https://github.com/psi4/psi4/issues/1116 :

1.) Split Prop into 
- - Prop: All One Electron convenience accessors and setters and getters, but no access to globals at all. Prop is now only a convenience class, which sets up a few nice accessors.
- - TaskListComputer: This class handles all the compute baseclass elements of Prop, adding, removing tasks from a task queue and computing them. It's very low complexity.
This was done to allow Prop to be easily inheritable without having to implement all the Taskqueue things, which honestly did not have a lot do with Prop itself. This commit makes using Prop inside the code a ton easier.
This was done in commit 
528c0d7 : https://github.com/psi4/psi4/commit/528c0d719e8bb49b12652417b00db506241a4bee

2.) Split OEProp in three distinct classes:
- - MultipolePropCalc: This class calculates all multipole properties and mo extents in commit: 
59005ee https://github.com/psi4/psi4/commit/59005eed1c0bc8b893927284c31386eb4b715f1e
- - PopulationAnalysisCalc: This class calculates Mulliken / Loewdin charges and Bond Orders in commit: a6caee7 https://github.com/psi4/psi4/commit/a6caee7091afc6b0e8071ef0d077f93fcb6c9370
- - ESPPropCalc: This class allows calculation of fields on Grids in commit: 
325149b https://github.com/psi4/psi4/commit/325149b31751b629486f0478cc5cfe1ee1ec9fb1

The rest of the commits are mostly fixups and linking up the three new classes to the old completely unchanged OEProp class, which now does not calculation itself. Also I implemented an in-memory routine calculating grid properties based on a grid, which was passed on.
The three new classes do not touch any global and no environment. They mostly exist without data storage for the grids, all functions have explicit (and mostly shared pointer return values).
Their complete setup is explicit. All environment variables are only set by OEProp.

The reason is again: This allows to the new helpers to be used directly without any interference from Python and C++. The reason they were split this way: ESPPropCalc and PopulationAnalysisCalc and MultipolePropCalc do not share any members or variables.  Example: only MPC requires an explicit origin to be set.

## Questions
- [x]  I changed a return type to const & to avoid a large copy: https://github.com/psi4/psi4/commit/325149b31751b629486f0478cc5cfe1ee1ec9fb1#r30055651
- [x] The return type in compute_mo_extents is an actual vector instead of a Shared pointer. It contains maximum three elements, so I left it at that: https://github.com/psi4/psi4/commit/59005eed1c0bc8b893927284c31386eb4b715f1e#r30055734
- [x] I could remove the Prop baseclass completely from OEProp in the future. Only one function uses something from this.

## Checklist
- [x] Tests added for any new features
  The tests are all still called from OEProp. The only new thing is the in-memory grid routine.
- [x] [All or relevant fraction of full tests run]
ctest -L quick was run. No errors

## Status
- [x] Ready for review
- [x] Ready for merge
