### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
         - clang-3.6
         - libhdf5-serial-dev
         - gfortran
+        - g++-4.9
     env:
       - CXX_COMPILER='clang++-3.6'
       - PYTHON_VER='3.6'
@@ -143,7 +144,7 @@ install:
 - conda info -a
 - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
 - source activate p4env
-- conda install dftd3 gcp resp snsmp2 pybind11=2.2.3 -c psi4/label/dev
+- conda install dftd3 gcp resp snsmp2 pylibefp pybind11=2.2.3 -c psi4/label/dev
 - conda list
 before_script:
 - python -V


### PR DESCRIPTION
## Description
Some strange travis change (llvm pkg repo --> ubuntu or clang 3.6.2 --> 3.6.0 maybe) has left travis clang unable to find its c++ headers. So it fell back on gfortran's 4.8 ones, which were too old for regex support. So fail.

thanks to @andysim and @amjames for debugging help

## Status
- [x] Ready for review
- [x] Ready for merge
