### PR TITLE
Fix OpenMP for Windows in dfep2

### DIFF
--- a/psi4/src/psi4/dfep2/dfep2.cc
+++ b/psi4/src/psi4/dfep2/dfep2.cc
@@ -349,7 +349,6 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
     // thread info
     std::vector<std::vector<double>> deriv_temps(num_threads_, std::vector<double>(nE));
     std::vector<std::vector<double>> sigma_temps(num_threads_, std::vector<double>(nE));
-    size_t rank = 0;
 
     for (size_t iter = 0; iter < max_iter_; iter++) {
         // Reset data for loop
@@ -380,9 +379,10 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
             psio_->read(unit_, "EP2 I_ovvE Integrals", (char*)I_ovvEp[0], (sizeof(double) * ib_size * nvir * nvir * nE),
                         ovvE_addr, &ovvE_addr);
 
-#pragma omp parallel for private(rank) schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
-            for (size_t i = 0; i < ib_size; i++) {
+#pragma omp parallel for schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
+            for (long i = 0; i < ib_size; i++) {
                 for (size_t a = 0; a < nvir; a++) {
+                    int rank = 0;
 #ifdef _OPENMP
                     rank = omp_get_thread_num();
 #endif
@@ -419,9 +419,10 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
             psio_->read(unit_, "EP2 I_vooE Integrals", (char*)I_vooEp[0], sizeof(double) * ab_size * nocc * nocc * nE,
                         vooE_addr, &vooE_addr);
 
-#pragma omp parallel for private(rank) schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
-            for (size_t a = 0; a < ab_size; a++) {
+#pragma omp parallel for schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
+            for (long a = 0; a < ab_size; a++) {
                 for (size_t i = 0; i < nocc; i++) {
+                    int rank = 0;
 #ifdef _OPENMP
                     rank = omp_get_thread_num();
 #endif

--- a/psi4/src/psi4/dfep2/dfep2.cc
+++ b/psi4/src/psi4/dfep2/dfep2.cc
@@ -378,8 +378,11 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
 
             psio_->read(unit_, "EP2 I_ovvE Integrals", (char*)I_ovvEp[0], (sizeof(double) * ib_size * nvir * nvir * nE),
                         ovvE_addr, &ovvE_addr);
-
-#pragma omp parallel for schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads_) collapse(2)
+#else
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads_)
+#endif
             for (long i = 0; i < ib_size; i++) {
                 for (size_t a = 0; a < nvir; a++) {
                     int rank = 0;
@@ -419,7 +422,11 @@ std::vector<std::vector<std::pair<double, double>>> DFEP2Wavefunction::compute(
             psio_->read(unit_, "EP2 I_vooE Integrals", (char*)I_vooEp[0], sizeof(double) * ab_size * nocc * nocc * nE,
                         vooE_addr, &vooE_addr);
 
-#pragma omp parallel for schedule(dynamic, 1) collapse(2) num_threads(num_threads_)
+#if _OPENMP >= 201307 // OpenMP 4.0 or newer
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads_) collapse(2)
+#else
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads_)
+#endif
             for (long a = 0; a < ab_size; a++) {
                 for (size_t i = 0; i < nocc; i++) {
                     int rank = 0;


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some parts.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops
- [x] Conditional compilation of `collapse` clause

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
