### PR TITLE
return wfn after FISAPT

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3668,7 +3668,7 @@ def run_fisapt(name, **kwargs):
     fisapt_wfn.compute_energy()
 
     optstash.restore()
-    return fisapt_wfn
+    return ref_wfn
 
 
 def run_mrcc(name, **kwargs):


### PR DESCRIPTION
## Description
Since we [say we're returning the dimer wfn](https://github.com/psi4/psi4/blob/master/psi4/driver/driver.py#L505-L507), let's return the dimer wfn for fisapt. currently returning a `psi4.core.FISAPT` object that does not inherit from Wfn. Hence no way to drive OEPROP on a sapt calc.

## Checklist
- [x] I checked that the dipole/quadrupole from running oeprop on this returned wfn matches a forced quadrupole in the early scf_helper
- [x] ran all the sapt tests

## Status
- [x] Ready for review
- [x] Ready for merge
