### PR TITLE
Fix OpenMP for Windows in dcft

### DIFF
--- a/psi4/src/psi4/dcft/dcft_density_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_density_UHF.cc
@@ -98,7 +98,7 @@ void DCFTSolver::compute_unrelaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gaa.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gaa.params->rowtot[h]; ++ij) {
             size_t i = Gaa.params->roworb[h][ij][0];
             int Gi = Gaa.params->psym[i];
             i -= Gaa.params->poff[Gi];
@@ -141,7 +141,7 @@ void DCFTSolver::compute_unrelaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gab.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gab.params->rowtot[h]; ++ij) {
             size_t i = Gab.params->roworb[h][ij][0];
             int Gi = Gab.params->psym[i];
             i -= Gab.params->poff[Gi];
@@ -179,7 +179,7 @@ void DCFTSolver::compute_unrelaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gbb.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gbb.params->rowtot[h]; ++ij) {
             size_t i = Gbb.params->roworb[h][ij][0];
             int Gi = Gbb.params->psym[i];
             i -= Gbb.params->poff[Gi];
@@ -810,7 +810,7 @@ void DCFTSolver::compute_unrelaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gaa.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gaa.params->rowtot[h]; ++ia) {
             size_t i = Gaa.params->roworb[h][ia][0];
             int Gi = Gaa.params->psym[i];
             i -= Gaa.params->poff[Gi];
@@ -864,7 +864,7 @@ void DCFTSolver::compute_unrelaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gab.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gab.params->rowtot[h]; ++ia) {
             size_t i = Gab.params->roworb[h][ia][0];
             int Gi = Gab.params->psym[i];
             i -= Gab.params->poff[Gi];
@@ -897,7 +897,7 @@ void DCFTSolver::compute_unrelaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gba, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gba.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gba.params->rowtot[h]; ++ia) {
             size_t i = Gba.params->roworb[h][ia][0];
             int Gi = Gba.params->psym[i];
             i -= Gba.params->poff[Gi];
@@ -962,7 +962,7 @@ void DCFTSolver::compute_unrelaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gbb.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gbb.params->rowtot[h]; ++ia) {
             size_t i = Gbb.params->roworb[h][ia][0];
             int Gi = Gbb.params->psym[i];
             i -= Gbb.params->poff[Gi];
@@ -1041,7 +1041,7 @@ void DCFTSolver::compute_unrelaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gaa.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gaa.params->rowtot[h]; ++ab) {
             size_t a = Gaa.params->roworb[h][ab][0];
             int Ga = Gaa.params->psym[a];
             a -= Gaa.params->poff[Ga];
@@ -1075,7 +1075,7 @@ void DCFTSolver::compute_unrelaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gab.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gab.params->rowtot[h]; ++ab) {
             size_t a = Gab.params->roworb[h][ab][0];
             int Ga = Gab.params->psym[a];
             a -= Gab.params->poff[Ga];
@@ -1107,7 +1107,7 @@ void DCFTSolver::compute_unrelaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gbb.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gbb.params->rowtot[h]; ++ab) {
             size_t a = Gbb.params->roworb[h][ab][0];
             int Ga = Gbb.params->psym[a];
             a -= Gbb.params->poff[Ga];
@@ -1189,7 +1189,7 @@ void DCFTSolver::compute_relaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gaa.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gaa.params->rowtot[h]; ++ij) {
             size_t i = Gaa.params->roworb[h][ij][0];
             int Gi = Gaa.params->psym[i];
             i -= Gaa.params->poff[Gi];
@@ -1236,7 +1236,7 @@ void DCFTSolver::compute_relaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gab.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gab.params->rowtot[h]; ++ij) {
             size_t i = Gab.params->roworb[h][ij][0];
             int Gi = Gab.params->psym[i];
             i -= Gab.params->poff[Gi];
@@ -1276,7 +1276,7 @@ void DCFTSolver::compute_relaxed_density_OOOO() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ij = 0; ij < Gbb.params->rowtot[h]; ++ij) {
+        for (long ij = 0; ij < Gbb.params->rowtot[h]; ++ij) {
             size_t i = Gbb.params->roworb[h][ij][0];
             int Gi = Gbb.params->psym[i];
             i -= Gbb.params->poff[Gi];
@@ -1447,7 +1447,7 @@ void DCFTSolver::compute_relaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gaa.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gaa.params->rowtot[h]; ++ia) {
             size_t i = Gaa.params->roworb[h][ia][0];
             int Gi = Gaa.params->psym[i];
             i -= Gaa.params->poff[Gi];
@@ -1506,7 +1506,7 @@ void DCFTSolver::compute_relaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gab.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gab.params->rowtot[h]; ++ia) {
             size_t i = Gab.params->roworb[h][ia][0];
             int Gi = Gab.params->psym[i];
             i -= Gab.params->poff[Gi];
@@ -1541,7 +1541,7 @@ void DCFTSolver::compute_relaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gba, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gba.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gba.params->rowtot[h]; ++ia) {
             size_t i = Gba.params->roworb[h][ia][0];
             int Gi = Gba.params->psym[i];
             i -= Gba.params->poff[Gi];
@@ -1638,7 +1638,7 @@ void DCFTSolver::compute_relaxed_density_OVOV() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ia = 0; ia < Gbb.params->rowtot[h]; ++ia) {
+        for (long ia = 0; ia < Gbb.params->rowtot[h]; ++ia) {
             size_t i = Gbb.params->roworb[h][ia][0];
             int Gi = Gbb.params->psym[i];
             i -= Gbb.params->poff[Gi];
@@ -1721,7 +1721,7 @@ void DCFTSolver::compute_relaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gaa, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gaa.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gaa.params->rowtot[h]; ++ab) {
             size_t a = Gaa.params->roworb[h][ab][0];
             int Ga = Gaa.params->psym[a];
             a -= Gaa.params->poff[Ga];
@@ -1760,7 +1760,7 @@ void DCFTSolver::compute_relaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gab, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gab.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gab.params->rowtot[h]; ++ab) {
             size_t a = Gab.params->roworb[h][ab][0];
             int Ga = Gab.params->psym[a];
             a -= Gab.params->poff[Ga];
@@ -1795,7 +1795,7 @@ void DCFTSolver::compute_relaxed_density_VVVV() {
         global_dpd_->buf4_mat_irrep_rd(&Gbb, h);
 
 #pragma omp parallel for
-        for (size_t ab = 0; ab < Gbb.params->rowtot[h]; ++ab) {
+        for (long ab = 0; ab < Gbb.params->rowtot[h]; ++ab) {
             size_t a = Gbb.params->roworb[h][ab][0];
             int Ga = Gbb.params->psym[a];
             a -= Gbb.params->poff[Ga];


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some parts.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
