### PR TITLE
Fix OpenMP for Windows in libsapt_solver

### DIFF
--- a/psi4/src/psi4/libsapt_solver/disp2ccd.cc
+++ b/psi4/src/psi4/libsapt_solver/disp2ccd.cc
@@ -1375,7 +1375,7 @@ double **SAPT2p::vvvv_ccd(const char *TARAR, const char *RRRRp, const char *RRRR
         double **Vp = mo2no->pointer();
         double **T1 = block_matrix(occA * occA, virA * virA2);
 #pragma omp parallel for
-        for (size_t ij = 0L; ij < occA * occA; ij++) {
+        for (long ij = 0L; ij < occA * occA; ij++) {
             C_DGEMM('N', 'N', virA, virA2, virA2, 1.0, Vp[0], virA2, t2AARR[ij], virA2, 0.0, T1[ij], virA2);
         }
         free_block(t2AARR);

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -464,7 +464,11 @@ SharedMatrix FDDS_Dispersion::form_unc_amplitude(std::string monomer, double ome
         dfh_->fill_tensor(ovQ_tensor_name, tmp, {bcount, bcount + osize});
         size_t shift_i = block * bsize;
 
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
 #pragma omp parallel for collapse(2)
+#else
+#pragma omp parallel for
+#endif
         for (long i = 0; i < osize; i++) {
             for (size_t a = 0; a < nvir; a++) {
                 double val = ampp[i + shift_i][a];

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -468,7 +468,9 @@ SharedMatrix FDDS_Dispersion::form_unc_amplitude(std::string monomer, double ome
         for (long i = 0; i < osize; i++) {
             for (size_t a = 0; a < nvir; a++) {
                 double val = ampp[i + shift_i][a];
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
 #pragma omp simd
+#endif
                 for (size_t Q = 0; Q < naux; Q++) {
                     tmpp[i * nvir + a][Q] *= val;
                 }

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -98,7 +98,7 @@ FDDS_Dispersion::FDDS_Dispersion(std::shared_ptr<BasisSet> primary, std::shared_
     double** metricp = metric_->pointer();
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-    for (size_t MU = 0; MU < auxiliary_->nshell(); ++MU) {
+    for (long MU = 0; MU < auxiliary_->nshell(); ++MU) {
         size_t nummu = auxiliary_->shell(MU).nfunction();
 
         size_t thread = 0;
@@ -234,7 +234,7 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
 
 // Do the contraction
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-    for (size_t Rshell = 0; Rshell < auxiliary_->nshell(); Rshell++) {
+    for (long Rshell = 0; Rshell < auxiliary_->nshell(); Rshell++) {
         size_t thread = 0;
 #ifdef _OPENMP
         thread = omp_get_thread_num();
@@ -324,7 +324,7 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
     }
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-    for (size_t PQi = 0; PQi < aux_pairs.size(); PQi++) {
+    for (long PQi = 0; PQi < aux_pairs.size(); PQi++) {
         size_t thread = 0;
 #ifdef _OPENMP
         thread = omp_get_thread_num();
@@ -418,7 +418,7 @@ SharedMatrix FDDS_Dispersion::form_unc_amplitude(std::string monomer, double ome
     double* evirp = eps_vir->pointer();
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nocc; i++) {
+    for (long i = 0; i < nocc; i++) {
         for (size_t a = 0; a < nvir; a++) {
             double val = -1.0 * (eoccp[i] - evirp[a]);
             double tmp = 4.0 * val / (val * val + omega * omega);
@@ -465,7 +465,7 @@ SharedMatrix FDDS_Dispersion::form_unc_amplitude(std::string monomer, double ome
         size_t shift_i = block * bsize;
 
 #pragma omp parallel for collapse(2)
-        for (size_t i = 0; i < osize; i++) {
+        for (long i = 0; i < osize; i++) {
             for (size_t a = 0; a < nvir; a++) {
                 double val = ampp[i + shift_i][a];
 #pragma omp simd


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some parts.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops
- [x] Conditional compilation of `simd` clause
- [x] Conditional compilation of `collapse` clause

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
