### PR TITLE
Removed uneccesary minus sign in ROHF stability analysis.

### DIFF
--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1288,7 +1288,7 @@ bool ROHF::stability_analysis() {
         global_dpd_->buf4_close(&A);
         Process::environment.arrays["SCF STABILITY EIGENVALUES"] = stabvals;
 
-        outfile->Printf("    Lowest ROHF->ROHF stability eigenvalues:-\n");
+        outfile->Printf("    Lowest ROHF->ROHF stability eigenvalues:\n");
         print_stability_analysis(eval_sym);
         psio_->close(PSIF_LIBTRANS_DPD, 1);
     }


### PR DESCRIPTION
## Description
Changes L1291 to read:

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
