### PR TITLE
Improve build configuration for MSVC

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -170,6 +170,13 @@ endif()
 
 # <<<  Build  >>>
 
+if(MSVC)
+    # MSVC does not include <cmath> constants, unless _USE_MATH_DEFINES is defined.
+    add_definitions("/D_USE_MATH_DEFINES")
+    # Set the exception handling model
+    add_definitions("/EHsc")
+endif()
+
 include_directories(include)
 include_directories(src)
 add_subdirectory(src)

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -45,7 +45,12 @@ else()
 endif()
 
 #  <<  Pybind11 & Python  >>
-set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
+if(MSVC)
+    # As for MSVC 14.0, it is not possible to set anything bellow C++14, so just use defaults
+    set(PYBIND11_CPP_STANDARD "")
+else()
+    set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
+endif()
 find_package(pybind11 2.2.3 EXACT CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")
 message(STATUS "${Cyan}Using Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE}")

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -61,6 +61,10 @@ if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)
   target_compile_definitions(core PRIVATE -DINTEL_Fortran_ENABLED)
 endif()
 
+if(MSVC)
+    # Increase the number of addressable sections
+    target_compile_options(core PRIVATE "/bigobj")
+endif()
 
 # LAPACK & BLAS linking attached to modules in BIN/LIBLIST to maximally defer
 


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Add MSVC-specific compiler definitions (`/D_USE_MATH_DEFINES` and `/EHsc`)
- [x] Add MSVC-specific compiler options (`/bigobj`)
- [x] Disable PyBind C++ standard on MSVC

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
