### PR TITLE
DF-CCSD iterations print aligned

### DIFF
--- a/psi4/src/psi4/dfocc/ccd_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccd_iterations.cc
@@ -95,7 +95,7 @@ void DFOCC::ccd_iterations() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/ccd_iterations_low.cc
+++ b/psi4/src/psi4/dfocc/ccd_iterations_low.cc
@@ -95,7 +95,7 @@ void DFOCC::ccd_iterations_low() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/ccdl_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccdl_iterations.cc
@@ -135,7 +135,7 @@ void DFOCC::ccdl_iterations() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  \n", itr_occ, EcorrL, DE, rms_t2);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  \n", itr_occ, EcorrL, DE, rms_t2);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/ccsd_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccsd_iterations.cc
@@ -106,7 +106,7 @@ void DFOCC::ccsd_iterations() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  %12.2e \n", itr_occ, Ecorr, DE, rms_t2, rms_t1);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  %12.2e \n", itr_occ, Ecorr, DE, rms_t2, rms_t1);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/ccsd_iterations_low.cc
+++ b/psi4/src/psi4/dfocc/ccsd_iterations_low.cc
@@ -106,7 +106,7 @@ void DFOCC::ccsd_iterations_low() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  %12.2e \n", itr_occ, Ecorr, DE, rms_t2, rms_t1);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  %12.2e \n", itr_occ, Ecorr, DE, rms_t2, rms_t1);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/ccsdl_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccsdl_iterations.cc
@@ -159,7 +159,7 @@ void DFOCC::ccsdl_iterations() {
         }
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  %12.2e \n", itr_occ, EcorrL, DE, rms_t2,
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  %12.2e \n", itr_occ, EcorrL, DE, rms_t2,
                         rms_t1);
 
         if (itr_occ >= cc_maxiter) {

--- a/psi4/src/psi4/dfocc/lccd_iterations.cc
+++ b/psi4/src/psi4/dfocc/lccd_iterations.cc
@@ -102,7 +102,7 @@ void DFOCC::lccd_iterations() {
         Elccd_old = Elccd;
 
         // print
-        outfile->Printf(" %3d      %12.10f         %12.10f      %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  \n", itr_occ, Ecorr, DE, rms_t2);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged


### PR DESCRIPTION
## Description
The formatting of the iteration tables was off when dE > 0.

## Todos
- [x] Fixed the above

## Checklist
- [x] `ctest -L dfccsd` passes

## Status
- [x] Ready for review
- [x] Ready for merge
