### PR TITLE
Add missing PSI_API in fnocc

### DIFF
--- a/psi4/src/psi4/fnocc/blas.h
+++ b/psi4/src/psi4/fnocc/blas.h
@@ -44,8 +44,8 @@ namespace psi{ namespace fnocc{
 /**
  * fortran-ordered dgemv
  */
-void F_DGEMV(char trans,integer m,integer n,doublereal alpha,doublereal*A,integer lda,
-            doublereal*X,integer incx,doublereal beta,doublereal*Y,integer incy);
+void PSI_API F_DGEMV(char trans, integer m, integer n, doublereal alpha, doublereal *A, integer lda, doublereal *X,
+                     integer incx, doublereal beta, doublereal *Y, integer incy);
 /**
  * fortran-ordered dgemm
  */


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Add missing `PSI_API` in fnocc

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
