### PR TITLE
Fix OpenMP for Windows in libfock

### DIFF
--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -256,7 +256,7 @@ void DirectJK::build_JK(std::vector<std::shared_ptr<TwoBodyAOInt> >& ints,
     // ==> Master Task Loop <== //
 
     #pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+: computed_shells)
-    for (size_t task = 0L; task < ntask_pair2; task++) {
+    for (long task = 0; task < ntask_pair2; task++) {
 
         size_t task1 = task / ntask_pair;
         size_t task2 = task % ntask_pair;

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -524,7 +524,7 @@ void DiskDFJK::initialize_JK_core() {
 //                             whether or not functions have been screened.
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-    for (size_t mn_block_idx = 0; mn_block_idx < mn_blocks.size(); mn_block_idx++) {
+    for (long mn_block_idx = 0; mn_block_idx < mn_blocks.size(); mn_block_idx++) {
 #ifdef _OPENMP
         const int rank = omp_get_thread_num();
 #else
@@ -1492,7 +1492,7 @@ void DiskDFJK::initialize_wK_disk() {
         timer_on("JK: (Q|mn)^R");
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-        for (size_t QMN = 0L; QMN < (Qstop - Qstart) * (size_t)npairs; QMN++) {
+        for (long QMN = 0; QMN < (Qstop - Qstart) * (size_t)npairs; QMN++) {
             int thread = 0;
 #ifdef _OPENMP
             thread = omp_get_thread_num();
@@ -1615,7 +1615,7 @@ void DiskDFJK::rebuild_wK_disk() {
         timer_on("JK: (Q|mn)^R");
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-        for (size_t QMN = 0L; QMN < (Qstop - Qstart) * (size_t)npairs; QMN++) {
+        for (long QMN = 0; QMN < (Qstop - Qstart) * (size_t)npairs; QMN++) {
             int thread = 0;
 #ifdef _OPENMP
             thread = omp_get_thread_num();

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -216,7 +216,7 @@ void PKManager::compute_integrals(bool wK) {
 
     size_t nshqu = 0;
 #pragma omp parallel for num_threads(nthreads_) schedule(dynamic) reduction(+ : nshqu)
-    for (size_t i = 0; i < ntasks_; ++i) {
+    for (long i = 0; i < ntasks_; ++i) {
         // We need to get the list of shell quartets for each task
         int thread = 0;
 #ifdef _OPENMP
@@ -1056,7 +1056,7 @@ void PKMgrYoshimine::compute_integrals(bool wK) {
     // We avoid having one more branch in the loop by moving it outside
     if (!wK) {
 #pragma omp parallel for schedule(dynamic) num_threads(nthreads())
-        for (size_t i = 0; i < npairs; ++i) {
+        for (long i = 0; i < npairs; ++i) {
             int PP = sh_pairs[i].first;
             int QQ = sh_pairs[i].second;
             int thread = 0;
@@ -1095,7 +1095,7 @@ void PKMgrYoshimine::compute_integrals(bool wK) {
         write();
     } else {
 #pragma omp parallel for schedule(dynamic) num_threads(nthreads())
-        for (size_t i = 0; i < npairs; ++i) {
+        for (long i = 0; i < npairs; ++i) {
             int PP = sh_pairs[i].first;
             int QQ = sh_pairs[i].second;
             int thread = 0;

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -385,12 +385,12 @@ double VBase::vv10_nlc(SharedMatrix D, SharedMatrix ret) {
             int mg = function_map[ml];
             for (int nl = 0; nl < ml; nl++) {
                 int ng = function_map[nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vp[mg][ng] += V2p[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vp[ng][mg] += V2p[ml][nl];
             }
-#pragma omp atomic update
+#pragma omp atomic
             Vp[mg][mg] += V2p[ml][ml];
         }
         parallel_timer_off("VV10 Fock", rank);
@@ -585,12 +585,12 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
             int mg = function_map[ml];
             for (int nl = 0; nl < ml; nl++) {
                 int ng = function_map[nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vp[mg][ng] += V2p[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vp[ng][mg] += V2p[ml][nl];
             }
-#pragma omp atomic update
+#pragma omp atomic
             Vp[mg][mg] += V2p[ml][ml];
         }
         parallel_timer_off("V_xc", rank);
@@ -869,12 +869,12 @@ void RV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
                 int mg = function_map[ml];
                 for (int nl = 0; nl < ml; nl++) {
                     int ng = function_map[nl];
-#pragma omp atomic update
+#pragma omp atomic
                     Vxp[mg][ng] += Vx_localp[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                     Vxp[ng][mg] += Vx_localp[ml][nl];
                 }
-#pragma omp atomic update
+#pragma omp atomic
                 Vxp[mg][mg] += Vx_localp[ml][ml];
             }
             parallel_timer_off("V_XCd", rank);
@@ -1654,18 +1654,18 @@ void UV::compute_V(std::vector<SharedMatrix> ret) {
             int mg = function_map[ml];
             for (int nl = 0; nl < ml; nl++) {
                 int ng = function_map[nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vap[mg][ng] += Va2p[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vap[ng][mg] += Va2p[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vbp[mg][ng] += Vb2p[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                 Vbp[ng][mg] += Vb2p[ml][nl];
             }
-#pragma omp atomic update
+#pragma omp atomic
             Vap[mg][mg] += Va2p[ml][ml];
-#pragma omp atomic update
+#pragma omp atomic
             Vbp[mg][mg] += Vb2p[ml][ml];
         }
         parallel_timer_off("V_xc", rank);
@@ -2153,19 +2153,19 @@ void UV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
                 for (int nl = 0; nl < ml; nl++) {
                     int ng = function_map[nl];
 
-#pragma omp atomic update
+#pragma omp atomic
                     Vaxp[mg][ng] += Vax_localp[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                     Vaxp[ng][mg] += Vax_localp[ml][nl];
 
-#pragma omp atomic update
+#pragma omp atomic
                     Vbxp[mg][ng] += Vbx_localp[ml][nl];
-#pragma omp atomic update
+#pragma omp atomic
                     Vbxp[ng][mg] += Vbx_localp[ml][nl];
                 }
-#pragma omp atomic update
+#pragma omp atomic
                 Vaxp[mg][mg] += Vax_localp[ml][ml];
-#pragma omp atomic update
+#pragma omp atomic
                 Vbxp[mg][mg] += Vbx_localp[ml][ml];
             }
         }

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -248,7 +248,7 @@ double VBase::vv10_nlc(SharedMatrix D, SharedMatrix ret) {
     vv10_tmp_cache.resize(nlgrid.blocks().size());
 
 #pragma omp parallel for private(rank) schedule(guided) num_threads(num_threads_)
-    for (size_t Q = 0; Q < nlgrid.blocks().size(); Q++) {
+    for (long Q = 0; Q < nlgrid.blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -311,7 +311,7 @@ double VBase::vv10_nlc(SharedMatrix D, SharedMatrix ret) {
 
 // => Compute the kernel <=
 #pragma omp parallel for private(rank) schedule(guided) num_threads(num_threads_)
-    for (size_t Q = 0; Q < nlgrid.blocks().size(); Q++) {
+    for (long Q = 0; Q < nlgrid.blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -460,7 +460,7 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
 
 // Traverse the blocks of points
 #pragma omp parallel for private(rank) schedule(guided) num_threads(num_threads_)
-    for (size_t Q = 0; Q < grid_->blocks().size(); Q++) {
+    for (long Q = 0; Q < grid_->blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -707,7 +707,7 @@ void RV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
 
 // Traverse the blocks of points
 #pragma omp parallel for private(rank) schedule(guided) num_threads(num_threads_)
-    for (size_t Q = 0; Q < grid_->blocks().size(); Q++) {
+    for (long Q = 0; Q < grid_->blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -942,7 +942,7 @@ SharedMatrix RV::compute_gradient() {
 
 // Traverse the blocks of points
 #pragma omp parallel for private(rank) schedule(dynamic) num_threads(num_threads_)
-    for (size_t Q = 0; Q < grid_->blocks().size(); Q++) {
+    for (long Q = 0; Q < grid_->blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -1809,7 +1809,7 @@ void UV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
 
 // Traverse the blocks of points
 #pragma omp parallel for private(rank) schedule(guided) num_threads(num_threads_)
-    for (size_t Q = 0; Q < grid_->blocks().size(); Q++) {
+    for (long Q = 0; Q < grid_->blocks().size(); Q++) {
 // Get thread info
 #ifdef _OPENMP
         rank = omp_get_thread_num();


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some parts.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops
- [x] Remove `update` from OpenMP atomic, as it is default behaviour

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
