### PR TITLE
Fix psi::CharacterTable assignment operator to copy bits_

### DIFF
--- a/psi4/src/psi4/libmints/chartab.cc
+++ b/psi4/src/psi4/libmints/chartab.cc
@@ -146,6 +146,8 @@ CharacterTable::operator=(const CharacterTable& ct)
         memcpy(_inv,ct._inv,sizeof(int)* nirrep_);
     }
 
+    bits_ = ct.bits_;
+
     return *this;
 }
 


### PR DESCRIPTION
## Description

This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix `psi::CharacterTable` assignment operator to copy `bits_`. 

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
