### PR TITLE
Remove initialization of DFHelper object in fisapt fexch and find.

### DIFF
--- a/psi4/src/psi4/fisapt/fisapt.h
+++ b/psi4/src/psi4/fisapt/fisapt.h
@@ -33,8 +33,6 @@
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
-//#include "psi4/lib3index/dfhelper.h"
-
 
 #include <map>
 #include <tuple>

--- a/psi4/src/psi4/fisapt/fisapt.h
+++ b/psi4/src/psi4/fisapt/fisapt.h
@@ -33,7 +33,7 @@
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/lib3index/dfhelper.h"
+//#include "psi4/lib3index/dfhelper.h"
 
 
 #include <map>
@@ -43,6 +43,7 @@ namespace psi {
 
 class JK;
 class BasisSet;
+class DFHelper;
 
 namespace fisapt {
 
@@ -79,7 +80,7 @@ protected:
     std::shared_ptr<Matrix> build_ind_pot(std::map<std::string, std::shared_ptr<Matrix> >& vars);
 
     // DFHelper object
-    std::shared_ptr<DFHelper::DFHelper> dfh_;
+    std::shared_ptr<DFHelper> dfh_;
 
     /// Helper to drop a matrix to filepath/A->name().dat
     /// Helper to drop a vector to filepath/A->name().dat

--- a/psi4/src/psi4/fisapt/fisapt.h
+++ b/psi4/src/psi4/fisapt/fisapt.h
@@ -33,6 +33,8 @@
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/lib3index/dfhelper.h"
+
 
 #include <map>
 #include <tuple>
@@ -75,6 +77,9 @@ protected:
     std::shared_ptr<Matrix> build_exch_ind_pot(std::map<std::string, std::shared_ptr<Matrix> >& vars);
     // Build the Ind20 potential in the monomer A ov space
     std::shared_ptr<Matrix> build_ind_pot(std::map<std::string, std::shared_ptr<Matrix> >& vars);
+
+    // DFHelper object
+    std::shared_ptr<DFHelper::DFHelper> dfh_;
 
     /// Helper to drop a matrix to filepath/A->name().dat
     /// Helper to drop a vector to filepath/A->name().dat


### PR DESCRIPTION
## Description
Removes initialization of DFHelper object in fexch and find by having a dfh object as member data.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Circumvents recalculation of molecular integrals in the fisapt package.
- [x] Provides a corresponding speed-up 

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
