### PR TITLE
Fix Casting Incompatibility with Multiple Geometries

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1255,9 +1255,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.IO.change_file_namespace(180, guesspace, namespace)
         core.IO.set_default_namespace(namespace)
 
-        # Set to read and project, and reset bases to final ones
         optstash2.restore()
-        core.set_local_option('SCF', 'GUESS', 'READ')
 
         # Print the banner for the standard operation
         core.print_out('\n')


### PR DESCRIPTION
## Description
There was a bug (see conversation between myself and Andy Simmonett in Slack channel earlier today) where if you attempted to use orbital casting on a frequency computation with symmetry, the first symmetry-breaking displacement would succeed at the small basis computation but crash at the large basis computation, saying that it couldn't cast orbitals between symmetries.

The code was previously set so that GUESS would be set to READ. This would cause Psi to attempt to read the last saved orbitals. As [the casting mechanism has nothing to do with reading](https://github.com/psi4/psi4/blob/master/psi4/driver/procrouting/proc.py#L1336-L1341), the last saved orbitals weren't the orbitals from the small basis computation, but the orbitals from the last geometry, which may well be of the wrong point group.

As I can find no reason to have GUESS set to READ, the offending code has been removed.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix a bug causing `basis_guess` to crash if the user has geometries of different symmetries, e.g., a finite difference hessian for a system with symmetry

## Checklist
- [x] [Quicktests and cast tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
- [x] Confirmed this fixes the problem I saw

## Status
- [x] Ready for review
- [x] Ready for merge
