### PR TITLE
Fix OpenMP for Windows in libmints

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1197,7 +1197,12 @@ void Matrix::apply_denominator(const Matrix *const plus) {
         if (size) {
             lhs = matrix_[h][0];
             rhs = plus->matrix_[h][0];
+
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
 #pragma omp parallel for simd
+#else
+#pragma omp parallel for
+#endif
             for (long ij = 0; ij < size; ++ij) {
                 lhs[ij] /= rhs[ij];
             }
@@ -2547,7 +2552,11 @@ void Matrix::zero_row(int h, int i) {
     if (i >= rowspi_[h]) {
         throw PSIEXCEPTION("Matrix::zero_row: index is out of bounds.");
     }
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
 #pragma omp parallel for simd
+#else
+#pragma omp parallel for
+#endif
     for (int m = 0; m < colspi_[h]; ++m) {
         matrix_[h][i][m] = 0.0;
     }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1198,7 +1198,7 @@ void Matrix::apply_denominator(const Matrix *const plus) {
             lhs = matrix_[h][0];
             rhs = plus->matrix_[h][0];
 #pragma omp parallel for simd
-            for (size_t ij = 0; ij < size; ++ij) {
+            for (long ij = 0; ij < size; ++ij) {
                 lhs[ij] /= rhs[ij];
             }
         }

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -430,7 +430,7 @@ void MintsHelper::one_body_ao_computer(std::vector<std::shared_ptr<OneBodyAOInt>
 
 // Loop it
 #pragma omp parallel for schedule(guided) num_threads(nthread)
-    for (size_t MU = 0; MU < bs1->nshell(); ++MU) {
+    for (long MU = 0; MU < bs1->nshell(); ++MU) {
         const size_t num_mu = bs1->shell(MU).nfunction();
         const size_t index_mu = bs1->shell(MU).function_index();
 
@@ -503,7 +503,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
     double **Dp = D->pointer();
 
 #pragma omp parallel for schedule(guided) num_threads(nthread)
-    for (size_t P = 0; P < basisset_->nshell(); P++) {
+    for (long P = 0; P < basisset_->nshell(); P++) {
         size_t rank = 0;
 #ifdef _OPENMP
         rank = omp_get_thread_num();
@@ -1721,7 +1721,7 @@ SharedMatrix MintsHelper::potential_grad(SharedMatrix D) {
     double **Dp = D->pointer();
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread_)
-    for (size_t PQ = 0L; PQ < PQ_pairs.size(); PQ++) {
+    for (long PQ = 0L; PQ < PQ_pairs.size(); PQ++) {
         size_t P = PQ_pairs[PQ].first;
         size_t Q = PQ_pairs[PQ].second;
 

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -530,7 +530,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Px += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aP][0] += Px;
 
             // Py
@@ -540,7 +540,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Py += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aP][1] += Py;
 
             // Pz
@@ -550,7 +550,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Pz += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aP][2] += Pz;
 
             // Qx
@@ -560,7 +560,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Qx += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aQ][0] += Qx;
 
             // Qy
@@ -570,7 +570,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Qy += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aQ][1] += Qy;
 
             // Qz
@@ -580,7 +580,7 @@ void MintsHelper::grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAO
                     Qz += perm * Dp[p + oP][q + oQ] * (*ref++);
                 }
             }
-#pragma omp atomic update
+#pragma omp atomic
             outp[aQ][2] += Qz;
         }
     }


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some part

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops
- [x] Remove `update` from OpenMP atomic
- [x] Conditional compilation for `simd`

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
