### PR TITLE
Fix OpenMP for Windows in detci, libfunctional, and scfgrad

### DIFF
--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -542,7 +542,7 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only) {
         SharedMatrix J = jk_->J()[D_tasks];
         SharedMatrix half_trans = Matrix::triplet(Crot, J, Cact, true, false, false);
 #pragma omp parallel for schedule(static)
-        for (size_t p = 0; p < nrot; p++) {
+        for (long p = 0; p < nrot; p++) {
             for (size_t q = 0; q < nact; q++) {
                 casscf_ints->set(p * nact + q, i * nact + j, half_trans->get(p, q));
                 casscf_ints->set(p * nact + q, j * nact + i, half_trans->get(p, q));

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -634,7 +634,9 @@ std::map<std::string, SharedVector>& SuperFunctional::compute_functional(
             const double pow43 = 4.0 / 3.0;
             double denx;
 
-            # pragma omp simd
+            #if _OPENMP >= 201307 // OpenMP 4.0 or newer
+            #pragma omp simd
+            #endif
             for (size_t i = 0; i < npoints; i++){
 
                 if (rho[i] < 1.e-16) {
@@ -729,7 +731,9 @@ std::map<std::string, SharedVector> SuperFunctional::compute_vv10_cache(
     double* gammap = vals.find("GAMMA_AA")->second->pointer();
 
     // Eh, worth a shot
-    # pragma omp simd
+    #if _OPENMP >= 201307 // OpenMP 4.0 or newer
+    #pragma omp simd
+    #endif
     for (size_t i = 0; i < npoints; i++) {
         if (rhop[i] < rho_thresh) continue;
 
@@ -850,7 +854,9 @@ double SuperFunctional::compute_vv10_kernel(
             size_t r_npoints = r_block["KAPPA"]->dimpi()[0];
 
             // Interior Kernel
-            # pragma omp simd reduction(+: phi, U, W)
+            #if _OPENMP >= 201307 // OpenMP 4.0 or newer
+            #pragma omp simd reduction(+: phi, U, W)
+            #endif
             for (size_t j = 0; j < r_npoints; j++) {
                 // if (r_rho[i] < 1.e-8) continue;
 

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -2252,7 +2252,7 @@ std::map<std::string, std::shared_ptr<Matrix> > DirectJKGrad::compute1(std::vect
     double** Dbp = Db_->pointer();
 
 #pragma omp parallel for num_threads(nthreads) schedule(dynamic)
-    for (size_t index = 0L; index < npairs2; index++) {
+    for (long int index = 0L; index < npairs2; index++) {
 
         size_t PQ = index / npairs;
         size_t RS = index % npairs;
@@ -2501,7 +2501,7 @@ std::map<std::string, std::shared_ptr<Matrix> > DirectJKGrad::compute2(std::vect
     double** Dbp = Db_->pointer();
 
 #pragma omp parallel for num_threads(nthreads) schedule(dynamic)
-    for (size_t index = 0L; index < npairs2; index++) {
+    for (long int index = 0L; index < npairs2; index++) {
 
         size_t PQ = index / npairs;
         size_t RS = index % npairs;


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

MSVC supports only OpenMP 2.0, but *Psi4* needs higher at some parts.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change `size_t` to `long` in OpenMP loops
- [x] Conditional compilation of `simd` clause

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
