### PR TITLE
Fix undefine variable in psi::CIvect::dcalc2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,12 +77,12 @@ test_script:
   #     fsapt2 fsapt-terms sapt-dft1 sapt1 sapt8 tu5-sapt
   #     json-v11-energy
   #     molden1 molden2
-  #     mp2-module mpn-bh psi4numpy-dfmp2
+  #     psi4numpy-dfmp2
   #     python-3-index-transforms
-  #     pywrap-alias pywrap-cbs1 pywrap-db1
+  #     pywrap-alias pywrap-db1
   #
   - ctest --build-config %CONFIGURATION%
-          --exclude-regex "^(cbs-delta-energy|cbs-xtpl-gradient|dfmp2-ecp|fnocc2|psimrcc-sp1|pywrap-all|casscf-semi|casscf-fzc-sp|casscf-sa-sp|casscf-sp|ci-multi|ci-property|cubeprop|dfcasscf-fzc-sp|dfcasscf-sa-sp|dfcasscf-sp|dfrasscf-sp|fsapt2|fsapt-terms|molden1|molden2|mp2-module|mpn-bh|pywrap-alias|pywrap-cbs1|pywrap-db1|rasscf-sp|sapt-dft1|sapt1|sapt8|dfep2-1|dfep2-2|tu5-sapt|cc-module|psi4numpy-dfmp2|python-3-index-transforms|json-v11-energy)$"
+          --exclude-regex "^(cbs-delta-energy|cbs-xtpl-gradient|dfmp2-ecp|fnocc2|psimrcc-sp1|pywrap-all|casscf-semi|casscf-fzc-sp|casscf-sa-sp|casscf-sp|ci-multi|ci-property|cubeprop|dfcasscf-fzc-sp|dfcasscf-sa-sp|dfcasscf-sp|dfrasscf-sp|fsapt2|fsapt-terms|molden1|molden2|pywrap-alias|pywrap-db1|rasscf-sp|sapt-dft1|sapt1|sapt8|dfep2-1|dfep2-2|tu5-sapt|cc-module|psi4numpy-dfmp2|python-3-index-transforms|json-v11-energy)$"
           --label-regex quick
           --output-on-failure
           --parallel %NUMBER_OF_PROCESSORS%
@@ -91,7 +91,7 @@ after_test:
   # Run failling tests, but their results are ignored
   # TODO fix the tests
   - ctest --build-config %CONFIGURATION%
-          --tests-regex "^(casscf-fzc-sp|casscf-sa-sp|casscf-semi|casscf-sp|ci-multi|ci-property|cubeprop|fcasscf-fzc-sp|dfcasscf-sa-sp|dfcasscf-sp|dfrasscf-sp|fsapt2|fsapt-terms|molden1|molden2|mp2-module|mpn-bh|pywrap-alias|pywrap-cbs1|pywrap-db1|rasscf-sp|sapt-dft1|sapt1|sapt8|dfep2-1|dfep2-2|tu5-sapt|cc-module|psi4numpy-dfmp2|python-3-index-transforms|json-v11-energy)$"
+          --tests-regex "^(casscf-fzc-sp|casscf-sa-sp|casscf-semi|casscf-sp|ci-multi|ci-property|cubeprop|fcasscf-fzc-sp|dfcasscf-sa-sp|dfcasscf-sp|dfrasscf-sp|fsapt2|fsapt-terms|molden1|molden2|pywrap-alias|pywrap-db1|rasscf-sp|sapt-dft1|sapt1|sapt8|dfep2-1|dfep2-2|tu5-sapt|cc-module|psi4numpy-dfmp2|python-3-index-transforms|json-v11-energy)$"
           --output-on-failure
           --parallel %NUMBER_OF_PROCESSORS% & exit 0
   - python %INSTALL_FOLDER%\bin\psi4 --test & exit 0

--- a/psi4/src/psi4/detci/civect.cc
+++ b/psi4/src/psi4/detci/civect.cc
@@ -2201,7 +2201,7 @@ void CIvect::dcalc(int nr, int L, double **alpha, double *lambda, double *norm_a
 double CIvect::dcalc2(int rootnum, double lambda, CIvect &Hd, int precon, struct stringwr **alplist,
                       struct stringwr **betlist) {
     int buf, errcod, i;
-    double tval, norm = 0.0;
+    double tval = 0.0, norm = 0.0;
 
     for (buf = 0; buf < buf_per_vect_; buf++) {
         read(rootnum, buf);


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix undefine variable in `psi::CIvect::dcalc2`
- [x] Update passing Windows tests

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
