### PR TITLE
Added PSI_API macro to libqt/reorder_qt.

### DIFF
--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -59,9 +59,9 @@ PSI_API int schmidt_add(double **A, int rows, int cols, double *v);
 void normalize(double **A, int rows, int cols);
 double invert_matrix(double **a, double **y, int N, std::string out_fname);
 void solve_2x2_pep(double **H, double S, double *evals, double **evecs);
-void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in,
+PSI_API void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in,
       int *frozen_uocc_in, int *order, int *orbs_per_irrep, int nirreps);
-void reorder_qt_uhf(int *docc, int *socc, int *frozen_docc,
+PSI_API void reorder_qt_uhf(int *docc, int *socc, int *frozen_docc,
       int *frozen_uocc, int *order_alpha, int *order_beta,
       int *orbspi, int nirreps);
 // int ras_set(int nirreps, int nbfso, int freeze_core, int *orbspi,

--- a/psi4/src/psi4/libqt/reorder_qt.cc
+++ b/psi4/src/psi4/libqt/reorder_qt.cc
@@ -70,7 +70,7 @@ namespace psi {
 **
 ** \ingroup QT
 */
-void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in,
+PSI_API void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in,
       int *frozen_uocc_in, int *order, int *orbs_per_irrep, int nirreps)
 {
 
@@ -194,7 +194,7 @@ void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in,
 **
 ** \ingroup QT
 */
-void reorder_qt_uhf(int *docc, int *socc, int *frozen_docc,
+PSI_API void reorder_qt_uhf(int *docc, int *socc, int *frozen_docc,
                     int *frozen_uocc, int *order_alpha, int *order_beta,
                     int *orbspi, int nirreps)
 {


### PR DESCRIPTION
## Description
Added PSI_API macro to libqt/reorder_qt.cc functions and corresponding libqt/qt.h.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- Exposes libqt/reorder_qt() and libqt/reorder_qt_uhf() to plugins.

## Checklist
- [X] All or relevant fraction of full tests run

## Status
- [X] Ready for review
- [X] Ready for merge

## Comment
This seems pretty trivial, but I haven't made a PR in a long, long time...