### PR TITLE
Rework of CBS to use dictionaries

### DIFF
--- a/doc/sphinxman/source/cbs.rst
+++ b/doc/sphinxman/source/cbs.rst
@@ -191,24 +191,6 @@ existing examples are below.
 
 .. autofunction:: psi4.driver.aliases.allen_focal_point
 
-Other helper functions
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: psi4.driver.driver_cbs._expand_bracketed_basis
-
-.. autofunction:: psi4.driver.driver_cbs._contract_bracketed_basis
-
-.. autofunction:: psi4.driver.driver_cbs._process_cbs_kwargs
-
-.. autofunction:: psi4.driver.driver_cbs._expand_scheme_orders
-
-.. autofunction:: psi4.driver.driver_cbs._contract_scheme_orders
-
-.. autofunction:: psi4.driver.driver_cbs._cbs_wrapper_methods
-
-.. autofunction:: psi4.driver.driver_cbs._parse_cbs_gufunc_string
-
-.. autofunction:: psi4.driver.driver_cbs._cbs_gufunc
 
 
 

--- a/doc/sphinxman/source/cbs.rst
+++ b/doc/sphinxman/source/cbs.rst
@@ -43,37 +43,41 @@ Complete Basis Set
 
    cbs_eqn
 
-.. codeauthor:: Lori A. Burns and Daniel G. A. Smith
-.. sectionauthor:: Lori A. Burns
+.. codeauthor:: Lori A. Burns, Daniel G. A. Smith and Peter Kraus
+.. sectionauthor:: Lori A. Burns and Peter Kraus
 
 The :py:func:`psi4.cbs` function described below is
 powerful but complicated, requiring many options. For most common
 calculations, a shorthand can be accessed directly though
 :py:func:`psi4.energy`, :py:func:`psi4.gradient`, *etc.* For example,
 a MP2 single-point DT extrapolation can be accessed through the first item
-below more conveniently than the equivalent second item.
+below more conveniently than the equivalent second or third items.
 
 * ``energy('mp2/cc-pv[dt]z')``
 
 * ``energy(cbs, corl_wfn='mp2', corl_basis='cc-pv[dt]z')``
 
+* ``energy(cbs, cbs_metadata=[{"wfn": "hf", "basis": "cc-pvtz"}, {"wfn": "mp2", "basis": "cc-pv[dt]z"}])``
+
 A CCSD(T) DT coupled-cluster correction atop a TQ MP2 extrapolation
-geometry optimization can be accessed through the first item below more
-conveniently than the equivalent second item.
+geometry optimization can also be accessed through the first item below more
+conveniently than the equivalent second and third items.
 
 * ``optimize('mp2/cc-pv[tq]z + D:ccsd(t)/cc-pvdz')``
 
 * ``optimize(cbs, corl_wfn='mp2', corl_basis='cc-pv[tq]z', delta_wfn='ccsd(t)', delta_basis='cc-pvdz')``
 
+* ``optimize(cbs, cbs_metadata=[{"wfn": "hf", "basis": "cc-pvqz"}, {"wfn": "mp2", "basis": "cc-pv[tq]z"}, {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])``
+
 Many examples can be found at :srcsample:`cbs-xtpl-energy`,
 :srcsample:`cbs-xtpl-gradient`, :srcsample:`cbs-xtpl-opt`,
 :srcsample:`cbs-xtpl-freq`, :srcsample:`cbs-xtpl-func`,
-:srcsample:`cbs-xtpl-wrapper`.
+:srcsample:`cbs-xtpl-wrapper`, :srcsample:`cbs-xtpl-dict`.
 
 
-.. autofunction:: psi4.cbs(name [, scf_basis, scf_scheme, corl_wfn, corl_basis, corl_scheme, delta_wfn, delta_wfn_lesser, delta_basis, delta_scheme, delta2_wfn, delta2_wfn_lesser, delta2_basis, delta2_scheme, delta3_wfn, delta3_wfn_lesser, delta3_basis, delta3_scheme, delta4_wfn, delta4_wfn_lesser, delta4_basis, delta4_scheme, delta5_wfn, delta5_wfn_lesser, delta5_basis, delta5_scheme])
+.. autofunction:: psi4.cbs(name [, scf_basis, scf_scheme, corl_wfn, corl_basis, corl_scheme, delta_wfn, delta_wfn_lesser, delta_basis, delta_scheme, delta2_wfn, delta2_wfn_lesser, delta2_basis, delta2_scheme, cbs_metadata])
 
-.. note:: Presently (May 2016), only two of the five delta possibilities are active. Also, temporarily extrapolations are performed on differences of target and scf total energies, rather than on correlation energies directly. This doesn't affect the extrapolated values of the particular formulas defined here (though it does affect the betas, which are commented out), but it is sloppy and temporary and could affect any user-defined corl extrapolations.
+.. note:: As of October 2018, only two explicit ```deltaN_[wfn,basis,scheme]``` sets of options are active; if more delta functions are required, use the ```cbs_metadata``` interface. Also, temporarily extrapolations are performed on differences of target and scf total energies, rather than on correlation energies directly. This doesn't affect the extrapolated values of the particular formulas defined here (though it does affect the betas, which are commented out), but it is sloppy and temporary and could affect any user-defined corl extrapolations.
 
 .. index::
    pair: cbs(); output

--- a/doc/sphinxman/source/cbs.rst
+++ b/doc/sphinxman/source/cbs.rst
@@ -167,9 +167,15 @@ Extrapolation Schemes
 
 .. autofunction:: psi4.driver.driver_cbs.scf_xtpl_helgaker_2
 
+.. autofunction:: psi4.driver.driver_cbs.scf_xtpl_truhlar_2
+
+.. autofunction:: psi4.driver.driver_cbs.scf_xtpl_karton_2
+
 .. autofunction:: psi4.driver.driver_cbs.scf_xtpl_helgaker_3
 
 .. autofunction:: psi4.driver.driver_cbs.corl_xtpl_helgaker_2
+
+.. autofunction:: psi4.driver.driver_cbs._get_default_xtpl
 
 Aliases
 ^^^^^^^
@@ -184,4 +190,25 @@ existing examples are below.
 .. autofunction:: psi4.driver.aliases.sherrill_gold_standard
 
 .. autofunction:: psi4.driver.aliases.allen_focal_point
+
+Other helper functions
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: psi4.driver.driver_cbs._expand_bracketed_basis
+
+.. autofunction:: psi4.driver.driver_cbs._contract_bracketed_basis
+
+.. autofunction:: psi4.driver.driver_cbs._process_cbs_kwargs
+
+.. autofunction:: psi4.driver.driver_cbs._expand_scheme_orders
+
+.. autofunction:: psi4.driver.driver_cbs._contract_scheme_orders
+
+.. autofunction:: psi4.driver.driver_cbs._cbs_wrapper_methods
+
+.. autofunction:: psi4.driver.driver_cbs._parse_cbs_gufunc_string
+
+.. autofunction:: psi4.driver.driver_cbs._cbs_gufunc
+
+
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1767,19 +1767,6 @@ def frequency(name, **kwargs):
     """
     kwargs = p4util.kwargs_lower(kwargs)
 
-    # Let hessian() handle this!
-    # # Bounce (someday) if name is function
-    # if hasattr(name, '__call__'):
-    #     raise ValidationError("Frequency: Cannot use custom function")
-    #
-    # lowername = name.lower()
-    #
-    # if "/" in lowername:
-    #     return driver_cbs._cbs_gufunc(frequency, name, ptype='frequency', **kwargs)
-    #
-    # if kwargs.get('bsse_type', None) is not None:
-    #     raise ValdiationError("Frequency: Does not currently support 'bsse_type' arguements")
-
     return_wfn = kwargs.pop('return_wfn', False)
 
     # are we in sow/reap mode?

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1280,14 +1280,17 @@ def hessian(name, **kwargs):
     else:
         gradient_type = 'conventional'
 
-    if gradient_type != 'conventional':
-        raise ValidationError("Hessian: Does not yet support more advanced input or custom functions.")
+    #if gradient_type != 'conventional':
+    #    raise ValidationError("Hessian: Does not yet support more advanced input or custom functions.")
 
     lowername = name.lower()
 
     # Check if this is a CBS extrapolation
+    print("hessian()")
+    print(lowername)
+    print(kwargs)
     if "/" in lowername:
-        return driver_cbs._cbs_gufunc('hessian', lowername, **kwargs)
+        return driver_cbs._cbs_gufunc(hessian, lowername, **kwargs, ptype="hessian")
 
     return_wfn = kwargs.pop('return_wfn', False)
     core.clean_variables()
@@ -1746,18 +1749,19 @@ def frequency(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
-
-    # Bounce (someday) if name is function
-    if hasattr(name, '__call__'):
-        raise ValidationError("Frequency: Cannot use custom function")
-
-    lowername = name.lower()
-
-    if "/" in lowername:
-        return driver_cbs._cbs_gufunc(frequency, name, ptype='frequency', **kwargs)
-
-    if kwargs.get('bsse_type', None) is not None:
-        raise ValdiationError("Frequency: Does not currently support 'bsse_type' arguements")
+ 
+    # Let hessian() handle this!
+    # # Bounce (someday) if name is function
+    # if hasattr(name, '__call__'):
+    #     raise ValidationError("Frequency: Cannot use custom function")
+    # 
+    # lowername = name.lower()
+    # 
+    # if "/" in lowername:
+    #     return driver_cbs._cbs_gufunc(frequency, name, ptype='frequency', **kwargs)
+    # 
+    # if kwargs.get('bsse_type', None) is not None:
+    #     raise ValdiationError("Frequency: Does not currently support 'bsse_type' arguements")
 
     return_wfn = kwargs.pop('return_wfn', False)
 
@@ -1771,7 +1775,8 @@ def frequency(name, **kwargs):
     molecule.update_geometry()
 
     # Compute the hessian
-    H, wfn = hessian(lowername, return_wfn=True, molecule=molecule, **kwargs)
+    print(name)
+    H, wfn = hessian(name, return_wfn=True, molecule=molecule, **kwargs)
 
     # S/R: Quit after getting new displacements
     if freq_mode == 'sow':

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -25,7 +25,6 @@
 #
 # @END LICENSE
 #
-
 """Module with a *procedures* dictionary specifying available quantum
 chemical methods and functions driving the main quantum chemical
 functionality, namely single-point energies, geometry optimizations,
@@ -50,7 +49,9 @@ from psi4.driver import p4util
 from psi4.driver import qcdb
 from psi4.driver.procrouting import *
 from psi4.driver.p4util.exceptions import *
+
 # never import wrappers or aliases into this file
+
 
 def _find_derivative_type(ptype, method_name, user_dertype):
     r"""
@@ -105,7 +106,7 @@ def _find_derivative_type(ptype, method_name, user_dertype):
             alternatives = """ Did you mean? %s""" % (' '.join(alt_method_name))
 
         raise ValidationError("""Derivative method 'name' %s and derivative level 'dertype' %s are not available.%s"""
-            % (method_name, str(dertype), alternatives))
+                              % (method_name, str(dertype), alternatives))
 
     return dertype
 
@@ -121,11 +122,9 @@ def _energy_is_invariant(gradient, stationary_criterion=1.e-2):
     mol = core.get_active_molecule()
     efp_present = hasattr(mol, 'EFP')
 
-    translations_projection_sound = (not core.get_option('SCF', 'EXTERN') and
-                                     not core.get_option('SCF', 'PERTURB_H') and
-                                     not efp_present)
-    rotations_projection_sound = (translations_projection_sound and
-                                  stationary_point)
+    translations_projection_sound = (not core.get_option('SCF', 'EXTERN') and not core.get_option('SCF', 'PERTURB_H')
+                                     and not efp_present)
+    rotations_projection_sound = (translations_projection_sound and stationary_point)
 
     return translations_projection_sound, rotations_projection_sound
 
@@ -425,11 +424,11 @@ def energy(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
-    
+
     # Bounce to CP if bsse kwarg
     if kwargs.get('bsse_type', None) is not None:
         return driver_nbody.nbody_gufunc(energy, name, ptype='energy', **kwargs)
-    
+
     # Bounce if name is function
     if hasattr(name, '__call__'):
         return name(energy, kwargs.pop('label', 'custom function'), ptype='energy', **kwargs)
@@ -555,7 +554,9 @@ def gradient(name, **kwargs):
     if gradient_type == 'custom_function':
         if user_dertype is None:
             dertype = 0
-            core.print_out("\nGradient: Custom function passed in without a defined dertype, assuming fd-energy based gradient.\n")
+            core.print_out(
+                "\nGradient: Custom function passed in without a defined dertype, assuming fd-energy based gradient.\n"
+            )
         else:
             core.print_out("\nGradient: Custom function passed in with a dertype of %d\n" % user_dertype)
             dertype = user_dertype
@@ -666,7 +667,8 @@ def gradient(name, **kwargs):
         if opt_mode == 'sow':
             instructionsO = """\n    The optimization sow/reap procedure has been selected through mode='sow'. In addition\n"""
             instructionsO += """    to this output file (which contains no quantum chemical calculations), this job\n"""
-            instructionsO += """    has produced a number of input files (OPT-%s-*.in) for individual components\n""" % (str(opt_iter))
+            instructionsO += """    has produced a number of input files (OPT-%s-*.in) for individual components\n""" % (
+                str(opt_iter))
             instructionsO += """    and a single input file (OPT-master.in) with an optimize(mode='reap') command.\n"""
             instructionsO += """    These files may look very peculiar since they contain processed and pickled python\n"""
             instructionsO += """    rather than normal input. Follow the instructions in OPT-master.in to continue.\n\n"""
@@ -675,7 +677,8 @@ def gradient(name, **kwargs):
             core.print_out(instructionsO)
 
             instructionsM = """\n#    Follow the instructions below to carry out this optimization cycle.\n#\n"""
-            instructionsM += """#    (1)  Run all of the OPT-%s-*.in input files on any variety of computer architecture.\n""" % (str(opt_iter))
+            instructionsM += """#    (1)  Run all of the OPT-%s-*.in input files on any variety of computer architecture.\n""" % (
+                str(opt_iter))
             instructionsM += """#       The output file names must be as given below.\n#\n"""
             for rgt in range(ndisp):
                 pre = 'OPT-' + str(opt_iter) + '-' + str(rgt + 1)
@@ -686,14 +689,16 @@ def gradient(name, **kwargs):
             if opt_iter == 1:
                 instructionsM += """#             psi4 -i %-27s -o %-27s\n#\n""" % ('OPT-master.in', 'OPT-master.out')
             else:
-                instructionsM += """#             psi4 -a -i %-27s -o %-27s\n#\n""" % ('OPT-master.in', 'OPT-master.out')
+                instructionsM += """#             psi4 -a -i %-27s -o %-27s\n#\n""" % ('OPT-master.in',
+                                                                                       'OPT-master.out')
             instructionsM += """#    After each optimization iteration, the OPT-master.in file is overwritten so return here\n"""
             instructionsM += """#    for new instructions. With the use of the psi4 -a flag, OPT-master.out is not\n"""
             instructionsM += """#    overwritten and so maintains a history of the job. To use the (binary) optimizer\n"""
             instructionsM += """#    data file to accelerate convergence, the OPT-master jobs must run on the same computer.\n\n"""
 
             with open('OPT-master.in', 'wb') as fmaster:
-                fmaster.write('# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
+                fmaster.write(
+                    '# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
                 fmaster.write(p4util.format_molecule_for_input(moleculeclone).encode('utf-8'))
                 fmaster.write(p4util.format_options_for_input().encode('utf-8'))
                 p4util.format_kwargs_for_input(fmaster, lmode=2, return_wfn=True, dertype=dertype, **kwargs)
@@ -730,15 +735,19 @@ def gradient(name, **kwargs):
 
                 # S/R: Prepare molecule, options, and kwargs
                 with open('%s.in' % (rfile), 'wb') as freagent:
-                    freagent.write('# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
+                    freagent.write(
+                        '# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
                     freagent.write(p4util.format_molecule_for_input(moleculeclone).encode('utf-8'))
                     freagent.write(p4util.format_options_for_input().encode('utf-8'))
                     p4util.format_kwargs_for_input(freagent, **kwargs)
 
                     # S/R: Prepare function call and energy save
-                    freagent.write(("""electronic_energy = energy('%s', **kwargs)\n\n""" % (lowername)).encode('utf-8'))
-                    freagent.write(("""core.print_out('\\nGRADIENT RESULT: computation %d for item %d """ % (os.getpid(), n + 1)).encode('utf-8'))
-                    freagent.write("""yields electronic energy %20.12f\\n' % (electronic_energy))\n\n""".encode('utf-8'))
+                    freagent.write(
+                        ("""electronic_energy = energy('%s', **kwargs)\n\n""" % (lowername)).encode('utf-8'))
+                    freagent.write(("""core.print_out('\\nGRADIENT RESULT: computation %d for item %d """ %
+                                    (os.getpid(), n + 1)).encode('utf-8'))
+                    freagent.write(
+                        """yields electronic energy %20.12f\\n' % (electronic_energy))\n\n""".encode('utf-8'))
 
             # S/R: Read energy from each displaced geometry output file and save in energies array
             elif opt_mode == 'reap':
@@ -764,13 +773,11 @@ def gradient(name, **kwargs):
         grad_psi_matrix.print_out()
         wfn.set_gradient(grad_psi_matrix)
 
-
     optstash.restore()
 
     if core.get_option('FINDIF', 'GRADIENT_WRITE'):
         filename = core.get_writer_file_prefix(wfn.molecule().name()) + ".grad"
-        qcdb.gradparse.to_string(np.asarray(wfn.gradient()), filename, dtype='GRD',
-                                     mol=molecule, energy=wfn.energy())
+        qcdb.gradparse.to_string(np.asarray(wfn.gradient()), filename, dtype='GRD', mol=molecule, energy=wfn.energy())
 
     if return_wfn:
         return (wfn.gradient(), wfn)
@@ -1044,9 +1051,9 @@ def optimize(name, **kwargs):
     return_history = kwargs.pop('return_history', False)
     if return_history:
         # Add wfn once the deep copy issues are worked out
-        step_energies      = []
-        step_gradients     = []
-        step_coordinates   = []
+        step_energies = []
+        step_gradients = []
+        step_coordinates = []
 
     # For CBS wrapper, need to set retention on INTCO file
     if custom_gradient or ('/' in lowername):
@@ -1096,8 +1103,7 @@ def optimize(name, **kwargs):
             raise ValidationError("""Point group changed! (%s <-- %s) You should restart """
                                   """using the last geometry in the output, after """
                                   """carefully making sure all symmetry-dependent """
-                                  """input, such as DOCC, is correct.""" %
-                                  (current_sym, initial_sym))
+                                  """input, such as DOCC, is correct.""" % (current_sym, initial_sym))
         kwargs['opt_iter'] = n
 
         # Use orbitals from previous iteration as a guess
@@ -1188,7 +1194,8 @@ def optimize(name, **kwargs):
             # S/R: Clean up opt input file
             if opt_mode == 'reap':
                 with open('OPT-master.in', 'wb') as fmaster:
-                    fmaster.write('# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
+                    fmaster.write(
+                        '# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
                     fmaster.write('# Optimization complete!\n\n'.encode('utf-8'))
 
             # Cleanup binary file 1
@@ -1198,10 +1205,11 @@ def optimize(name, **kwargs):
             optstash.restore()
 
             if return_history:
-                history = { 'energy'        : step_energies ,
-                            'gradient'      : step_gradients ,
-                            'coordinates'   : step_coordinates,
-                          }
+                history = {
+                    'energy': step_energies,
+                    'gradient': step_gradients,
+                    'coordinates': step_coordinates,
+                }
 
             if return_wfn and return_history:
                 return (thisenergy, wfn, history)
@@ -1301,7 +1309,7 @@ def hessian(name, **kwargs):
     optstash = p4util.OptionsState(
         ['FINDIF', 'HESSIAN_WRITE'],
         ['FINDIF', 'FD_PROJECT'],
-        )
+    )
 
     # Allow specification of methods to arbitrary order
     lowername, level = driver_util.parse_arbitrary_order(lowername)
@@ -1339,7 +1347,8 @@ def hessian(name, **kwargs):
         irrep = driver_util.parse_cotton_irreps(irrep, molecule.schoenflies_symbol())
         irrep -= 1  # A1 irrep is externally 1, internally 0
         if dertype == 2:
-            core.print_out("""hessian() switching to finite difference by gradients for partial Hessian calculation.\n""")
+            core.print_out(
+                """hessian() switching to finite difference by gradients for partial Hessian calculation.\n""")
             dertype = 1
 
     # At stationary point?
@@ -1349,9 +1358,10 @@ def hessian(name, **kwargs):
     else:
         G0 = gradient(lowername, molecule=molecule, **kwargs)
     translations_projection_sound, rotations_projection_sound = _energy_is_invariant(G0)
-    core.print_out('\n  Based on options and gradient (rms={:.2E}), recommend {}projecting translations and {}projecting rotations.\n'.
-                   format(G0.rms(), '' if translations_projection_sound else 'not ',
-                   '' if rotations_projection_sound else 'not '))
+    core.print_out(
+        '\n  Based on options and gradient (rms={:.2E}), recommend {}projecting translations and {}projecting rotations.\n'
+        .format(G0.rms(), '' if translations_projection_sound else 'not ',
+                '' if rotations_projection_sound else 'not '))
     if not core.has_option_changed('FINDIF', 'FD_PROJECT'):
         core.set_local_option('FINDIF', 'FD_PROJECT', rotations_projection_sound)
 
@@ -1375,7 +1385,8 @@ def hessian(name, **kwargs):
             return wfn.hessian()
 
     elif dertype == 1:
-        core.print_out("""hessian() will perform frequency computation by finite difference of analytic gradients.\n""")
+        core.print_out(
+            """hessian() will perform frequency computation by finite difference of analytic gradients.\n""")
 
         # Shifting the geometry so need to copy the active molecule
         moleculeclone = molecule.clone()
@@ -1419,11 +1430,13 @@ def hessian(name, **kwargs):
             instructionsM += """#             psi4 -i %-27s -o %-27s\n#\n\n""" % ('FREQ-master.in', 'FREQ-master.out')
 
             with open('FREQ-master.in', 'wb') as fmaster:
-                fmaster.write('# This is a psi4 input file auto-generated from the hessian() wrapper.\n\n'.encode('utf-8'))
+                fmaster.write(
+                    '# This is a psi4 input file auto-generated from the hessian() wrapper.\n\n'.encode('utf-8'))
                 fmaster.write(p4util.format_molecule_for_input(moleculeclone).encode('utf-8'))
                 fmaster.write(p4util.format_options_for_input(moleculeclone, **kwargs))
                 p4util.format_kwargs_for_input(fmaster, lmode=2, return_wfn=True, freq_dertype=1, **kwargs)
-                fmaster.write(("""retE, retwfn = %s('%s', **kwargs)\n\n""" % (frequency.__name__, lowername)).encode('utf-8'))
+                fmaster.write(
+                    ("""retE, retwfn = %s('%s', **kwargs)\n\n""" % (frequency.__name__, lowername)).encode('utf-8'))
                 fmaster.write(instructionsM.encode('utf-8'))
             core.print_out(instructionsM)
 
@@ -1468,16 +1481,19 @@ def hessian(name, **kwargs):
                     kwargs['return_wfn'] = True
                     p4util.format_kwargs_for_input(freagent, **kwargs)
                     freagent.write("""G, wfn = %s('%s', **kwargs)\n\n""" % (gradient.__name__, lowername))
-                    freagent.write("""core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
+                    freagent.write(
+                        """core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
                     freagent.write("""yields electronic gradient %r\\n' % (p4util.mat2arr(wfn.gradient())))\n\n""")
-                    freagent.write("""core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
+                    freagent.write(
+                        """core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
                     freagent.write("""yields electronic energy %20.12f\\n' % (get_variable('CURRENT ENERGY')))\n\n""")
 
             # S/R: Read energy from each displaced geometry output file and save in energies array
             elif freq_mode == 'reap':
                 exec(banners)
                 core.set_variable('NUCLEAR REPULSION ENERGY', moleculeclone.nuclear_repulsion_energy())
-                pygrad = p4util.extract_sowreap_from_output(rfile, 'HESSIAN', n, freq_linkage, True, label='electronic gradient')
+                pygrad = p4util.extract_sowreap_from_output(
+                    rfile, 'HESSIAN', n, freq_linkage, True, label='electronic gradient')
                 p4mat = core.Matrix.from_list(pygrad)
                 p4mat.print_out()
                 gradients.append(p4mat)
@@ -1565,11 +1581,13 @@ def hessian(name, **kwargs):
             instructionsM += """#             psi4 -i %-27s -o %-27s\n#\n\n""" % ('FREQ-master.in', 'FREQ-master.out')
 
             with open('FREQ-master.in', 'wb') as fmaster:
-                fmaster.write('# This is a psi4 input file auto-generated from the hessian() wrapper.\n\n'.encode('utf-8'))
+                fmaster.write(
+                    '# This is a psi4 input file auto-generated from the hessian() wrapper.\n\n'.encode('utf-8'))
                 fmaster.write(p4util.format_molecule_for_input(moleculeclone).encode('utf-8'))
                 fmaster.write(p4util.format_options_for_input(moleculeclone, **kwargs))
                 p4util.format_kwargs_for_input(fmaster, lmode=2, return_wfn=True, freq_dertype=0, **kwargs)
-                fmaster.write(("""retE, retwfn = %s('%s', **kwargs)\n\n""" % (frequency.__name__, lowername)).encode('utf-8'))
+                fmaster.write(
+                    ("""retE, retwfn = %s('%s', **kwargs)\n\n""" % (frequency.__name__, lowername)).encode('utf-8'))
                 fmaster.write(instructionsM.encode('utf-8'))
             core.print_out(instructionsM)
 
@@ -1611,7 +1629,8 @@ def hessian(name, **kwargs):
                     freagent.write(p4util.format_options_for_input(moleculeclone, **kwargs).encode('utf-8'))
                     p4util.format_kwargs_for_input(freagent, **kwargs)
                     freagent.write("""electronic_energy = %s('%s', **kwargs)\n\n""" % (energy.__name__, lowername))
-                    freagent.write("""core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
+                    freagent.write(
+                        """core.print_out('\\nHESSIAN RESULT: computation %d for item %d """ % (os.getpid(), n + 1))
                     freagent.write("""yields electronic energy %20.12f\\n' % (electronic_energy))\n\n""")
 
             # S/R: Read energy from each displaced geometry output file and save in energies array
@@ -1629,7 +1648,7 @@ def hessian(name, **kwargs):
             else:
                 return None
         elif freq_mode == 'reap':
-        #    core.set_variable('CURRENT ENERGY', energies[-1])
+            #    core.set_variable('CURRENT ENERGY', energies[-1])
             wfn = core.Wavefunction.build(molecule, core.get_global_option('BASIS'))
 
         # Assemble Hessian from energies
@@ -1747,17 +1766,17 @@ def frequency(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
- 
+
     # Let hessian() handle this!
     # # Bounce (someday) if name is function
     # if hasattr(name, '__call__'):
     #     raise ValidationError("Frequency: Cannot use custom function")
-    # 
+    #
     # lowername = name.lower()
-    # 
+    #
     # if "/" in lowername:
     #     return driver_cbs._cbs_gufunc(frequency, name, ptype='frequency', **kwargs)
-    # 
+    #
     # if kwargs.get('bsse_type', None) is not None:
     #     raise ValdiationError("Frequency: Does not currently support 'bsse_type' arguements")
 
@@ -1837,17 +1856,20 @@ def vibanal_wfn(wfn, hess=None, irrep=None, molecule=None, project_trans=True, p
     geom = np.asarray(mol.geometry())
     symbols = [mol.symbol(at) for at in range(mol.natom())]
 
-    vibrec = {'molecule': mol.to_dict(np_out=False),
-              'hessian': nmwhess.tolist()}
+    vibrec = {'molecule': mol.to_dict(np_out=False), 'hessian': nmwhess.tolist()}
 
     if molecule is not None:
         molecule.update_geometry()
         if mol.natom() != molecule.natom():
-            raise ValidationError('Impostor molecule trying to be analyzed! natom {} != {}'.format(mol.natom(), molecule.natom()))
+            raise ValidationError('Impostor molecule trying to be analyzed! natom {} != {}'.format(
+                mol.natom(), molecule.natom()))
         if abs(mol.nuclear_repulsion_energy() - molecule.nuclear_repulsion_energy()) > 1.e-6:
-            raise ValidationError('Impostor molecule trying to be analyzed! NRE {} != {}'.format(mol.nuclear_repulsion_energy(), molecule.nuclear_repulsion_energy()))
+            raise ValidationError('Impostor molecule trying to be analyzed! NRE {} != {}'.format(
+                mol.nuclear_repulsion_energy(), molecule.nuclear_repulsion_energy()))
         if not np.allclose(np.asarray(mol.geometry()), np.asarray(molecule.geometry()), atol=1.e-6):
-            core.print_out('Warning: geometry center/orientation mismatch. Normal modes may not be in expected coordinate system.')
+            core.print_out(
+                'Warning: geometry center/orientation mismatch. Normal modes may not be in expected coordinate system.'
+            )
         #    raise ValidationError('Impostor molecule trying to be analyzed! geometry\n{}\n   !=\n{}'.format(
         #        np.asarray(mol.geometry()), np.asarray(molecule.geometry())))
         mol = molecule
@@ -1855,8 +1877,8 @@ def vibanal_wfn(wfn, hess=None, irrep=None, molecule=None, project_trans=True, p
     m = np.asarray([mol.mass(at) for at in range(mol.natom())])
     irrep_labels = mol.irrep_labels()
 
-    vibinfo, vibtext = qcdb.vib.harmonic_analysis(nmwhess, geom, m, wfn.basisset(), irrep_labels,
-                                                  project_trans=project_trans, project_rot=project_rot)
+    vibinfo, vibtext = qcdb.vib.harmonic_analysis(
+        nmwhess, geom, m, wfn.basisset(), irrep_labels, project_trans=project_trans, project_rot=project_rot)
     vibrec.update({k: qca.to_dict() for k, qca in vibinfo.items()})
 
     core.print_out(vibtext)
@@ -1868,15 +1890,16 @@ def vibanal_wfn(wfn, hess=None, irrep=None, molecule=None, project_trans=True, p
         rsn = mol.rotational_symmetry_number()
 
     if irrep is None:
-        therminfo, thermtext = qcdb.vib.thermo(vibinfo,
-                                      T=core.get_option("THERMO", "T"),  # 298.15 [K]
-                                      P=core.get_option("THERMO", "P"),  # 101325. [Pa]
-                                      multiplicity=mol.multiplicity(),
-                                      molecular_mass=np.sum(m),
-                                      sigma=rsn,
-                                      rotor_type=mol.rotor_type(),
-                                      rot_const=np.asarray(mol.rotational_constants()),
-                                      E0=core.get_variable('CURRENT ENERGY'))  # someday, wfn.energy()
+        therminfo, thermtext = qcdb.vib.thermo(
+            vibinfo,
+            T=core.get_option("THERMO", "T"),  # 298.15 [K]
+            P=core.get_option("THERMO", "P"),  # 101325. [Pa]
+            multiplicity=mol.multiplicity(),
+            molecular_mass=np.sum(m),
+            sigma=rsn,
+            rotor_type=mol.rotor_type(),
+            rot_const=np.asarray(mol.rotational_constants()),
+            E0=core.get_variable('CURRENT ENERGY'))  # someday, wfn.energy()
         vibrec.update({k: qca.to_dict() for k, qca in therminfo.items()})
 
         core.set_variable("ZPVE", therminfo['ZPE_corr'].data)

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1280,17 +1280,15 @@ def hessian(name, **kwargs):
     else:
         gradient_type = 'conventional'
 
-    #if gradient_type != 'conventional':
-    #    raise ValidationError("Hessian: Does not yet support more advanced input or custom functions.")
-
-    lowername = name.lower()
-
     # Check if this is a CBS extrapolation
-    print("hessian()")
-    print(lowername)
-    print(kwargs)
-    if "/" in lowername:
-        return driver_cbs._cbs_gufunc(hessian, lowername, **kwargs, ptype="hessian")
+    if gradient_type == "cbs_gufunc":
+        return driver_cbs._cbs_gufunc(hessian, name.lower(), **kwargs, ptype="hessian")
+    elif gradient_type == "cbs_wrapper":
+        return driver_cbs.cbs(hessian, "cbs", **kwargs, ptype="hessian")
+    elif gradient_type != "conventional":
+        raise ValidationError("Hessian: Does not yet support custom functions.")
+    else:
+        lowername = name.lower()
 
     return_wfn = kwargs.pop('return_wfn', False)
     core.clean_variables()
@@ -1775,7 +1773,6 @@ def frequency(name, **kwargs):
     molecule.update_geometry()
 
     # Compute the hessian
-    print(name)
     H, wfn = hessian(name, return_wfn=True, molecule=molecule, **kwargs)
 
     # S/R: Quit after getting new displacements

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1315,11 +1315,7 @@ def cbs(func, label, **kwargs):
             optionstash = False
         
         # Make energy(), etc. call
-        print("Running func(molecule=molecule, **kwargs)")
-        print(func.__name__)
-        print(kwargs)
         response = func(molecule=molecule, **kwargs)
-        print("Back")
         if ptype == 'energy':
             mc['f_energy'] = response
         elif ptype == 'gradient':
@@ -1676,10 +1672,7 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
         cbs_kwargs['delta_basis'] = basis_list[1]
         if 'delta_scheme' in kwargs:
             cbs_kwargs['delta_scheme'] = kwargs['delta_scheme']
-    print("cbs_gufunc()")
-    print(func)
-    print(label)
-    print(cbs_kwargs)
+    
     ptype_value, wfn = cbs(func, label, **cbs_kwargs)
 
     if return_wfn:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -719,217 +719,175 @@ def corl_xtpl_helgaker_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True,
     else:
         raise ValidationError("corl_xtpl_helgaker_2: datatype is not recognized '%s'." % type(valueLO))
 
-
 def return_energy_components():
-    """A helper function that describes which energy components are available
-    following a given calculation.
-
-    Returns
-    -------
-    dict
-        A dictionary in the format: {'method': {'submethod': 'PSI VARIABLE'}}.
-    """
-
     # yapf: disable
     VARH = {}
-    VARH['scf'] = {'scf': 'SCF TOTAL ENERGY'}
-    VARH['hf'] = {'hf': 'HF TOTAL ENERGY'}
+    VARH['scf'] = {
+                            'scf': 'SCF TOTAL ENERGY'}
+    VARH['hf'] = {
+                             'hf': 'HF TOTAL ENERGY'}
     VARH['mp2'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY'}
     VARH['mp2.5'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY'}
     VARH['mp3'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY'}
     VARH['mp4(sdq)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY',
-        'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY',
+                       'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY'}
     VARH['mp4'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY',
-        'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
-        'mp4': 'MP4(SDTQ) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY',
+                       'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
+                            'mp4': 'MP4(SDTQ) TOTAL ENERGY'}
     VARH['omp2'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'omp2': 'OMP2 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'omp2': 'OMP2 TOTAL ENERGY'}
     VARH['omp2.5'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'omp2.5': 'OMP2.5 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                         'omp2.5': 'OMP2.5 TOTAL ENERGY'}
     VARH['omp3'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY',
-        'omp3': 'OMP3 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY',
+                           'omp3': 'OMP3 TOTAL ENERGY'}
     VARH['olccd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'olccd': 'OLCCD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'olccd': 'OLCCD TOTAL ENERGY'}
     VARH['lccd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'lccd': 'LCCD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'lccd': 'LCCD TOTAL ENERGY'}
     VARH['lccsd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'lccsd': 'LCCSD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'lccsd': 'LCCSD TOTAL ENERGY'}
     VARH['cepa(0)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'cepa(0)': 'CEPA(0) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                        'cepa(0)': 'CEPA(0) TOTAL ENERGY'}
     VARH['cepa(1)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'cepa(1)': 'CEPA(1) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                        'cepa(1)': 'CEPA(1) TOTAL ENERGY'}
     VARH['cepa(3)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'cepa(3)': 'CEPA(3) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                        'cepa(3)': 'CEPA(3) TOTAL ENERGY'}
     VARH['acpf'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'acpf': 'ACPF TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'acpf': 'ACPF TOTAL ENERGY'}
     VARH['aqcc'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'aqcc': 'AQCC TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'aqcc': 'AQCC TOTAL ENERGY'}
     VARH['qcisd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY',
-        'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
-        'qcisd': 'QCISD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY',
+                       'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
+                          'qcisd': 'QCISD TOTAL ENERGY'}
     VARH['cc2'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'cc2': 'CC2 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                            'cc2': 'CC2 TOTAL ENERGY'}
     VARH['ccsd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'ccsd': 'CCSD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'ccsd': 'CCSD TOTAL ENERGY'}
     VARH['bccd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'bccd': 'CCSD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'bccd': 'CCSD TOTAL ENERGY'}
     VARH['cc3'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'cc3': 'CC3 TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                            'cc3': 'CC3 TOTAL ENERGY'}
     VARH['fno-ccsd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'fno-ccsd': 'CCSD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                       'fno-ccsd': 'CCSD TOTAL ENERGY'}
     VARH['fno-ccsd(t)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'ccsd': 'CCSD TOTAL ENERGY',
-        'fno-ccsd(t)': 'CCSD(T) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'ccsd': 'CCSD TOTAL ENERGY',
+                    'fno-ccsd(t)': 'CCSD(T) TOTAL ENERGY'}
     VARH['qcisd(t)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mp2.5': 'MP2.5 TOTAL ENERGY',
-        'mp3': 'MP3 TOTAL ENERGY',
-        'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
-        'qcisd': 'QCISD TOTAL ENERGY',
-        'qcisd(t)': 'QCISD(T) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                          'mp2.5': 'MP2.5 TOTAL ENERGY',
+                            'mp3': 'MP3 TOTAL ENERGY',
+                       'mp4(sdq)': 'MP4(SDQ) TOTAL ENERGY',
+                          'qcisd': 'QCISD TOTAL ENERGY',
+                       'qcisd(t)': 'QCISD(T) TOTAL ENERGY'}
     VARH['ccsd(t)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'ccsd': 'CCSD TOTAL ENERGY',
-        'ccsd(t)': 'CCSD(T) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'ccsd': 'CCSD TOTAL ENERGY',
+                        'ccsd(t)': 'CCSD(T) TOTAL ENERGY'}
     VARH['bccd(t)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'ccsd': 'CCSD TOTAL ENERGY',
-        'bccd(t)': 'CCSD(T) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'ccsd': 'CCSD TOTAL ENERGY',
+                        'bccd(t)': 'CCSD(T) TOTAL ENERGY'}
     VARH['cisd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'cisd': 'CISD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                           'cisd': 'CISD TOTAL ENERGY'}
     VARH['cisdt'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'cisdt': 'CISDT TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                          'cisdt': 'CISDT TOTAL ENERGY'}
     VARH['cisdtq'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'cisdtq': 'CISDTQ TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                         'cisdtq': 'CISDTQ TOTAL ENERGY'}
     VARH['fci'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'fci': 'FCI TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'fci': 'FCI TOTAL ENERGY'}
     VARH['mrccsd'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mrccsd': 'CCSD TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                         'mrccsd': 'CCSD TOTAL ENERGY'}
     VARH['mrccsd(t)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mrccsd': 'CCSD TOTAL ENERGY',
-        'mrccsd(t)': 'CCSD(T) TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                         'mrccsd': 'CCSD TOTAL ENERGY',
+                      'mrccsd(t)': 'CCSD(T) TOTAL ENERGY'}
     VARH['mrccsdt'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mrccsdt': 'CCSDT TOTAL ENERGY'
-    }
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                        'mrccsdt': 'CCSDT TOTAL ENERGY'}
     VARH['mrccsdt(q)'] = {
-        'hf': 'HF TOTAL ENERGY',
-        'mp2': 'MP2 TOTAL ENERGY',
-        'mrccsdt': 'CCSDT TOTAL ENERGY',
-        'mrccsdt(q)': 'CCSDT(Q) TOTAL ENERGY'
-    }
-    # yapf: enable
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                        'mrccsdt': 'CCSDT TOTAL ENERGY',
+                     'mrccsdt(q)': 'CCSDT(Q) TOTAL ENERGY'}
 
     for cilevel in range(2, 99):
-        VARH['ci%s' % (str(cilevel))] = {'hf': 'HF TOTAL ENERGY', 'ci%s' % (str(cilevel)): 'CI TOTAL ENERGY'}
+        VARH['ci%s' % (str(cilevel))] = {
+                             'hf': 'HF TOTAL ENERGY',
+          'ci%s' % (str(cilevel)): 'CI TOTAL ENERGY'}
 
     for mplevel in range(5, 99):
         VARH['mp%s' % (str(mplevel))] = {
-            'hf': 'HF TOTAL ENERGY',
-            'mp%s' % (str(mplevel)): 'MP%s TOTAL ENERGY' % (str(mplevel))
-        }
+                             'hf': 'HF TOTAL ENERGY',
+          'mp%s' % (str(mplevel)): 'MP%s TOTAL ENERGY' % (str(mplevel))}
         for mplevel2 in range(2, mplevel):
             VARH['mp%s' % (str(mplevel))]['mp%s' % (str(mplevel2))] = \
                                       'MP%s TOTAL ENERGY' % (str(mplevel2))
@@ -937,7 +895,7 @@ def return_energy_components():
     # Integrate CFOUR methods
     VARH.update(cfour_psivar_list())
     return VARH
-
+    # yapf: enable
 
 VARH = return_energy_components()
 
@@ -989,7 +947,7 @@ def _validate_cbs_inputs(cbs_metadata, molecule):
     Returns
     -------
     list
-        Validatet list of dictionaries, with each item consisting of an extrapolation
+        Validated list of dictionaries, with each item consisting of an extrapolation
         stage. All validation takes place here.
     """
 
@@ -2013,25 +1971,38 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
         cbs_kwargs['dertype'] = user_dertype
 
     # Find method and basis
+    metadata = []
     if method_list[0] in ['scf', 'hf', 'c4-scf', 'c4-hf']:
-        cbs_kwargs['scf_wfn'] = method_list[0]
-        cbs_kwargs['scf_basis'] = basis_list[0]
+        stage = {}
+        stage['wfn'] = method_list[0]
+        stage['basis'] = basis_list[0]
         if 'scf_scheme' in kwargs:
-            cbs_kwargs['scf_scheme'] = kwargs['scf_scheme']
+            stage['scheme'] = kwargs.pop('scf_scheme')
+        stage['stage'] = "scf"
+        stage['treatment'] = "scf"
     else:
-        cbs_kwargs['corl_wfn'] = method_list[0]
-        cbs_kwargs['corl_basis'] = basis_list[0]
+        # _validate_cbs_inputs will produce scf stage automatically
+        stage['wfn'] = method_list[0]
+        stage['basis'] = basis_list[0]
         if 'corl_scheme' in kwargs:
-            cbs_kwargs['corl_scheme'] = kwargs['corl_scheme']
-
+            stage['scheme'] = kwargs.pop('corl_scheme')
+        stage['stage'] = "corl"
+        stage['treatment'] = "corl"
+    metadata.append(stage)
+    
     # "method/basis" syntax only allows for one delta correction
     # via "method/basis+D:delta/basis". Maximum length of method_list is 2.
     if len(method_list) == 2:
-        cbs_kwargs['delta_wfn'] = method_list[1]
-        cbs_kwargs['delta_basis'] = basis_list[1]
+        stage = {}
+        stage['wfn'] = method_list[1]
+        stage['basis'] = basis_list[1]
         if 'delta_scheme' in kwargs:
-            cbs_kwargs['delta_scheme'] = kwargs['delta_scheme']
-
+            stage['scheme'] = kwargs.pop('delta_scheme')
+        stage['stage'] = "delta1"
+        stage['treatment'] = "corl"
+        metadata.append(stage)
+        
+    cbs_kwargs["cbs_metadata"] = metadata
     ptype_value, wfn = cbs(func, label, **cbs_kwargs)
 
     if return_wfn:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -116,6 +116,8 @@ def _expand_bracketed_basis(basisstring, molecule=None):
 
     if molecule is None:
         molecule = """\nH\nH 1 1.00\n"""
+    elif isinstance(molecule, core.Molecule):
+        molecule = qcdb.Molecule(molecule.to_dict())
 
     for basis in BSET:
         try:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -728,18 +728,18 @@ def _process_cbs_kwargs(kwargs):
             metadata.append({})
             if "wfn" in item:
                 metadata[-1]["wfn"] = item.pop("wfn")
-                metadata[-1]["basis"] = _expand_bracketed_basis(item.pop("basis"))
+                metadata[-1]["basis"] = _expand_bracketed_basis(item.pop("basis").lower())
                 metadata[-1]["scheme"] = item.pop("scheme",
-                                                  _get_default_xtpl(len(metadata[-1]["basis"][1]), "hf")) 
+                                                  _get_default_xtpl(len(metadata[-1]["basis"][1]), "scf")) 
             else:
                 metadata[-1]["wfn_hi"] = item.get("wfn_hi")
                 metadata[-1]["wfn_lo"] = item.pop("wfn_lo", metadata[-2].get("wfn", 
                                                             metadata[-2].get("wfn_hi")))
-                metadata[-1]["basis_hi"] = _expand_bracketed_basis(item.get("basis_hi"))
+                metadata[-1]["basis_hi"] = _expand_bracketed_basis(item.get("basis_hi").lower())
                 metadata[-1]["basis_lo"] = _expand_bracketed_basis(item.pop("basis_lo", 
-                                                                   item.pop("basis_hi")))
+                                                                   item.pop("basis_hi")).lower())
                 metadata[-1]["scheme"] = item.pop("scheme",
-                                                  _get_default_xtpl(len(metadata[-1]["basis_hi"][1]), "corl"))
+                                                  _get_default_xtpl(len(metadata[-1]["basis_hi"][1]),"corl"))
             metadata[-1]["alpha"] = item.pop("alpha", None)
             metadata[-1]["options"] = item.pop("options", False)
     else:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -917,7 +917,7 @@ def _get_default_xtpl(nbasis, xtpl_type):
         Extrapolation function to be used.
     """
 
-    if nbasis == 1:
+    if nbasis == 1 and xtpl_type in ["scf", "corl"]:
         return xtpl_highest_1
     elif xtpl_type == "scf":
         if nbasis == 2:
@@ -931,6 +931,8 @@ def _get_default_xtpl(nbasis, xtpl_type):
             return corl_xtpl_helgaker_2
         else:
             raise ValidationError("Wrong number of basis sets supplied to corl_xtpl: %d" % nbasis)
+    else:
+        raise ValidationError("Stage treatment must be 'corl' or 'scf', not '%s'" % xtpl_type)
 
 
 def _validate_cbs_inputs(cbs_metadata, molecule):

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1315,7 +1315,11 @@ def cbs(func, label, **kwargs):
             optionstash = False
         
         # Make energy(), etc. call
+        print("Running func(molecule=molecule, **kwargs)")
+        print(func.__name__)
+        print(kwargs)
         response = func(molecule=molecule, **kwargs)
+        print("Back")
         if ptype == 'energy':
             mc['f_energy'] = response
         elif ptype == 'gradient':
@@ -1348,7 +1352,7 @@ def cbs(func, label, **kwargs):
             core.print_variables()
         core.clean_variables()
         core.clean()
-
+    
         # Copy data from 'run' to 'obtained' table
         for mce in JOBS_EXT:
             if (mc['f_wfn'] == mce['f_wfn']) and (mc['f_basis'] == mce['f_basis']) and \
@@ -1488,6 +1492,7 @@ def cbs(func, label, **kwargs):
             finalquantity.print_out()
     elif ptype == 'hessian':
         finalquantity = finalhessian
+        wfn.set_gradient(finalgradient)
         wfn.set_hessian(finalquantity)
         if finalquantity.rows(0) < 20:
             core.print_out('CURRENT HESSIAN')
@@ -1650,6 +1655,9 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
     cbs_kwargs['return_wfn'] = True
     cbs_kwargs['molecule'] = molecule
     cbs_kwargs['verbose'] = cbs_verbose
+    
+    if user_dertype != None:
+        cbs_kwargs['dertype'] = user_dertype
 
     # Find method and basis
     if method_list[0] in ['scf', 'hf', 'c4-scf', 'c4-hf']:
@@ -1668,7 +1676,10 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
         cbs_kwargs['delta_basis'] = basis_list[1]
         if 'delta_scheme' in kwargs:
             cbs_kwargs['delta_scheme'] = kwargs['delta_scheme']
-
+    print("cbs_gufunc()")
+    print(func)
+    print(label)
+    print(cbs_kwargs)
     ptype_value, wfn = cbs(func, label, **cbs_kwargs)
 
     if return_wfn:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -53,25 +53,25 @@ def _expand_bracketed_basis(basisstring, molecule=None):
     
     Parameters
     ----------
-    basisstring: string
+    basisstring : string
         A string containing the basis sets to be expanded.
         A basis set with no paired square brackets is passed through 
-        with zeta level 0 (e.g., '6-31+G(d,p)' is returned as
-        [6-31+G(d,p)] and [0]). A basis set with square brackets is checked
-        for sensible sequence and Dunning-ness and returned as separate basis
-        sets (e.g., 'cc-pV[Q5]Z' is returned as [cc-pVQZ, cc-pV5Z] and [4, 5]). 
-        Allows out-of-order zeta specification (e.g., [qtd]) and numeral for 
-        number (e.g., [23]). Does not allow skipped zetas (e.g., [dq]), zetas 
+        with zeta level 0 (e.g., ``'6-31+G(d,p)'`` is returned as
+        ``(["6-31+G(d,p)"], [0])``). A basis set with square brackets is checked
+        for sensible sequence and returned as separate basis sets 
+        (e.g., ``'cc-pV[Q5]Z'` is returned as ``(["cc-pVQZ", "cc-pV5Z"], [4, 5])``). 
+        Allows out-of-order zeta specification (e.g., ``[qtd]``) and numeral for 
+        number (e.g., ``[23]``). Does not allow skipped zetas (e.g., ``[dq]``), zetas 
         outside the [2,8] range, non-Dunning, non-Ahlrichs, or non-Jensen sets,
         or non-findable .gbs sets.
-    molecule: qcdb.molecule or psi4.core.Molecule
+    molecule : qcdb.molecule or psi4.core.Molecule
         This function checks that the basis is valid by trying to build
         the qcdb.BasisSet object for *molecule* or for H2 if None. 
     
     Returns
     -------
     tuple
-        Tuple in the ([basis set names], [basis set zetas]) format.
+        Tuple in the ``([basis set names], [basis set zetas])`` format.
     """
     
     BSET = []
@@ -132,12 +132,12 @@ def _contract_bracketed_basis(basisarray):
     Parameters
     ----------
     basisarray : array 
-        E.g.: [cc-pvqz, cc-pv5z]
+        E.g.: ``["cc-pvqz", "cc-pv5z"]``
     
     Returns
     -------
     string
-        A nicely formatted basis set string, e.g. cc-pv[q5]z for the above example.
+        A nicely formatted basis set string, e.g. ``"cc-pv[q5]z"`` for the above example.
 
     """
     
@@ -170,7 +170,7 @@ def xtpl_highest_1(functionname, zHI, valueHI, verbose=True, **kwargs):
     Returns
     -------
     float
-        Returns E_{total}^{\infty} which is equal to valueHI.
+        Returns :math:`E_{total}^{\infty}` which is equal to valueHI.
         
     Notes
     -----
@@ -220,12 +220,12 @@ def scf_xtpl_helgaker_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True, 
     Returns
     -------
     float
-        Returns E_{total}^{\infty}, see below.
+        Returns :math:`E_{total}^{\infty}`, see below.
         
     Notes
     -----
     The extrapolation is calculated according to [1]_:
-    .. math:: E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha X}, \alpha = 1.63
+    :math:`E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha X}, \alpha = 1.63`
     
     References
     ----------
@@ -320,12 +320,12 @@ def scf_xtpl_truhlar_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True, a
     Returns
     -------
     float
-        Returns E_{total}^{\infty}, see below.
+        Returns :math:`E_{total}^{\infty}`, see below.
         
     Notes
     -----
     The extrapolation is calculated according to [2]_:
-    .. math:: E_{total}^X = E_{total}^{\infty} + \beta X^{-\alpha}, \alpha = 3.4
+    :math:`E_{total}^X = E_{total}^{\infty} + \beta X^{-\alpha}, \alpha = 3.4`
     
     References
     ----------
@@ -404,7 +404,7 @@ def scf_xtpl_karton_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True, al
     
     Parameters
     ----------
-    functionname : string
+    functionname : str
         Name of the CBS component.
     zLO : int
         Lower zeta level.
@@ -424,8 +424,8 @@ def scf_xtpl_karton_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True, al
         
     Notes
     -----
-    The extrapolation is calculated according to [3]_:
-    .. math:: E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha\sqrt{X}}, \alpha = 6.3
+    The extrapolation is calculated according to [3]_: 
+    :math:`E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha\sqrt{X}}, \alpha = 6.3`
     
     References
     ----------
@@ -502,10 +502,9 @@ def scf_xtpl_helgaker_3(functionname, zLO, valueLO, zMD, valueMD, zHI, valueHI, 
     r"""Extrapolation scheme for reference energies with three adjacent zeta-level bases.
     Used by :py:func:`~psi4.cbs`.
     
-
     Parameters
     ----------
-    functionname : string
+    functionname : str
         Name of the CBS component.
     zLO : int
         Lower zeta level.
@@ -525,12 +524,12 @@ def scf_xtpl_helgaker_3(functionname, zLO, valueLO, zMD, valueMD, zHI, valueHI, 
     Returns
     -------
     float
-        Returns E_{total}^{\infty}, see below.
+        Returns :math:`E_{total}^{\infty}`, see below.
         
     Notes
     -----
     The extrapolation is calculated according to [4]_:
-    .. math:: E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha X}, \alpha = 3.0
+    :math:`E_{total}^X = E_{total}^{\infty} + \beta e^{-\alpha X}, \alpha = 3.0`
     
     References
     ----------
@@ -604,7 +603,7 @@ def corl_xtpl_helgaker_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True,
 
     Parameters
     ----------
-    functionname : string
+    functionname : str
         Name of the CBS component.
     zLO : int
         Lower zeta level.
@@ -625,7 +624,7 @@ def corl_xtpl_helgaker_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True,
     Notes
     -----
     The extrapolation is calculated according to [5]_:
-    .. math:: E_{corl}^X = E_{corl}^{\infty} + \beta X^{-alpha}
+    :math:`E_{corl}^X = E_{corl}^{\infty} + \beta X^{-alpha}`
     
     References
     ----------
@@ -901,7 +900,7 @@ def _get_default_xtpl(nbasis, xtpl_type):
     ----------
     nbasis : int
         Number of basis sets
-    xtpl_type : string
+    xtpl_type : str
         Extrapolation type ("scf" or "corl").
     
     Returns
@@ -928,12 +927,12 @@ def _get_default_xtpl(nbasis, xtpl_type):
 
 def _process_cbs_kwargs(kwargs):
     """ A helper function which either translates supplied kwargs into the
-    cbs_metadata format, or validates a provided cbs_metadata array.
+    ``cbs_metadata`` format, or validates a provided cbs_metadata array.
     
     Parameters
     ----------
     kwargs : dict
-        kwargs
+        kwargs containing the CBS function specification.
     
     Returns
     -------
@@ -1131,14 +1130,14 @@ def cbs(func, label, **kwargs):
            * mrccsdt
            * mrccsdt(q)
 
-    :type name: string
+    :type name: str
     :param name: ``'scf'`` || ``'ccsd'`` || etc.
 
         First argument, usually unlabeled. Indicates the computational method
         for the correlation energy, unless only reference step to be performed,
         in which case should be ``'scf'``. Overruled if stage_wfn keywords supplied.
 
-    :type scf_wfn: string
+    :type scf_wfn: str
     :param scf_wfn: |dl| ``'scf'`` |dr| || ``'c4-scf'`` || etc.
 
         Indicates the energy method for which the reference energy is to be
@@ -1146,32 +1145,32 @@ def cbs(func, label, **kwargs):
         can be used to direct lone scf components to run in |PSIfour| or Cfour
         in a mixed-program composite method.
 
-    :type corl_wfn: string
+    :type corl_wfn: str
     :param corl_wfn: ``'mp2'`` || ``'ccsd(t)'`` || etc.
 
         Indicates the energy method for which the correlation energy is to be
         obtained. Can also be specified with ``name`` or as the unlabeled
         first argument to the function.
 
-    :type delta_wfn: string
+    :type delta_wfn: str
     :param delta_wfn: ``'ccsd'`` || ``'ccsd(t)'`` || etc.
 
         Indicates the (superior) energy method for which a delta correction
         to the correlation energy is to be obtained.
 
-    :type delta_wfn_lesser: string
+    :type delta_wfn_lesser: str
     :param delta_wfn_lesser: |dl| ``corl_wfn`` |dr| || ``'mp2'`` || etc.
 
         Indicates the inferior energy method for which a delta correction
         to the correlation energy is to be obtained.
 
-    :type delta2_wfn: string
+    :type delta2_wfn: str
     :param delta2_wfn: ``'ccsd'`` || ``'ccsd(t)'`` || etc.
 
         Indicates the (superior) energy method for which a second delta correction
         to the correlation energy is to be obtained.
 
-    :type delta2_wfn_lesser: string
+    :type delta2_wfn_lesser: str
     :param delta2_wfn_lesser: |dl| ``delta_wfn`` |dr| || ``'ccsd(t)'`` || etc.
 
         Indicates the inferior energy method for which a second delta correction
@@ -1780,8 +1779,8 @@ def _cbs_wrapper_methods(**kwargs):
     Parameters
     ----------
     kwargs : dict
-        kwargs containing cbs specification either in the cbs_metadata format,
-        or in separate keywords.
+        kwargs containing cbs specification either in the ``cbs_metadata``
+        format, or in separate keywords (``scf_wfn``, ``corl_wfn`` etc.).
     
     Returns
     -------
@@ -1803,22 +1802,22 @@ def _cbs_wrapper_methods(**kwargs):
 
 
 def _parse_cbs_gufunc_string(method_name):
-    """ A helper function that parses a "method/basis" input string
+    """ A helper function that parses a ``"method/basis"`` input string
     into separate method and basis components. Also handles delta corrections.
     
     Parameters
     ----------
-    method_name : string
-        A "method/basis" style string defining the calculation.
+    method_name : str
+        A ``"method/basis"`` style string defining the calculation.
     
     Returns
     -------
     tuple
-        Tuple in the (method_list, basis_list) format, where method_list
-        is the list of the component methods and basis_list is the list of
+        Tuple in the ``(method_list, basis_list)`` format, where ``method_list``
+        is the list of the component methods, and ``basis_list`` is the list of
         basis sets forming the extrapolation for each specified method.
-        E.g. "mp2/cc-pv[tq]z+D:ccsd(t)/cc-pvtz" would return:
-        ([mp2, ccsd(t)], [cc-pv[tq]z, cc-pvtz]).
+        E.g. ``"mp2/cc-pv[tq]z+D:ccsd(t)/cc-pvtz"`` would return:
+        ``(["mp2", "ccsd(t)"], ["cc-pv[tq]z", "cc-pvtz"])``.
     """
     
     method_name_list = re.split( """\+(?=\s*[Dd]:)""", method_name)
@@ -1856,17 +1855,16 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
     ----------
     func : function
         Function to be called (energy, gradient, frequency or cbs).
-    total_method_name : string
-        String in a "method/basis" syntax. Simple calls (e.g. "blyp/sto-3g") are
-        bounced out of CBS. More complex calls (e.g. "mp2/cc-pv[tq]z" or 
-        "mp2/cc-pv[tq]z+D:ccsd(t)/cc-pvtz") are expanded by `_parse_cbs_gufunc_string()` 
+    total_method_name : str
+        String in a ``"method/basis"`` syntax. Simple calls (e.g. ``"blyp/sto-3g"``) are
+        bounced out of CBS. More complex calls (e.g. ``"mp2/cc-pv[tq]z"`` or 
+        ``"mp2/cc-pv[tq]z+D:ccsd(t)/cc-pvtz"``) are expanded by `_parse_cbs_gufunc_string()` 
         and pushed through :py:func:`~psi4.cbs`.
     
     Returns
     -------
-    tuple
-        Tuple in the (value, wavefunction) format - wfn is only included if "return_wfn"
-        is specified.
+    tuple or float
+        Float, or if ``return_wfn`` is specified, a tuple of ``(value, wavefunction)``.
     """
 
     # Catch kwarg issues for all methods

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1096,12 +1096,15 @@ def cbs(func, label, **kwargs):
         
         Other supported arguments for the first dictionary are:
         
-        * ```scheme```: scf extrapolation scheme, by default it is worked out from the number of basis sets
-        (1 - 3) supplied as ```basis```.
+        * ```scheme```: scf extrapolation scheme function, by default it is worked out from the number of 
+        basis sets (1 - 3) supplied as ```basis```.
         * ```alpha```: alpha for the above scheme, if the default is to be overriden
         * ```options```: if special options are required for a step, they should be entered as a dict here.
         This is helpful for calculating all electron corrections in otherwise frozen core calculations, or
         relativistic (DKH) Hamiltionian corrections for otherwise 2-component Hamiltonians.
+        * ```treatment```: treat extrapolation stage as ```scf``` or ```corl```, by default only the first
+        stage is ```scf``` and every later one is ```corl```.
+        * ```stage```: tag for the stage used in tables.
         
         The next items in the ```cbs_metadata``` array extrapolate correlation. All of the above parameters
         are available, with only the ```wfn``` and ```basis``` keywords required. Other supported parameters

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -723,25 +723,25 @@ def _get_default_xtpl(nbasis, xtpl_type):
 def _process_cbs_kwargs(kwargs):
     metadata = []
     if "cbs_metadata" in kwargs:
-        cbs_metadata = kwargs.pop("cbs_metadata")
+        cbs_metadata = kwargs.get("cbs_metadata")
         for item in cbs_metadata:
             metadata.append({})
             if "wfn" in item:
-                metadata[-1]["wfn"] = item.pop("wfn")
-                metadata[-1]["basis"] = _expand_bracketed_basis(item.pop("basis").lower())
-                metadata[-1]["scheme"] = item.pop("scheme",
+                metadata[-1]["wfn"] = item.get("wfn")
+                metadata[-1]["basis"] = _expand_bracketed_basis(item.get("basis").lower())
+                metadata[-1]["scheme"] = item.get("scheme",
                                                   _get_default_xtpl(len(metadata[-1]["basis"][1]), "scf")) 
             else:
                 metadata[-1]["wfn_hi"] = item.get("wfn_hi")
-                metadata[-1]["wfn_lo"] = item.pop("wfn_lo", metadata[-2].get("wfn", 
+                metadata[-1]["wfn_lo"] = item.get("wfn_lo", metadata[-2].get("wfn", 
                                                             metadata[-2].get("wfn_hi")))
                 metadata[-1]["basis_hi"] = _expand_bracketed_basis(item.get("basis_hi").lower())
-                metadata[-1]["basis_lo"] = _expand_bracketed_basis(item.pop("basis_lo", 
-                                                                   item.pop("basis_hi")).lower())
-                metadata[-1]["scheme"] = item.pop("scheme",
+                metadata[-1]["basis_lo"] = _expand_bracketed_basis(item.get("basis_lo", 
+                                                                   item.get("basis_hi")).lower())
+                metadata[-1]["scheme"] = item.get("scheme",
                                                   _get_default_xtpl(len(metadata[-1]["basis_hi"][1]),"corl"))
-            metadata[-1]["alpha"] = item.pop("alpha", None)
-            metadata[-1]["options"] = item.pop("options", False)
+            metadata[-1]["alpha"] = item.get("alpha", None)
+            metadata[-1]["options"] = item.get("options", False)
     else:
         scf = {}
         corl = {}
@@ -1581,13 +1581,16 @@ complete_basis_set = cbs
 
 
 def _cbs_wrapper_methods(**kwargs):
-    cbs_method_kwargs = ['scf_wfn', 'corl_wfn', 'delta_wfn']
-    cbs_method_kwargs += ['delta%d_wfn' % x for x in range(2, 6)]
-
     cbs_methods = []
-    for method in cbs_method_kwargs:
-        if method in kwargs:
-            cbs_methods.append(kwargs[method])
+    if "cbs_metadata" in kwargs:
+        for item in kwargs["cbs_metadata"]:
+            cbs_methods.append(item.get("wfn", item.get("wfn_hi")))
+    else:
+        cbs_method_kwargs = ['scf_wfn', 'corl_wfn', 'delta_wfn']
+        cbs_method_kwargs += ['delta%d_wfn' % x for x in range(2, 6)]
+        for method in cbs_method_kwargs:
+            if method in kwargs:
+                cbs_methods.append(kwargs[method])
     return cbs_methods
 
 

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1984,6 +1984,7 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
         stage['treatment'] = "scf"
     else:
         # _validate_cbs_inputs will produce scf stage automatically
+        stage = {}
         stage['wfn'] = method_list[0]
         stage['basis'] = basis_list[0]
         if 'corl_scheme' in kwargs:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,8 @@ set(py3_fail_list pywrap-freq-e-sowreap
 foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp casscf-sp castup1
                   castup2 castup3 cbs-delta-energy cbs-parser cbs-xtpl-alpha cbs-xtpl-energy
                   cbs-xtpl-freq cbs-xtpl-gradient cbs-xtpl-opt cbs-xtpl-func cbs-xtpl-nbody
-                  cbs-xtpl-wrapper cc1 cc10 cc11 cc12 cc13 cc13a cc13b cc13c cc13d cc14 cc15 cc16
-                  cc17 cc18 cc19 cc2 cc21 cc22 cc23 cc24 cc25 cc26 cc27 cc28
+                  cbs-xtpl-wrapper cbs-xtpl-dict cc1 cc10 cc11 cc12 cc13 cc13a cc13b cc13c 
+                  cc13d cc14 cc15 cc16 cc17 cc18 cc19 cc2 cc21 cc22 cc23 cc24 cc25 cc26 cc27 cc28
                   cc29 cc3 cc30 cc31 cc32 cc33 cc34 cc35 cc36 cc37 cc38 cc39
                   cc4 cc40 cc41 cc42 cc43 cc44 cc45 cc46 cc47 cc48 cc49 cc4a
                   cc50 cc51 cc52 cc53 cc54 cc55 cc5a cc6 cc7 cc8 cc8a cc8b cc8c

--- a/tests/cbs-xtpl-dict/CMakeLists.txt
+++ b/tests/cbs-xtpl-dict/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cbs-xtpl-dict "psi;quicktests;cbs")

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -51,6 +51,11 @@ cbs_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                       {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
 compare_values(cbs_ref, cbs_dtz, 6, "MP2/[DT]Z + D:CCSD(T)/DZ Energy Check")  #TEST
 
+cbs_no_scf = energy(cbs, cbs_metadata=[{"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                       {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
+compare_values(cbs_ref, cbs_no_scf, 6, "MP2/[DT]Z + D:CCSD(T)/DZ without explicit SCF stage") #TEST
+
+
 # Options test
 set freeze_core True
 
@@ -60,4 +65,5 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        "options": {"freeze_core": "False"}}])
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
+
 

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -1,7 +1,7 @@
 #! Extrapolated water energies
 import numpy as np
 
-nucenergy_ref =   8.801465529972    #TEST
+nucenergy_ref =   8.8014655646    #TEST
 scf_dz_ref    = -76.0213974638      #TEST
 scf_adtz_ref  = -76.059124724830    #TEST
 mp2_addz_ref  = -76.261216702741    #TEST

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -8,7 +8,7 @@ mp2_addz_ref  = -76.261216702741    #TEST
 mp2_atz_ref   = -76.341088480148    #TEST
 mp2_adtz_ref  = -76.3667778886      #TEST
 cbs_ref       = -76.371589026502    #TEST
-ae_ref        = -76.356547268183    #TEST
+ae_ref        = -76.34300450653124  #TEST
 
 molecule h2o {
     O
@@ -41,19 +41,23 @@ mp2_atz = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "aug-cc-pVTZ"}])
 compare_values(mp2_atz_ref, mp2_atz, 6, "MP2/aTZ Energy Check")  #TEST
 
 mp2_adtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "aug-cc-pvtz"},
-                                       {"wfn_hi": "mp2", "basis_hi": "aug-cc-pv[dt]z"}])
+                                       {"wfn": "mp2", "basis": "aug-cc-pv[dt]z"}])
 compare_values(mp2_adtz_ref, mp2_adtz, 6, "MP2/a[DT]Z Energy Check")  #TEST
 
 # D:CCSD(T) TESTS
 
 cbs_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
-                                      {"wfn_hi": "mp2", "basis_hi": "cc-pv[dt]z"},
-                                      {"wfn_hi": "ccsd(t)", "basis_hi": "cc-pvdz"}])
+                                      {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                      {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
 compare_values(cbs_ref, cbs_dtz, 6, "MP2/[DT]Z + D:CCSD(T)/DZ Energy Check")  #TEST
 
+# Options test
+set freeze_core True
+
 ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
-                                      {"wfn_hi": "mp2", "basis_hi": "cc-pv[dt]z"},
-                                      {"wfn_hi": "mp2", "basis_hi": "cc-pvdz",
-                                       "options": {"freeze_core": "True"}}])
+                                      {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                      {"wfn": "mp2", "basis": "cc-pvdz",
+                                       "options": {"freeze_core": "False"}}])
+                                       
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
 

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -9,6 +9,7 @@ mp2_atz_ref   = -76.341088480148    #TEST
 mp2_adtz_ref  = -76.3667778886      #TEST
 cbs_ref       = -76.371589026502    #TEST
 ae_ref        = -76.34300450653124  #TEST
+b_lo_ref      = -76.3482732705      #TEST
 
 molecule h2o {
     O
@@ -66,4 +67,7 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
 
-
+b_lo  = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "cc-pvtz", "stage": "corr"},
+                                    {"wfn": "mp2", "wfn_lo": "mp2", 
+                                     "basis": "aug-cc-pvdz", "basis_lo": "cc-pvdz", "stage": "diff"}])
+compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #TEST

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -1,0 +1,59 @@
+#! Extrapolated water energies
+import numpy as np
+
+nucenergy_ref =   8.801465529972    #TEST
+scf_dz_ref    = -76.0213974638      #TEST
+scf_adtz_ref  = -76.059124724830    #TEST
+mp2_addz_ref  = -76.261216702741    #TEST
+mp2_atz_ref   = -76.341088480148    #TEST
+mp2_adtz_ref  = -76.3667778886      #TEST
+cbs_ref       = -76.371589026502    #TEST
+ae_ref        = -76.356547268183    #TEST
+
+molecule h2o {
+    O
+    H 1 1.0
+    H 1 1.0 2 104.5
+}
+
+# Use DF to save some time
+set {
+    scf_type      df
+    mp2_type      df
+    cc_type       df
+    e_convergence 7
+    reference     rhf
+}
+
+h2o.update_geometry()
+compare_values(nucenergy_ref, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+
+# SCF TESTS
+scf_dz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pVDZ"}])
+compare_values(scf_dz_ref, scf_dz, 6, "SCF/DZ Energy Check")  #TEST
+
+scf_adtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "aug-cc-pV[2T]Z"}])
+compare_values(scf_adtz_ref, scf_adtz, 6, "SCF/a[DT]Z Energy Check")  #TEST
+
+
+# MP2 TESTS
+mp2_atz = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "aug-cc-pVTZ"}])
+compare_values(mp2_atz_ref, mp2_atz, 6, "MP2/aTZ Energy Check")  #TEST
+
+mp2_adtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "aug-cc-pvtz"},
+                                       {"wfn_hi": "mp2", "basis_hi": "aug-cc-pv[dt]z"}])
+compare_values(mp2_adtz_ref, mp2_adtz, 6, "MP2/a[DT]Z Energy Check")  #TEST
+
+# D:CCSD(T) TESTS
+
+cbs_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                      {"wfn_hi": "mp2", "basis_hi": "cc-pv[dt]z"},
+                                      {"wfn_hi": "ccsd(t)", "basis_hi": "cc-pvdz"}])
+compare_values(cbs_ref, cbs_dtz, 6, "MP2/[DT]Z + D:CCSD(T)/DZ Energy Check")  #TEST
+
+ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                      {"wfn_hi": "mp2", "basis_hi": "cc-pv[dt]z"},
+                                      {"wfn_hi": "mp2", "basis_hi": "cc-pvdz",
+                                       "options": {"freeze_core": "True"}}])
+compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
+

--- a/tests/cbs-xtpl-dict/output.ref
+++ b/tests/cbs-xtpl-dict/output.ref
@@ -1,0 +1,3631 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {cbs_dict} ac4755f 
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 02 October 2018 10:50PM
+
+    Process ID: 25976
+    Host:       dream
+    PSIDATADIR: /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Extrapolated water energies
+import numpy as np
+
+nucenergy_ref =   8.8014655646    #TEST
+scf_dz_ref    = -76.0213974638      #TEST
+scf_adtz_ref  = -76.059124724830    #TEST
+mp2_addz_ref  = -76.261216702741    #TEST
+mp2_atz_ref   = -76.341088480148    #TEST
+mp2_adtz_ref  = -76.3667778886      #TEST
+cbs_ref       = -76.371589026502    #TEST
+ae_ref        = -76.34300450653124  #TEST
+
+molecule h2o {
+    O
+    H 1 1.0
+    H 1 1.0 2 104.5
+}
+
+# Use DF to save some time
+set {
+    scf_type      df
+    mp2_type      df
+    cc_type       df
+    e_convergence 7
+    reference     rhf
+}
+
+h2o.update_geometry()
+compare_values(nucenergy_ref, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+
+# SCF TESTS
+scf_dz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pVDZ"}])
+compare_values(scf_dz_ref, scf_dz, 6, "SCF/DZ Energy Check")  #TEST
+
+scf_adtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "aug-cc-pV[2T]Z"}])
+compare_values(scf_adtz_ref, scf_adtz, 6, "SCF/a[DT]Z Energy Check")  #TEST
+
+
+# MP2 TESTS
+mp2_atz = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "aug-cc-pVTZ"}])
+compare_values(mp2_atz_ref, mp2_atz, 6, "MP2/aTZ Energy Check")  #TEST
+
+mp2_adtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "aug-cc-pvtz"},
+                                       {"wfn": "mp2", "basis": "aug-cc-pv[dt]z"}])
+compare_values(mp2_adtz_ref, mp2_adtz, 6, "MP2/a[DT]Z Energy Check")  #TEST
+
+# D:CCSD(T) TESTS
+
+cbs_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                      {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                      {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
+compare_values(cbs_ref, cbs_dtz, 6, "MP2/[DT]Z + D:CCSD(T)/DZ Energy Check")  #TEST
+
+# Options test
+set freeze_core True
+
+ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                      {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                      {"wfn": "mp2", "basis": "cc-pvdz",
+                                       "options": {"freeze_core": "False"}}])
+                                       
+compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
+
+--------------------------------------------------------------------------
+	Nuclear repulsion energy..........................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+
+    Enlightened listing of computations required.
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: HF / CC-PVDZ   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:05 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557850     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465018
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453045310542336
+    Two-Electron Energy =                  37.6224415018366827
+    Total Energy =                        -76.0213974646501924
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:06 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.021397464650
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvdz                      1     -76.02139746   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvdz                            -76.02139746   xtpl_highest_1
+      total                  CBS                                      -76.02139746   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	SCF/DZ Energy Check...............................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+
+    Enlightened listing of computations required.
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: HF / AUG-CC-PVDZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:06 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   250 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 19
+    Number of basis function: 41
+    Number of Cartesian functions: 43
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   270 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        18      18       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1         7       7       0       0       0       0
+     B2        12      12       0       0       0       0
+   -------------------------------------------------------
+    Total      41      41       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.003 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 52
+    Number of basis function: 150
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.1766171140E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
+   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
+   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
+   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
+   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
+   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
+   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.584239     2A1    -1.335646     1B2    -0.696479  
+       3A1    -0.577438     1B1    -0.506107  
+
+    Virtual:                                                              
+
+       4A1     0.034658     2B2     0.057722     5A1     0.174901  
+       2B1     0.198750     6A1     0.219018     3B2     0.232772  
+       4B2     0.278550     7A1     0.326071     1A2     0.382614  
+       8A1     0.397881     3B1     0.427473     5B2     0.532911  
+       9A1     0.636696     6B2     0.654104     7B2     0.794625  
+      10A1     0.917437     4B1     1.105428    11A1     1.117509  
+       2A2     1.145099    12A1     1.291955     8B2     1.454194  
+       5B1     1.470010    13A1     1.572206     9B2     1.971535  
+       3A2     1.988356     6B1     2.082925    14A1     2.346452  
+      10B2     2.398798    15A1     2.533949    11B2     2.701650  
+      16A1     2.959676     7B1     3.671283    17A1     3.683511  
+       4A2     3.694440    18A1     3.974412    12B2     4.219132  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.03566968441635
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.2744532990845414
+    Two-Electron Energy =                  37.4373180501008278
+    Total Energy =                        -76.0356696844163480
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2197
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7994     Total:     0.7994
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:06 2018
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.90 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: HF / AUG-CC-PVTZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:06 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis function: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        35      35       0       0       0       0
+     A2        12      12       0       0       0       0
+     B1        18      18       0       0       0       0
+     B2        27      27       0       0       0       0
+   -------------------------------------------------------
+    Total      92      92       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-JKFIT
+    Number of shells: 58
+    Number of basis function: 196
+    Number of Cartesian functions: 241
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 4.2172015036E-04.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
+   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
+   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
+   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
+   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
+   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
+   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.574539     2A1    -1.332638     1B2    -0.695024  
+       3A1    -0.576753     1B1    -0.507036  
+
+    Virtual:                                                              
+
+       4A1     0.028857     2B2     0.047504     5A1     0.135675  
+       2B1     0.160604     6A1     0.173592     3B2     0.182889  
+       4B2     0.223508     7A1     0.243195     1A2     0.265014  
+       3B1     0.298614     8A1     0.308977     5B2     0.364390  
+       9A1     0.429252     6B2     0.458076     7B2     0.597483  
+      10A1     0.654324    11A1     0.706924     2A2     0.723448  
+       4B1     0.733308    12A1     0.817266     5B1     0.842069  
+      13A1     0.900258     8B2     0.903876     3A2     0.917595  
+       6B1     0.923740     9B2     0.927192    14A1     0.958248  
+      15A1     1.007272    10B2     1.031146     7B1     1.076378  
+      11B2     1.099813     4A2     1.166222    16A1     1.167626  
+      12B2     1.275446     5A2     1.496498    17A1     1.544368  
+       8B1     1.561529    13B2     1.783358    18A1     1.823747  
+      14B2     1.937333    19A1     2.076507     9B1     2.257870  
+       6A2     2.306761    20A1     2.330896    21A1     2.409897  
+      10B1     2.411769    15B2     2.442435    22A1     2.495911  
+      11B1     2.705590    16B2     2.706415    23A1     2.728639  
+      17B2     2.811108     7A2     2.862490    18B2     3.585310  
+      24A1     3.686446     8A2     3.985704    12B1     4.040917  
+      25A1     4.142823    19B2     4.188612    13B1     4.267485  
+       9A2     4.359029    14B1     4.374579    26A1     4.388443  
+      20B2     4.475531    27A1     4.665372    21B2     4.732011  
+      22B2     5.043219    10A2     5.047932    28A1     5.175757  
+      23B2     5.205684    15B1     5.398353    29A1     5.595097  
+      30A1     6.124197    24B2     6.530717    16B1     6.702525  
+      31A1     6.832480    17B1     7.082729    11A2     7.217367  
+      25B2     7.222436    18B1     7.238114    32A1     7.320931  
+      12A2     7.361765    33A1     7.429305    26B2     7.817219  
+      34A1     7.850720    27B2     8.591961    35A1    14.586348  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05452918814437
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.3400347680288718
+    Two-Electron Energy =                  37.4840400153171203
+    Total Energy =                        -76.0545291881443717
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2255
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7936     Total:     0.7936
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:07 2018
+Module time:
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.44 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> Helgaker 2-point exponential SCF extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.035669684416
+   HI-zeta (3) Energy:               -76.054529188144
+   Alpha (exponent) Value:             1.630000000000
+   Beta (coefficient) Value:           0.610992926794
+
+   @Extrapolated HF/(D,T):          -76.059124724076
+
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / aug-cc-pvdz                  *     -76.03566968   HF TOTAL ENERGY
+                              hf / aug-cc-pvtz                  *     -76.05452919   HF TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / aug-cc-pv[dt]z               1     -76.05912472   scf_xtpl_helgaker_2
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / aug-cc-pv[dt]z                     -76.05912472   scf_xtpl_helgaker_2
+      total                  CBS                                      -76.05912472   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	SCF/a[DT]Z Energy Check...........................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / AUG-CC-PVTZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:07 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis function: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        35      35       0       0       0       0
+     A2        12      12       0       0       0       0
+     B1        18      18       0       0       0       0
+     B2        27      27       0       0       0       0
+   -------------------------------------------------------
+    Total      92      92       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-JKFIT
+    Number of shells: 58
+    Number of basis function: 196
+    Number of Cartesian functions: 241
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 4.2172015036E-04.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
+   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
+   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
+   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
+   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
+   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
+   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
+   @DF-RHF iter   8:   -76.05452918958582   -1.44145e-09   1.06395e-07 DIIS
+   @DF-RHF iter   9:   -76.05452918962280   -3.69766e-11   2.36221e-08 DIIS
+   @DF-RHF iter  10:   -76.05452918962467   -1.87583e-12   3.66594e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.574537     2A1    -1.332637     1B2    -0.695022  
+       3A1    -0.576754     1B1    -0.507035  
+
+    Virtual:                                                              
+
+       4A1     0.028857     2B2     0.047504     5A1     0.135675  
+       2B1     0.160604     6A1     0.173592     3B2     0.182889  
+       4B2     0.223509     7A1     0.243195     1A2     0.265014  
+       3B1     0.298614     8A1     0.308977     5B2     0.364390  
+       9A1     0.429252     6B2     0.458077     7B2     0.597483  
+      10A1     0.654325    11A1     0.706925     2A2     0.723448  
+       4B1     0.733308    12A1     0.817266     5B1     0.842069  
+      13A1     0.900258     8B2     0.903876     3A2     0.917595  
+       6B1     0.923741     9B2     0.927192    14A1     0.958248  
+      15A1     1.007272    10B2     1.031147     7B1     1.076378  
+      11B2     1.099814     4A2     1.166223    16A1     1.167626  
+      12B2     1.275446     5A2     1.496499    17A1     1.544368  
+       8B1     1.561529    13B2     1.783358    18A1     1.823748  
+      14B2     1.937334    19A1     2.076508     9B1     2.257871  
+       6A2     2.306762    20A1     2.330898    21A1     2.409898  
+      10B1     2.411770    15B2     2.442436    22A1     2.495912  
+      11B1     2.705591    16B2     2.706416    23A1     2.728640  
+      17B2     2.811109     7A2     2.862491    18B2     3.585311  
+      24A1     3.686447     8A2     3.985704    12B1     4.040918  
+      25A1     4.142824    19B2     4.188613    13B1     4.267486  
+       9A2     4.359030    14B1     4.374579    26A1     4.388443  
+      20B2     4.475532    27A1     4.665373    21B2     4.732012  
+      22B2     5.043220    10A2     5.047933    28A1     5.175758  
+      23B2     5.205685    15B1     5.398354    29A1     5.595098  
+      30A1     6.124199    24B2     6.530718    16B1     6.702527  
+      31A1     6.832482    17B1     7.082730    11A2     7.217369  
+      25B2     7.222438    18B1     7.238116    32A1     7.320933  
+      12A2     7.361767    33A1     7.429307    26B2     7.817221  
+      34A1     7.850722    27B2     8.591962    35A1    14.586349  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05452918962467
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.3400215788308003
+    Two-Electron Energy =                  37.4840268246387680
+    Total Energy =                        -76.0545291896246738
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2255
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7936     Total:     0.7936
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:07 2018
+Module time:
+	user time   =       0.54 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.07 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:07 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   264 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-RI
+    Number of shells: 56
+    Number of basis function: 198
+    Number of Cartesian functions: 246
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    92, NAUX =   198
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      87      87       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0545291896246738 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0690823043574056 [Eh]
+	 Opposite-Spin Energy      =      -0.2174769846217335 [Eh]
+	 Correlation Energy        =      -0.2865592889791391 [Eh]
+	 Total Energy              =     -76.3410884786038082 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0230274347858019 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2609723815460802 [Eh]
+	 SCS Correlation Energy    =      -0.2839998163318820 [Eh]
+	 SCS Total Energy          =     -76.3385290059565591 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+Module time:
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.22 seconds =       0.04 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.341088478604
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / aug-cc-pvtz                        -76.05452919   HF TOTAL ENERGY
+                             mp2 / aug-cc-pvtz                  *     -76.34108848   MP2 TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                  mp2 / aug-cc-pvtz                  1     -76.34108848   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                  mp2 / aug-cc-pvtz                        -76.34108848   xtpl_highest_1
+      total                  CBS                                      -76.34108848   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	MP2/aTZ Energy Check..............................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / AUG-CC-PVDZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:08 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   250 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 19
+    Number of basis function: 41
+    Number of Cartesian functions: 43
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   270 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        18      18       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1         7       7       0       0       0       0
+     B2        12      12       0       0       0       0
+   -------------------------------------------------------
+    Total      41      41       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.003 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 52
+    Number of basis function: 150
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.1766171140E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
+   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
+   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
+   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
+   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
+   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
+   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
+   @DF-RHF iter   9:   -76.03566968454179   -1.25439e-10   8.11191e-08 DIIS
+   @DF-RHF iter  10:   -76.03566968454702   -5.22959e-12   8.06200e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.584239     2A1    -1.335647     1B2    -0.696479  
+       3A1    -0.577439     1B1    -0.506106  
+
+    Virtual:                                                              
+
+       4A1     0.034658     2B2     0.057722     5A1     0.174901  
+       2B1     0.198751     6A1     0.219018     3B2     0.232772  
+       4B2     0.278549     7A1     0.326071     1A2     0.382613  
+       8A1     0.397881     3B1     0.427473     5B2     0.532911  
+       9A1     0.636696     6B2     0.654104     7B2     0.794625  
+      10A1     0.917437     4B1     1.105427    11A1     1.117509  
+       2A2     1.145099    12A1     1.291954     8B2     1.454194  
+       5B1     1.470010    13A1     1.572206     9B2     1.971534  
+       3A2     1.988356     6B1     2.082925    14A1     2.346452  
+      10B2     2.398798    15A1     2.533949    11B2     2.701650  
+      16A1     2.959675     7B1     3.671282    17A1     3.683511  
+       4A2     3.694439    18A1     3.974411    12B2     4.219132  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.03566968454702
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.2744487679137961
+    Two-Electron Energy =                  37.4373135187993995
+    Total Energy =                        -76.0356696845470168
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2197
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7994     Total:     0.7994
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.85 seconds =       0.05 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:08 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   204 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-RI
+    Number of shells: 40
+    Number of basis function: 118
+    Number of Cartesian functions: 136
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    41, NAUX =   118
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      36      36       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0356696845470168 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0575478414024630 [Eh]
+	 Opposite-Spin Energy      =      -0.1679991764235108 [Eh]
+	 Correlation Energy        =      -0.2255470178259738 [Eh]
+	 Total Energy              =     -76.2612167023729910 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0191826138008210 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2015990117082130 [Eh]
+	 SCS Correlation Energy    =      -0.2207816255090339 [Eh]
+	 SCS Total Energy          =     -76.2564513100560504 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.94 seconds =       0.05 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / AUG-CC-PVTZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:08 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis function: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        35      35       0       0       0       0
+     A2        12      12       0       0       0       0
+     B1        18      18       0       0       0       0
+     B2        27      27       0       0       0       0
+   -------------------------------------------------------
+    Total      92      92       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-JKFIT
+    Number of shells: 58
+    Number of basis function: 196
+    Number of Cartesian functions: 241
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 4.2172015036E-04.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
+   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
+   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
+   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
+   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
+   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
+   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
+   @DF-RHF iter   8:   -76.05452918958582   -1.44145e-09   1.06395e-07 DIIS
+   @DF-RHF iter   9:   -76.05452918962280   -3.69766e-11   2.36221e-08 DIIS
+   @DF-RHF iter  10:   -76.05452918962467   -1.87583e-12   3.66594e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.574537     2A1    -1.332637     1B2    -0.695022  
+       3A1    -0.576754     1B1    -0.507035  
+
+    Virtual:                                                              
+
+       4A1     0.028857     2B2     0.047504     5A1     0.135675  
+       2B1     0.160604     6A1     0.173592     3B2     0.182889  
+       4B2     0.223509     7A1     0.243195     1A2     0.265014  
+       3B1     0.298614     8A1     0.308977     5B2     0.364390  
+       9A1     0.429252     6B2     0.458077     7B2     0.597483  
+      10A1     0.654325    11A1     0.706925     2A2     0.723448  
+       4B1     0.733308    12A1     0.817266     5B1     0.842069  
+      13A1     0.900258     8B2     0.903876     3A2     0.917595  
+       6B1     0.923741     9B2     0.927192    14A1     0.958248  
+      15A1     1.007272    10B2     1.031147     7B1     1.076378  
+      11B2     1.099814     4A2     1.166223    16A1     1.167626  
+      12B2     1.275446     5A2     1.496499    17A1     1.544368  
+       8B1     1.561529    13B2     1.783358    18A1     1.823748  
+      14B2     1.937334    19A1     2.076508     9B1     2.257871  
+       6A2     2.306762    20A1     2.330898    21A1     2.409898  
+      10B1     2.411770    15B2     2.442436    22A1     2.495912  
+      11B1     2.705591    16B2     2.706416    23A1     2.728640  
+      17B2     2.811109     7A2     2.862491    18B2     3.585311  
+      24A1     3.686447     8A2     3.985704    12B1     4.040918  
+      25A1     4.142824    19B2     4.188613    13B1     4.267486  
+       9A2     4.359030    14B1     4.374579    26A1     4.388443  
+      20B2     4.475532    27A1     4.665373    21B2     4.732012  
+      22B2     5.043220    10A2     5.047933    28A1     5.175758  
+      23B2     5.205685    15B1     5.398354    29A1     5.595098  
+      30A1     6.124199    24B2     6.530718    16B1     6.702527  
+      31A1     6.832482    17B1     7.082730    11A2     7.217369  
+      25B2     7.222438    18B1     7.238116    32A1     7.320933  
+      12A2     7.361767    33A1     7.429307    26B2     7.817221  
+      34A1     7.850722    27B2     8.591962    35A1    14.586349  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05452918962467
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.3400215788308003
+    Two-Electron Energy =                  37.4840268246387680
+    Total Energy =                        -76.0545291896246738
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2255
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7936     Total:     0.7936
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:09 2018
+Module time:
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.52 seconds =       0.06 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:09 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   264 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-RI
+    Number of shells: 56
+    Number of basis function: 198
+    Number of Cartesian functions: 246
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    92, NAUX =   198
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      87      87       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0545291896246738 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0690823043574056 [Eh]
+	 Opposite-Spin Energy      =      -0.2174769846217335 [Eh]
+	 Correlation Energy        =      -0.2865592889791391 [Eh]
+	 Total Energy              =     -76.3410884786038082 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0230274347858019 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2609723815460802 [Eh]
+	 SCS Correlation Energy    =      -0.2839998163318820 [Eh]
+	 SCS Total Energy          =     -76.3385290059565591 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:09 2018
+Module time:
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.68 seconds =       0.06 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.054529189625
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
+
+   LO-zeta (2) Energy:               -76.261216702373
+   HI-zeta (3) Energy:               -76.341088478604
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.374718700175
+
+   @Extrapolated MP2/(D,T):          -76.374718700175
+
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.035669684547
+   HI-zeta (3) Energy:               -76.054529189625
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.062470033868
+
+   @Extrapolated HF/(D,T):           -76.062470033868
+
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / aug-cc-pvdz                  *     -76.03566968   HF TOTAL ENERGY
+                             mp2 / aug-cc-pvdz                  *     -76.26121670   MP2 TOTAL ENERGY
+                              hf / aug-cc-pvtz                  *     -76.05452919   HF TOTAL ENERGY
+                             mp2 / aug-cc-pvtz                  *     -76.34108848   MP2 TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / aug-cc-pvtz                  1     -76.05452919   xtpl_highest_1
+       corl                  mp2 / aug-cc-pv[dt]z               1     -76.37471870   corl_xtpl_helgaker_2
+       corl                   hf / aug-cc-pv[dt]z              -1     -76.06247003   corl_xtpl_helgaker_2
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / aug-cc-pvtz                        -76.05452919   xtpl_highest_1
+       corl                  mp2 / aug-cc-pv[dt]z                      -0.31224867   corl_xtpl_helgaker_2
+      total                  CBS                                      -76.36677786   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	MP2/a[DT]Z Energy Check...........................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+           ccsd / cc-pvdz                  for  CCSD TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVTZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:09 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.9026033530E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
+   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
+   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
+   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
+   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
+   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
+   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.562138     2A1    -1.324719     1B2    -0.687037  
+       3A1    -0.569630     1B1    -0.501255  
+
+    Virtual:                                                              
+
+       4A1     0.137557     2B2     0.199842     3B2     0.526492  
+       5A1     0.576831     6A1     0.677461     2B1     0.785997  
+       7A1     0.793875     4B2     0.805787     1A2     0.852292  
+       3B1     0.951778     8A1     1.165822     5B2     1.172443  
+       6B2     1.489228     9A1     1.501210     4B1     2.019244  
+       2A2     2.048947     7B2     2.115800    10A1     2.157398  
+      11A1     2.253311    12A1     2.570131     8B2     2.925729  
+       5B1     3.356690    13A1     3.471321     3A2     3.552110  
+       9B2     3.599876     6B1     3.766354    10B2     3.826770  
+      14A1     3.874687     4A2     3.936042     7B1     4.015354  
+      11B2     4.055492    15A1     4.135577     5A2     4.246989  
+      16A1     4.323614    12B2     4.478353     8B1     4.645991  
+      13B2     4.776742    17A1     5.012617    18A1     5.229074  
+      14B2     5.516784     9B1     5.976687    19A1     6.414996  
+      10B1     6.772506     6A2     6.849685    20A1     6.905158  
+      15B2     6.934087    11B1     7.012922    21A1     7.168713  
+       7A2     7.181120    22A1     7.433881    16B2     7.697134  
+      17B2     8.106356    23A1    12.196039  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05098620392070
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4153442205643501
+    Two-Electron Energy =                  37.5628924520762908
+    Total Energy =                        -76.0509862039207007
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2092
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8099     Total:     0.8099
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+Module time:
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.43 seconds =       0.07 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:10 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-RI
+    Number of shells: 43
+    Number of basis function: 141
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    58, NAUX =   141
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      53      53       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0671893164872170 [Eh]
+	 Opposite-Spin Energy      =      -0.2107317227474363 [Eh]
+	 Correlation Energy        =      -0.2779210392346533 [Eh]
+	 Total Energy              =     -76.3289072431553564 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0223964388290723 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2528780672969235 [Eh]
+	 SCS Correlation Energy    =      -0.2752745061259959 [Eh]
+	 SCS Total Energy          =     -76.3262607100466965 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.55 seconds =       0.08 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: CCSD(T) / CC-PVDZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:10 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223862   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294925   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823113   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972314   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684775   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720758   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108557   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439252   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465032   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465760   -7.27596e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465772   -1.27898e-13   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756146686
+    Two-Electron Energy =                  37.6224401463895788
+    Total Energy =                        -76.0213974646577242
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.93 seconds =       0.08 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for FNOCC...
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:10 2018
+
+
+
+        *******************************************************
+        *                                                     *
+        *                       DF-CCSD                       *
+        *                 Density-fitted CCSD                 *
+        *                                                     *
+        *                   Eugene DePrince                   *
+        *                                                     *
+        *******************************************************
+
+
+  ==> 3-index integrals <==
+
+  ==> DF Tensor (by Rob Parrish) <==
+
+ => Primary Basis Set <= 
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+ => Auxiliary Basis Set <= 
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+    Number of auxiliary functions:          84
+
+  ==> Memory <==
+
+        Total memory available:             500.00 mb
+
+        CCSD memory requirements:             1.14 mb
+            3-index integrals:                0.40 mb
+            CCSD intermediates:               0.74 mb
+
+        (T) part (regular algorithm):         0.31 mb
+
+  ==> Input parameters <==
+
+        Freeze core orbitals?                  no
+        Use frozen natural orbitals?           no
+        r_convergence:                  1.000e-07
+        e_convergence:                  1.000e-07
+        Number of DIIS vectors:                 8
+        Number of frozen core orbitals:         0
+        Number of active occupied orbitals:     5
+        Number of active virtual orbitals:     19
+        Number of frozen virtual orbitals:      0
+
+
+  Begin singles and doubles coupled cluster iterations
+
+   Iter  DIIS          Energy       d(Energy)          |d(T)|     time
+      0   0 1   -0.2069166881   -0.2069166881    0.1987680224        0
+      1   1 1   -0.2115086020   -0.0045919139    0.0285450513        0
+      2   2 1   -0.2150893167   -0.0035807147    0.0104812617        0
+      3   3 1   -0.2164079298   -0.0013186131    0.0041114403        0
+      4   4 1   -0.2164214813   -0.0000135515    0.0006921551        0
+      5   5 1   -0.2164352956   -0.0000138142    0.0002259101        0
+      6   6 1   -0.2164322775    0.0000030180    0.0000766918        0
+      7   7 1   -0.2164319614    0.0000003161    0.0000190236        0
+      8   8 1   -0.2164317633    0.0000001981    0.0000033759        0
+      9   8 2   -0.2164317097    0.0000000536    0.0000008461        0
+     10   8 3   -0.2164317283   -0.0000000185    0.0000001639        0
+     11   8 4   -0.2164317252    0.0000000031    0.0000000356        0
+
+  CCSD iterations converged!
+
+        T1 diagnostic:                        0.005907931879
+        D1 diagnostic:                        0.012980613017
+
+        OS MP2 correlation energy:           -0.154889086934
+        SS MP2 correlation energy:           -0.052027601148
+        MP2 correlation energy:              -0.206916688082
+      * MP2 total energy:                   -76.228314152740
+
+        OS CCSD correlation energy:          -0.170520745005
+        SS CCSD correlation energy:          -0.045910980201
+        CCSD correlation energy:             -0.216431725206
+      * CCSD total energy:                  -76.237829189864
+
+  Total time for CCSD iterations:       0.03 s (user)
+                                        0.03 s (system)
+                                           0 s (total)
+
+  Time per iteration:                   0.00 s (user)
+                                        0.00 s (system)
+                                        0.00 s (total)
+
+*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.14 seconds =       0.09 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:11 2018
+
+
+        *******************************************************
+        *                                                     *
+        *                      CCSD(T)                        *
+        *                                                     *
+        *******************************************************
+
+        num_threads:                      1
+        available memory:         500.00 mb
+        memory requirements:        0.31 mb
+
+        Number of ijk combinations: 35
+
+        Computing (T) correction...
+
+        % complete  total time
+              11.4         0 s
+              20.0         0 s
+              31.4         0 s
+              40.0         0 s
+              51.4         0 s
+              60.0         0 s
+              71.4         0 s
+              80.0         0 s
+              91.4         0 s
+
+        (T) energy                            -0.003270177621
+
+        CCSD(T) correlation energy            -0.219701902827
+      * CCSD(T) total energy                 -76.241099367485
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.15 seconds =       0.09 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.15 seconds =       0.09 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.050986203921
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
+
+   LO-zeta (2) Energy:               -76.228314152740
+   HI-zeta (3) Energy:               -76.328907243155
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.371262228593
+
+   @Extrapolated MP2/(D,T):          -76.371262228593
+
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.021397464658
+   HI-zeta (3) Energy:               -76.050986203921
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.063444620452
+
+   @Extrapolated HF/(D,T):           -76.063444620452
+
+
+   ==> CCSD(T) <==
+
+   HI-zeta (0) Energy:               -76.241099367485
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.228314152740
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvtz                      *     -76.05098620   HF TOTAL ENERGY
+                             mp2 / cc-pvtz                      *     -76.32890724   MP2 TOTAL ENERGY
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22831415   MP2 TOTAL ENERGY
+                            ccsd / cc-pvdz                            -76.23782919   CCSD TOTAL ENERGY
+                         ccsd(t) / cc-pvdz                      *     -76.24109937   CCSD(T) TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                      1     -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                   1     -76.37126223   corl_xtpl_helgaker_2
+       corl                   hf / cc-pv[dt]z                  -1     -76.06344462   corl_xtpl_helgaker_2
+     delta1              ccsd(t) / cc-pvdz                      1     -76.24109937   xtpl_highest_1
+     delta1                  mp2 / cc-pvdz                     -1     -76.22831415   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                            -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                          -0.30781761   corl_xtpl_helgaker_2
+     delta1        ccsd(t) - mp2 / cc-pvdz                             -0.01278521   xtpl_highest_1
+      total                  CBS                                      -76.37158903   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	MP2/[DT]Z + D:CCSD(T)/DZ Energy Check.............................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz + options        for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVDZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:11 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465751
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756143702
+    Two-Electron Energy =                  37.6224401463894793
+    Total Energy =                        -76.0213974646575110
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+Module time:
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.82 seconds =       0.10 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:11 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
+	 Correlation Energy        =      -0.2046601442173612 [Eh]
+	 Total Energy              =     -76.2260576088748678 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
+	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
+	 SCS Total Energy          =     -76.2225726876842913 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.90 seconds =       0.10 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVTZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:11 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.9026033530E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
+   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
+   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
+   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
+   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
+   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
+   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.562138     2A1    -1.324719     1B2    -0.687037  
+       3A1    -0.569630     1B1    -0.501255  
+
+    Virtual:                                                              
+
+       4A1     0.137557     2B2     0.199842     3B2     0.526492  
+       5A1     0.576831     6A1     0.677461     2B1     0.785997  
+       7A1     0.793875     4B2     0.805787     1A2     0.852292  
+       3B1     0.951778     8A1     1.165822     5B2     1.172443  
+       6B2     1.489228     9A1     1.501210     4B1     2.019244  
+       2A2     2.048947     7B2     2.115800    10A1     2.157398  
+      11A1     2.253311    12A1     2.570131     8B2     2.925729  
+       5B1     3.356690    13A1     3.471321     3A2     3.552110  
+       9B2     3.599876     6B1     3.766354    10B2     3.826770  
+      14A1     3.874687     4A2     3.936042     7B1     4.015354  
+      11B2     4.055492    15A1     4.135577     5A2     4.246989  
+      16A1     4.323614    12B2     4.478353     8B1     4.645991  
+      13B2     4.776742    17A1     5.012617    18A1     5.229074  
+      14B2     5.516784     9B1     5.976687    19A1     6.414996  
+      10B1     6.772506     6A2     6.849685    20A1     6.905158  
+      15B2     6.934087    11B1     7.012922    21A1     7.168713  
+       7A2     7.181120    22A1     7.433881    16B2     7.697134  
+      17B2     8.106356    23A1    12.196039  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05098620392070
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4153442205643501
+    Two-Electron Energy =                  37.5628924520762908
+    Total Energy =                        -76.0509862039207007
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2092
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8099     Total:     0.8099
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+Module time:
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.37 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:12 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-RI
+    Number of shells: 43
+    Number of basis function: 141
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    58, NAUX =   141
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      53      53       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
+	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
+	 Correlation Energy        =      -0.2645464656227105 [Eh]
+	 Total Energy              =     -76.3155326695434155 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
+	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
+	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.49 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / CC-PVDZ + opts. //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:12 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465751
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756143702
+    Two-Electron Energy =                  37.6224401463894793
+    Total Energy =                        -76.0213974646575110
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.88 seconds =       0.11 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on dream
+*** at Tue Oct  2 22:50:12 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0520276011385693 [Eh]
+	 Opposite-Spin Energy      =      -0.1548890869185279 [Eh]
+	 Correlation Energy        =      -0.2069166880570971 [Eh]
+	 Total Energy              =     -76.2283141527146029 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0173425337128564 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1858669043022334 [Eh]
+	 SCS Correlation Energy    =      -0.2032094380150899 [Eh]
+	 SCS Total Energy          =     -76.2246069026726047 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.97 seconds =       0.12 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.050986203921
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
+
+   LO-zeta (2) Energy:               -76.226057608875
+   HI-zeta (3) Energy:               -76.315532669543
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.353206379299
+
+   @Extrapolated MP2/(D,T):          -76.353206379299
+
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.021397464658
+   HI-zeta (3) Energy:               -76.050986203921
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.063444620453
+
+   @Extrapolated HF/(D,T):           -76.063444620453
+
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.228314152715
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.226057608875
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22605761   MP2 TOTAL ENERGY
+                              hf / cc-pvtz                      *     -76.05098620   HF TOTAL ENERGY
+                             mp2 / cc-pvtz                      *     -76.31553267   MP2 TOTAL ENERGY
+                              hf / cc-pvdz + options            *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz + options            *     -76.22831415   MP2 TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                      1     -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                   1     -76.35320638   corl_xtpl_helgaker_2
+       corl                   hf / cc-pv[dt]z                  -1     -76.06344462   corl_xtpl_helgaker_2
+     delta1                  mp2 / cc-pvdz                      1     -76.22831415   xtpl_highest_1
+     delta1                  mp2 / cc-pvdz                     -1     -76.22605761   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                            -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                          -0.28976176   corl_xtpl_helgaker_2
+     delta1            mp2 - mp2 / cc-pvdz                             -0.00225654   xtpl_highest_1
+      total                  CBS                                      -76.34300451   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check..........................PASSED
+
+    Psi4 stopped on: Tuesday, 02 October 2018 10:50PM
+    Psi4 wall time for execution: 0:00:07.37
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cbs-xtpl-dict/output.ref
+++ b/tests/cbs-xtpl-dict/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {cbs_dict} ac4755f 
+                         Git: Rev {cbs_dict} d8e92a8 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -22,9 +22,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 02 October 2018 10:50PM
+    Psi4 started on: Friday, 05 October 2018 11:19PM
 
-    Process ID: 25976
+    Process ID: 3703
     Host:       dream
     PSIDATADIR: /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4
     Memory:     500.0 MiB
@@ -86,6 +86,11 @@ cbs_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                       {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
 compare_values(cbs_ref, cbs_dtz, 6, "MP2/[DT]Z + D:CCSD(T)/DZ Energy Check")  #TEST
 
+cbs_no_scf = energy(cbs, cbs_metadata=[{"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                       {"wfn": "ccsd(t)", "basis": "cc-pvdz"}])
+compare_values(cbs_ref, cbs_no_scf, 6, "MP2/[DT]Z + D:CCSD(T)/DZ without explicit SCF stage") #TEST
+
+
 # Options test
 set freeze_core True
 
@@ -95,6 +100,7 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        "options": {"freeze_core": "False"}}])
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
+
 
 --------------------------------------------------------------------------
 	Nuclear repulsion energy..........................................PASSED
@@ -118,7 +124,7 @@ compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:05 2018
+*** at Fri Oct  5 23:19:33 2018
 
    => Loading Basis Set <=
 
@@ -304,7 +310,7 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:06 2018
+*** tstop() called on dream at Fri Oct  5 23:19:34 2018
 Module time:
 	user time   =       0.38 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
@@ -379,7 +385,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:06 2018
+*** at Fri Oct  5 23:19:34 2018
 
    => Loading Basis Set <=
 
@@ -570,14 +576,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:06 2018
+*** tstop() called on dream at Fri Oct  5 23:19:34 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.90 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.89 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -586,7 +592,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:06 2018
+*** at Fri Oct  5 23:19:34 2018
 
    => Loading Basis Set <=
 
@@ -793,13 +799,13 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:07 2018
+*** tstop() called on dream at Fri Oct  5 23:19:35 2018
 Module time:
 	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.44 seconds =       0.02 minutes
+	user time   =       1.43 seconds =       0.02 minutes
 	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
@@ -858,7 +864,9 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
     Naive listing of computations required.
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
             mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
+             hf / aug-cc-pvtz              for  HF TOTAL ENERGY
 
     Enlightened listing of computations required.
             mp2 / aug-cc-pvtz              for  MP2 TOTAL ENERGY
@@ -873,7 +881,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:07 2018
+*** at Fri Oct  5 23:19:35 2018
 
    => Loading Basis Set <=
 
@@ -1083,18 +1091,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:07 2018
+*** tstop() called on dream at Fri Oct  5 23:19:35 2018
 Module time:
-	user time   =       0.54 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.55 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.07 seconds =       0.03 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:07 2018
+*** at Fri Oct  5 23:19:35 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1156,14 +1164,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+*** tstop() called on dream at Fri Oct  5 23:19:36 2018
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.22 seconds =       0.04 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       2.27 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1171,16 +1179,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.054529189625
+
    ==> MP2 <==
 
    HI-zeta (0) Energy:               -76.341088478604
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.054529189625
 
    ==> Components <==
 
   ---------------------------------------------------------------------------------------------------------
                           Method / Basis                      Rqd      Energy [Eh]   Variable
   ---------------------------------------------------------------------------------------------------------
-                              hf / aug-cc-pvtz                        -76.05452919   HF TOTAL ENERGY
+                              hf / aug-cc-pvtz                  *     -76.05452919   HF TOTAL ENERGY
                              mp2 / aug-cc-pvtz                  *     -76.34108848   MP2 TOTAL ENERGY
   ---------------------------------------------------------------------------------------------------------
 
@@ -1189,7 +1205,9 @@ Total time:
   ---------------------------------------------------------------------------------------------------------
       Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
   ---------------------------------------------------------------------------------------------------------
-        scf                  mp2 / aug-cc-pvtz                  1     -76.34108848   xtpl_highest_1
+        scf                   hf / aug-cc-pvtz                  1     -76.05452919   xtpl_highest_1
+       corl                  mp2 / aug-cc-pvtz                  1     -76.34108848   xtpl_highest_1
+       corl                   hf / aug-cc-pvtz                 -1     -76.05452919   xtpl_highest_1
   ---------------------------------------------------------------------------------------------------------
 
    ==> CBS <==
@@ -1197,7 +1215,8 @@ Total time:
   ---------------------------------------------------------------------------------------------------------
       Stage               Method / Basis                               Energy [Eh]   Scheme
   ---------------------------------------------------------------------------------------------------------
-        scf                  mp2 / aug-cc-pvtz                        -76.34108848   xtpl_highest_1
+        scf                   hf / aug-cc-pvtz                        -76.05452919   xtpl_highest_1
+       corl                  mp2 / aug-cc-pvtz                         -0.28655929   xtpl_highest_1
       total                  CBS                                      -76.34108848   
   ---------------------------------------------------------------------------------------------------------
    => Loading Basis Set <=
@@ -1237,7 +1256,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:08 2018
+*** at Fri Oct  5 23:19:36 2018
 
    => Loading Basis Set <=
 
@@ -1430,18 +1449,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+*** tstop() called on dream at Fri Oct  5 23:19:36 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
+	user time   =       0.39 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.85 seconds =       0.05 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       2.90 seconds =       0.05 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:08 2018
+*** at Fri Oct  5 23:19:36 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1503,14 +1522,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:08 2018
+*** tstop() called on dream at Fri Oct  5 23:19:36 2018
 Module time:
 	user time   =       0.09 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.94 seconds =       0.05 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       2.99 seconds =       0.05 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1519,7 +1538,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:08 2018
+*** at Fri Oct  5 23:19:36 2018
 
    => Loading Basis Set <=
 
@@ -1729,18 +1748,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:09 2018
+*** tstop() called on dream at Fri Oct  5 23:19:37 2018
 Module time:
-	user time   =       0.57 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.55 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.52 seconds =       0.06 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       3.55 seconds =       0.06 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:09 2018
+*** at Fri Oct  5 23:19:37 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1802,14 +1821,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:09 2018
+*** tstop() called on dream at Fri Oct  5 23:19:37 2018
 Module time:
 	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.68 seconds =       0.06 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       3.71 seconds =       0.06 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          4 seconds =       0.07 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1914,7 +1933,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:09 2018
+*** at Fri Oct  5 23:19:37 2018
 
    => Loading Basis Set <=
 
@@ -2113,18 +2132,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+*** tstop() called on dream at Fri Oct  5 23:19:38 2018
 Module time:
 	user time   =       0.45 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.43 seconds =       0.07 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       4.47 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:10 2018
+*** at Fri Oct  5 23:19:38 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2186,14 +2205,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+*** tstop() called on dream at Fri Oct  5 23:19:38 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.55 seconds =       0.08 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       4.58 seconds =       0.08 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2203,7 +2222,7 @@ Total time:
     Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:10 2018
+*** at Fri Oct  5 23:19:38 2018
 
    => Loading Basis Set <=
 
@@ -2390,14 +2409,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:10 2018
+*** tstop() called on dream at Fri Oct  5 23:19:38 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
+	user time   =       0.42 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.93 seconds =       0.08 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       5.00 seconds =       0.08 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
@@ -2422,7 +2441,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:10 2018
+*** at Fri Oct  5 23:19:39 2018
 
 
 
@@ -2516,26 +2535,26 @@ Total time:
         CCSD correlation energy:             -0.216431725206
       * CCSD total energy:                  -76.237829189864
 
-  Total time for CCSD iterations:       0.03 s (user)
-                                        0.03 s (system)
+  Total time for CCSD iterations:       0.04 s (user)
+                                        0.02 s (system)
                                            0 s (total)
 
   Time per iteration:                   0.00 s (user)
                                         0.00 s (system)
                                         0.00 s (total)
 
-*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+*** tstop() called on dream at Fri Oct  5 23:19:39 2018
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.14 seconds =       0.09 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =       5.24 seconds =       0.09 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          6 seconds =       0.10 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:11 2018
+*** at Fri Oct  5 23:19:39 2018
 
 
         *******************************************************
@@ -2569,23 +2588,23 @@ Total time:
       * CCSD(T) total energy                 -76.241099367485
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+*** tstop() called on dream at Fri Oct  5 23:19:39 2018
 Module time:
 	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.15 seconds =       0.09 minutes
+	user time   =       5.25 seconds =       0.09 minutes
 	system time =       0.09 seconds =       0.00 minutes
 	total time  =          6 seconds =       0.10 minutes
 
-*** tstop() called on dream at Tue Oct  2 22:50:11 2018
+*** tstop() called on dream at Fri Oct  5 23:19:39 2018
 Module time:
 	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.15 seconds =       0.09 minutes
+	user time   =       5.25 seconds =       0.09 minutes
 	system time =       0.09 seconds =       0.00 minutes
 	total time  =          6 seconds =       0.10 minutes
 
@@ -2683,298 +2702,20 @@ Total time:
             mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
              hf / cc-pvdz                  for  HF TOTAL ENERGY
              hf / cc-pvtz                  for  HF TOTAL ENERGY
-            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
             mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
 
     Enlightened listing of computations required.
-            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
             mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
-            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
 
     Full listing of computations to be obtained (required and bonus).
-             hf / cc-pvdz                  for  HF TOTAL ENERGY
-            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
              hf / cc-pvtz                  for  HF TOTAL ENERGY
             mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
-             hf / cc-pvdz + options        for  HF TOTAL ENERGY
-            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
-
-  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
-  //   CBS Computation: MP2 / CC-PVDZ  //
-  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
-
-
-*** tstart() called on dream
-*** at Tue Oct  2 22:50:11 2018
-
-   => Loading Basis Set <=
-
-    Name: CC-PVDZ
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c2v
-    Full point group: C2v
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
-
-  Running in c2v symmetry.
-
-  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 10
-  Nalpha       = 5
-  Nbeta        = 5
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-07
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  Basis Set: CC-PVDZ
-    Blend: CC-PVDZ
-    Number of shells: 12
-    Number of basis function: 24
-    Number of Cartesian functions: 25
-    Spherical Harmonics?: true
-    Max angular momentum: 2
-
-   => Loading Basis Set <=
-
-    Name: (CC-PVDZ AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       5       5       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory (MB):                375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVDZ AUX)
-    Blend: CC-PVDZ-JKFIT
-    Number of shells: 42
-    Number of basis function: 116
-    Number of Cartesian functions: 131
-    Spherical Harmonics?: true
-    Max angular momentum: 3
-
-  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
-  Energy converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
-       3A1    -0.558723     1B1    -0.490375  
-
-    Virtual:                                                              
-
-       4A1     0.178016     2B2     0.249486     3B2     0.760311  
-       5A1     0.816144     6A1     1.166347     2B1     1.198686  
-       4B2     1.256576     7A1     1.452880     1A2     1.466534  
-       3B1     1.668515     8A1     1.877409     5B2     1.890443  
-       6B2     2.355075     9A1     2.388631     4B1     3.249433  
-       2A2     3.298364    10A1     3.454607    11A1     3.821967  
-       7B2     4.099335  
-
-    Final Occupation by Irrep:
-             A1    A2    B1    B2 
-    DOCC [     3,    0,    1,    1 ]
-
-  @DF-RHF Final Energy:   -76.02139746465751
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756143702
-    Two-Electron Energy =                  37.6224401463894793
-    Total Energy =                        -76.0213974646575110
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1945
-
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
-
-  Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
-
-
-*** tstop() called on dream at Tue Oct  2 22:50:11 2018
-Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       5.82 seconds =       0.10 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
-
-*** tstart() called on dream
-*** at Tue Oct  2 22:50:11 2018
-
-
-  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
-  //               DFMP2               //
-  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
-
-   => Loading Basis Set <=
-
-    Name: (CC-PVDZ AUX)
-    Role: RIFIT
-    Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-
-	 --------------------------------------------------------
-	                          DF-MP2                         
-	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
-	                                                         
-	        Rob Parrish, Justin Turney, Andy Simmonett,      
-	           Ed Hohenstein, and C. David Sherrill          
-	 --------------------------------------------------------
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVDZ AUX)
-    Blend: CC-PVDZ-RI
-    Number of shells: 30
-    Number of basis function: 84
-    Number of Cartesian functions: 96
-    Spherical Harmonics?: true
-    Max angular momentum: 3
-
-	 --------------------------------------------------------
-	                 NBF =    24, NAUX =    84
-	 --------------------------------------------------------
-	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
-	   PAIRS       1       5       4      19      19       0
-	 --------------------------------------------------------
-
-	-----------------------------------------------------------
-	 ==================> DF-MP2 Energies <==================== 
-	-----------------------------------------------------------
-	 Reference Energy          =     -76.0213974646575110 [Eh]
-	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
-	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
-	 Correlation Energy        =      -0.2046601442173612 [Eh]
-	 Total Energy              =     -76.2260576088748678 [Eh]
-	-----------------------------------------------------------
-	 ================> DF-SCS-MP2 Energies <================== 
-	-----------------------------------------------------------
-	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
-	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
-	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
-	 SCS Total Energy          =     -76.2225726876842913 [Eh]
-	-----------------------------------------------------------
-
-
-*** tstop() called on dream at Tue Oct  2 22:50:11 2018
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       5.90 seconds =       0.10 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+           ccsd / cc-pvdz                  for  CCSD TOTAL ENERGY
+        ccsd(t) / cc-pvdz                  for  CCSD(T) TOTAL ENERGY
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //   CBS Computation: MP2 / CC-PVTZ  //
@@ -2982,7 +2723,7 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:11 2018
+*** at Fri Oct  5 23:19:39 2018
 
    => Loading Basis Set <=
 
@@ -3181,18 +2922,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
 Module time:
 	user time   =       0.47 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.37 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       6.01 seconds =       0.10 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:12 2018
+*** at Fri Oct  5 23:19:40 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3230,7 +2971,7 @@ Total time:
 	                 NBF =    58, NAUX =   141
 	 --------------------------------------------------------
 	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
-	   PAIRS       1       5       4      53      53       0
+	   PAIRS       0       5       5      53      53       0
 	 --------------------------------------------------------
 
 	-----------------------------------------------------------
@@ -3238,39 +2979,542 @@ Total time:
 	-----------------------------------------------------------
 	 Reference Energy          =     -76.0509862039207007 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
-	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
-	 Correlation Energy        =      -0.2645464656227105 [Eh]
-	 Total Energy              =     -76.3155326695434155 [Eh]
+	 Same-Spin Energy          =      -0.0671893164872170 [Eh]
+	 Opposite-Spin Energy      =      -0.2107317227474363 [Eh]
+	 Correlation Energy        =      -0.2779210392346533 [Eh]
+	 Total Energy              =     -76.3289072431553564 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
-	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
-	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	 SCS Same-Spin Energy      =      -0.0223964388290723 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2528780672969235 [Eh]
+	 SCS Correlation Energy    =      -0.2752745061259959 [Eh]
+	 SCS Total Energy          =     -76.3262607100466965 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
 Module time:
 	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.49 seconds =       0.11 minutes
+	user time   =       6.13 seconds =       0.10 minutes
 	system time =       0.10 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
-  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
-  // CBS Computation: MP2 / CC-PVDZ + opts. //
-  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: CCSD(T) / CC-PVDZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:40 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223862   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294925   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823113   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972314   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684775   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720758   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108557   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439252   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465032   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465760   -7.27596e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465772   -1.27898e-13   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756146686
+    Two-Electron Energy =                  37.6224401463895788
+    Total Energy =                        -76.0213974646577242
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.51 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for FNOCC...
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
 
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:12 2018
+*** at Fri Oct  5 23:19:40 2018
+
+
+
+        *******************************************************
+        *                                                     *
+        *                       DF-CCSD                       *
+        *                 Density-fitted CCSD                 *
+        *                                                     *
+        *                   Eugene DePrince                   *
+        *                                                     *
+        *******************************************************
+
+
+  ==> 3-index integrals <==
+
+  ==> DF Tensor (by Rob Parrish) <==
+
+ => Primary Basis Set <= 
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+ => Auxiliary Basis Set <= 
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+    Number of auxiliary functions:          84
+
+  ==> Memory <==
+
+        Total memory available:             500.00 mb
+
+        CCSD memory requirements:             1.14 mb
+            3-index integrals:                0.40 mb
+            CCSD intermediates:               0.74 mb
+
+        (T) part (regular algorithm):         0.31 mb
+
+  ==> Input parameters <==
+
+        Freeze core orbitals?                  no
+        Use frozen natural orbitals?           no
+        r_convergence:                  1.000e-07
+        e_convergence:                  1.000e-07
+        Number of DIIS vectors:                 8
+        Number of frozen core orbitals:         0
+        Number of active occupied orbitals:     5
+        Number of active virtual orbitals:     19
+        Number of frozen virtual orbitals:      0
+
+
+  Begin singles and doubles coupled cluster iterations
+
+   Iter  DIIS          Energy       d(Energy)          |d(T)|     time
+      0   0 1   -0.2069166881   -0.2069166881    0.1987680224        0
+      1   1 1   -0.2115086020   -0.0045919139    0.0285450513        0
+      2   2 1   -0.2150893167   -0.0035807147    0.0104812617        0
+      3   3 1   -0.2164079298   -0.0013186131    0.0041114403        0
+      4   4 1   -0.2164214813   -0.0000135515    0.0006921551        0
+      5   5 1   -0.2164352956   -0.0000138142    0.0002259101        0
+      6   6 1   -0.2164322775    0.0000030180    0.0000766918        0
+      7   7 1   -0.2164319614    0.0000003161    0.0000190236        0
+      8   8 1   -0.2164317633    0.0000001981    0.0000033759        0
+      9   8 2   -0.2164317097    0.0000000536    0.0000008461        0
+     10   8 3   -0.2164317283   -0.0000000185    0.0000001639        0
+     11   8 4   -0.2164317252    0.0000000031    0.0000000356        0
+
+  CCSD iterations converged!
+
+        T1 diagnostic:                        0.005907931879
+        D1 diagnostic:                        0.012980613017
+
+        OS MP2 correlation energy:           -0.154889086934
+        SS MP2 correlation energy:           -0.052027601148
+        MP2 correlation energy:              -0.206916688082
+      * MP2 total energy:                   -76.228314152740
+
+        OS CCSD correlation energy:          -0.170520745005
+        SS CCSD correlation energy:          -0.045910980201
+        CCSD correlation energy:             -0.216431725206
+      * CCSD total energy:                  -76.237829189864
+
+  Total time for CCSD iterations:       0.05 s (user)
+                                        0.01 s (system)
+                                           0 s (total)
+
+  Time per iteration:                   0.00 s (user)
+                                        0.00 s (system)
+                                        0.00 s (total)
+
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.76 seconds =       0.11 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:40 2018
+
+
+        *******************************************************
+        *                                                     *
+        *                      CCSD(T)                        *
+        *                                                     *
+        *******************************************************
+
+        num_threads:                      1
+        available memory:         500.00 mb
+        memory requirements:        0.31 mb
+
+        Number of ijk combinations: 35
+
+        Computing (T) correction...
+
+        % complete  total time
+              11.4         0 s
+              20.0         0 s
+              31.4         0 s
+              40.0         0 s
+              51.4         0 s
+              60.0         0 s
+              71.4         0 s
+              80.0         0 s
+              91.4         0 s
+
+        (T) energy                            -0.003270177621
+
+        CCSD(T) correlation energy            -0.219701902827
+      * CCSD(T) total energy                 -76.241099367485
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.77 seconds =       0.11 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.77 seconds =       0.11 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (3) Energy:               -76.050986203921
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
+
+   LO-zeta (2) Energy:               -76.228314152740
+   HI-zeta (3) Energy:               -76.328907243155
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.371262228593
+
+   @Extrapolated MP2/(D,T):          -76.371262228593
+
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.021397464658
+   HI-zeta (3) Energy:               -76.050986203921
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.063444620452
+
+   @Extrapolated HF/(D,T):           -76.063444620452
+
+
+   ==> CCSD(T) <==
+
+   HI-zeta (0) Energy:               -76.241099367485
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.228314152740
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvtz                      *     -76.05098620   HF TOTAL ENERGY
+                             mp2 / cc-pvtz                      *     -76.32890724   MP2 TOTAL ENERGY
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22831415   MP2 TOTAL ENERGY
+                            ccsd / cc-pvdz                            -76.23782919   CCSD TOTAL ENERGY
+                         ccsd(t) / cc-pvdz                      *     -76.24109937   CCSD(T) TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                      1     -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                   1     -76.37126223   corl_xtpl_helgaker_2
+       corl                   hf / cc-pv[dt]z                  -1     -76.06344462   corl_xtpl_helgaker_2
+     delta1              ccsd(t) / cc-pvdz                      1     -76.24109937   xtpl_highest_1
+     delta1                  mp2 / cc-pvdz                     -1     -76.22831415   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                            -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                          -0.30781761   corl_xtpl_helgaker_2
+     delta1        ccsd(t) - mp2 / cc-pvdz                             -0.01278521   xtpl_highest_1
+      total                  CBS                                      -76.37158903   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+
+	MP2/[DT]Z + D:CCSD(T)/DZ without explicit SCF stage...............PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz + options        for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVDZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:41 2018
 
    => Loading Basis Set <=
 
@@ -3458,18 +3702,583 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+*** tstop() called on dream at Fri Oct  5 23:19:41 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.48 seconds =       0.12 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:41 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
+	 Correlation Energy        =      -0.2046601442173612 [Eh]
+	 Total Energy              =     -76.2260576088748678 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
+	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
+	 SCS Total Energy          =     -76.2225726876842913 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:41 2018
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.88 seconds =       0.11 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       7.55 seconds =       0.13 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVTZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
 
 *** tstart() called on dream
-*** at Tue Oct  2 22:50:12 2018
+*** at Fri Oct  5 23:19:41 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.9026033530E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
+   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
+   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
+   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
+   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
+   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
+   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.562138     2A1    -1.324719     1B2    -0.687037  
+       3A1    -0.569630     1B1    -0.501255  
+
+    Virtual:                                                              
+
+       4A1     0.137557     2B2     0.199842     3B2     0.526492  
+       5A1     0.576831     6A1     0.677461     2B1     0.785997  
+       7A1     0.793875     4B2     0.805787     1A2     0.852292  
+       3B1     0.951778     8A1     1.165822     5B2     1.172443  
+       6B2     1.489228     9A1     1.501210     4B1     2.019244  
+       2A2     2.048947     7B2     2.115800    10A1     2.157398  
+      11A1     2.253311    12A1     2.570131     8B2     2.925729  
+       5B1     3.356690    13A1     3.471321     3A2     3.552110  
+       9B2     3.599876     6B1     3.766354    10B2     3.826770  
+      14A1     3.874687     4A2     3.936042     7B1     4.015354  
+      11B2     4.055492    15A1     4.135577     5A2     4.246989  
+      16A1     4.323614    12B2     4.478353     8B1     4.645991  
+      13B2     4.776742    17A1     5.012617    18A1     5.229074  
+      14B2     5.516784     9B1     5.976687    19A1     6.414996  
+      10B1     6.772506     6A2     6.849685    20A1     6.905158  
+      15B2     6.934087    11B1     7.012922    21A1     7.168713  
+       7A2     7.181120    22A1     7.433881    16B2     7.697134  
+      17B2     8.106356    23A1    12.196039  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05098620392070
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4153442205643501
+    Two-Electron Energy =                  37.5628924520762908
+    Total Energy =                        -76.0509862039207007
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2092
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8099     Total:     0.8099
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+Module time:
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.00 seconds =       0.13 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:42 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-RI
+    Number of shells: 43
+    Number of basis function: 141
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    58, NAUX =   141
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      53      53       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
+	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
+	 Correlation Energy        =      -0.2645464656227105 [Eh]
+	 Total Energy              =     -76.3155326695434155 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
+	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
+	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.12 seconds =       0.14 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / CC-PVDZ + opts. //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:42 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465751
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756143702
+    Two-Electron Energy =                  37.6224401463894793
+    Total Energy =                        -76.0213974646575110
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+Module time:
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.48 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on dream
+*** at Fri Oct  5 23:19:42 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3531,15 +4340,15 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Tue Oct  2 22:50:12 2018
+*** tstop() called on dream at Fri Oct  5 23:19:42 2018
 Module time:
 	user time   =       0.09 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.97 seconds =       0.12 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       8.57 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -3625,7 +4434,7 @@ Total time:
 
 	MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check..........................PASSED
 
-    Psi4 stopped on: Tuesday, 02 October 2018 10:50PM
-    Psi4 wall time for execution: 0:00:07.37
+    Psi4 stopped on: Friday, 05 October 2018 11:19PM
+    Psi4 wall time for execution: 0:00:09.06
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cbs-xtpl-dict/output.ref
+++ b/tests/cbs-xtpl-dict/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.3a2.dev71 
 
-                         Git: Rev {cbs_dict} d8e92a8 dirty
+                         Git: Rev {cbs_dict} 51d75f9 dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -22,11 +22,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 05 October 2018 11:19PM
+    Psi4 started on: Monday, 29 October 2018 10:03PM
 
-    Process ID: 3703
+    Process ID: 19048
     Host:       dream
-    PSIDATADIR: /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4
+    PSIDATADIR: /home/kraus/Applications/psi4-cbs_dict/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -44,6 +44,7 @@ mp2_atz_ref   = -76.341088480148    #TEST
 mp2_adtz_ref  = -76.3667778886      #TEST
 cbs_ref       = -76.371589026502    #TEST
 ae_ref        = -76.34300450653124  #TEST
+b_lo_ref      = -76.3482732705      #TEST
 
 molecule h2o {
     O
@@ -101,7 +102,10 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
 
-
+b_lo  = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "cc-pvtz", "stage": "corr"},
+                                    {"wfn": "mp2", "wfn_lo": "mp2", 
+                                     "basis": "aug-cc-pvdz", "basis_lo": "cc-pvdz", "stage": "diff"}])
+compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #TEST
 --------------------------------------------------------------------------
 	Nuclear repulsion energy..........................................PASSED
 
@@ -124,15 +128,15 @@ compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:33 2018
+*** at Mon Oct 29 22:03:52 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -194,8 +198,8 @@ compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -212,7 +216,7 @@ compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -220,7 +224,7 @@ compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -310,15 +314,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:34 2018
+*** tstop() called on dream at Mon Oct 29 22:03:52 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -358,8 +362,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	SCF/DZ Energy Check...............................................PASSED
 
@@ -385,15 +389,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:34 2018
+*** at Mon Oct 29 22:03:52 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   250 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -455,8 +459,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -473,7 +477,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.003 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -481,7 +485,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -576,14 +580,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:34 2018
+*** tstop() called on dream at Mon Oct 29 22:03:53 2018
 Module time:
 	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.89 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.88 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -592,15 +596,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:34 2018
+*** at Mon Oct 29 22:03:53 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -662,8 +666,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -680,7 +684,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -688,7 +692,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -799,15 +803,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:35 2018
+*** tstop() called on dream at Mon Oct 29 22:03:53 2018
 Module time:
-	user time   =       0.53 seconds =       0.01 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.40 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.43 seconds =       0.02 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -854,8 +858,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	SCF/a[DT]Z Energy Check...........................................PASSED
 
@@ -881,15 +885,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:35 2018
+*** at Mon Oct 29 22:03:54 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -951,8 +955,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -969,7 +973,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -977,7 +981,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -1091,18 +1095,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:35 2018
+*** tstop() called on dream at Mon Oct 29 22:03:54 2018
 Module time:
-	user time   =       0.55 seconds =       0.01 minutes
+	user time   =       0.53 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.11 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       2.08 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:35 2018
+*** at Mon Oct 29 22:03:54 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1114,8 +1118,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   264 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -1164,15 +1168,15 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:36 2018
+*** tstop() called on dream at Mon Oct 29 22:03:54 2018
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.27 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -1224,8 +1228,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	MP2/aTZ Energy Check..............................................PASSED
 
@@ -1256,15 +1260,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:36 2018
+*** at Mon Oct 29 22:03:55 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   250 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -1326,8 +1330,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1344,7 +1348,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.003 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -1352,7 +1356,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -1449,18 +1453,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:36 2018
+*** tstop() called on dream at Mon Oct 29 22:03:55 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.90 seconds =       0.05 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       2.87 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:36 2018
+*** at Mon Oct 29 22:03:55 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1472,8 +1476,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   204 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -1522,14 +1526,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:36 2018
+*** tstop() called on dream at Mon Oct 29 22:03:55 2018
 Module time:
 	user time   =       0.09 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.99 seconds =       0.05 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       2.96 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1538,15 +1542,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:36 2018
+*** at Mon Oct 29 22:03:55 2018
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1608,8 +1612,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1626,7 +1630,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.018 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -1634,7 +1638,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -1748,18 +1752,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:37 2018
+*** tstop() called on dream at Mon Oct 29 22:03:56 2018
 Module time:
-	user time   =       0.55 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.55 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       3.49 seconds =       0.06 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:37 2018
+*** at Mon Oct 29 22:03:56 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1771,8 +1775,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   264 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -1821,14 +1825,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:37 2018
+*** tstop() called on dream at Mon Oct 29 22:03:56 2018
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.71 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       3.64 seconds =       0.06 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          4 seconds =       0.07 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1897,8 +1901,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	MP2/a[DT]Z Energy Check...........................................PASSED
 
@@ -1933,15 +1937,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:37 2018
+*** at Mon Oct 29 22:03:56 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2003,8 +2007,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2021,7 +2025,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -2029,7 +2033,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -2132,18 +2136,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:38 2018
+*** tstop() called on dream at Mon Oct 29 22:03:56 2018
 Module time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.47 seconds =       0.07 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       4.40 seconds =       0.07 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:38 2018
+*** at Mon Oct 29 22:03:56 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2155,8 +2159,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -2205,14 +2209,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:38 2018
+*** tstop() called on dream at Mon Oct 29 22:03:57 2018
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
+	user time   =       0.12 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.58 seconds =       0.08 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       4.52 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2222,15 +2226,15 @@ Total time:
     Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:38 2018
+*** at Mon Oct 29 22:03:57 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -2292,8 +2296,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2317,7 +2321,7 @@ Total time:
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           SAVE
     Schwarz Cutoff:          1E-12
@@ -2409,14 +2413,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:38 2018
+*** tstop() called on dream at Mon Oct 29 22:03:57 2018
 Module time:
-	user time   =       0.42 seconds =       0.01 minutes
+	user time   =       0.37 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.00 seconds =       0.08 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       4.89 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
@@ -2428,20 +2432,20 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_CC
-    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:39 2018
+*** at Mon Oct 29 22:03:57 2018
 
 
 
@@ -2543,18 +2547,18 @@ Total time:
                                         0.00 s (system)
                                         0.00 s (total)
 
-*** tstop() called on dream at Fri Oct  5 23:19:39 2018
+*** tstop() called on dream at Mon Oct 29 22:03:57 2018
 Module time:
-	user time   =       0.10 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.24 seconds =       0.09 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       5.10 seconds =       0.08 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:39 2018
+*** at Mon Oct 29 22:03:57 2018
 
 
         *******************************************************
@@ -2588,25 +2592,25 @@ Total time:
       * CCSD(T) total energy                 -76.241099367485
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:39 2018
+*** tstop() called on dream at Mon Oct 29 22:03:57 2018
 Module time:
 	user time   =       0.01 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.25 seconds =       0.09 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       5.11 seconds =       0.09 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-*** tstop() called on dream at Fri Oct  5 23:19:39 2018
+*** tstop() called on dream at Mon Oct 29 22:03:57 2018
 Module time:
 	user time   =       0.01 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.25 seconds =       0.09 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       5.11 seconds =       0.09 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -2687,8 +2691,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:CCSD(T)/DZ Energy Check.............................PASSED
 
@@ -2723,15 +2727,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:39 2018
+*** at Mon Oct 29 22:03:58 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2793,8 +2797,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2811,7 +2815,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -2819,7 +2823,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -2922,18 +2926,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:58 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.01 seconds =       0.10 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       5.85 seconds =       0.10 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:40 2018
+*** at Mon Oct 29 22:03:58 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2945,8 +2949,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -2995,15 +2999,15 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:58 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.13 seconds =       0.10 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       5.96 seconds =       0.10 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: CCSD(T) / CC-PVDZ //
@@ -3012,15 +3016,15 @@ Total time:
     Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:40 2018
+*** at Mon Oct 29 22:03:58 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -3082,8 +3086,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3107,7 +3111,7 @@ Total time:
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           SAVE
     Schwarz Cutoff:          1E-12
@@ -3199,14 +3203,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:59 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
+	user time   =       0.37 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.51 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       6.33 seconds =       0.11 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
@@ -3218,20 +3222,20 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_CC
-    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:40 2018
+*** at Mon Oct 29 22:03:59 2018
 
 
 
@@ -3333,18 +3337,18 @@ Total time:
                                         0.00 s (system)
                                         0.00 s (total)
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:59 2018
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
+	user time   =       0.10 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.76 seconds =       0.11 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       6.55 seconds =       0.11 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:40 2018
+*** at Mon Oct 29 22:03:59 2018
 
 
         *******************************************************
@@ -3378,24 +3382,24 @@ Total time:
       * CCSD(T) total energy                 -76.241099367485
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:59 2018
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.77 seconds =       0.11 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       6.55 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
-*** tstop() called on dream at Fri Oct  5 23:19:40 2018
+*** tstop() called on dream at Mon Oct 29 22:03:59 2018
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.77 seconds =       0.11 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       6.55 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3477,8 +3481,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:CCSD(T)/DZ without explicit SCF stage...............PASSED
 
@@ -3514,15 +3518,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:41 2018
+*** at Mon Oct 29 22:03:59 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -3584,8 +3588,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3602,7 +3606,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -3610,7 +3614,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -3702,18 +3706,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:41 2018
+*** tstop() called on dream at Mon Oct 29 22:03:59 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.48 seconds =       0.12 minutes
+	user time   =       7.24 seconds =       0.12 minutes
 	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	total time  =          7 seconds =       0.12 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:41 2018
+*** at Mon Oct 29 22:03:59 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3725,8 +3729,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -3775,14 +3779,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:41 2018
+*** tstop() called on dream at Mon Oct 29 22:04:00 2018
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.55 seconds =       0.13 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       7.32 seconds =       0.12 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3791,15 +3795,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:41 2018
+*** at Mon Oct 29 22:04:00 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3861,8 +3865,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3879,7 +3883,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -3887,7 +3891,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -3990,18 +3994,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+*** tstop() called on dream at Mon Oct 29 22:04:00 2018
 Module time:
 	user time   =       0.44 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.00 seconds =       0.13 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       7.76 seconds =       0.13 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:42 2018
+*** at Mon Oct 29 22:04:00 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4013,8 +4017,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -4063,15 +4067,15 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+*** tstop() called on dream at Mon Oct 29 22:04:00 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.12 seconds =       0.14 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       7.87 seconds =       0.13 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: MP2 / CC-PVDZ + opts. //
@@ -4079,15 +4083,15 @@ Total time:
 
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:42 2018
+*** at Mon Oct 29 22:04:00 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -4149,8 +4153,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4167,7 +4171,7 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -4175,7 +4179,7 @@ Total time:
     K tasked:                   Yes
     wK tasked:                   No
     OpenMP threads:               1
-    Memory (MB):                375
+    Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
@@ -4267,18 +4271,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+*** tstop() called on dream at Mon Oct 29 22:04:00 2018
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
+	user time   =       0.35 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.48 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       8.22 seconds =       0.14 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
 *** tstart() called on dream
-*** at Fri Oct  5 23:19:42 2018
+*** at Mon Oct 29 22:04:00 2018
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4290,8 +4294,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
@@ -4340,14 +4344,14 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Fri Oct  5 23:19:42 2018
+*** tstop() called on dream at Mon Oct 29 22:04:01 2018
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
+	user time   =       0.08 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.57 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       8.30 seconds =       0.14 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          9 seconds =       0.15 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4429,12 +4433,953 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/pk/Build/psi4/BUILDS/cbs_dict/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check..........................PASSED
 
-    Psi4 stopped on: Friday, 05 October 2018 11:19PM
-    Psi4 wall time for execution: 0:00:09.06
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / aug-cc-pvdz              for  HF TOTAL ENERGY
+            mp2 / aug-cc-pvdz              for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVTZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:01 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.9026033530E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
+   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
+   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
+   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
+   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
+   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
+   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.562138     2A1    -1.324719     1B2    -0.687037  
+       3A1    -0.569630     1B1    -0.501255  
+
+    Virtual:                                                              
+
+       4A1     0.137557     2B2     0.199842     3B2     0.526492  
+       5A1     0.576831     6A1     0.677461     2B1     0.785997  
+       7A1     0.793875     4B2     0.805787     1A2     0.852292  
+       3B1     0.951778     8A1     1.165822     5B2     1.172443  
+       6B2     1.489228     9A1     1.501210     4B1     2.019244  
+       2A2     2.048947     7B2     2.115800    10A1     2.157398  
+      11A1     2.253311    12A1     2.570131     8B2     2.925729  
+       5B1     3.356690    13A1     3.471321     3A2     3.552110  
+       9B2     3.599876     6B1     3.766354    10B2     3.826770  
+      14A1     3.874687     4A2     3.936042     7B1     4.015354  
+      11B2     4.055492    15A1     4.135577     5A2     4.246989  
+      16A1     4.323614    12B2     4.478353     8B1     4.645991  
+      13B2     4.776742    17A1     5.012617    18A1     5.229074  
+      14B2     5.516784     9B1     5.976687    19A1     6.414996  
+      10B1     6.772506     6A2     6.849685    20A1     6.905158  
+      15B2     6.934087    11B1     7.012922    21A1     7.168713  
+       7A2     7.181120    22A1     7.433881    16B2     7.697134  
+      17B2     8.106356    23A1    12.196039  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05098620392070
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4153442205643501
+    Two-Electron Energy =                  37.5628924520762908
+    Total Energy =                        -76.0509862039207007
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2092
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8099     Total:     0.8099
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:01 2018
+Module time:
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.98 seconds =       0.15 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:01 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-RI
+    Number of shells: 43
+    Number of basis function: 141
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    58, NAUX =   141
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      53      53       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
+	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
+	 Correlation Energy        =      -0.2645464656227105 [Eh]
+	 Total Energy              =     -76.3155326695434155 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
+	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
+	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:01 2018
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.09 seconds =       0.15 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / AUG-CC-PVDZ //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:01 2018
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 19
+    Number of basis function: 41
+    Number of Cartesian functions: 43
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        18      18       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1         7       7       0       0       0       0
+     B2        12      12       0       0       0       0
+   -------------------------------------------------------
+    Total      41      41       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 52
+    Number of basis function: 150
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.1766171140E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
+   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
+   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
+   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
+   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
+   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
+   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
+   @DF-RHF iter   9:   -76.03566968454179   -1.25439e-10   8.11191e-08 DIIS
+   @DF-RHF iter  10:   -76.03566968454702   -5.22959e-12   8.06200e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.584239     2A1    -1.335647     1B2    -0.696479  
+       3A1    -0.577439     1B1    -0.506106  
+
+    Virtual:                                                              
+
+       4A1     0.034658     2B2     0.057722     5A1     0.174901  
+       2B1     0.198751     6A1     0.219018     3B2     0.232772  
+       4B2     0.278549     7A1     0.326071     1A2     0.382613  
+       8A1     0.397881     3B1     0.427473     5B2     0.532911  
+       9A1     0.636696     6B2     0.654104     7B2     0.794625  
+      10A1     0.917437     4B1     1.105427    11A1     1.117509  
+       2A2     1.145099    12A1     1.291954     8B2     1.454194  
+       5B1     1.470010    13A1     1.572206     9B2     1.971534  
+       3A2     1.988356     6B1     2.082925    14A1     2.346452  
+      10B2     2.398798    15A1     2.533949    11B2     2.701650  
+      16A1     2.959675     7B1     3.671282    17A1     3.683511  
+       4A2     3.694439    18A1     3.974411    12B2     4.219132  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.03566968454702
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.2744487679137961
+    Two-Electron Energy =                  37.4373135187993995
+    Total Energy =                        -76.0356696845470168
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2197
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7994     Total:     0.7994
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       9.47 seconds =       0.16 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:02 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-RI
+    Number of shells: 40
+    Number of basis function: 118
+    Number of Cartesian functions: 136
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    41, NAUX =   118
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      36      36       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0356696845470168 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0567122937952484 [Eh]
+	 Opposite-Spin Energy      =      -0.1664162315254514 [Eh]
+	 Correlation Energy        =      -0.2231285253206998 [Eh]
+	 Total Energy              =     -76.2587982098677202 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0189040979317495 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1996994778305416 [Eh]
+	 SCS Correlation Energy    =      -0.2186035757622911 [Eh]
+	 SCS Total Energy          =     -76.2542732603093043 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.56 seconds =       0.16 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVDZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:02 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
+         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
+         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
+  Nuclear repulsion =    8.801465564567373
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
+   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
+   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
+   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
+   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
+   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
+   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465751
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673727
+    One-Electron Energy =                -122.4453031756143702
+    Two-Electron Energy =                  37.6224401463894793
+    Total Energy =                        -76.0213974646575110
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+Module time:
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.91 seconds =       0.17 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+*** tstart() called on dream
+*** at Mon Oct 29 22:04:02 2018
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
+	 Correlation Energy        =      -0.2046601442173612 [Eh]
+	 Total Energy              =     -76.2260576088748678 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
+	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
+	 SCS Total Energy          =     -76.2225726876842913 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.99 seconds =       0.17 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.050986203921
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.315532669543
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.050986203921
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.258798209868
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.226057608875
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvtz                      *     -76.05098620   HF TOTAL ENERGY
+                             mp2 / cc-pvtz                      *     -76.31553267   MP2 TOTAL ENERGY
+                              hf / aug-cc-pvdz                        -76.03566968   HF TOTAL ENERGY
+                             mp2 / aug-cc-pvdz                  *     -76.25879821   MP2 TOTAL ENERGY
+                              hf / cc-pvdz                            -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22605761   MP2 TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                      1     -76.05098620   xtpl_highest_1
+       corr                  mp2 / cc-pvtz                      1     -76.31553267   xtpl_highest_1
+       corr                   hf / cc-pvtz                     -1     -76.05098620   xtpl_highest_1
+       diff                  mp2 / aug-cc-pvdz                  1     -76.25879821   xtpl_highest_1
+       diff                  mp2 / cc-pvdz                     -1     -76.22605761   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                            -76.05098620   xtpl_highest_1
+       corr                  mp2 / cc-pvtz                             -0.26454647   xtpl_highest_1
+       diff            mp2 - mp2 / aug-cc-pvdz                         -0.03274060   xtpl_highest_1
+      total                  CBS                                      -76.34827327   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+
+	MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)..........................PASSED
+
+    Psi4 stopped on: Monday, 29 October 2018 10:04PM
+    Psi4 wall time for execution: 0:00:10.48
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cbs-xtpl-freq/input.dat
+++ b/tests/cbs-xtpl-freq/input.dat
@@ -1,12 +1,12 @@
 #! Various gradients for a strained helium dimer and water molecule
 import numpy as np
 
-nucenergy_ref = 9.1681932964
+nucenergy_ref = 9.3008469403
 
 molecule h2o_dz {
-  O
-  H 1 0.96
-  H 1 0.96 2 104.5
+    O       
+    H             1    0.946279
+    H             1    0.946279      2  104.619334
 }
 
 molecule h2o_tz {
@@ -36,12 +36,12 @@ clean()
 
 # reference frequencies: CFOUR v1.0 with:
 # *ACES2(CALC=HF,BASIS=PVDZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
-# 1808.8119, 3923.3122, 4020.3029
+# 1775.7236, 4113.8382, 4212.2220
 
 scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1, molecule=h2o_dz)
-compare_values(wfn_dz.frequencies().get(0), 1809.2462, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
-compare_values(wfn_dz.frequencies().get(1), 3923.1513, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
-compare_values(wfn_dz.frequencies().get(2), 4020.1774, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
+compare_values(wfn_dz.frequencies().get(0), 1776.1550, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
+compare_values(wfn_dz.frequencies().get(1), 4113.6950, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
+compare_values(wfn_dz.frequencies().get(2), 4212.1246, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
 
 # reference frequencies: G09.D01 with:
 # freq=noraman hf/cc-pvtz

--- a/tests/cbs-xtpl-freq/input.dat
+++ b/tests/cbs-xtpl-freq/input.dat
@@ -39,9 +39,9 @@ clean()
 # 1775.7236, 4113.8382, 4212.2220
 
 scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1, molecule=h2o_dz)
-compare_values(wfn_dz.frequencies().get(0), 1776.1550, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
-compare_values(wfn_dz.frequencies().get(1), 4113.6950, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
-compare_values(wfn_dz.frequencies().get(2), 4212.1246, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
+compare_values(wfn_dz.frequencies().get(0), 1776.1550, 1, "SCF/cc-pVDZ Frequency 1")            #TEST
+compare_values(wfn_dz.frequencies().get(1), 4113.6950, 1, "SCF/cc-pVDZ Frequency 2")            #TEST
+compare_values(wfn_dz.frequencies().get(2), 4212.1246, 1, "SCF/cc-pVDZ Frequency 3")            #TEST
 
 # reference frequencies: G09.D01 with:
 # freq=noraman hf/cc-pvtz
@@ -51,13 +51,13 @@ compare_values(wfn_dz.frequencies().get(2), 4212.1246, 2, "SCF/cc-pVDZ Frequency
 # 1753.0405, 4126.9714, 4226.8671
 
 scf_tz, wfn_tz = freq('SCF/cc-pVTZ', return_wfn=True, dertype=1, molecule=h2o_tz)
-compare_values(wfn_tz.frequencies().get(0), 1753.0273, 2, "SCF/cc-pVTZ Frequency 1")            #TEST
-compare_values(wfn_tz.frequencies().get(1), 4127.0329, 2, "SCF/cc-pVTZ Frequency 2")            #TEST
-compare_values(wfn_tz.frequencies().get(2), 4227.0130, 2, "SCF/cc-pVTZ Frequency 3")            #TEST
+compare_values(wfn_tz.frequencies().get(0), 1753.0273, 1, "SCF/cc-pVTZ Frequency 1")            #TEST
+compare_values(wfn_tz.frequencies().get(1), 4127.0329, 1, "SCF/cc-pVTZ Frequency 2")            #TEST
+compare_values(wfn_tz.frequencies().get(2), 4227.0130, 1, "SCF/cc-pVTZ Frequency 3")            #TEST
 
 scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, dertype=1, molecule=h2o_dtz)
-compare_values(wfn_dtz.frequencies().get(0), 1747.7069, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(1), 4130.2408, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(2), 4230.6358, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(0), 1747.7069, 1, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(1), 4130.2408, 1, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(2), 4230.6358, 1, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
 
 

--- a/tests/cbs-xtpl-freq/input.dat
+++ b/tests/cbs-xtpl-freq/input.dat
@@ -3,42 +3,61 @@ import numpy as np
 
 nucenergy_ref = 9.1681932964
 
-molecule h2o {
+molecule h2o_dz {
   O
   H 1 0.96
   H 1 0.96 2 104.5
 }
 
+molecule h2o_tz {
+    O       
+    H             1    0.940607
+    H             1    0.940607      2  106.000618
+}
+
+molecule h2o_dtz {
+    O       
+    H             1    0.939201
+    H             1    0.939201      2  106.350145
+}
+
 # Conventional to keep angular momentum low
 set {
-    scf_type      df
+    scf_type df
     e_convergence 1.e-10
 }
 
-h2o.update_geometry()
-compare_values(nucenergy_ref, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+h2o_dz.update_geometry()
+compare_values(nucenergy_ref, h2o_dz.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+
+clean()
 
 # SCF TESTS
-scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1)
+
+# reference frequencies: CFOUR v1.0 with:
+# *ACES2(CALC=HF,BASIS=PVDZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
+# 1808.8119, 3923.3122, 4020.3029
+
+scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1, molecule=h2o_dz)
 compare_values(wfn_dz.frequencies().get(0), 1809.2462, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
 compare_values(wfn_dz.frequencies().get(1), 3923.1513, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
 compare_values(wfn_dz.frequencies().get(2), 4020.1774, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
 
-# scf_tz, wfn_tz = freq('SCF/cc-pVTZ', return_wfn=True)
-# compare_values(wfn_tz.frequencies().get(0), 1813.8360744, 4, "SCF/cc-pVTZ Frequency 1")            #TEST
-# compare_values(wfn_tz.frequencies().get(1), 3867.8213943, 4, "SCF/cc-pVTZ Frequency 2")            #TEST
-# compare_values(wfn_tz.frequencies().get(2), 3952.4994821, 4, "SCF/cc-pVTZ Frequency 3")            #TEST
+# reference frequencies: G09.D01 with:
+# freq=noraman hf/cc-pvtz
+# 1753.0400, 4126.9754, 4226.8715
+# reference frequencies: CFOUR v1.0 with: 
+# *ACES2(CALC=HF,BASIS=PVTZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
+# 1753.0405, 4126.9714, 4226.8671
 
+scf_tz, wfn_tz = freq('SCF/cc-pVTZ', return_wfn=True, dertype=1, molecule=h2o_tz)
+compare_values(wfn_tz.frequencies().get(0), 1753.0273, 2, "SCF/cc-pVTZ Frequency 1")            #TEST
+compare_values(wfn_tz.frequencies().get(1), 4127.0329, 2, "SCF/cc-pVTZ Frequency 2")            #TEST
+compare_values(wfn_tz.frequencies().get(2), 4227.0130, 2, "SCF/cc-pVTZ Frequency 3")            #TEST
 
-# Not yet implemented #TEST
-#scf_dtz = gradient('SCF/cc-pV[23]Z')
-#compare_matrices(ref_scf_dtz, scf_dtz, 6, "SCF/cc-pV[DT]Z Gradient")  #TEST
-#
-#scf_dtqz = gradient('SCF/cc-pV[DTQ]Z')
-#compare_matrices(ref_scf_dtqz, scf_dtqz, 6, "SCF/cc-pV[DTQ]Z Gradient")  #TEST
-#
-## MP2 TESTS
-#mp2_dtz = gradient('MP2/cc-pV[DT]Z')
-#compare_matrices(ref_mp2_dtz, mp2_dtz, 6, "MP2/cc-pV[DT]Z Gradient")  #TEST
+scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, molecule=h2o_dtz)
+compare_values(wfn_dtz.frequencies().get(0), 1747.7410, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(1), 4130.2255, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(2), 4230.5752, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
 
 

--- a/tests/cbs-xtpl-freq/input.dat
+++ b/tests/cbs-xtpl-freq/input.dat
@@ -55,9 +55,9 @@ compare_values(wfn_tz.frequencies().get(0), 1753.0273, 2, "SCF/cc-pVTZ Frequency
 compare_values(wfn_tz.frequencies().get(1), 4127.0329, 2, "SCF/cc-pVTZ Frequency 2")            #TEST
 compare_values(wfn_tz.frequencies().get(2), 4227.0130, 2, "SCF/cc-pVTZ Frequency 3")            #TEST
 
-scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, molecule=h2o_dtz)
-compare_values(wfn_dtz.frequencies().get(0), 1747.7410, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(1), 4130.2255, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(2), 4230.5752, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, dertype=1, molecule=h2o_dtz)
+compare_values(wfn_dtz.frequencies().get(0), 1747.7069, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(1), 4130.2408, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(2), 4230.6358, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
 
 

--- a/tests/cbs-xtpl-freq/output.ref
+++ b/tests/cbs-xtpl-freq/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.3a1.dev455 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {cbs_dict} ed71323 
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -12,18 +12,23 @@
     H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
     P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
     F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
     (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Tuesday, 25 September 2018 01:51PM
 
-    Process ID:  12227
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 15329
+    Host:       silver
+    PSIDATADIR: /home/kraus/psi4bin/cbs_dict/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    8
     
   ==> Input File <==
 
@@ -33,102 +38,86 @@ import numpy as np
 
 nucenergy_ref = 9.16819326039
 
-molecule h2o {
+molecule h2o_dz {
   O
   H 1 0.96
   H 1 0.96 2 104.5
 }
 
+molecule h2o_tz {
+    O       
+    H             1    0.940607
+    H             1    0.940607      2  106.000618
+}
+
+molecule h2o_dtz {
+    O       
+    H             1    0.939201
+    H             1    0.939201      2  106.350145
+}
+
 # Conventional to keep angular momentum low
 set {
-    scf_type      df
+    scf_type df
     e_convergence 1.e-10
 }
 
-h2o.update_geometry()
-compare_values(nucenergy_ref, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+h2o_dz.update_geometry()
+compare_values(nucenergy_ref, h2o_dz.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+
+clean()
 
 # SCF TESTS
-scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1)
-compare_values(wfn_dz.frequencies().get(0), 1809.2345729, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
-compare_values(wfn_dz.frequencies().get(1), 3923.1569958, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
-compare_values(wfn_dz.frequencies().get(2), 4020.1821381, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
 
-# scf_tz, wfn_tz = freq('SCF/cc-pVTZ', return_wfn=True)
-# compare_values(wfn_tz.frequencies().get(0), 1813.8360744, 4, "SCF/cc-pVTZ Frequency 1")            #TEST
-# compare_values(wfn_tz.frequencies().get(1), 3867.8213943, 4, "SCF/cc-pVTZ Frequency 2")            #TEST
-# compare_values(wfn_tz.frequencies().get(2), 3952.4994821, 4, "SCF/cc-pVTZ Frequency 3")            #TEST
+# reference frequencies: CFOUR v1.0 with:
+# *ACES2(CALC=HF,BASIS=PVDZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
+# 1808.8119, 3923.3122, 4020.3029
 
+scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1, molecule=h2o_dz)
+compare_values(wfn_dz.frequencies().get(0), 1809.2462, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
+compare_values(wfn_dz.frequencies().get(1), 3923.1513, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
+compare_values(wfn_dz.frequencies().get(2), 4020.1774, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
 
-# Not yet implemented #TEST
-#scf_dtz = gradient('SCF/cc-pV[23]Z')
-#compare_matrices(ref_scf_dtz, scf_dtz, 6, "SCF/cc-pV[DT]Z Gradient")  #TEST
-#
-#scf_dtqz = gradient('SCF/cc-pV[DTQ]Z')
-#compare_matrices(ref_scf_dtqz, scf_dtqz, 6, "SCF/cc-pV[DTQ]Z Gradient")  #TEST
-#
-## MP2 TESTS
-#mp2_dtz = gradient('MP2/cc-pV[DT]Z')
-#compare_matrices(ref_mp2_dtz, mp2_dtz, 6, "MP2/cc-pV[DT]Z Gradient")  #TEST
+# reference frequencies: G09.D01 with:
+# freq=noraman hf/cc-pvtz
+# 1753.0400, 4126.9754, 4226.8715
+# reference frequencies: CFOUR v1.0 with: 
+# *ACES2(CALC=HF,BASIS=PVTZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
+# 1753.0405, 4126.9714, 4226.8671
+
+scf_tz, wfn_tz = freq('SCF/cc-pVTZ', return_wfn=True, dertype=1, molecule=h2o_tz)
+compare_values(wfn_tz.frequencies().get(0), 1753.0273, 2, "SCF/cc-pVTZ Frequency 1")            #TEST
+compare_values(wfn_tz.frequencies().get(1), 4127.0329, 2, "SCF/cc-pVTZ Frequency 2")            #TEST
+compare_values(wfn_tz.frequencies().get(2), 4227.0130, 2, "SCF/cc-pVTZ Frequency 3")            #TEST
+
+scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, molecule=h2o_dtz)
+compare_values(wfn_dtz.frequencies().get(0), 1747.7410, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(1), 4130.2255, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(2), 4230.5752, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
 
 
 --------------------------------------------------------------------------
 	Nuclear repulsion energy..........................................PASSED
-hessian() will perform frequency computation by finite difference of analytic gradients.
-
--------------------------------------------------------------
-
-  Using finite-differences of gradients to determine vibrational frequencies and 
-  normal modes.  Resulting frequencies are only valid at stationary points.
-	Generating geometries for use with 3-point formula.
-	Displacement size will be 5.00e-03.
-	Number of atoms is 3.
-	Number of irreps is 4.
-	Number of SALCS is 3.
-	Index of salcs per irrep:
-	 1 :  0  1 
-	 2 : 
-	 3 : 
-	 4 :  2 
-	Number of SALC's per irrep:
-		 Irrep 1: 2
-		 Irrep 2: 0
-		 Irrep 3: 0
-		 Irrep 4: 1
-	Number of geometries (including reference) is 6.
-	Number of displacements per irrep:
-	  Irrep 1: 4
-	  Irrep 2: 0
-	  Irrep 3: 0
-	  Irrep 4: 1
-
--------------------------------------------------------------
-
-  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
-  //    Loading displacement 1 of 6    //
-  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:02 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:13 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -140,15 +129,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065996892278    15.994914619560
-           H          0.000000000000    -0.759061990794     0.523709286607     1.007825032070
-           H          0.000000000000     0.759061990794     0.523709286607     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
+         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.08042  B =     14.51533  C =      9.45003 [cm^-1]
-  Rotational constants: A = 811850.58131  B = 435158.59817  C = 283304.85990 [MHz]
-  Nuclear repulsion =    9.157072652201338
+  Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
+  Rotational constants: A = 817323.20514  B = 435158.59817  C = 283968.37324 [MHz]
+  Nuclear repulsion =    9.168193260387573
 
   Charge       = 0
   Multiplicity = 1
@@ -182,8 +171,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -200,18 +189,332 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.4377086883E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.99554773877419   -7.59955e+01   2.07061e-01 
+   @DF-RHF iter   1:   -75.98243705758790    1.31107e-02   3.47009e-02 
+   @DF-RHF iter   2:   -76.01715752504842   -3.47205e-02   1.75558e-02 DIIS
+   @DF-RHF iter   3:   -76.02597931961122   -8.82179e-03   3.72961e-03 DIIS
+   @DF-RHF iter   4:   -76.02657012930283   -5.90810e-04   9.02803e-04 DIIS
+   @DF-RHF iter   5:   -76.02663007727399   -5.99480e-05   1.43099e-04 DIIS
+   @DF-RHF iter   6:   -76.02663263740753   -2.56013e-06   3.44423e-05 DIIS
+   @DF-RHF iter   7:   -76.02663273258347   -9.51759e-08   4.40081e-06 DIIS
+   @DF-RHF iter   8:   -76.02663273487059   -2.28712e-09   6.33475e-07 DIIS
+   @DF-RHF iter   9:   -76.02663273490650   -3.59108e-11   5.90759e-08 DIIS
+   @DF-RHF iter  10:   -76.02663273490671   -2.13163e-13   5.77635e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550925     2A1    -1.335311     1B2    -0.697803  
+       3A1    -0.566087     1B1    -0.492948  
+
+    Virtual:                                                              
+
+       4A1     0.185107     2B2     0.255846     3B2     0.787336  
+       5A1     0.851826     6A1     1.163856     2B1     1.200424  
+       4B2     1.253573     7A1     1.445291     1A2     1.476011  
+       3B1     1.674661     8A1     1.868110     5B2     1.932579  
+       6B2     2.446529     9A1     2.483817     4B1     3.283958  
+       2A2     3.336669    10A1     3.507634    11A1     3.863421  
+       7B2     4.144760  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02663273490671
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1681932603875733
+    One-Electron Energy =                -123.1035071074840346
+    Two-Electron Energy =                  37.9086811121897540
+    Total Energy =                        -76.0266327349067126
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9783
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1680
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8103     Total:     0.8103
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:15 2018
+Module time:
+	user time   =       7.28 seconds =       0.12 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       7.28 seconds =       0.12 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:15 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
+         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
+
+  Nuclear repulsion =    9.168193260387575
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
+    Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000    -0.017641632736
+       2        0.000000000000    -0.012438417883     0.008820816368
+       3       -0.000000000000     0.012438417883     0.008820816368
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:16 2018
+Module time:
+	user time   =       9.31 seconds =       0.16 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      16.61 seconds =       0.28 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  Based on options and gradient (rms=1.14E-02), recommend projecting translations and projecting rotations.
+hessian() will perform frequency computation by finite difference of analytic gradients.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes.  Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 3.
+    Number of irreps is 4.
+    Number of SALCs is 3.
+    Translations projected? 1. Rotations projected? 1.
+    Index of SALCs per irrep:
+     1 :  0  1 
+     2 : 
+     3 : 
+     4 :  2 
+    Number of SALCs per irrep:
+     Irrep 1: 2
+     Irrep 2: 0
+     Irrep 3: 0
+     Irrep 4: 1
+    Number of geometries (including reference) is 6.
+    Number of displacements per irrep:
+      Irrep 1: 4
+      Irrep 2: 0
+      Irrep 3: 0
+      Irrep 4: 1
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:16 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065996892278    15.994914619560
+         H            0.000000000000    -0.759061990794     0.523709286607     1.007825032070
+         H            0.000000000000     0.759061990794     0.523709286607     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     27.08042  B =     14.51533  C =      9.45003 [cm^-1]
+  Rotational constants: A = 811850.58131  B = 435158.59817  C = 283304.85990 [MHz]
+  Nuclear repulsion =    9.157072652201339
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -232,22 +535,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.89947593598208   -7.58995e+01   1.20340e-01 
-   @DF-RHF iter   1:   -76.00545372659981   -1.05978e-01   1.67621e-02 
-   @DF-RHF iter   2:   -76.02210792823047   -1.66542e-02   7.88910e-03 DIIS
-   @DF-RHF iter   3:   -76.02635375174857   -4.24582e-03   1.27875e-03 DIIS
-   @DF-RHF iter   4:   -76.02654242106777   -1.88669e-04   2.89042e-04 DIIS
-   @DF-RHF iter   5:   -76.02656189622051   -1.94752e-05   6.90724e-05 DIIS
-   @DF-RHF iter   6:   -76.02656323557829   -1.33936e-06   1.13807e-05 DIIS
-   @DF-RHF iter   7:   -76.02656326821550   -3.26372e-08   1.40570e-06 DIIS
-   @DF-RHF iter   8:   -76.02656326866720   -4.51706e-10   2.40938e-07 DIIS
-   @DF-RHF iter   9:   -76.02656326867901   -1.18092e-11   2.65138e-08 DIIS
-   @DF-RHF iter  10:   -76.02656326867915   -1.42109e-13   2.34592e-09 DIIS
+   @DF-RHF iter   0:   -75.91957309019273   -7.59196e+01   1.64764e-01 
+   @DF-RHF iter   1:   -75.99559333498026   -7.60202e-02   3.05678e-02 
+   @DF-RHF iter   2:   -76.01964277974788   -2.40494e-02   1.50784e-02 DIIS
+   @DF-RHF iter   3:   -76.02630086754195   -6.65809e-03   1.98510e-03 DIIS
+   @DF-RHF iter   4:   -76.02653589926793   -2.35032e-04   6.36913e-04 DIIS
+   @DF-RHF iter   5:   -76.02656133821952   -2.54390e-05   1.46032e-04 DIIS
+   @DF-RHF iter   6:   -76.02656321576180   -1.87754e-06   2.19564e-05 DIIS
+   @DF-RHF iter   7:   -76.02656326821511   -5.24533e-08   2.21541e-06 DIIS
+   @DF-RHF iter   8:   -76.02656326866223   -4.47116e-10   4.69006e-07 DIIS
+   @DF-RHF iter   9:   -76.02656326867898   -1.67546e-11   3.89812e-08 DIIS
+   @DF-RHF iter  10:   -76.02656326867917   -1.84741e-13   3.85323e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -268,52 +573,47 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02656326867915
+  @DF-RHF Final Energy:   -76.02656326867917
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1570726522013377
-    One-Electron Energy =                -123.0831369268955058
-    Two-Electron Energy =                  37.8995010060150150
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0265632686791548
+    Nuclear Repulsion Energy =              9.1570726522013395
+    One-Electron Energy =                -123.0831369380330216
+    Two-Electron Energy =                  37.8995010171525166
+    Total Energy =                        -76.0265632686791690
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9816
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1698
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8119     Total:     0.8119
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0635     Total:     2.0635
 
 
-*** tstop() called on psinet at Mon May 15 15:34:02 2017
+*** tstop() called on silver at Tue Sep 25 13:51:17 2018
 Module time:
-	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       8.30 seconds =       0.14 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =      25.04 seconds =       0.42 minutes
+	system time =       0.44 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:02 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:17 2018
 
 
          ------------------------------------------------------------
@@ -331,11 +631,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065996892278    15.994914619560
-           H          0.000000000000    -0.759061990794     0.523709286607     1.007825032070
-           H          0.000000000000     0.759061990794     0.523709286607     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065996892278    15.994914619560
+         H            0.000000000000    -0.759061990794     0.523709286607     1.007825032070
+         H            0.000000000000     0.759061990794     0.523709286607     1.007825032070
 
-  Nuclear repulsion =    9.157072652201338
+  Nuclear repulsion =    9.157072652201339
 
   ==> Basis Set <==
 
@@ -353,8 +653,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -373,43 +673,44 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.019533908613
-       2        0.000000000000    -0.013209291947     0.009766954306
-       3       -0.000000000000     0.013209291947     0.009766954306
+       1       -0.000000000000     0.000000000000    -0.019533905890
+       2        0.000000000000    -0.013209290715     0.009766952945
+       3       -0.000000000000     0.013209290715     0.009766952945
 
 
-*** tstop() called on psinet at Mon May 15 15:34:03 2017
+*** tstop() called on silver at Tue Sep 25 13:51:19 2018
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       9.32 seconds =       0.16 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.54 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =      34.38 seconds =       0.57 minutes
+	system time =       0.65 seconds =       0.01 minutes
+	total time  =          6 seconds =       0.10 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:03 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:19 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -421,9 +722,9 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065554248798    15.994914619560
-           H          0.000000000000    -0.759061990794     0.520196749984     1.007825032070
-           H          0.000000000000     0.759061990794     0.520196749984     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065554248798    15.994914619560
+         H            0.000000000000    -0.759061990794     0.520196749984     1.007825032070
+         H            0.000000000000     0.759061990794     0.520196749984     1.007825032070
 
   Running in c2v symmetry.
 
@@ -463,8 +764,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -481,18 +782,19 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -513,22 +815,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.01988237078834   -7.60199e+01   1.22556e-01 
-   @DF-RHF iter   1:   -75.99062526299822    2.92571e-02   2.06356e-02 
-   @DF-RHF iter   2:   -76.01898377941771   -2.83585e-02   1.02730e-02 DIIS
-   @DF-RHF iter   3:   -76.02612242896438   -7.13865e-03   1.74573e-03 DIIS
-   @DF-RHF iter   4:   -76.02663802139857   -5.15592e-04   4.94405e-04 DIIS
-   @DF-RHF iter   5:   -76.02669204189058   -5.40205e-05   1.01675e-04 DIIS
-   @DF-RHF iter   6:   -76.02669504613220   -3.00424e-06   1.57226e-05 DIIS
-   @DF-RHF iter   7:   -76.02669511782139   -7.16892e-08   1.99800e-06 DIIS
-   @DF-RHF iter   8:   -76.02669511867394   -8.52552e-10   3.49808e-07 DIIS
-   @DF-RHF iter   9:   -76.02669511869779   -2.38458e-11   3.14990e-08 DIIS
-   @DF-RHF iter  10:   -76.02669511869790   -1.13687e-13   4.45949e-09 DIIS
+   @DF-RHF iter   0:   -75.98367848452720   -7.59837e+01   1.92100e-01 
+   @DF-RHF iter   1:   -75.98843482191133   -4.75634e-03   2.89682e-02 
+   @DF-RHF iter   2:   -76.01834607107234   -2.99112e-02   2.19070e-02 DIIS
+   @DF-RHF iter   3:   -76.02628287808560   -7.93681e-03   2.60077e-03 DIIS
+   @DF-RHF iter   4:   -76.02665706061252   -3.74183e-04   6.90952e-04 DIIS
+   @DF-RHF iter   5:   -76.02669317452700   -3.61139e-05   1.35979e-04 DIIS
+   @DF-RHF iter   6:   -76.02669504992893   -1.87540e-06   2.54659e-05 DIIS
+   @DF-RHF iter   7:   -76.02669511721706   -6.72881e-08   3.73909e-06 DIIS
+   @DF-RHF iter   8:   -76.02669511866613   -1.44907e-09   5.60471e-07 DIIS
+   @DF-RHF iter   9:   -76.02669511869709   -3.09655e-11   4.73204e-08 DIIS
+   @DF-RHF iter  10:   -76.02669511869721   -1.13687e-13   4.94403e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -549,52 +853,47 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02669511869790
+  @DF-RHF Final Energy:   -76.02669511869721
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1793185254287639
-    One-Electron Energy =                -123.1238719392706713
-    Two-Electron Energy =                  37.9178582951440006
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0266951186979014
+    One-Electron Energy =                -123.1238719154403327
+    Two-Electron Energy =                  37.9178582713143655
+    Total Energy =                        -76.0266951186972051
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9750
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1663
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8087     Total:     0.8087
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0555     Total:     2.0555
 
 
-*** tstop() called on psinet at Mon May 15 15:34:03 2017
+*** tstop() called on silver at Tue Sep 25 13:51:20 2018
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.03 seconds =       0.02 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       8.30 seconds =       0.14 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      42.80 seconds =       0.71 minutes
+	system time =       0.75 seconds =       0.01 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:03 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:20 2018
 
 
          ------------------------------------------------------------
@@ -612,9 +911,9 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065554248798    15.994914619560
-           H          0.000000000000    -0.759061990794     0.520196749984     1.007825032070
-           H          0.000000000000     0.759061990794     0.520196749984     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065554248798    15.994914619560
+         H            0.000000000000    -0.759061990794     0.520196749984     1.007825032070
+         H            0.000000000000     0.759061990794     0.520196749984     1.007825032070
 
   Nuclear repulsion =    9.179318525428764
 
@@ -634,8 +933,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -654,43 +953,44 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.015743588331
-       2        0.000000000000    -0.011659060189     0.007871794166
-       3       -0.000000000000     0.011659060189     0.007871794166
+       1       -0.000000000000     0.000000000000    -0.015743588759
+       2        0.000000000000    -0.011659060650     0.007871794379
+       3       -0.000000000000     0.011659060650     0.007871794379
 
 
-*** tstop() called on psinet at Mon May 15 15:34:03 2017
+*** tstop() called on silver at Tue Sep 25 13:51:21 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       9.32 seconds =       0.16 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      52.14 seconds =       0.87 minutes
+	system time =       0.96 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:03 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:21 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -702,15 +1002,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.760925637419     0.521953018295     1.007825032070
-           H          0.000000000000     0.760925637419     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.760925637419     0.521953018295     1.007825032070
+         H            0.000000000000     0.760925637419     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.26297  B =     14.44431  C =      9.44187 [cm^-1]
   Rotational constants: A = 817323.20514  B = 433029.64182  C = 283060.23826 [MHz]
-  Nuclear repulsion =    9.153816284505737
+  Nuclear repulsion =    9.153816284505739
 
   Charge       = 0
   Multiplicity = 1
@@ -744,8 +1044,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -762,18 +1062,19 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -794,22 +1095,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05569333207563   -7.60557e+01   1.22108e-01 
-   @DF-RHF iter   1:   -75.97560949486493    8.00838e-02   2.39164e-02 
-   @DF-RHF iter   2:   -76.01583254264183   -4.02230e-02   1.21607e-02 DIIS
-   @DF-RHF iter   3:   -76.02574546762710   -9.91292e-03   2.16719e-03 DIIS
-   @DF-RHF iter   4:   -76.02647541385356   -7.29946e-04   5.69967e-04 DIIS
-   @DF-RHF iter   5:   -76.02653762087996   -6.22070e-05   9.22996e-05 DIIS
-   @DF-RHF iter   6:   -76.02653975474686   -2.13387e-06   1.88404e-05 DIIS
-   @DF-RHF iter   7:   -76.02653984810819   -9.33613e-08   3.30630e-06 DIIS
-   @DF-RHF iter   8:   -76.02653985109535   -2.98716e-09   4.46048e-07 DIIS
-   @DF-RHF iter   9:   -76.02653985113969   -4.43379e-11   3.51737e-08 DIIS
-   @DF-RHF iter  10:   -76.02653985113983   -1.42109e-13   3.42926e-09 DIIS
+   @DF-RHF iter   0:   -75.89253678848510   -7.58925e+01   1.66571e-01 
+   @DF-RHF iter   1:   -76.00519083235311   -1.12654e-01   2.34857e-02 
+   @DF-RHF iter   2:   -76.02198604766386   -1.67952e-02   1.36537e-02 DIIS
+   @DF-RHF iter   3:   -76.02635882876913   -4.37278e-03   2.07481e-03 DIIS
+   @DF-RHF iter   4:   -76.02652322009256   -1.64391e-04   3.59075e-04 DIIS
+   @DF-RHF iter   5:   -76.02653872046388   -1.55004e-05   9.23871e-05 DIIS
+   @DF-RHF iter   6:   -76.02653981858883   -1.09812e-06   1.70879e-05 DIIS
+   @DF-RHF iter   7:   -76.02653985072483   -3.21360e-08   2.17645e-06 DIIS
+   @DF-RHF iter   8:   -76.02653985113137   -4.06544e-10   4.16740e-07 DIIS
+   @DF-RHF iter   9:   -76.02653985114262   -1.12408e-11   4.16666e-08 DIIS
+   @DF-RHF iter  10:   -76.02653985114273   -1.13687e-13   4.07017e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -830,52 +1133,47 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02653985113983
+  @DF-RHF Final Energy:   -76.02653985114273
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1538162845057371
-    One-Electron Energy =                -123.0783779632031667
-    Two-Electron Energy =                  37.8980218275575993
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0265398511398303
+    Nuclear Repulsion Energy =              9.1538162845057389
+    One-Electron Energy =                -123.0783779688797637
+    Two-Electron Energy =                  37.8980218332312973
+    Total Energy =                        -76.0265398511427293
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9783
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1683
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8100     Total:     0.8100
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0589     Total:     2.0589
 
 
-*** tstop() called on psinet at Mon May 15 15:34:04 2017
+*** tstop() called on silver at Tue Sep 25 13:51:23 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.56 seconds =       0.03 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       8.30 seconds =       0.14 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      60.56 seconds =       1.01 minutes
+	system time =       1.07 seconds =       0.02 minutes
+	total time  =         10 seconds =       0.17 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:04 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:23 2018
 
 
          ------------------------------------------------------------
@@ -893,11 +1191,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.760925637419     0.521953018295     1.007825032070
-           H          0.000000000000     0.760925637419     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.760925637419     0.521953018295     1.007825032070
+         H            0.000000000000     0.760925637419     0.521953018295     1.007825032070
 
-  Nuclear repulsion =    9.153816284505737
+  Nuclear repulsion =    9.153816284505739
 
   ==> Basis Set <==
 
@@ -915,8 +1213,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -935,43 +1233,44 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.019091966628
-       2        0.000000000000    -0.013933555017     0.009545983314
-       3       -0.000000000000     0.013933555017     0.009545983314
+       1        0.000000000000     0.000000000000    -0.019091966387
+       2        0.000000000000    -0.013933554794     0.009545983193
+       3       -0.000000000000     0.013933554794     0.009545983193
 
 
-*** tstop() called on psinet at Mon May 15 15:34:04 2017
+*** tstop() called on silver at Tue Sep 25 13:51:24 2018
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       9.34 seconds =       0.16 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.70 seconds =       0.03 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      69.92 seconds =       1.17 minutes
+	system time =       1.28 seconds =       0.02 minutes
+	total time  =         11 seconds =       0.18 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:04 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:24 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -983,9 +1282,9 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.757198344170     0.521953018295     1.007825032070
-           H          0.000000000000     0.757198344170     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.757198344170     0.521953018295     1.007825032070
+         H            0.000000000000     0.757198344170     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
@@ -1025,8 +1324,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1043,18 +1342,19 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -1075,22 +1375,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.09904638664366   -7.60990e+01   1.23150e-01 
-   @DF-RHF iter   1:   -75.97333458841702    1.25712e-01   2.41085e-02 
-   @DF-RHF iter   2:   -76.01572013266113   -4.23855e-02   1.21011e-02 DIIS
-   @DF-RHF iter   3:   -76.02573108814755   -1.00110e-02   2.36648e-03 DIIS
-   @DF-RHF iter   4:   -76.02663465384842   -9.03566e-04   6.15335e-04 DIIS
-   @DF-RHF iter   5:   -76.02671203371776   -7.73799e-05   1.04249e-04 DIIS
-   @DF-RHF iter   6:   -76.02671491090906   -2.87719e-06   2.20914e-05 DIIS
-   @DF-RHF iter   7:   -76.02671503949860   -1.28590e-07   3.56979e-06 DIIS
-   @DF-RHF iter   8:   -76.02671504281535   -3.31676e-09   4.45907e-07 DIIS
-   @DF-RHF iter   9:   -76.02671504285600   -4.06430e-11   3.81998e-08 DIIS
-   @DF-RHF iter  10:   -76.02671504285610   -9.94760e-14   3.83082e-09 DIIS
+   @DF-RHF iter   0:   -75.89807589421447   -7.58981e+01   2.05350e-01 
+   @DF-RHF iter   1:   -76.00529159902791   -1.07216e-01   2.66830e-02 
+   @DF-RHF iter   2:   -76.02216222924777   -1.68706e-02   1.49610e-02 DIIS
+   @DF-RHF iter   3:   -76.02653354068680   -4.37131e-03   1.69307e-03 DIIS
+   @DF-RHF iter   4:   -76.02669840083654   -1.64860e-04   4.75159e-04 DIIS
+   @DF-RHF iter   5:   -76.02671392214720   -1.55213e-05   1.01213e-04 DIIS
+   @DF-RHF iter   6:   -76.02671501103666   -1.08889e-06   1.53335e-05 DIIS
+   @DF-RHF iter   7:   -76.02671504244923   -3.14126e-08   2.00491e-06 DIIS
+   @DF-RHF iter   8:   -76.02671504284672   -3.97492e-10   3.03148e-07 DIIS
+   @DF-RHF iter   9:   -76.02671504285773   -1.10134e-11   3.61700e-08 DIIS
+   @DF-RHF iter  10:   -76.02671504285797   -2.41585e-13   3.19341e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1111,52 +1413,47 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02671504285610
+  @DF-RHF Final Energy:   -76.02671504285797
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1826035407948741
-    One-Electron Energy =                -123.1286765145645603
-    Two-Electron Energy =                  37.9193579309135913
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0267150428560967
+    One-Electron Energy =                -123.1286765158269105
+    Two-Electron Energy =                  37.9193579321740728
+    Total Energy =                        -76.0267150428579725
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9783
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1678
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8105     Total:     0.8105
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0602     Total:     2.0602
 
 
-*** tstop() called on psinet at Mon May 15 15:34:04 2017
+*** tstop() called on silver at Tue Sep 25 13:51:26 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       2.12 seconds =       0.04 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       8.49 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      78.52 seconds =       1.31 minutes
+	system time =       1.41 seconds =       0.02 minutes
+	total time  =         13 seconds =       0.22 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:04 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:26 2018
 
 
          ------------------------------------------------------------
@@ -1174,9 +1471,9 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.757198344170     0.521953018295     1.007825032070
-           H          0.000000000000     0.757198344170     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.757198344170     0.521953018295     1.007825032070
+         H            0.000000000000     0.757198344170     0.521953018295     1.007825032070
 
   Nuclear repulsion =    9.182603540794874
 
@@ -1196,8 +1493,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1216,43 +1513,44 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.016170102143
-       2        0.000000000000    -0.010930574200     0.008085051071
-       3       -0.000000000000     0.010930574200     0.008085051071
+       1       -0.000000000000     0.000000000000    -0.016170101482
+       2        0.000000000000    -0.010930573734     0.008085050741
+       3       -0.000000000000     0.010930573734     0.008085050741
 
 
-*** tstop() called on psinet at Mon May 15 15:34:04 2017
+*** tstop() called on silver at Tue Sep 25 13:51:27 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       9.32 seconds =       0.16 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.24 seconds =       0.04 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      87.86 seconds =       1.46 minutes
+	system time =       1.61 seconds =       0.03 minutes
+	total time  =         14 seconds =       0.23 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:04 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:27 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1264,15 +1562,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.757643253230     0.520854514304     1.007825032070
-           H          0.000000000000     0.760480728358     0.523051522286     1.007825032070
+         O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.757643253230     0.520854514304     1.007825032070
+         H            0.000000000000     0.760480728358     0.523051522286     1.007825032070
 
   Running in cs symmetry.
 
   Rotational constants: A =     27.26378  B =     14.51501  C =      9.47213 [cm^-1]
   Rotational constants: A = 817347.49341  B = 435149.09044  C = 283967.25621 [MHz]
-  Nuclear repulsion =    9.168228694827294
+  Nuclear repulsion =    9.168228694827295
 
   Charge       = 0
   Multiplicity = 1
@@ -1306,8 +1604,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1322,18 +1620,19 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -1354,22 +1653,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.02127723243197   -7.60213e+01   8.88538e-02 
-   @DF-RHF iter   1:   -75.98967767192784    3.15996e-02   1.51095e-02 
-   @DF-RHF iter   2:   -76.01880704760180   -2.91294e-02   7.51206e-03 DIIS
-   @DF-RHF iter   3:   -76.02604034172973   -7.23329e-03   1.29210e-03 DIIS
-   @DF-RHF iter   4:   -76.02656742054805   -5.27079e-04   3.63998e-04 DIIS
-   @DF-RHF iter   5:   -76.02662208901125   -5.46685e-05   7.35025e-05 DIIS
-   @DF-RHF iter   6:   -76.02662501408236   -2.92507e-06   1.16673e-05 DIIS
-   @DF-RHF iter   7:   -76.02662508857200   -7.44896e-08   1.61746e-06 DIIS
-   @DF-RHF iter   8:   -76.02662508969885   -1.12685e-09   3.32040e-07 DIIS
-   @DF-RHF iter   9:   -76.02662508974012   -4.12683e-11   5.48975e-08 DIIS
-   @DF-RHF iter  10:   -76.02662508974120   -1.08002e-12   9.70161e-09 DIIS
+   @DF-RHF iter   0:   -76.09613561767939   -7.60961e+01   1.78355e-01 
+   @DF-RHF iter   1:   -75.97316728851428    1.22968e-01   2.82905e-02 
+   @DF-RHF iter   2:   -76.01558749618056   -4.24202e-02   1.76125e-02 DIIS
+   @DF-RHF iter   3:   -76.02563619243142   -1.00487e-02   2.56671e-03 DIIS
+   @DF-RHF iter   4:   -76.02654410240216   -9.07910e-04   6.94461e-04 DIIS
+   @DF-RHF iter   5:   -76.02662205151748   -7.79491e-05   1.38761e-04 DIIS
+   @DF-RHF iter   6:   -76.02662495547526   -2.90396e-06   2.61080e-05 DIIS
+   @DF-RHF iter   7:   -76.02662508631546   -1.30840e-07   3.76631e-06 DIIS
+   @DF-RHF iter   8:   -76.02662508970069   -3.38522e-09   5.49808e-07 DIIS
+   @DF-RHF iter   9:   -76.02662508974153   -4.08420e-11   4.16107e-08 DIIS
+   @DF-RHF iter  10:   -76.02662508974171   -1.84741e-13   4.54830e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1390,52 +1691,47 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02662508974120
+  @DF-RHF Final Energy:   -76.02662508974171
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1682286948272935
-    One-Electron Energy =                -123.1035546717954503
-    Two-Electron Energy =                  37.9087008872269635
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0266250897412021
+    Nuclear Repulsion Energy =              9.1682286948272953
+    One-Electron Energy =                -123.1035547533186474
+    Two-Electron Energy =                  37.9087009687496419
+    Total Energy =                        -76.0266250897417137
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0027      Z:     0.9783
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:    -0.0015      Z:    -0.1680
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0012      Z:     0.8103     Total:     0.8103
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0031      Z:     2.0595     Total:     2.0595
 
 
-*** tstop() called on psinet at Mon May 15 15:34:05 2017
+*** tstop() called on silver at Tue Sep 25 13:51:28 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       8.31 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.65 seconds =       0.04 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      96.28 seconds =       1.60 minutes
+	system time =       1.74 seconds =       0.03 minutes
+	total time  =         15 seconds =       0.25 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:05 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:28 2018
 
 
          ------------------------------------------------------------
@@ -1453,11 +1749,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.757643253230     0.520854514304     1.007825032070
-           H          0.000000000000     0.760480728358     0.523051522286     1.007825032070
+         O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.757643253230     0.520854514304     1.007825032070
+         H            0.000000000000     0.760480728358     0.523051522286     1.007825032070
 
-  Nuclear repulsion =    9.168228694827294
+  Nuclear repulsion =    9.168228694827295
 
   ==> Basis Set <==
 
@@ -1475,8 +1771,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1495,43 +1791,44 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003305712586    -0.017624080124
-       2        0.000000000000    -0.010774934679     0.007532815881
-       3        0.000000000000     0.014080647264     0.010091264243
+       1        0.000000000000    -0.003305711403    -0.017624077668
+       2        0.000000000000    -0.010774934449     0.007532821609
+       3        0.000000000000     0.014080645852     0.010091256059
 
 
-*** tstop() called on psinet at Mon May 15 15:34:05 2017
+*** tstop() called on silver at Tue Sep 25 13:51:30 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       9.29 seconds =       0.15 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       2.77 seconds =       0.05 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =     105.59 seconds =       1.76 minutes
+	system time =       1.97 seconds =       0.03 minutes
+	total time  =         17 seconds =       0.28 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:05 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:30 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1543,9 +1840,9 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-           H          0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
+         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
@@ -1585,8 +1882,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    50 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1603,18 +1900,19 @@ gradient() will perform analytic gradient computation.
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
 
    => Auxiliary Basis Set <=
 
@@ -1635,22 +1933,24 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.06908966324400   -7.60691e+01   1.22574e-01 
-   @DF-RHF iter   1:   -75.97502194446606    9.40677e-02   2.39777e-02 
-   @DF-RHF iter   2:   -76.01585802048496   -4.08361e-02   1.21398e-02 DIIS
-   @DF-RHF iter   3:   -76.02578771308337   -9.92969e-03   2.22311e-03 DIIS
-   @DF-RHF iter   4:   -76.02656395588136   -7.76243e-04   5.82674e-04 DIIS
-   @DF-RHF iter   5:   -76.02663028524800   -6.63294e-05   9.57906e-05 DIIS
-   @DF-RHF iter   6:   -76.02663262794955   -2.34270e-06   1.98435e-05 DIIS
-   @DF-RHF iter   7:   -76.02663273177045   -1.03821e-07   3.39172e-06 DIIS
-   @DF-RHF iter   8:   -76.02663273486544   -3.09500e-09   4.44760e-07 DIIS
-   @DF-RHF iter   9:   -76.02663273490825   -4.28031e-11   3.59212e-08 DIIS
-   @DF-RHF iter  10:   -76.02663273490839   -1.42109e-13   3.53592e-09 DIIS
+   @DF-RHF iter   0:   -75.89530570965437   -7.58953e+01   1.67118e-01 
+   @DF-RHF iter   1:   -76.00524669119459   -1.09941e-01   2.66565e-02 
+   @DF-RHF iter   2:   -76.02207948980923   -1.68328e-02   1.26425e-02 DIIS
+   @DF-RHF iter   3:   -76.02645147277228   -4.37198e-03   1.87232e-03 DIIS
+   @DF-RHF iter   4:   -76.02661609804781   -1.64625e-04   3.80227e-04 DIIS
+   @DF-RHF iter   5:   -76.02663160921207   -1.55112e-05   1.03473e-04 DIIS
+   @DF-RHF iter   6:   -76.02663270272370   -1.09351e-06   2.21092e-05 DIIS
+   @DF-RHF iter   7:   -76.02663273449569   -3.17720e-08   2.23126e-06 DIIS
+   @DF-RHF iter   8:   -76.02663273489758   -4.01883e-10   3.40083e-07 DIIS
+   @DF-RHF iter   9:   -76.02663273490883   -1.12550e-11   4.38701e-08 DIIS
+   @DF-RHF iter  10:   -76.02663273490893   -9.94760e-14   3.43845e-09 DIIS
+  Energy converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1671,52 +1971,47 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:   -76.02663273490839
+  @DF-RHF Final Energy:   -76.02663273490893
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1681932603875769
-    One-Electron Energy =                -123.1035071020140492
-    Two-Electron Energy =                  37.9086811067180847
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0266327349083895
+    One-Electron Energy =                -123.1035071065877560
+    Two-Electron Energy =                  37.9086811112912443
+    Total Energy =                        -76.0266327349089295
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9783
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1680
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8103     Total:     0.8103
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
 
 
-*** tstop() called on psinet at Mon May 15 15:34:05 2017
+*** tstop() called on silver at Tue Sep 25 13:51:31 2018
 Module time:
-	user time   =       0.42 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       8.34 seconds =       0.14 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.20 seconds =       0.05 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =     114.04 seconds =       1.90 minutes
+	system time =       2.11 seconds =       0.04 minutes
+	total time  =         18 seconds =       0.30 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:05 2017
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:31 2018
 
 
          ------------------------------------------------------------
@@ -1734,9 +2029,9 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-           H          0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-           H          0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
+         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
+         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
 
   Nuclear repulsion =    9.168193260387577
 
@@ -1756,8 +2051,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1776,155 +2071,3852 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.017641632658
-       2        0.000000000000    -0.012438417774     0.008820816329
-       3       -0.000000000000     0.012438417774     0.008820816329
+       1       -0.000000000000     0.000000000000    -0.017641632307
+       2        0.000000000000    -0.012438417484     0.008820816153
+       3       -0.000000000000     0.012438417484     0.008820816153
 
 
-*** tstop() called on psinet at Mon May 15 15:34:06 2017
+*** tstop() called on silver at Tue Sep 25 13:51:32 2018
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       9.35 seconds =       0.16 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.34 seconds =       0.06 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =     123.40 seconds =       2.06 minutes
+	system time =       2.28 seconds =       0.04 minutes
+	total time  =         19 seconds =       0.32 minutes
 
--------------------------------------------------------------
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
 
   Computing second-derivative from gradients using projected, 
-  symmetry-adapted, cartesian coordinates (fd_freq_1).
+  symmetry-adapted, cartesian coordinates.
 
   6 gradients passed in, including the reference geometry.
   Generating complete list of displacements from unique ones.
 
-	Operation 2 takes plus displacements of irrep B2 to minus ones.
-
-	  Irrep      Harmonic Frequency   
-	                  (cm-1)          
-	-----------------------------------------------
-	     A1         1809.2360  
-	     A1         3923.1571  
-	     B2         4020.1859  
-	-----------------------------------------------
-
-	Normal Modes (non-mass-weighted).
-	Molecular mass is   18.01056 amu.
-	Frequencies in cm^-1; force constants in au.
-
-   Frequency:       1809.24
-   Force constant:   0.1239
-	     X       Y       Z           mass	
-  O 	   0.000   0.000  -0.068      15.994915
-  H 	   0.000   0.415   0.536       1.007825
-  H 	   0.000  -0.415   0.536       1.007825
-
-   Frequency:       3923.16
-   Force constant:   0.5825
-	     X       Y       Z           mass	
-  O 	   0.000   0.000   0.049      15.994915
-  H 	   0.000   0.569  -0.391       1.007825
-  H 	   0.000  -0.569  -0.391       1.007825
-
-   Frequency:       4020.19
-   Force constant:   0.6116
-	     X       Y       Z           mass	
-  O 	   0.000   0.068   0.000      15.994915
-  H 	   0.000  -0.536   0.415       1.007825
-  H 	   0.000  -0.536  -0.415       1.007825
+    Operation 2 takes plus displacements of irrep B2 to minus ones.
 
 -------------------------------------------------------------
 
- #  #
- Irrep: 1
-      1: 1809.2359693
-      2: 3923.1571232
-      3: 4020.1858792
 
+  ==> Harmonic Vibrational Analysis <==
 
-            *********************************************
-            * Thermodynamic Analysis by R.A. King, 2012 *
-            *********************************************
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
+  projection of translations (True) and rotations (True) removed 6 degrees of freedom (6)
+  total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1809.2464'
+ '3923.1516' '4020.1816']
+  projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1809.2464'
+ '3923.1516' '4020.1816']
 
-  ==> Inputs to Thermochemistry <==
+  Vibration                       7                   8                   9           
+  Freq [cm^-1]                1809.2464           3923.1516           4020.1816       
+  Irrep                           A1                  A1                  B2          
+  Reduced mass [u]              1.0818              1.0460              1.0819        
+  Force const [mDyne/A]         2.0864              9.4849             10.3018        
+  Turning point v=0 [a0]        0.2480              0.1713              0.1664        
+  RMS dev v=0 [a0 u^1/2]        0.1824              0.1239              0.1224        
+  Char temp [K]               2603.0988           5644.5331           5784.1374       
+  ----------------------------------------------------------------------------------
+      1   O               -0.00 -0.00 -0.07   -0.00 -0.00  0.05    0.00 -0.07 -0.00   
+      2   H               -0.00  0.43  0.56    0.00  0.58 -0.40    0.00  0.56 -0.43   
+      3   H               -0.00 -0.43  0.56   -0.00 -0.58 -0.40   -0.00  0.56  0.43   
 
-  Temperature:                       298.15 [K]
-  Pressure:                       101325.00 [Pa]
-  Multiplicity:                           1
-  Full point group:                 Cnv (C2v)
-  Rotor type:                ASYMMETRIC_TOP
-  Rotational symmetry no.:                2
-  Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
-  Rotational constants: A = 817323.20514  B = 435158.59817  C = 283968.37324 [MHz]
-
-  No.    Vib. Freq. [cm^-1]      Vib. Temp. [K]
-    1              1809.236            2603.084
-    2              3923.157            5644.541
-    3              4020.186            5784.144
-
-  ==> Components <==
+  ==> Thermochemistry Components <==
 
   Entropy, S
-    Electronic S          0.000 [cal/(mol K)]       0.000 [J/(mol K)]      0.00000000 [mEh/K] (multiplicity = 1)
-    Translational S      34.608 [cal/(mol K)]     144.801 [J/(mol K)]      0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
-    Rotational S         10.463 [cal/(mol K)]      43.779 [J/(mol K)]      0.01667448 [mEh/K] (symmetry no. = 2)
-    Vibrational S         0.003 [cal/(mol K)]       0.013 [J/(mol K)]      0.00000498 [mEh/K]
-  Total S                45.075 [cal/(mol K)]     188.593 [J/(mol K)]      0.07183131 [mEh/K]
+    Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.463 [cal/(mol K)]       43.779 [J/(mol K)]       0.01667448 [mEh/K] (symmetry no. = 2)
+    Vibrational S           0.003 [cal/(mol K)]        0.013 [J/(mol K)]       0.00000498 [mEh/K]
+  Total S                  45.075 [cal/(mol K)]      188.593 [J/(mol K)]       0.07183131 [mEh/K]
+  Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant volume heat capacity, Cv
-    Electronic Cv         0.000 [cal/(mol K)]       0.000 [J/(mol K)]      0.00000000 [mEh/K]
-    Translational Cv      2.981 [cal/(mol K)]      12.472 [J/(mol K)]      0.00475022 [mEh/K]
-    Rotational Cv         2.981 [cal/(mol K)]      12.472 [J/(mol K)]      0.00475022 [mEh/K]
-    Vibrational Cv        0.024 [cal/(mol K)]       0.102 [J/(mol K)]      0.00003902 [mEh/K]
-  Total Cv                5.986 [cal/(mol K)]      25.046 [J/(mol K)]      0.00953946 [mEh/K]
+    Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cv          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
+  Total Cv                  5.986 [cal/(mol K)]       25.046 [J/(mol K)]       0.00953946 [mEh/K]
+  Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant pressure heat capacity, Cp
-    Electronic Cp         0.000 [cal/(mol K)]       0.000 [J/(mol K)]      0.00000000 [mEh/K]
-    Translational Cp      4.968 [cal/(mol K)]      20.786 [J/(mol K)]      0.00791704 [mEh/K]
-    Rotational Cp         2.981 [cal/(mol K)]      12.472 [J/(mol K)]      0.00475022 [mEh/K]
-    Vibrational Cp        0.024 [cal/(mol K)]       0.102 [J/(mol K)]      0.00003902 [mEh/K]
-  Total Cp                7.973 [cal/(mol K)]      33.360 [J/(mol K)]      0.01270628 [mEh/K]
+    Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cp          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
+  Total Cp                  7.973 [cal/(mol K)]       33.360 [J/(mol K)]       0.01270628 [mEh/K]
+  Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
-  ==> Energy Analysis <== 
+  ==> Thermochemistry Energy Analysis <==
 
   Raw electronic energy, E0
-  Total E0, Electronic energy at well bottom at 0 [K]              -76.02663273 [Eh]
+  Total E0, Electronic energy at well bottom at 0 [K]                  -76.02663273 [Eh]
 
   Zero-point energy, ZPE_vib = Sum_i nu_i / 2
-    Electronic ZPE        0.000 [kcal/mol]       0.000 [kJ/mol]      0.00000000 [Eh]
-    Translational ZPE     0.000 [kcal/mol]       0.000 [kJ/mol]      0.00000000 [Eh]
-    Rotational ZPE        0.000 [kcal/mol]       0.000 [kJ/mol]      0.00000000 [Eh]
-    Vibrational ZPE      13.942 [kcal/mol]      58.333 [kJ/mol]      0.02221801 [Eh]        4876.289 [cm^-1]
-    Correction ZPE       13.942 [kcal/mol]      58.333 [kJ/mol]      0.02221801 [Eh]        4876.289 [cm^-1]
-  Total ZPE, Electronic energy at 0 [K]                            -76.00441472 [Eh]
+    Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Vibrational ZPE        13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.288 [cm^-1]
+  Correction ZPE           13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.288 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.00441473 [Eh]
 
   Thermal Energy, E (includes ZPE)
-    Electronic E          0.000 [kcal/mol]       0.000 [kJ/mol]      0.00000000 [Eh]
-    Translational E       0.889 [kcal/mol]       3.718 [kJ/mol]      0.00141628 [Eh]
-    Rotational E          0.889 [kcal/mol]       3.718 [kJ/mol]      0.00141628 [Eh]
-    Vibrational E        13.943 [kcal/mol]      58.337 [kJ/mol]      0.02221934 [Eh]
-  Correction E           15.720 [kcal/mol]      65.774 [kJ/mol]      0.02505189 [Eh]
-  Total E, Electronic energy at  298.15 [K]                        -76.00158084 [Eh]
+    Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational E          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
+  Correction E             15.720 [kcal/mol]       65.774 [kJ/mol]       0.02505190 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.00158084 [Eh]
 
   Enthalpy, H_trans = E_trans + k_B * T
-    Electronic H          0.000 [kcal/mol]       0.000 [kJ/mol]      0.00000000 [Eh]
-    Translational H       1.481 [kcal/mol]       6.197 [kJ/mol]      0.00236046 [Eh]
-    Rotational H          0.889 [kcal/mol]       3.718 [kJ/mol]      0.00141628 [Eh]
-    Vibrational H        13.943 [kcal/mol]      58.337 [kJ/mol]      0.02221934 [Eh]
-  Correction H           16.313 [kcal/mol]      68.253 [kJ/mol]      0.02599608 [Eh]
-  Total H, Enthalpy at  298.15 [K]                                 -76.00063665 [Eh]
+    Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
+    Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational H          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
+  Correction H             16.313 [kcal/mol]       68.253 [kJ/mol]       0.02599608 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.00063665 [Eh]
 
   Gibbs free energy, G = H - T * S
-    Electronic G         -0.000 [kcal/mol]      -0.000 [kJ/mol]     -0.00000000 [Eh]
-    Translational G      -8.837 [kcal/mol]     -36.975 [kJ/mol]     -0.01408306 [Eh]
-    Rotational G         -2.231 [kcal/mol]      -9.334 [kJ/mol]     -0.00355522 [Eh]
-    Vibrational G        13.942 [kcal/mol]      58.333 [kJ/mol]      0.02221785 [Eh]
-  Correction G            2.874 [kcal/mol]      12.024 [kJ/mol]      0.00457957 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                            -76.02205316 [Eh]
-
+    Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
+    Rotational G           -2.231 [kcal/mol]       -9.334 [kJ/mol]      -0.00355522 [Eh]
+    Vibrational G          13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221785 [Eh]
+  Correction G              2.874 [kcal/mol]       12.024 [kJ/mol]       0.00457958 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.02205316 [Eh]
 	SCF/cc-pVDZ Frequency 1...........................................PASSED
 	SCF/cc-pVDZ Frequency 2...........................................PASSED
 	SCF/cc-pVDZ Frequency 3...........................................PASSED
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:32 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
+         H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.38939  B =     14.82055  C =      9.85224 [cm^-1]
+  Rotational constants: A = 881071.62781  B = 444308.76784  C = 295362.63749 [MHz]
+  Nuclear repulsion =    9.353677802986757
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3474054466E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15347657941527   -7.61535e+01   9.81852e-02 
+   @DF-RHF iter   1:   -76.00793896105995    1.45538e-01   1.84569e-02 
+   @DF-RHF iter   2:   -76.04631497044016   -3.83760e-02   1.12829e-02 DIIS
+   @DF-RHF iter   3:   -76.05687689488875   -1.05619e-02   1.94969e-03 DIIS
+   @DF-RHF iter   4:   -76.05767028195160   -7.93387e-04   4.22642e-04 DIIS
+   @DF-RHF iter   5:   -76.05775930899149   -8.90270e-05   9.01147e-05 DIIS
+   @DF-RHF iter   6:   -76.05776302330433   -3.71431e-06   1.66785e-05 DIIS
+   @DF-RHF iter   7:   -76.05776311541881   -9.21145e-08   2.66779e-06 DIIS
+   @DF-RHF iter   8:   -76.05776311845361   -3.03480e-09   4.83629e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854483   -9.12195e-11   5.57321e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854611   -1.27898e-12   5.95904e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.551028     2A1    -1.353301     1B2    -0.721937  
+       3A1    -0.577892     1B1    -0.505384  
+
+    Virtual:                                                              
+
+       4A1     0.144319     2B2     0.205173     3B2     0.553672  
+       5A1     0.606501     6A1     0.666793     2B1     0.787514  
+       4B2     0.805097     7A1     0.811469     1A2     0.861557  
+       3B1     0.963988     8A1     1.118808     5B2     1.202677  
+       6B2     1.546259     9A1     1.589176     7B2     2.031142  
+       4B1     2.037085     2A2     2.075917    10A1     2.171714  
+      11A1     2.232214    12A1     2.609949     8B2     2.973570  
+       5B1     3.371299    13A1     3.508424     3A2     3.582881  
+       9B2     3.670144     6B1     3.817086    14A1     3.887085  
+      10B2     3.900630     4A2     3.968349     7B1     4.026369  
+      11B2     4.087653    15A1     4.212757     5A2     4.349836  
+      16A1     4.428865    12B2     4.599070     8B1     4.703366  
+      13B2     4.910416    17A1     5.211746    18A1     5.270269  
+      14B2     5.547693     9B1     6.083565    19A1     6.616731  
+      10B1     6.966231     6A2     6.974972    11B1     7.038442  
+      20A1     7.063988    15B2     7.158417    21A1     7.176967  
+       7A2     7.280150    22A1     7.488141    16B2     7.838859  
+      17B2     8.357375    23A1    13.167130  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05776311854611
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3536778029867573
+    One-Electron Energy =                -123.4037988369638157
+    Two-Electron Energy =                  37.9923579154309650
+    Total Energy =                        -76.0577631185460916
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9423
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1602
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7821     Total:     0.7821
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:34 2018
+Module time:
+	user time   =      10.69 seconds =       0.18 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     134.55 seconds =       2.24 minutes
+	system time =       2.46 seconds =       0.04 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:34 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
+         H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
+
+  Nuclear repulsion =    9.353677802986757
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.000000197633
+       2       -0.000000000000     0.000000172869    -0.000000098817
+       3        0.000000000000    -0.000000172869    -0.000000098817
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:37 2018
+Module time:
+	user time   =      10.81 seconds =       0.18 minutes
+	system time =       0.43 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     145.37 seconds =       2.42 minutes
+	system time =       2.89 seconds =       0.05 minutes
+	total time  =         24 seconds =       0.40 minutes
+
+  Based on options and gradient (rms=1.40E-07), recommend projecting translations and projecting rotations.
+hessian() will perform frequency computation by finite difference of analytic gradients.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes.  Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 3.
+    Number of irreps is 4.
+    Number of SALCs is 3.
+    Translations projected? 1. Rotations projected? 1.
+    Index of SALCs per irrep:
+     1 :  0  1 
+     2 : 
+     3 : 
+     4 :  2 
+    Number of SALCs per irrep:
+     Irrep 1: 2
+     Irrep 2: 0
+     Irrep 3: 0
+     Irrep 4: 1
+    Number of geometries (including reference) is 6.
+    Number of displacements per irrep:
+      Irrep 1: 4
+      Irrep 2: 0
+      Irrep 3: 0
+      Irrep 4: 1
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:37 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063572679962    15.994914619560
+         H            0.000000000000    -0.751205204049     0.504472282279     1.007825032070
+         H            0.000000000000     0.751205204049     0.504472282279     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.18511  B =     14.82055  C =      9.82917 [cm^-1]
+  Rotational constants: A = 874947.58619  B = 444308.76784  C = 294671.22350 [MHz]
+  Nuclear repulsion =    9.342290153252501
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3581937959E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.05720258816422   -7.60572e+01   9.87457e-02 
+   @DF-RHF iter   1:   -76.02240815304293    3.47944e-02   1.59432e-02 
+   @DF-RHF iter   2:   -76.04928834023821   -2.68802e-02   8.86949e-03 DIIS
+   @DF-RHF iter   3:   -76.05723791249567   -7.94957e-03   1.27620e-03 DIIS
+   @DF-RHF iter   4:   -76.05769607664327   -4.58164e-04   3.94804e-04 DIIS
+   @DF-RHF iter   5:   -76.05775566684947   -5.95902e-05   8.64764e-05 DIIS
+   @DF-RHF iter   6:   -76.05775934350825   -3.67666e-06   1.34224e-05 DIIS
+   @DF-RHF iter   7:   -76.05775943727865   -9.37704e-08   1.87649e-06 DIIS
+   @DF-RHF iter   8:   -76.05775943834119   -1.06255e-09   1.69902e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943835189   -1.07008e-11   4.49964e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943835255   -6.53699e-13   5.18958e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.551337     2A1    -1.352811     1B2    -0.720888  
+       3A1    -0.578051     1B1    -0.505343  
+
+    Virtual:                                                              
+
+       4A1     0.144166     2B2     0.205119     3B2     0.552850  
+       5A1     0.606540     6A1     0.666826     2B1     0.787518  
+       4B2     0.805159     7A1     0.810262     1A2     0.861713  
+       3B1     0.962986     8A1     1.119806     5B2     1.202539  
+       6B2     1.544637     9A1     1.587733     7B2     2.032557  
+       4B1     2.037541     2A2     2.075063    10A1     2.172070  
+      11A1     2.232264    12A1     2.607818     8B2     2.973227  
+       5B1     3.369373    13A1     3.506801     3A2     3.583570  
+       9B2     3.669846     6B1     3.815861    14A1     3.887120  
+      10B2     3.898920     4A2     3.968305     7B1     4.025660  
+      11B2     4.086675    15A1     4.211463     5A2     4.346743  
+      16A1     4.425161    12B2     4.599894     8B1     4.702048  
+      13B2     4.906618    17A1     5.208687    18A1     5.268736  
+      14B2     5.546166     9B1     6.082148    19A1     6.615197  
+      10B1     6.965914     6A2     6.973374    11B1     7.033839  
+      20A1     7.062142    15B2     7.150019    21A1     7.176905  
+       7A2     7.277445    22A1     7.485436    16B2     7.836276  
+      17B2     8.353707    23A1    13.145783  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775943835255
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3422901532525007
+    One-Electron Energy =                -123.3832392415439898
+    Two-Electron Energy =                  37.9831896499389430
+    Total Energy =                        -76.0577594383525479
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9455
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1619
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7837     Total:     0.7837
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9919     Total:     1.9919
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:38 2018
+Module time:
+	user time   =      10.15 seconds =       0.17 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     155.65 seconds =       2.59 minutes
+	system time =       3.05 seconds =       0.05 minutes
+	total time  =         25 seconds =       0.42 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:38 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063572679962    15.994914619560
+         H            0.000000000000    -0.751205204049     0.504472282279     1.007825032070
+         H            0.000000000000     0.751205204049     0.504472282279     1.007825032070
+
+  Nuclear repulsion =    9.342290153252501
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000    -0.001968921420
+       2        0.000000000000    -0.000882093202     0.000984460710
+       3       -0.000000000000     0.000882093202     0.000984460710
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:41 2018
+Module time:
+	user time   =      10.82 seconds =       0.18 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     166.49 seconds =       2.77 minutes
+	system time =       3.45 seconds =       0.06 minutes
+	total time  =         28 seconds =       0.47 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:41 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063130036482    15.994914619560
+         H            0.000000000000    -0.751205204049     0.500959745656     1.007825032070
+         H            0.000000000000     0.751205204049     0.500959745656     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.59581  B =     14.82055  C =      9.87533 [cm^-1]
+  Rotational constants: A = 887260.19140  B = 444308.76784  C = 296054.87546 [MHz]
+  Nuclear repulsion =    9.365068895503725
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3367218974E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.05434140393025   -7.60543e+01   1.08041e-01 
+   @DF-RHF iter   1:   -76.02283326943338    3.15081e-02   1.37528e-02 
+   @DF-RHF iter   2:   -76.04938811991445   -2.65549e-02   8.08845e-03 DIIS
+   @DF-RHF iter   3:   -76.05726179215876   -7.87367e-03   1.30993e-03 DIIS
+   @DF-RHF iter   4:   -76.05769928334497   -4.37491e-04   3.61132e-04 DIIS
+   @DF-RHF iter   5:   -76.05775578899907   -5.65057e-05   8.22393e-05 DIIS
+   @DF-RHF iter   6:   -76.05775933830853   -3.54931e-06   1.41009e-05 DIIS
+   @DF-RHF iter   7:   -76.05775942973456   -9.14260e-08   1.52804e-06 DIIS
+   @DF-RHF iter   8:   -76.05775943075444   -1.01988e-09   1.68167e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943076327   -8.82494e-12   3.89285e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943076378   -5.11591e-13   5.06319e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550719     2A1    -1.353792     1B2    -0.722987  
+       3A1    -0.577730     1B1    -0.505425  
+
+    Virtual:                                                              
+
+       4A1     0.144473     2B2     0.205225     3B2     0.554494  
+       5A1     0.606454     6A1     0.666764     2B1     0.787508  
+       4B2     0.805036     7A1     0.812682     1A2     0.861399  
+       3B1     0.964997     8A1     1.117819     5B2     1.202811  
+       6B2     1.547887     9A1     1.590615     7B2     2.029743  
+       4B1     2.036619     2A2     2.076769    10A1     2.171329  
+      11A1     2.232167    12A1     2.612131     8B2     2.973899  
+       5B1     3.373238    13A1     3.510051     3A2     3.582191  
+       9B2     3.670419     6B1     3.818304    14A1     3.887061  
+      10B2     3.902367     4A2     3.968377     7B1     4.027085  
+      11B2     4.088625    15A1     4.214049     5A2     4.352951  
+      16A1     4.432552    12B2     4.598182     8B1     4.704682  
+      13B2     4.914304    17A1     5.214782    18A1     5.271848  
+      14B2     5.549229     9B1     6.084956    19A1     6.618184  
+      10B1     6.966283     6A2     6.976510    11B1     7.043326  
+      20A1     7.065717    15B2     7.166829    21A1     7.177166  
+       7A2     7.282884    22A1     7.490905    16B2     7.841452  
+      17B2     8.361007    23A1    13.188475  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775943076378
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3650688955037253
+    One-Electron Energy =                -123.4243509418998741
+    Two-Electron Energy =                  38.0015226156323678
+    Total Energy =                        -76.0577594307637810
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9390
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1585
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7805     Total:     0.7805
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9838     Total:     1.9838
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:43 2018
+Module time:
+	user time   =      10.27 seconds =       0.17 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     176.87 seconds =       2.95 minutes
+	system time =       3.59 seconds =       0.06 minutes
+	total time  =         30 seconds =       0.50 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:43 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063130036482    15.994914619560
+         H            0.000000000000    -0.751205204049     0.500959745656     1.007825032070
+         H            0.000000000000     0.751205204049     0.500959745656     1.007825032070
+
+  Nuclear repulsion =    9.365068895503725
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.001974206228
+       2       -0.000000000000     0.000891427016    -0.000987103114
+       3        0.000000000000    -0.000891427016    -0.000987103114
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:45 2018
+Module time:
+	user time   =      10.87 seconds =       0.18 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     187.76 seconds =       3.13 minutes
+	system time =       3.99 seconds =       0.07 minutes
+	total time  =         32 seconds =       0.53 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:45 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.753068850674     0.502716013968     1.007825032070
+         H            0.000000000000     0.753068850674     0.502716013968     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.38939  B =     14.74728  C =      9.81981 [cm^-1]
+  Rotational constants: A = 881071.62781  B = 442112.39509  C = 294390.41046 [MHz]
+  Nuclear repulsion =    9.338578725249000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3577687428E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15053603594994   -7.61505e+01   1.08489e-01 
+   @DF-RHF iter   1:   -76.00787144634835    1.42665e-01   1.64638e-02 
+   @DF-RHF iter   2:   -76.04626774604756   -3.83963e-02   9.23703e-03 DIIS
+   @DF-RHF iter   3:   -76.05686632446407   -1.05986e-02   1.97704e-03 DIIS
+   @DF-RHF iter   4:   -76.05766372361738   -7.97399e-04   5.52884e-04 DIIS
+   @DF-RHF iter   5:   -76.05775347147349   -8.97479e-05   8.56277e-05 DIIS
+   @DF-RHF iter   6:   -76.05775721239509   -3.74092e-06   1.77172e-05 DIIS
+   @DF-RHF iter   7:   -76.05775730576686   -9.33718e-08   2.62445e-06 DIIS
+   @DF-RHF iter   8:   -76.05775730887341   -3.10655e-09   4.63636e-07 DIIS
+   @DF-RHF iter   9:   -76.05775730896659   -9.31806e-11   6.15678e-08 DIIS
+   @DF-RHF iter  10:   -76.05775730896798   -1.39266e-12   5.79885e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.551229     2A1    -1.352395     1B2    -0.721355  
+       3A1    -0.577339     1B1    -0.505210  
+
+    Virtual:                                                              
+
+       4A1     0.144196     2B2     0.205019     3B2     0.553306  
+       5A1     0.605140     6A1     0.667118     2B1     0.787581  
+       4B2     0.804944     7A1     0.811919     1A2     0.860960  
+       3B1     0.964348     8A1     1.119636     5B2     1.201403  
+       6B2     1.545238     9A1     1.586539     7B2     2.033308  
+       4B1     2.035819     2A2     2.075672    10A1     2.170890  
+      11A1     2.232691    12A1     2.610069     8B2     2.971876  
+       5B1     3.372579    13A1     3.508212     3A2     3.580734  
+       9B2     3.667080     6B1     3.816074    14A1     3.886354  
+      10B2     3.899215     4A2     3.966782     7B1     4.026372  
+      11B2     4.087517    15A1     4.210782     5A2     4.348259  
+      16A1     4.428247    12B2     4.593000     8B1     4.702268  
+      13B2     4.906862    17A1     5.204875    18A1     5.269405  
+      14B2     5.546927     9B1     6.079697    19A1     6.608940  
+      10B1     6.965048     6A2     6.973845    11B1     7.034424  
+      20A1     7.060586    15B2     7.156043    21A1     7.173355  
+       7A2     7.275189    22A1     7.487741    16B2     7.834011  
+      17B2     8.349685    23A1    13.142525  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775730896798
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3385787252490005
+    One-Electron Energy =                -123.3776177281716571
+    Two-Electron Energy =                  37.9812816939546778
+    Total Energy =                        -76.0577573089679788
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9423
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1606
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7817     Total:     0.7817
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9869     Total:     1.9869
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:47 2018
+Module time:
+	user time   =      10.95 seconds =       0.18 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     198.82 seconds =       3.31 minutes
+	system time =       4.14 seconds =       0.07 minutes
+	total time  =         34 seconds =       0.57 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:47 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.753068850674     0.502716013968     1.007825032070
+         H            0.000000000000     0.753068850674     0.502716013968     1.007825032070
+
+  Nuclear repulsion =    9.338578725249000
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000    -0.001659364850
+       2        0.000000000000    -0.001647522925     0.000829682425
+       3       -0.000000000000     0.001647522925     0.000829682425
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:50 2018
+Module time:
+	user time   =      10.84 seconds =       0.18 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     209.68 seconds =       3.49 minutes
+	system time =       4.56 seconds =       0.08 minutes
+	total time  =         37 seconds =       0.62 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:50 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.749341557425     0.502716013968     1.007825032070
+         H            0.000000000000     0.749341557425     0.502716013968     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.38939  B =     14.89436  C =      9.88480 [cm^-1]
+  Rotational constants: A = 881071.62781  B = 446521.54840  C = 296338.87440 [MHz]
+  Nuclear repulsion =    9.368813495214249
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3370966868E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15641409189925   -7.61564e+01   1.15547e-01 
+   @DF-RHF iter   1:   -76.00799400035822    1.48420e-01   1.74338e-02 
+   @DF-RHF iter   2:   -76.04635005933554   -3.83561e-02   9.77165e-03 DIIS
+   @DF-RHF iter   3:   -76.05687577841728   -1.05257e-02   1.79150e-03 DIIS
+   @DF-RHF iter   4:   -76.05766518084985   -7.89402e-04   4.55606e-04 DIIS
+   @DF-RHF iter   5:   -76.05775349264781   -8.83118e-05   9.22519e-05 DIIS
+   @DF-RHF iter   6:   -76.05775718058869   -3.68794e-06   1.47549e-05 DIIS
+   @DF-RHF iter   7:   -76.05775727147068   -9.08820e-08   2.65747e-06 DIIS
+   @DF-RHF iter   8:   -76.05775727443550   -2.96482e-09   4.28281e-07 DIIS
+   @DF-RHF iter   9:   -76.05775727452513   -8.96279e-11   6.89250e-08 DIIS
+   @DF-RHF iter  10:   -76.05775727452630   -1.16529e-12   5.36758e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550826     2A1    -1.354211     1B2    -0.722517  
+       3A1    -0.578445     1B1    -0.505559  
+
+    Virtual:                                                              
+
+       4A1     0.144441     2B2     0.205326     3B2     0.554036  
+       5A1     0.607858     6A1     0.666478     2B1     0.787445  
+       4B2     0.805254     7A1     0.811024     1A2     0.862155  
+       3B1     0.963630     8A1     1.117989     5B2     1.203951  
+       6B2     1.547279     9A1     1.591816     7B2     2.028984  
+       4B1     2.038350     2A2     2.076160    10A1     2.172525  
+      11A1     2.231744    12A1     2.609857     8B2     2.975260  
+       5B1     3.369997    13A1     3.508632     3A2     3.585031  
+       9B2     3.673217     6B1     3.818088    14A1     3.887842  
+      10B2     3.902025     4A2     3.969940     7B1     4.026383  
+      11B2     4.087792    15A1     4.214711     5A2     4.351413  
+      16A1     4.429470    12B2     4.605171     8B1     4.704442  
+      13B2     4.913966    17A1     5.218638    18A1     5.271139  
+      14B2     5.548517     9B1     6.087431    19A1     6.624485  
+      10B1     6.967243     6A2     6.976005    11B1     7.042649  
+      20A1     7.067252    15B2     7.160797    21A1     7.180805  
+       7A2     7.285205    22A1     7.488562    16B2     7.843696  
+      17B2     8.365089    23A1    13.191769  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775727452630
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3688134952142494
+    One-Electron Energy =                -123.4300253298779353
+    Two-Electron Energy =                  38.0034545601373850
+    Total Energy =                        -76.0577572745262955
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9423
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1598
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7825     Total:     0.7825
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9888     Total:     1.9888
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:51 2018
+Module time:
+	user time   =      10.20 seconds =       0.17 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     219.99 seconds =       3.67 minutes
+	system time =       4.67 seconds =       0.08 minutes
+	total time  =         38 seconds =       0.63 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:51 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.749341557425     0.502716013968     1.007825032070
+         H            0.000000000000     0.749341557425     0.502716013968     1.007825032070
+
+  Nuclear repulsion =    9.368813495214249
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.001683360761
+       2       -0.000000000000     0.001661493923    -0.000841680380
+       3        0.000000000000    -0.001661493923    -0.000841680380
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:54 2018
+Module time:
+	user time   =      10.66 seconds =       0.18 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     230.67 seconds =       3.84 minutes
+	system time =       5.12 seconds =       0.09 minutes
+	total time  =         41 seconds =       0.68 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:54 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180451050    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.749773259494     0.501636978456     1.007825032070
+         H            0.000000000000     0.752637148604     0.503795049479     1.007825032070
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     29.39024  B =     14.82024  C =      9.85220 [cm^-1]
+  Rotational constants: A = 881097.11080  B = 444299.55328  C = 295361.42902 [MHz]
+  Nuclear repulsion =    9.353715556558956
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        40      40       0       0       0       0
+     A"        18      18       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3472658993E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.06525630786143   -7.60653e+01   8.17655e-02 
+   @DF-RHF iter   1:   -76.02219553072642    4.30608e-02   1.32888e-02 
+   @DF-RHF iter   2:   -76.04927776425214   -2.70822e-02   7.12885e-03 DIIS
+   @DF-RHF iter   3:   -76.05721709647048   -7.93933e-03   1.36250e-03 DIIS
+   @DF-RHF iter   4:   -76.05768986288618   -4.72766e-04   3.35259e-04 DIIS
+   @DF-RHF iter   5:   -76.05775086856649   -6.10057e-05   7.02408e-05 DIIS
+   @DF-RHF iter   6:   -76.05775457126012   -3.70269e-06   1.14779e-05 DIIS
+   @DF-RHF iter   7:   -76.05775466538284   -9.41227e-08   1.41309e-06 DIIS
+   @DF-RHF iter   8:   -76.05775466646492   -1.08207e-09   1.48238e-07 DIIS
+   @DF-RHF iter   9:   -76.05775466647601   -1.10987e-11   3.38599e-08 DIIS
+   @DF-RHF iter  10:   -76.05775466647667   -6.53699e-13   4.35834e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.551027     2Ap    -1.353305     3Ap    -0.721938  
+       4Ap    -0.577891     1App   -0.505385  
+
+    Virtual:                                                              
+
+       5Ap     0.144318     6Ap     0.205173     7Ap     0.553652  
+       8Ap     0.606515     9Ap     0.666796     2App    0.787509  
+      10Ap     0.805103    11Ap     0.811470     3App    0.861561  
+       4App    0.963990    12Ap     1.118801    13Ap     1.202679  
+      14Ap     1.546086    15Ap     1.589360    16Ap     2.031159  
+       5App    2.037063     6App    2.075936    17Ap     2.171719  
+      18Ap     2.232220    19Ap     2.609947    20Ap     2.973575  
+       7App    3.371299    21Ap     3.508422     8App    3.582879  
+      22Ap     3.670141     9App    3.817085    23Ap     3.887000  
+      24Ap     3.900699    10App    3.968346    11App    4.026367  
+      25Ap     4.087623    26Ap     4.212786    12App    4.349842  
+      27Ap     4.428876    28Ap     4.599063    13App    4.703367  
+      29Ap     4.910291    30Ap     5.211928    31Ap     5.270270  
+      32Ap     5.547709    14App    6.083575    33Ap     6.616736  
+      15App    6.965990    16App    6.974755    17App    7.038725  
+      34Ap     7.063684    35Ap     7.158426    36Ap     7.177325  
+      18App    7.280346    37Ap     7.488113    38Ap     7.838914  
+      39Ap     8.357368    40Ap    13.167194  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     4,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775466647667
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3537155565589565
+    One-Electron Energy =                -123.4038503418129551
+    Two-Electron Energy =                  37.9923801187773336
+    Total Energy =                        -76.0577546664766686
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0027      Z:     0.9423
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0013      Z:    -0.1602
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0014      Z:     0.7821     Total:     0.7821
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0035      Z:     1.9878     Total:     1.9878
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:56 2018
+Module time:
+	user time   =      10.06 seconds =       0.17 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     240.84 seconds =       4.01 minutes
+	system time =       5.24 seconds =       0.09 minutes
+	total time  =         43 seconds =       0.72 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:56 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180451050    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.749773259494     0.501636978456     1.007825032070
+         H            0.000000000000     0.752637148604     0.503795049479     1.007825032070
+
+  Nuclear repulsion =    9.353715556558956
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.003688064045     0.000019110626
+       2        0.000000000000     0.001856011450    -0.001399120927
+       3        0.000000000000     0.001832052596     0.001380010301
+
+
+*** tstop() called on silver at Tue Sep 25 13:51:58 2018
+Module time:
+	user time   =      10.78 seconds =       0.18 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     251.64 seconds =       4.19 minutes
+	system time =       5.59 seconds =       0.09 minutes
+	total time  =         45 seconds =       0.75 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:51:58 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
+         H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.38939  B =     14.82055  C =      9.85224 [cm^-1]
+  Rotational constants: A = 881071.62781  B = 444308.76784  C = 295362.63749 [MHz]
+  Nuclear repulsion =    9.353677802986757
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3474054466E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15347657941527   -7.61535e+01   9.19129e-02 
+   @DF-RHF iter   1:   -76.00793896106001    1.45538e-01   1.71858e-02 
+   @DF-RHF iter   2:   -76.04631497044015   -3.83760e-02   1.02163e-02 DIIS
+   @DF-RHF iter   3:   -76.05687689488875   -1.05619e-02   1.87621e-03 DIIS
+   @DF-RHF iter   4:   -76.05767028195150   -7.93387e-04   4.93739e-04 DIIS
+   @DF-RHF iter   5:   -76.05775930899148   -8.90270e-05   9.40851e-05 DIIS
+   @DF-RHF iter   6:   -76.05776302330437   -3.71431e-06   1.73353e-05 DIIS
+   @DF-RHF iter   7:   -76.05776311541894   -9.21146e-08   2.76053e-06 DIIS
+   @DF-RHF iter   8:   -76.05776311845355   -3.03461e-09   4.97384e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854486   -9.13047e-11   6.12345e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854615   -1.29319e-12   6.59762e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.551028     2A1    -1.353301     1B2    -0.721937  
+       3A1    -0.577892     1B1    -0.505384  
+
+    Virtual:                                                              
+
+       4A1     0.144319     2B2     0.205173     3B2     0.553672  
+       5A1     0.606501     6A1     0.666793     2B1     0.787514  
+       4B2     0.805097     7A1     0.811469     1A2     0.861557  
+       3B1     0.963988     8A1     1.118808     5B2     1.202677  
+       6B2     1.546259     9A1     1.589176     7B2     2.031142  
+       4B1     2.037085     2A2     2.075917    10A1     2.171714  
+      11A1     2.232214    12A1     2.609949     8B2     2.973570  
+       5B1     3.371299    13A1     3.508424     3A2     3.582881  
+       9B2     3.670144     6B1     3.817086    14A1     3.887085  
+      10B2     3.900630     4A2     3.968349     7B1     4.026369  
+      11B2     4.087653    15A1     4.212757     5A2     4.349836  
+      16A1     4.428865    12B2     4.599070     8B1     4.703366  
+      13B2     4.910416    17A1     5.211746    18A1     5.270269  
+      14B2     5.547693     9B1     6.083565    19A1     6.616731  
+      10B1     6.966231     6A2     6.974972    11B1     7.038442  
+      20A1     7.063988    15B2     7.158417    21A1     7.176967  
+       7A2     7.280150    22A1     7.488141    16B2     7.838859  
+      17B2     8.357375    23A1    13.167130  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05776311854615
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3536778029867573
+    One-Electron Energy =                -123.4037988369638583
+    Two-Electron Energy =                  37.9923579154309508
+    Total Energy =                        -76.0577631185461485
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9423
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1602
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7821     Total:     0.7821
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:00 2018
+Module time:
+	user time   =       9.95 seconds =       0.17 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     261.70 seconds =       4.36 minutes
+	system time =       5.74 seconds =       0.10 minutes
+	total time  =         47 seconds =       0.78 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:00 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
+         H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
+         H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
+
+  Nuclear repulsion =    9.353677802986757
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.000000197618
+       2       -0.000000000000     0.000000172860    -0.000000098809
+       3        0.000000000000    -0.000000172860    -0.000000098809
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:02 2018
+Module time:
+	user time   =      10.84 seconds =       0.18 minutes
+	system time =       0.43 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     272.56 seconds =       4.54 minutes
+	system time =       6.17 seconds =       0.10 minutes
+	total time  =         49 seconds =       0.82 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing second-derivative from gradients using projected, 
+  symmetry-adapted, cartesian coordinates.
+
+  6 gradients passed in, including the reference geometry.
+  Generating complete list of displacements from unique ones.
+
+    Operation 2 takes plus displacements of irrep B2 to minus ones.
+
+-------------------------------------------------------------
+
+
+  ==> Harmonic Vibrational Analysis <==
+
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
+  projection of translations (True) and rotations (True) removed 6 degrees of freedom (6)
+  total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1753.0273'
+ '4127.0329' '4227.0130']
+  projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
+  post-proj  all modes:['0.0001i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0001' '1753.0273'
+ '4127.0329' '4227.0130']
+
+  Vibration                       7                   8                   9           
+  Freq [cm^-1]                1753.0273           4127.0329           4227.0130       
+  Irrep                           A1                  A1                  B2          
+  Reduced mass [u]              1.0830              1.0448              1.0833        
+  Force const [mDyne/A]         1.9610             10.4851             11.4047        
+  Turning point v=0 [a0]        0.2518              0.1671              0.1621        
+  RMS dev v=0 [a0 u^1/2]        0.1853              0.1208              0.1193        
+  Char temp [K]               2522.2122           5937.8724           6081.7213       
+  ----------------------------------------------------------------------------------
+      1   O               -0.00  0.00 -0.07   -0.00 -0.00  0.05   -0.00 -0.07 -0.00   
+      2   H               -0.00  0.43  0.56   -0.00  0.59 -0.39    0.00  0.56 -0.42   
+      3   H                0.00 -0.43  0.56    0.00 -0.59 -0.39    0.00  0.56  0.42   
+
+  ==> Thermochemistry Components <==
+
+  Entropy, S
+    Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.329 [cal/(mol K)]       43.217 [J/(mol K)]       0.01646032 [mEh/K] (symmetry no. = 2)
+    Vibrational S           0.004 [cal/(mol K)]        0.017 [J/(mol K)]       0.00000635 [mEh/K]
+  Total S                  44.941 [cal/(mol K)]      188.034 [J/(mol K)]       0.07161852 [mEh/K]
+  Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant volume heat capacity, Cv
+    Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cv          0.030 [cal/(mol K)]        0.126 [J/(mol K)]       0.00004804 [mEh/K]
+  Total Cv                  5.992 [cal/(mol K)]       25.070 [J/(mol K)]       0.00954848 [mEh/K]
+  Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant pressure heat capacity, Cp
+    Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cp          0.030 [cal/(mol K)]        0.126 [J/(mol K)]       0.00004804 [mEh/K]
+  Total Cp                  7.979 [cal/(mol K)]       33.384 [J/(mol K)]       0.01271530 [mEh/K]
+  Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  ==> Thermochemistry Energy Analysis <==
+
+  Raw electronic energy, E0
+  Total E0, Electronic energy at well bottom at 0 [K]                  -76.05776312 [Eh]
+
+  Zero-point energy, ZPE_vib = Sum_i nu_i / 2
+    Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Vibrational ZPE        14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302560 [Eh]        5053.535 [cm^-1]
+  Correction ZPE           14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302560 [Eh]        5053.535 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.03473752 [Eh]
+
+  Thermal Energy, E (includes ZPE)
+    Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational E          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302729 [Eh]
+  Correction E             16.227 [kcal/mol]       67.895 [kJ/mol]       0.02585985 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.03190327 [Eh]
+
+  Enthalpy, H_trans = E_trans + k_B * T
+    Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
+    Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational H          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302729 [Eh]
+  Correction H             16.820 [kcal/mol]       70.374 [kJ/mol]       0.02680404 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.03095908 [Eh]
+
+  Gibbs free energy, G = H - T * S
+    Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
+    Rotational G           -2.191 [kcal/mol]       -9.167 [kJ/mol]      -0.00349136 [Eh]
+    Vibrational G          14.449 [kcal/mol]       60.453 [kJ/mol]       0.02302540 [Eh]
+  Correction G              3.421 [kcal/mol]       14.312 [kJ/mol]       0.00545098 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.05231214 [Eh]
+	SCF/cc-pVTZ Frequency 1...........................................PASSED
+	SCF/cc-pVTZ Frequency 2...........................................PASSED
+	SCF/cc-pVTZ Frequency 3...........................................PASSED
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: scf/cc-pv[dt]z     //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+            scf / cc-pvdz                  for  SCF TOTAL ENERGY, HESSIAN
+            scf / cc-pvtz                  for  SCF TOTAL ENERGY, HESSIAN
+
+    Enlightened listing of computations required.
+            scf / cc-pvdz                  for  SCF TOTAL ENERGY, HESSIAN
+            scf / cc-pvtz                  for  SCF TOTAL ENERGY, HESSIAN
+
+    Full listing of computations to be obtained (required and bonus).
+            scf / cc-pvdz                  for  SCF TOTAL ENERGY, HESSIAN
+            scf / cc-pvtz                  for  SCF TOTAL ENERGY, HESSIAN
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: SCF / CC-PVDZ, HESSIAN //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:03 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
+  Nuclear repulsion =    9.366873138898288
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3164319961E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.05275428124520   -7.60528e+01   1.99861e-01 
+   @DF-RHF iter   1:   -75.99200119240541    6.07531e-02   3.02136e-02 
+   @DF-RHF iter   2:   -76.01962153001254   -2.76203e-02   1.57016e-02 DIIS
+   @DF-RHF iter   3:   -76.02634728120981   -6.72575e-03   2.66136e-03 DIIS
+   @DF-RHF iter   4:   -76.02681451124214   -4.67230e-04   8.26017e-04 DIIS
+   @DF-RHF iter   5:   -76.02686007340120   -4.55622e-05   1.43356e-04 DIIS
+   @DF-RHF iter   6:   -76.02686266200632   -2.58861e-06   2.66889e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272186608   -5.98598e-08   2.96966e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272244343   -5.77344e-10   4.38080e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272246083   -1.74083e-11   4.64208e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272246096   -1.27898e-13   6.90407e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.546231     2A1    -1.344591     1B2    -0.712700  
+       3A1    -0.566132     1B1    -0.493851  
+
+    Virtual:                                                              
+
+       4A1     0.188952     2B2     0.258523     3B2     0.809303  
+       5A1     0.863096     6A1     1.160982     2B1     1.200778  
+       4B2     1.250639     7A1     1.458715     1A2     1.475502  
+       3B1     1.689570     8A1     1.868196     5B2     1.944812  
+       6B2     2.502378     9A1     2.533450     4B1     3.292132  
+       2A2     3.364714    10A1     3.524703    11A1     3.903721  
+       7B2     4.157003  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02686272246096
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3668731388982884
+    One-Electron Energy =                -123.4604615511582466
+    Two-Electron Energy =                  38.0667256897990001
+    Total Energy =                        -76.0268627224609617
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1458
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7912     Total:     0.7912
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:04 2018
+Module time:
+	user time   =       7.34 seconds =       0.12 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     281.54 seconds =       4.69 minutes
+	system time =       6.30 seconds =       0.10 minutes
+	total time  =         51 seconds =       0.85 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:04 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.013215498853
+       2       -0.000000000000     0.004499298742    -0.006607749426
+       3        0.000000000000    -0.004499298742    -0.006607749426
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:05 2018
+Module time:
+	user time   =       9.25 seconds =       0.15 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     290.81 seconds =       4.85 minutes
+	system time =       6.54 seconds =       0.11 minutes
+	total time  =         52 seconds =       0.87 minutes
+
+  Based on options and gradient (rms=5.80E-03), recommend projecting translations and projecting rotations.
+hessian() will perform analytic frequency computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:05 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
+  Nuclear repulsion =    9.366873138898288
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3164319961E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.05275428124524   -7.60528e+01   1.86953e-01 
+   @DF-RHF iter   1:   -75.99200119240544    6.07531e-02   3.02136e-02 
+   @DF-RHF iter   2:   -76.01962153001251   -2.76203e-02   1.57016e-02 DIIS
+   @DF-RHF iter   3:   -76.02634728120981   -6.72575e-03   2.79125e-03 DIIS
+   @DF-RHF iter   4:   -76.02681451124209   -4.67230e-04   7.04973e-04 DIIS
+   @DF-RHF iter   5:   -76.02686007340120   -4.55622e-05   1.45986e-04 DIIS
+   @DF-RHF iter   6:   -76.02686266200634   -2.58861e-06   2.36572e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272186614   -5.98598e-08   2.72636e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272244347   -5.77330e-10   4.56617e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272246086   -1.73941e-11   4.34226e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272246095   -8.52651e-14   6.52021e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.546231     2A1    -1.344591     1B2    -0.712700  
+       3A1    -0.566132     1B1    -0.493851  
+
+    Virtual:                                                              
+
+       4A1     0.188952     2B2     0.258523     3B2     0.809303  
+       5A1     0.863096     6A1     1.160982     2B1     1.200778  
+       4B2     1.250639     7A1     1.458715     1A2     1.475502  
+       3B1     1.689570     8A1     1.868196     5B2     1.944812  
+       6B2     2.502378     9A1     2.533450     4B1     3.292132  
+       2A2     3.364714    10A1     3.524703    11A1     3.903721  
+       7B2     4.157003  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02686272246095
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3668731388982884
+    One-Electron Energy =                -123.4604615511582608
+    Two-Electron Energy =                  38.0667256897990356
+    Total Energy =                        -76.0268627224609475
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1458
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7912     Total:     0.7912
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:07 2018
+Module time:
+	user time   =       8.31 seconds =       0.14 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     299.21 seconds =       4.99 minutes
+	system time =       6.64 seconds =       0.11 minutes
+	total time  =         54 seconds =       0.90 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:07 2018
+
+
+         ------------------------------------------------------------
+                                   SCF HESS                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    2
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.439 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                450
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+         ------------------------------------------------------------
+                                     CPHF                           
+                                  Rob Parrish                       
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+  Reference energy  =  -76.026862722460947
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> CGRSolver (by Rob Parrish) <==
+
+   Number of roots    =         9
+   Preconditioning    =    JACOBI
+   Convergence cutoff =     1E-06
+   Maximum iterations =       100
+
+  ==> CPHFRHamiltonian (by Rob Parrish) <== 
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                450
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> CPHF Iterations <==
+
+  => Iterations <=
+
+             Iter  Converged  Remaining    Residual
+  CGR           1          0          9   1.105E-01
+  CGR           2          0          9   2.301E-02
+  CGR           3          0          9   5.351E-03
+  CGR           4          0          9   8.369E-04
+  CGR           5          0          9   1.388E-04
+  CGR           6          0          9   2.599E-05
+  CGR           7          4          5   4.864E-06
+  CGR           8          9          0   8.335E-07
+
+    CGRSolver converged.
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:12 2018
+Module time:
+	user time   =      32.94 seconds =       0.55 minutes
+	system time =       0.47 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =     332.17 seconds =       5.54 minutes
+	system time =       7.11 seconds =       0.12 minutes
+	total time  =         59 seconds =       0.98 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: SCF / CC-PVTZ, HESSIAN //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:12 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
+  Nuclear repulsion =    9.366873138898288
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3337883263E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15705386304175   -7.61571e+01   1.11607e-01 
+   @DF-RHF iter   1:   -76.00804928770357    1.49005e-01   1.92765e-02 
+   @DF-RHF iter   2:   -76.04636975319131   -3.83205e-02   1.11355e-02 DIIS
+   @DF-RHF iter   3:   -76.05688013370900   -1.05104e-02   1.84203e-03 DIIS
+   @DF-RHF iter   4:   -76.05766529844000   -7.85165e-04   5.36020e-04 DIIS
+   @DF-RHF iter   5:   -76.05775268794596   -8.73895e-05   9.76128e-05 DIIS
+   @DF-RHF iter   6:   -76.05775634090108   -3.65296e-06   1.59778e-05 DIIS
+   @DF-RHF iter   7:   -76.05775643131149   -9.04104e-08   2.76460e-06 DIIS
+   @DF-RHF iter   8:   -76.05775643428072   -2.96923e-09   4.88989e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643437045   -8.97273e-11   6.37665e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643437173   -1.27898e-12   5.39548e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550603     2A1    -1.353787     1B2    -0.723414  
+       3A1    -0.577458     1B1    -0.505393  
+
+    Virtual:                                                              
+
+       4A1     0.144523     2B2     0.205207     3B2     0.554859  
+       5A1     0.605988     6A1     0.666852     2B1     0.787526  
+       4B2     0.804951     7A1     0.813542     1A2     0.861115  
+       3B1     0.965704     8A1     1.117505     5B2     1.202479  
+       6B2     1.548515     9A1     1.590609     7B2     2.029622  
+       4B1     2.035935     2A2     2.077191    10A1     2.170818  
+      11A1     2.232287    12A1     2.613483     8B2     2.973543  
+       5B1     3.374789    13A1     3.510933     3A2     3.581099  
+       9B2     3.669581     6B1     3.818692    14A1     3.886820  
+      10B2     3.902954     4A2     3.967880     7B1     4.027505  
+      11B2     4.089152    15A1     4.214174     5A2     4.354286  
+      16A1     4.434508    12B2     4.595689     8B1     4.705102  
+      13B2     4.915471    17A1     5.214327    18A1     5.272513  
+      14B2     5.549873     9B1     6.084502    19A1     6.616489  
+      10B1     6.965942     6A2     6.977068    11B1     7.044900  
+      20A1     7.065647    15B2     7.170982    21A1     7.176103  
+       7A2     7.282849    22A1     7.492423    16B2     7.841409  
+      17B2     8.360643    23A1    13.193049  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775643437173
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3668731388982884
+    One-Electron Energy =                -123.4279505909431407
+    Two-Electron Energy =                  38.0033210176731302
+    Total Energy =                        -76.0577564343717256
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1576
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7794     Total:     0.7794
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:14 2018
+Module time:
+	user time   =       9.89 seconds =       0.16 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     342.21 seconds =       5.70 minutes
+	system time =       7.28 seconds =       0.12 minutes
+	total time  =         61 seconds =       1.02 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:14 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.002590005743
+       2       -0.000000000000     0.000881698350    -0.001295002872
+       3        0.000000000000    -0.000881698350    -0.001295002872
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:17 2018
+Module time:
+	user time   =      10.95 seconds =       0.18 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     353.18 seconds =       5.89 minutes
+	system time =       7.59 seconds =       0.13 minutes
+	total time  =         64 seconds =       1.07 minutes
+
+  Based on options and gradient (rms=1.39E-03), recommend projecting translations and projecting rotations.
+hessian() will perform analytic frequency computation.
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:17 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
+  Nuclear repulsion =    9.366873138898288
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3337883263E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.15705386304181   -7.61571e+01   1.06208e-01 
+   @DF-RHF iter   1:   -76.00804928770353    1.49005e-01   1.85731e-02 
+   @DF-RHF iter   2:   -76.04636975319127   -3.83205e-02   1.03756e-02 DIIS
+   @DF-RHF iter   3:   -76.05688013370886   -1.05104e-02   1.85069e-03 DIIS
+   @DF-RHF iter   4:   -76.05766529843999   -7.85165e-04   4.70449e-04 DIIS
+   @DF-RHF iter   5:   -76.05775268794584   -8.73895e-05   8.55563e-05 DIIS
+   @DF-RHF iter   6:   -76.05775634090102   -3.65296e-06   1.43308e-05 DIIS
+   @DF-RHF iter   7:   -76.05775643131153   -9.04105e-08   2.37188e-06 DIIS
+   @DF-RHF iter   8:   -76.05775643428069   -2.96916e-09   3.99763e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643437036   -8.96705e-11   5.99446e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643437175   -1.39266e-12   5.77584e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550603     2A1    -1.353787     1B2    -0.723414  
+       3A1    -0.577458     1B1    -0.505393  
+
+    Virtual:                                                              
+
+       4A1     0.144523     2B2     0.205207     3B2     0.554859  
+       5A1     0.605988     6A1     0.666852     2B1     0.787526  
+       4B2     0.804951     7A1     0.813542     1A2     0.861115  
+       3B1     0.965704     8A1     1.117505     5B2     1.202479  
+       6B2     1.548515     9A1     1.590609     7B2     2.029622  
+       4B1     2.035935     2A2     2.077191    10A1     2.170818  
+      11A1     2.232287    12A1     2.613483     8B2     2.973543  
+       5B1     3.374789    13A1     3.510933     3A2     3.581099  
+       9B2     3.669581     6B1     3.818692    14A1     3.886820  
+      10B2     3.902954     4A2     3.967880     7B1     4.027505  
+      11B2     4.089152    15A1     4.214174     5A2     4.354286  
+      16A1     4.434508    12B2     4.595689     8B1     4.705102  
+      13B2     4.915471    17A1     5.214327    18A1     5.272513  
+      14B2     5.549873     9B1     6.084502    19A1     6.616489  
+      10B1     6.965942     6A2     6.977068    11B1     7.044900  
+      20A1     7.065647    15B2     7.170982    21A1     7.176103  
+       7A2     7.282849    22A1     7.492423    16B2     7.841409  
+      17B2     8.360643    23A1    13.193049  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775643437175
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3668731388982884
+    One-Electron Energy =                -123.4279505909431549
+    Two-Electron Energy =                  38.0033210176731160
+    Total Energy =                        -76.0577564343717540
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1576
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7794     Total:     0.7794
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
+
+
+*** tstop() called on silver at Tue Sep 25 13:52:18 2018
+Module time:
+	user time   =      10.11 seconds =       0.17 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     363.37 seconds =       6.06 minutes
+	system time =       7.73 seconds =       0.13 minutes
+	total time  =         65 seconds =       1.08 minutes
+
+*** tstart() called on silver
+*** at Tue Sep 25 13:52:18 2018
+
+
+         ------------------------------------------------------------
+                                   SCF HESS                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    2
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.439 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                450
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+         ------------------------------------------------------------
+                                     CPHF                           
+                                  Rob Parrish                       
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.366873138898287
+  Reference energy  =  -76.057756434371754
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> CGRSolver (by Rob Parrish) <==
+
+   Number of roots    =         9
+   Preconditioning    =    JACOBI
+   Convergence cutoff =     1E-06
+   Maximum iterations =       100
+
+  ==> CPHFRHamiltonian (by Rob Parrish) <== 
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory (MB):                450
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  ==> CPHF Iterations <==
+
+  => Iterations <=
+
+             Iter  Converged  Remaining    Residual
+  CGR           1          0          9   1.038E-01
+  CGR           2          0          9   2.200E-02
+  CGR           3          0          9   5.774E-03
+  CGR           4          0          9   9.836E-04
+  CGR           5          0          9   1.407E-04
+  CGR           6          0          9   2.927E-05
+  CGR           7          2          7   5.625E-06
+  CGR           8          7          2   1.088E-06
+  CGR           9          9          0   1.597E-07
+
+    CGRSolver converged.
+
+
+*** tstop() called on silver at Tue Sep 25 13:54:11 2018
+Module time:
+	user time   =     860.68 seconds =      14.34 minutes
+	system time =       9.03 seconds =       0.15 minutes
+	total time  =        113 seconds =       1.88 minutes
+Total time:
+	user time   =    1224.08 seconds =      20.40 minutes
+	system time =      16.76 seconds =       0.28 minutes
+	total time  =        178 seconds =       2.97 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: scf/cc-pv[dt]z    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> Helgaker 2-point exponential SCF extrapolation for method: SCF <==
+
+   LO-zeta (2) Energy:               -76.026862722461
+   HI-zeta (3) Energy:               -76.057756434372
+   Alpha (exponent) Value:             1.630000000000
+   Beta (coefficient) Value:           1.000866180368
+
+   @Extrapolated SCF/(D,T):         -76.065284371755
+
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                             scf / cc-pvdz                      *     -76.02686272   SCF TOTAL ENERGY
+                             scf / cc-pvtz                      *     -76.05775643   SCF TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                  scf / cc-pv[dt]z                   1     -76.06528437   scf_xtpl_helgaker_2
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                  scf / cc-pv[dt]z                         -76.06528437   scf_xtpl_helgaker_2
+      total                  CBS                                      -76.06528437   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/def2-svp.gbs 
+
+CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
+
+                 1                   2                   3                   4                   5
+
+    1    -0.00000082421446    -0.00000000000000    -0.00000000000000     0.00000041209022     0.00000000000000
+    2    -0.00000000000000     0.80941676397245     0.00000000002091     0.00000000000000    -0.40470838202950
+    3    -0.00000000000000     0.00000000002091     0.52473604249242     0.00000000000000     0.23757205981746
+    4     0.00000041209022     0.00000000000000     0.00000000000000    -0.00000027386642    -0.00000000000000
+    5     0.00000000000000    -0.40470838202950     0.23757205981746    -0.00000000000000     0.43819678972030
+    6     0.00000000000000     0.30303556098622    -0.26236802124400    -0.00000000000000    -0.27030381038891
+    7     0.00000041209582     0.00000000000000     0.00000000000000    -0.00000013822968     0.00000000000000
+    8     0.00000000000000    -0.40470838200368    -0.23757205980965    -0.00000000000000    -0.03348840770598
+    9     0.00000000000000    -0.30303556100137    -0.26236802124729    -0.00000000000000     0.03273175058690
+
+                 6                   7                   8                   9
+
+    1     0.00000000000000     0.00000041209582     0.00000000000000     0.00000000000000
+    2     0.30303556098622     0.00000000000000    -0.40470838200368    -0.30303556100137
+    3    -0.26236802124400     0.00000000000000    -0.23757205980965    -0.26236802124729
+    4    -0.00000000000000    -0.00000013822968    -0.00000000000000    -0.00000000000000
+    5    -0.27030381038891     0.00000000000000    -0.03348840770598     0.03273175058690
+    6     0.24463657064502    -0.00000000000000    -0.03273175058859     0.01773145059490
+    7    -0.00000000000000    -0.00000027386242    -0.00000000000000    -0.00000000000000
+    8    -0.03273175058859    -0.00000000000000     0.43819678973381     0.27030381039509
+    9     0.01773145059490    -0.00000000000000     0.27030381039509     0.24463657065052
+
+
+
+
+
+  ==> Harmonic Vibrational Analysis <==
+
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  projection of translations (True) and rotations (True) removed 6 degrees of freedom (6)
+  total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0014  [cm^-1]
+  pre-proj  all modes:['3.4880i' '2.5233i' '1.8858i' '0.0092i' '0.0067i' '0.0014' '1747.7410'
+ '4130.2255' '4230.5752']
+  projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj  all modes:['0.0000i' '0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0000' '1747.7410'
+ '4130.2255' '4230.5752']
+
+  Vibration                       7                   8                   9           
+  Freq [cm^-1]                1747.7410           4130.2255           4230.5752       
+  Irrep                           A1                  A1                  B2          
+  Reduced mass [u]              1.0834              1.0445              1.0837        
+  Force const [mDyne/A]         1.9498             10.4982             11.4276        
+  Turning point v=0 [a0]        0.2522              0.1671              0.1621        
+  RMS dev v=0 [a0 u^1/2]        0.1856              0.1207              0.1193        
+  Char temp [K]               2514.6064           5942.4659           6086.8465       
+  ----------------------------------------------------------------------------------
+      1   O               -0.00 -0.00 -0.07   -0.00 -0.00  0.05   -0.00 -0.07 -0.00   
+      2   H               -0.00  0.42  0.56   -0.00  0.59 -0.39    0.00  0.56 -0.42   
+      3   H               -0.00 -0.42  0.56    0.00 -0.59 -0.39    0.00  0.56  0.42   
+
+  ==> Thermochemistry Components <==
+
+  Entropy, S
+    Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.317 [cal/(mol K)]       43.166 [J/(mol K)]       0.01644104 [mEh/K] (symmetry no. = 2)
+    Vibrational S           0.004 [cal/(mol K)]        0.017 [J/(mol K)]       0.00000649 [mEh/K]
+  Total S                  44.929 [cal/(mol K)]      187.984 [J/(mol K)]       0.07159939 [mEh/K]
+  Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant volume heat capacity, Cv
+    Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cv          0.031 [cal/(mol K)]        0.129 [J/(mol K)]       0.00004899 [mEh/K]
+  Total Cv                  5.992 [cal/(mol K)]       25.072 [J/(mol K)]       0.00954943 [mEh/K]
+  Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant pressure heat capacity, Cp
+    Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cp          0.031 [cal/(mol K)]        0.129 [J/(mol K)]       0.00004899 [mEh/K]
+  Total Cp                  7.980 [cal/(mol K)]       33.386 [J/(mol K)]       0.01271624 [mEh/K]
+  Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  ==> Thermochemistry Energy Analysis <==
+
+  Raw electronic energy, E0
+  Total E0, Electronic energy at well bottom at 0 [K]                  -76.06528437 [Eh]
+
+  Zero-point energy, ZPE_vib = Sum_i nu_i / 2
+    Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Vibrational ZPE        14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302895 [Eh]        5054.269 [cm^-1]
+  Correction ZPE           14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302895 [Eh]        5054.269 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.04225542 [Eh]
+
+  Thermal Energy, E (includes ZPE)
+    Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational E          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303068 [Eh]
+  Correction E             16.229 [kcal/mol]       67.904 [kJ/mol]       0.02586324 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.03942114 [Eh]
+
+  Enthalpy, H_trans = E_trans + k_B * T
+    Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
+    Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational H          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303068 [Eh]
+  Correction H             16.822 [kcal/mol]       70.383 [kJ/mol]       0.02680742 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.03847695 [Eh]
+
+  Gibbs free energy, G = H - T * S
+    Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
+    Rotational G           -2.187 [kcal/mol]       -9.151 [kJ/mol]      -0.00348562 [Eh]
+    Vibrational G          14.451 [kcal/mol]       60.462 [kJ/mol]       0.02302874 [Eh]
+  Correction G              3.426 [kcal/mol]       14.335 [kJ/mol]       0.00546006 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.05982431 [Eh]
+	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
+	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
+	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
+
+    Psi4 stopped on: Tuesday, 25 September 2018 01:54PM
+    Psi4 wall time for execution: 0:02:58.34
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cbs-xtpl-freq/output.ref
+++ b/tests/cbs-xtpl-freq/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.3a1.dev455 
+                               Psi4 1.3a2.dev41 
 
-                         Git: Rev {cbs_dict} ed71323 
+                         Git: Rev {cbs_dict_fix} d52033e 
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -22,13 +22,13 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 25 September 2018 01:51PM
+    Psi4 started on: Wednesday, 17 October 2018 08:15PM
 
-    Process ID: 15329
-    Host:       silver
-    PSIDATADIR: /home/kraus/psi4bin/cbs_dict/share/psi4
+    Process ID: 4839
+    Host:       dream
+    PSIDATADIR: /home/kraus/Applications/psi4-cbs_dict/share/psi4
     Memory:     500.0 MiB
-    Threads:    8
+    Threads:    1
     
   ==> Input File <==
 
@@ -36,7 +36,7 @@
 #! Various gradients for a strained helium dimer and water molecule
 import numpy as np
 
-nucenergy_ref = 9.16819326039
+nucenergy_ref = 9.1681932964
 
 molecule h2o_dz {
   O
@@ -90,26 +90,26 @@ compare_values(wfn_tz.frequencies().get(0), 1753.0273, 2, "SCF/cc-pVTZ Frequency
 compare_values(wfn_tz.frequencies().get(1), 4127.0329, 2, "SCF/cc-pVTZ Frequency 2")            #TEST
 compare_values(wfn_tz.frequencies().get(2), 4227.0130, 2, "SCF/cc-pVTZ Frequency 3")            #TEST
 
-scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, molecule=h2o_dtz)
-compare_values(wfn_dtz.frequencies().get(0), 1747.7410, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(1), 4130.2255, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
-compare_values(wfn_dtz.frequencies().get(2), 4230.5752, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+scf_dtz, wfn_dtz = freq('scf/cc-pv[dt]z', return_wfn=True, dertype=1, molecule=h2o_dtz)
+compare_values(wfn_dtz.frequencies().get(0), 1747.7069, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(1), 4130.2408, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
+compare_values(wfn_dtz.frequencies().get(2), 4230.6358, 2, "SCF/cc-pV[DT]Z Frequency 1")        #TEST
 
 
 --------------------------------------------------------------------------
 	Nuclear repulsion energy..........................................PASSED
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:13 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:03 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -117,7 +117,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -136,8 +136,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
-  Rotational constants: A = 817323.20514  B = 435158.59817  C = 283968.37324 [MHz]
-  Nuclear repulsion =    9.168193260387573
+  Rotational constants: A = 817323.21137  B = 435158.60148  C = 283968.37540 [MHz]
+  Nuclear repulsion =    9.168193296424349
 
   Charge       = 0
   Multiplicity = 1
@@ -171,8 +171,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -196,7 +196,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -213,7 +213,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4377086883E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4377086613E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -222,17 +222,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.99554773877419   -7.59955e+01   2.07061e-01 
-   @DF-RHF iter   1:   -75.98243705758790    1.31107e-02   3.47009e-02 
-   @DF-RHF iter   2:   -76.01715752504842   -3.47205e-02   1.75558e-02 DIIS
-   @DF-RHF iter   3:   -76.02597931961122   -8.82179e-03   3.72961e-03 DIIS
-   @DF-RHF iter   4:   -76.02657012930283   -5.90810e-04   9.02803e-04 DIIS
-   @DF-RHF iter   5:   -76.02663007727399   -5.99480e-05   1.43099e-04 DIIS
-   @DF-RHF iter   6:   -76.02663263740753   -2.56013e-06   3.44423e-05 DIIS
-   @DF-RHF iter   7:   -76.02663273258347   -9.51759e-08   4.40081e-06 DIIS
-   @DF-RHF iter   8:   -76.02663273487059   -2.28712e-09   6.33475e-07 DIIS
-   @DF-RHF iter   9:   -76.02663273490650   -3.59108e-11   5.90759e-08 DIIS
-   @DF-RHF iter  10:   -76.02663273490671   -2.13163e-13   5.77635e-09 DIIS
+   @DF-RHF iter   0:   -75.97345163006347   -7.59735e+01   1.21984e-01 
+   @DF-RHF iter   1:   -75.99199115726702   -1.85395e-02   2.06083e-02 
+   @DF-RHF iter   2:   -76.01906078469820   -2.70696e-02   1.03784e-02 DIIS
+   @DF-RHF iter   3:   -76.02620700522111   -7.14622e-03   1.55130e-03 DIIS
+   @DF-RHF iter   4:   -76.02658850207993   -3.81497e-04   4.43026e-04 DIIS
+   @DF-RHF iter   5:   -76.02663012198339   -4.16199e-05   9.43404e-05 DIIS
+   @DF-RHF iter   6:   -76.02663266836080   -2.54638e-06   1.49995e-05 DIIS
+   @DF-RHF iter   7:   -76.02663273428202   -6.59212e-08   1.92575e-06 DIIS
+   @DF-RHF iter   8:   -76.02663273509880   -8.16783e-10   3.41824e-07 DIIS
+   @DF-RHF iter   9:   -76.02663273512229   -2.34905e-11   2.82526e-08 DIIS
+   @DF-RHF iter  10:   -76.02663273512246   -1.70530e-13   3.50369e-09 DIIS
   Energy converged.
 
 
@@ -249,7 +249,7 @@ gradient() will perform analytic gradient computation.
     Virtual:                                                              
 
        4A1     0.185107     2B2     0.255846     3B2     0.787336  
-       5A1     0.851826     6A1     1.163856     2B1     1.200424  
+       5A1     0.851826     6A1     1.163855     2B1     1.200424  
        4B2     1.253573     7A1     1.445291     1A2     1.476011  
        3B1     1.674661     8A1     1.868110     5B2     1.932579  
        6B2     2.446529     9A1     2.483817     4B1     3.283958  
@@ -260,14 +260,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02663273490671
+  @DF-RHF Final Energy:   -76.02663273512246
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1681932603875733
-    One-Electron Energy =                -123.1035071074840346
-    Two-Electron Energy =                  37.9086811121897540
-    Total Energy =                        -76.0266327349067126
+    Nuclear Repulsion Energy =              9.1681932964243487
+    One-Electron Energy =                -123.1035072040179301
+    Two-Electron Energy =                  37.9086811724711268
+    Total Energy =                        -76.0266327351224618
 
 Computation Completed
 
@@ -289,18 +289,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:15 2018
+*** tstop() called on dream at Wed Oct 17 20:15:03 2018
 Module time:
-	user time   =       7.28 seconds =       0.12 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.28 seconds =       0.12 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:15 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:03 2018
 
 
          ------------------------------------------------------------
@@ -322,7 +322,7 @@ Total time:
          H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
          H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
 
-  Nuclear repulsion =    9.168193260387575
+  Nuclear repulsion =    9.168193296424349
 
   ==> Basis Set <==
 
@@ -340,8 +340,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -360,22 +360,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.017641632736
-       2        0.000000000000    -0.012438417883     0.008820816368
-       3       -0.000000000000     0.012438417883     0.008820816368
+       1       -0.000000000000     0.000000000000    -0.017641624495
+       2        0.000000000000    -0.012438412634     0.008820812248
+       3       -0.000000000000     0.012438412634     0.008820812248
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:16 2018
+*** tstop() called on dream at Wed Oct 17 20:15:03 2018
 Module time:
-	user time   =       9.31 seconds =       0.16 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.61 seconds =       0.28 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
-  Based on options and gradient (rms=1.14E-02), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=9.29E-03), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -413,16 +413,16 @@ hessian() will perform frequency computation by finite difference of analytic gr
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:16 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:03 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -430,7 +430,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -442,15 +442,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065996892278    15.994914619560
-         H            0.000000000000    -0.759061990794     0.523709286607     1.007825032070
-         H            0.000000000000     0.759061990794     0.523709286607     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065996892279    15.994914619560
+         H            0.000000000000    -0.759061990794     0.523709286614     1.007825032070
+         H            0.000000000000     0.759061990794     0.523709286614     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.08042  B =     14.51533  C =      9.45003 [cm^-1]
-  Rotational constants: A = 811850.58131  B = 435158.59817  C = 283304.85990 [MHz]
-  Nuclear repulsion =    9.157072652201339
+  Rotational constants: A = 811850.58748  B = 435158.60148  C = 283304.86205 [MHz]
+  Nuclear repulsion =    9.157072688150697
 
   Charge       = 0
   Multiplicity = 1
@@ -484,8 +484,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -509,7 +509,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -526,7 +526,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4436784146E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4436783875E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -535,17 +535,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.91957309019273   -7.59196e+01   1.64764e-01 
-   @DF-RHF iter   1:   -75.99559333498026   -7.60202e-02   3.05678e-02 
-   @DF-RHF iter   2:   -76.01964277974788   -2.40494e-02   1.50784e-02 DIIS
-   @DF-RHF iter   3:   -76.02630086754195   -6.65809e-03   1.98510e-03 DIIS
-   @DF-RHF iter   4:   -76.02653589926793   -2.35032e-04   6.36913e-04 DIIS
-   @DF-RHF iter   5:   -76.02656133821952   -2.54390e-05   1.46032e-04 DIIS
-   @DF-RHF iter   6:   -76.02656321576180   -1.87754e-06   2.19564e-05 DIIS
-   @DF-RHF iter   7:   -76.02656326821511   -5.24533e-08   2.21541e-06 DIIS
-   @DF-RHF iter   8:   -76.02656326866223   -4.47116e-10   4.69006e-07 DIIS
-   @DF-RHF iter   9:   -76.02656326867898   -1.67546e-11   3.89812e-08 DIIS
-   @DF-RHF iter  10:   -76.02656326867917   -1.84741e-13   3.85323e-09 DIIS
+   @DF-RHF iter   0:   -76.01024944333068   -7.60102e+01   1.21984e-01 
+   @DF-RHF iter   1:   -75.99010936736278    2.01401e-02   2.07780e-02 
+   @DF-RHF iter   2:   -76.01871392338774   -2.86046e-02   1.04125e-02 DIIS
+   @DF-RHF iter   3:   -76.02601039154391   -7.29647e-03   1.72268e-03 DIIS
+   @DF-RHF iter   4:   -76.02650762493073   -4.97233e-04   4.91158e-04 DIIS
+   @DF-RHF iter   5:   -76.02656024267506   -5.26177e-05   1.00962e-04 DIIS
+   @DF-RHF iter   6:   -76.02656319308875   -2.95041e-06   1.60189e-05 DIIS
+   @DF-RHF iter   7:   -76.02656326792095   -7.48322e-08   2.11245e-06 DIIS
+   @DF-RHF iter   8:   -76.02656326889166   -9.70715e-10   3.61271e-07 DIIS
+   @DF-RHF iter   9:   -76.02656326891703   -2.53664e-11   3.11391e-08 DIIS
+   @DF-RHF iter  10:   -76.02656326891726   -2.27374e-13   4.32135e-09 DIIS
   Energy converged.
 
 
@@ -573,14 +573,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02656326867917
+  @DF-RHF Final Energy:   -76.02656326891726
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1570726522013395
-    One-Electron Energy =                -123.0831369380330216
-    Two-Electron Energy =                  37.8995010171525166
-    Total Energy =                        -76.0265632686791690
+    Nuclear Repulsion Energy =              9.1570726881506967
+    One-Electron Energy =                -123.0831370350583853
+    Two-Electron Energy =                  37.8995010779904362
+    Total Energy =                        -76.0265632689172577
 
 Computation Completed
 
@@ -602,18 +602,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0635     Total:     2.0635
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:17 2018
+*** tstop() called on dream at Wed Oct 17 20:15:04 2018
 Module time:
-	user time   =       8.30 seconds =       0.14 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      25.04 seconds =       0.42 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       0.92 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:17 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:04 2018
 
 
          ------------------------------------------------------------
@@ -631,11 +631,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065996892278    15.994914619560
-         H            0.000000000000    -0.759061990794     0.523709286607     1.007825032070
-         H            0.000000000000     0.759061990794     0.523709286607     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065996892279    15.994914619560
+         H            0.000000000000    -0.759061990794     0.523709286614     1.007825032070
+         H            0.000000000000     0.759061990794     0.523709286614     1.007825032070
 
-  Nuclear repulsion =    9.157072652201339
+  Nuclear repulsion =    9.157072688150697
 
   ==> Basis Set <==
 
@@ -653,8 +653,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -673,36 +673,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.019533905890
-       2        0.000000000000    -0.013209290715     0.009766952945
-       3       -0.000000000000     0.013209290715     0.009766952945
+       1        0.000000000000     0.000000000000    -0.019533900491
+       2        0.000000000000    -0.013209286890     0.009766950246
+       3       -0.000000000000     0.013209286890     0.009766950246
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:19 2018
+*** tstop() called on dream at Wed Oct 17 20:15:04 2018
 Module time:
-	user time   =       9.32 seconds =       0.16 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      34.38 seconds =       0.57 minutes
-	system time =       0.65 seconds =       0.01 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:19 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:04 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -710,7 +710,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -722,15 +722,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065554248798    15.994914619560
-         H            0.000000000000    -0.759061990794     0.520196749984     1.007825032070
-         H            0.000000000000     0.759061990794     0.520196749984     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065554248797    15.994914619560
+         H            0.000000000000    -0.759061990794     0.520196749977     1.007825032070
+         H            0.000000000000     0.759061990794     0.520196749977     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.44737  B =     14.51533  C =      9.49433 [cm^-1]
-  Rotational constants: A = 822851.35188  B = 435158.59817  C = 284632.75729 [MHz]
-  Nuclear repulsion =    9.179318525428764
+  Rotational constants: A = 822851.35817  B = 435158.60148  C = 284632.75946 [MHz]
+  Nuclear repulsion =    9.179318561553005
 
   Charge       = 0
   Multiplicity = 1
@@ -764,8 +764,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -789,7 +789,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -806,7 +806,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4317700075E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4317699805E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -815,17 +815,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.98367848452720   -7.59837e+01   1.92100e-01 
-   @DF-RHF iter   1:   -75.98843482191133   -4.75634e-03   2.89682e-02 
-   @DF-RHF iter   2:   -76.01834607107234   -2.99112e-02   2.19070e-02 DIIS
-   @DF-RHF iter   3:   -76.02628287808560   -7.93681e-03   2.60077e-03 DIIS
-   @DF-RHF iter   4:   -76.02665706061252   -3.74183e-04   6.90952e-04 DIIS
-   @DF-RHF iter   5:   -76.02669317452700   -3.61139e-05   1.35979e-04 DIIS
-   @DF-RHF iter   6:   -76.02669504992893   -1.87540e-06   2.54659e-05 DIIS
-   @DF-RHF iter   7:   -76.02669511721706   -6.72881e-08   3.73909e-06 DIIS
-   @DF-RHF iter   8:   -76.02669511866613   -1.44907e-09   5.60471e-07 DIIS
-   @DF-RHF iter   9:   -76.02669511869709   -3.09655e-11   4.73204e-08 DIIS
-   @DF-RHF iter  10:   -76.02669511869721   -1.13687e-13   4.94403e-09 DIIS
+   @DF-RHF iter   0:   -76.06320548962216   -7.60632e+01   1.22791e-01 
+   @DF-RHF iter   1:   -75.97589024105974    8.73152e-02   2.38889e-02 
+   @DF-RHF iter   2:   -76.01607835751466   -4.01881e-02   1.20866e-02 DIIS
+   @DF-RHF iter   3:   -76.02589104611341   -9.81269e-03   2.17891e-03 DIIS
+   @DF-RHF iter   4:   -76.02662966683096   -7.38621e-04   5.70809e-04 DIIS
+   @DF-RHF iter   5:   -76.02669279804179   -6.31312e-05   9.36617e-05 DIIS
+   @DF-RHF iter   6:   -76.02669501917308   -2.22113e-06   1.91953e-05 DIIS
+   @DF-RHF iter   7:   -76.02669511591461   -9.67415e-08   3.29890e-06 DIIS
+   @DF-RHF iter   8:   -76.02669511885554   -2.94094e-09   4.41256e-07 DIIS
+   @DF-RHF iter   9:   -76.02669511889823   -4.26894e-11   3.53567e-08 DIIS
+   @DF-RHF iter  10:   -76.02669511889833   -9.94760e-14   3.46559e-09 DIIS
   Energy converged.
 
 
@@ -853,14 +853,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02669511869721
+  @DF-RHF Final Energy:   -76.02669511889833
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1793185254287639
-    One-Electron Energy =                -123.1238719154403327
-    Two-Electron Energy =                  37.9178582713143655
-    Total Energy =                        -76.0266951186972051
+    Nuclear Repulsion Energy =              9.1793185615530053
+    One-Electron Energy =                -123.1238719501144772
+    Two-Electron Energy =                  37.9178582696631281
+    Total Energy =                        -76.0266951188983455
 
 Computation Completed
 
@@ -882,18 +882,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0555     Total:     2.0555
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:20 2018
+*** tstop() called on dream at Wed Oct 17 20:15:04 2018
 Module time:
-	user time   =       8.30 seconds =       0.14 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      42.80 seconds =       0.71 minutes
-	system time =       0.75 seconds =       0.01 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       1.42 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:20 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:04 2018
 
 
          ------------------------------------------------------------
@@ -911,11 +911,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065554248798    15.994914619560
-         H            0.000000000000    -0.759061990794     0.520196749984     1.007825032070
-         H            0.000000000000     0.759061990794     0.520196749984     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065554248797    15.994914619560
+         H            0.000000000000    -0.759061990794     0.520196749977     1.007825032070
+         H            0.000000000000     0.759061990794     0.520196749977     1.007825032070
 
-  Nuclear repulsion =    9.179318525428764
+  Nuclear repulsion =    9.179318561553005
 
   ==> Basis Set <==
 
@@ -933,8 +933,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -953,36 +953,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.015743588759
-       2        0.000000000000    -0.011659060650     0.007871794379
-       3       -0.000000000000     0.011659060650     0.007871794379
+       1       -0.000000000000     0.000000000000    -0.015743587634
+       2        0.000000000000    -0.011659058987     0.007871793817
+       3       -0.000000000000     0.011659058987     0.007871793817
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:21 2018
+*** tstop() called on dream at Wed Oct 17 20:15:04 2018
 Module time:
-	user time   =       9.32 seconds =       0.16 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      52.14 seconds =       0.87 minutes
-	system time =       0.96 seconds =       0.02 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =       1.54 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:21 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:04 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -990,7 +990,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1003,14 +1003,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.760925637419     0.521953018295     1.007825032070
-         H            0.000000000000     0.760925637419     0.521953018295     1.007825032070
+         H            0.000000000000    -0.760925637426     0.521953018295     1.007825032070
+         H            0.000000000000     0.760925637426     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.26297  B =     14.44431  C =      9.44187 [cm^-1]
-  Rotational constants: A = 817323.20514  B = 433029.64182  C = 283060.23826 [MHz]
-  Nuclear repulsion =    9.153816284505739
+  Rotational constants: A = 817323.21137  B = 433029.64512  C = 283060.24042 [MHz]
+  Nuclear repulsion =    9.153816320429554
 
   Charge       = 0
   Multiplicity = 1
@@ -1044,8 +1044,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1069,7 +1069,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1086,7 +1086,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4503039484E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4503039213E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1095,17 +1095,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.89253678848510   -7.58925e+01   1.66571e-01 
-   @DF-RHF iter   1:   -76.00519083235311   -1.12654e-01   2.34857e-02 
-   @DF-RHF iter   2:   -76.02198604766386   -1.67952e-02   1.36537e-02 DIIS
-   @DF-RHF iter   3:   -76.02635882876913   -4.37278e-03   2.07481e-03 DIIS
-   @DF-RHF iter   4:   -76.02652322009256   -1.64391e-04   3.59075e-04 DIIS
-   @DF-RHF iter   5:   -76.02653872046388   -1.55004e-05   9.23871e-05 DIIS
-   @DF-RHF iter   6:   -76.02653981858883   -1.09812e-06   1.70879e-05 DIIS
-   @DF-RHF iter   7:   -76.02653985072483   -3.21360e-08   2.17645e-06 DIIS
-   @DF-RHF iter   8:   -76.02653985113137   -4.06544e-10   4.16740e-07 DIIS
-   @DF-RHF iter   9:   -76.02653985114262   -1.12408e-11   4.16666e-08 DIIS
-   @DF-RHF iter  10:   -76.02653985114273   -1.13687e-13   4.07017e-09 DIIS
+   @DF-RHF iter   0:   -75.97011702146608   -7.59701e+01   1.21582e-01 
+   @DF-RHF iter   1:   -75.99186913749836   -2.17521e-02   2.05996e-02 
+   @DF-RHF iter   2:   -76.01894156733934   -2.70724e-02   1.03915e-02 DIIS
+   @DF-RHF iter   3:   -76.02611008440884   -7.16852e-03   1.55417e-03 DIIS
+   @DF-RHF iter   4:   -76.02649499053453   -3.84906e-04   4.45396e-04 DIIS
+   @DF-RHF iter   5:   -76.02653720190094   -4.22114e-05   9.48795e-05 DIIS
+   @DF-RHF iter   6:   -76.02653978365447   -2.58175e-06   1.50974e-05 DIIS
+   @DF-RHF iter   7:   -76.02653985052302   -6.68686e-08   1.94586e-06 DIIS
+   @DF-RHF iter   8:   -76.02653985135767   -8.34646e-10   3.44396e-07 DIIS
+   @DF-RHF iter   9:   -76.02653985138151   -2.38458e-11   2.83674e-08 DIIS
+   @DF-RHF iter  10:   -76.02653985138163   -1.13687e-13   3.52381e-09 DIIS
   Energy converged.
 
 
@@ -1133,14 +1133,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02653985114273
+  @DF-RHF Final Energy:   -76.02653985138163
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1538162845057389
-    One-Electron Energy =                -123.0783779688797637
-    Two-Electron Energy =                  37.8980218332312973
-    Total Energy =                        -76.0265398511427293
+    Nuclear Repulsion Energy =              9.1538163204295540
+    One-Electron Energy =                -123.0783780667240421
+    Two-Electron Energy =                  37.8980218949128584
+    Total Energy =                        -76.0265398513816280
 
 Computation Completed
 
@@ -1162,18 +1162,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0589     Total:     2.0589
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:23 2018
+*** tstop() called on dream at Wed Oct 17 20:15:05 2018
 Module time:
-	user time   =       8.30 seconds =       0.14 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      60.56 seconds =       1.01 minutes
-	system time =       1.07 seconds =       0.02 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =       1.93 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:23 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:05 2018
 
 
          ------------------------------------------------------------
@@ -1192,10 +1192,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.760925637419     0.521953018295     1.007825032070
-         H            0.000000000000     0.760925637419     0.521953018295     1.007825032070
+         H            0.000000000000    -0.760925637426     0.521953018295     1.007825032070
+         H            0.000000000000     0.760925637426     0.521953018295     1.007825032070
 
-  Nuclear repulsion =    9.153816284505739
+  Nuclear repulsion =    9.153816320429554
 
   ==> Basis Set <==
 
@@ -1213,8 +1213,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1233,36 +1233,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.019091966387
-       2        0.000000000000    -0.013933554794     0.009545983193
-       3       -0.000000000000     0.013933554794     0.009545983193
+       1        0.000000000000     0.000000000000    -0.019091958545
+       2        0.000000000000    -0.013933549919     0.009545979273
+       3       -0.000000000000     0.013933549919     0.009545979273
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:24 2018
+*** tstop() called on dream at Wed Oct 17 20:15:05 2018
 Module time:
-	user time   =       9.34 seconds =       0.16 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      69.92 seconds =       1.17 minutes
-	system time =       1.28 seconds =       0.02 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =       2.04 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:24 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:05 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -1270,7 +1270,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1283,14 +1283,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757198344170     0.521953018295     1.007825032070
-         H            0.000000000000     0.757198344170     0.521953018295     1.007825032070
+         H            0.000000000000    -0.757198344162     0.521953018295     1.007825032070
+         H            0.000000000000     0.757198344162     0.521953018295     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.26297  B =     14.58687  C =      9.50258 [cm^-1]
-  Rotational constants: A = 817323.20514  B = 437303.29346  C = 284880.10562 [MHz]
-  Nuclear repulsion =    9.182603540794874
+  Rotational constants: A = 817323.21137  B = 437303.29680  C = 284880.10779 [MHz]
+  Nuclear repulsion =    9.182603576944995
 
   Charge       = 0
   Multiplicity = 1
@@ -1324,8 +1324,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1349,7 +1349,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1366,7 +1366,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4252102229E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4252101960E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1375,17 +1375,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.89807589421447   -7.58981e+01   2.05350e-01 
-   @DF-RHF iter   1:   -76.00529159902791   -1.07216e-01   2.66830e-02 
-   @DF-RHF iter   2:   -76.02216222924777   -1.68706e-02   1.49610e-02 DIIS
-   @DF-RHF iter   3:   -76.02653354068680   -4.37131e-03   1.69307e-03 DIIS
-   @DF-RHF iter   4:   -76.02669840083654   -1.64860e-04   4.75159e-04 DIIS
-   @DF-RHF iter   5:   -76.02671392214720   -1.55213e-05   1.01213e-04 DIIS
-   @DF-RHF iter   6:   -76.02671501103666   -1.08889e-06   1.53335e-05 DIIS
-   @DF-RHF iter   7:   -76.02671504244923   -3.14126e-08   2.00491e-06 DIIS
-   @DF-RHF iter   8:   -76.02671504284672   -3.97492e-10   3.03148e-07 DIIS
-   @DF-RHF iter   9:   -76.02671504285773   -1.10134e-11   3.61700e-08 DIIS
-   @DF-RHF iter  10:   -76.02671504285797   -2.41585e-13   3.19341e-09 DIIS
+   @DF-RHF iter   0:   -75.97679026553163   -7.59768e+01   1.22387e-01 
+   @DF-RHF iter   1:   -75.99210182724842   -1.53116e-02   2.06172e-02 
+   @DF-RHF iter   2:   -76.01916909472179   -2.70673e-02   1.03655e-02 DIIS
+   @DF-RHF iter   3:   -76.02629331264002   -7.12422e-03   1.54844e-03 DIIS
+   @DF-RHF iter   4:   -76.02667143033523   -3.78118e-04   4.40664e-04 DIIS
+   @DF-RHF iter   5:   -76.02671246581976   -4.10355e-05   9.38033e-05 DIIS
+   @DF-RHF iter   6:   -76.02671497723530   -2.51142e-06   1.49026e-05 DIIS
+   @DF-RHF iter   7:   -76.02671504222577   -6.49905e-08   1.90586e-06 DIIS
+   @DF-RHF iter   8:   -76.02671504302501   -7.99233e-10   3.39251e-07 DIIS
+   @DF-RHF iter   9:   -76.02671504304820   -2.31921e-11   2.81390e-08 DIIS
+   @DF-RHF iter  10:   -76.02671504304828   -8.52651e-14   3.48376e-09 DIIS
   Energy converged.
 
 
@@ -1413,14 +1413,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02671504285797
+  @DF-RHF Final Energy:   -76.02671504304828
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1826035407948741
-    One-Electron Energy =                -123.1286765158269105
-    Two-Electron Energy =                  37.9193579321740728
-    Total Energy =                        -76.0267150428579725
+    Nuclear Repulsion Energy =              9.1826035769449952
+    One-Electron Energy =                -123.1286766128514358
+    Two-Electron Energy =                  37.9193579928581457
+    Total Energy =                        -76.0267150430482843
 
 Computation Completed
 
@@ -1442,18 +1442,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0602     Total:     2.0602
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:26 2018
+*** tstop() called on dream at Wed Oct 17 20:15:05 2018
 Module time:
-	user time   =       8.49 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      78.52 seconds =       1.31 minutes
-	system time =       1.41 seconds =       0.02 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =       2.43 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:26 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:05 2018
 
 
          ------------------------------------------------------------
@@ -1472,10 +1472,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757198344170     0.521953018295     1.007825032070
-         H            0.000000000000     0.757198344170     0.521953018295     1.007825032070
+         H            0.000000000000    -0.757198344162     0.521953018295     1.007825032070
+         H            0.000000000000     0.757198344162     0.521953018295     1.007825032070
 
-  Nuclear repulsion =    9.182603540794874
+  Nuclear repulsion =    9.182603576944995
 
   ==> Basis Set <==
 
@@ -1493,8 +1493,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1513,36 +1513,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.016170101482
-       2        0.000000000000    -0.010930573734     0.008085050741
-       3       -0.000000000000     0.010930573734     0.008085050741
+       1       -0.000000000000     0.000000000000    -0.016170093615
+       2        0.000000000000    -0.010930568854     0.008085046807
+       3       -0.000000000000     0.010930568854     0.008085046807
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:27 2018
+*** tstop() called on dream at Wed Oct 17 20:15:05 2018
 Module time:
-	user time   =       9.32 seconds =       0.16 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      87.86 seconds =       1.46 minutes
-	system time =       1.61 seconds =       0.03 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =       2.55 seconds =       0.04 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:27 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:05 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -1550,7 +1550,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1563,14 +1563,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757643253230     0.520854514304     1.007825032070
-         H            0.000000000000     0.760480728358     0.523051522286     1.007825032070
+         H            0.000000000000    -0.757643253225     0.520854514300     1.007825032070
+         H            0.000000000000     0.760480728363     0.523051522291     1.007825032070
 
   Running in cs symmetry.
 
   Rotational constants: A =     27.26378  B =     14.51501  C =      9.47213 [cm^-1]
-  Rotational constants: A = 817347.49341  B = 435149.09044  C = 283967.25621 [MHz]
-  Nuclear repulsion =    9.168228694827295
+  Rotational constants: A = 817347.49964  B = 435149.09376  C = 283967.25838 [MHz]
+  Nuclear repulsion =    9.168228730864485
 
   Charge       = 0
   Multiplicity = 1
@@ -1604,8 +1604,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1627,7 +1627,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1644,7 +1644,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4376245210E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4376244940E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1653,17 +1653,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.09613561767939   -7.60961e+01   1.78355e-01 
-   @DF-RHF iter   1:   -75.97316728851428    1.22968e-01   2.82905e-02 
-   @DF-RHF iter   2:   -76.01558749618056   -4.24202e-02   1.76125e-02 DIIS
-   @DF-RHF iter   3:   -76.02563619243142   -1.00487e-02   2.56671e-03 DIIS
-   @DF-RHF iter   4:   -76.02654410240216   -9.07910e-04   6.94461e-04 DIIS
-   @DF-RHF iter   5:   -76.02662205151748   -7.79491e-05   1.38761e-04 DIIS
-   @DF-RHF iter   6:   -76.02662495547526   -2.90396e-06   2.61080e-05 DIIS
-   @DF-RHF iter   7:   -76.02662508631546   -1.30840e-07   3.76631e-06 DIIS
-   @DF-RHF iter   8:   -76.02662508970069   -3.38522e-09   5.49808e-07 DIIS
-   @DF-RHF iter   9:   -76.02662508974153   -4.08420e-11   4.16107e-08 DIIS
-   @DF-RHF iter  10:   -76.02662508974171   -1.84741e-13   4.54830e-09 DIIS
+   @DF-RHF iter   0:   -75.90152223128959   -7.59015e+01   8.76191e-02 
+   @DF-RHF iter   1:   -76.00548744597455   -1.03965e-01   1.21882e-02 
+   @DF-RHF iter   2:   -76.02217195056069   -1.66845e-02   5.73058e-03 DIIS
+   @DF-RHF iter   3:   -76.02641539245131   -4.24344e-03   9.29089e-04 DIIS
+   @DF-RHF iter   4:   -76.02660431866110   -1.88926e-04   2.09796e-04 DIIS
+   @DF-RHF iter   5:   -76.02662372700206   -1.94083e-05   5.00420e-05 DIIS
+   @DF-RHF iter   6:   -76.02662505700734   -1.33001e-06   8.25567e-06 DIIS
+   @DF-RHF iter   7:   -76.02662508949743   -3.24901e-08   1.01817e-06 DIIS
+   @DF-RHF iter   8:   -76.02662508994646   -4.49035e-10   1.74414e-07 DIIS
+   @DF-RHF iter   9:   -76.02662508995832   -1.18519e-11   1.92345e-08 DIIS
+   @DF-RHF iter  10:   -76.02662508995840   -8.52651e-14   1.76309e-09 DIIS
   Energy converged.
 
 
@@ -1691,14 +1691,14 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.02662508974171
+  @DF-RHF Final Energy:   -76.02662508995840
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1682286948272953
-    One-Electron Energy =                -123.1035547533186474
-    Two-Electron Energy =                  37.9087009687496419
-    Total Energy =                        -76.0266250897417137
+    Nuclear Repulsion Energy =              9.1682287308644845
+    One-Electron Energy =                -123.1035548200775622
+    Two-Electron Energy =                  37.9087009992546768
+    Total Energy =                        -76.0266250899584008
 
 Computation Completed
 
@@ -1720,18 +1720,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0031      Z:     2.0595     Total:     2.0595
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:28 2018
+*** tstop() called on dream at Wed Oct 17 20:15:06 2018
 Module time:
-	user time   =       8.31 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      96.28 seconds =       1.60 minutes
-	system time =       1.74 seconds =       0.03 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =       2.93 seconds =       0.05 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:28 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:06 2018
 
 
          ------------------------------------------------------------
@@ -1750,10 +1750,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757643253230     0.520854514304     1.007825032070
-         H            0.000000000000     0.760480728358     0.523051522286     1.007825032070
+         H            0.000000000000    -0.757643253225     0.520854514300     1.007825032070
+         H            0.000000000000     0.760480728363     0.523051522291     1.007825032070
 
-  Nuclear repulsion =    9.168228694827295
+  Nuclear repulsion =    9.168228730864485
 
   ==> Basis Set <==
 
@@ -1771,8 +1771,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1791,36 +1791,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003305711403    -0.017624077668
-       2        0.000000000000    -0.010774934449     0.007532821609
-       3        0.000000000000     0.014080645852     0.010091256059
+       1        0.000000000000    -0.003305710470    -0.017624072787
+       2        0.000000000000    -0.010774931247     0.007532819991
+       3        0.000000000000     0.014080641717     0.010091252796
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:30 2018
+*** tstop() called on dream at Wed Oct 17 20:15:06 2018
 Module time:
-	user time   =       9.29 seconds =       0.15 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     105.59 seconds =       1.76 minutes
-	system time =       1.97 seconds =       0.03 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =       3.05 seconds =       0.05 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:30 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:06 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -1828,7 +1828,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1847,8 +1847,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
-  Rotational constants: A = 817323.20514  B = 435158.59817  C = 283968.37324 [MHz]
-  Nuclear repulsion =    9.168193260387577
+  Rotational constants: A = 817323.21137  B = 435158.60148  C = 283968.37540 [MHz]
+  Nuclear repulsion =    9.168193296424349
 
   Charge       = 0
   Multiplicity = 1
@@ -1882,8 +1882,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1907,7 +1907,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1924,7 +1924,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4377086883E-02.
+  Minimum eigenvalue in the overlap matrix is 3.4377086613E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1933,17 +1933,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.89530570965437   -7.58953e+01   1.67118e-01 
-   @DF-RHF iter   1:   -76.00524669119459   -1.09941e-01   2.66565e-02 
-   @DF-RHF iter   2:   -76.02207948980923   -1.68328e-02   1.26425e-02 DIIS
-   @DF-RHF iter   3:   -76.02645147277228   -4.37198e-03   1.87232e-03 DIIS
-   @DF-RHF iter   4:   -76.02661609804781   -1.64625e-04   3.80227e-04 DIIS
-   @DF-RHF iter   5:   -76.02663160921207   -1.55112e-05   1.03473e-04 DIIS
-   @DF-RHF iter   6:   -76.02663270272370   -1.09351e-06   2.21092e-05 DIIS
-   @DF-RHF iter   7:   -76.02663273449569   -3.17720e-08   2.23126e-06 DIIS
-   @DF-RHF iter   8:   -76.02663273489758   -4.01883e-10   3.40083e-07 DIIS
-   @DF-RHF iter   9:   -76.02663273490883   -1.12550e-11   4.38701e-08 DIIS
-   @DF-RHF iter  10:   -76.02663273490893   -9.94760e-14   3.43845e-09 DIIS
+   @DF-RHF iter   0:   -75.97345163006347   -7.59735e+01   1.21984e-01 
+   @DF-RHF iter   1:   -75.99199115726702   -1.85395e-02   2.06083e-02 
+   @DF-RHF iter   2:   -76.01906078469820   -2.70696e-02   1.03784e-02 DIIS
+   @DF-RHF iter   3:   -76.02620700522111   -7.14622e-03   1.55130e-03 DIIS
+   @DF-RHF iter   4:   -76.02658850207993   -3.81497e-04   4.43026e-04 DIIS
+   @DF-RHF iter   5:   -76.02663012198339   -4.16199e-05   9.43404e-05 DIIS
+   @DF-RHF iter   6:   -76.02663266836080   -2.54638e-06   1.49995e-05 DIIS
+   @DF-RHF iter   7:   -76.02663273428202   -6.59212e-08   1.92575e-06 DIIS
+   @DF-RHF iter   8:   -76.02663273509880   -8.16783e-10   3.41824e-07 DIIS
+   @DF-RHF iter   9:   -76.02663273512229   -2.34905e-11   2.82526e-08 DIIS
+   @DF-RHF iter  10:   -76.02663273512246   -1.70530e-13   3.50369e-09 DIIS
   Energy converged.
 
 
@@ -1960,7 +1960,7 @@ gradient() will perform analytic gradient computation.
     Virtual:                                                              
 
        4A1     0.185107     2B2     0.255846     3B2     0.787336  
-       5A1     0.851826     6A1     1.163856     2B1     1.200424  
+       5A1     0.851826     6A1     1.163855     2B1     1.200424  
        4B2     1.253573     7A1     1.445291     1A2     1.476011  
        3B1     1.674661     8A1     1.868110     5B2     1.932579  
        6B2     2.446529     9A1     2.483817     4B1     3.283958  
@@ -1971,14 +1971,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02663273490893
+  @DF-RHF Final Energy:   -76.02663273512246
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1681932603875769
-    One-Electron Energy =                -123.1035071065877560
-    Two-Electron Energy =                  37.9086811112912443
-    Total Energy =                        -76.0266327349089295
+    Nuclear Repulsion Energy =              9.1681932964243487
+    One-Electron Energy =                -123.1035072040179301
+    Two-Electron Energy =                  37.9086811724711268
+    Total Energy =                        -76.0266327351224618
 
 Computation Completed
 
@@ -2000,18 +2000,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:31 2018
+*** tstop() called on dream at Wed Oct 17 20:15:06 2018
 Module time:
-	user time   =       8.34 seconds =       0.14 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     114.04 seconds =       1.90 minutes
-	system time =       2.11 seconds =       0.04 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =       3.44 seconds =       0.06 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:31 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:06 2018
 
 
          ------------------------------------------------------------
@@ -2033,7 +2033,7 @@ Total time:
          H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
          H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
 
-  Nuclear repulsion =    9.168193260387577
+  Nuclear repulsion =    9.168193296424349
 
   ==> Basis Set <==
 
@@ -2051,8 +2051,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2071,20 +2071,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.017641632307
-       2        0.000000000000    -0.012438417484     0.008820816153
-       3       -0.000000000000     0.012438417484     0.008820816153
+       1       -0.000000000000     0.000000000000    -0.017641624495
+       2        0.000000000000    -0.012438412634     0.008820812248
+       3       -0.000000000000     0.012438412634     0.008820812248
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:32 2018
+*** tstop() called on dream at Wed Oct 17 20:15:06 2018
 Module time:
-	user time   =       9.35 seconds =       0.16 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     123.40 seconds =       2.06 minutes
-	system time =       2.28 seconds =       0.04 minutes
-	total time  =         19 seconds =       0.32 minutes
+	user time   =       3.56 seconds =       0.06 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -2110,43 +2110,43 @@ Total time:
   mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1809.2464'
- '3923.1516' '4020.1816']
+  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '1809.2459'
+ '3923.1507' '4020.1808']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1809.2464'
- '3923.1516' '4020.1816']
+  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
+  post-proj  all modes:['0.0001i' '0.0001i' '0.0000i' '0.0000' '0.0000' '0.0001' '1809.2459'
+ '3923.1507' '4020.1808']
 
   Vibration                       7                   8                   9           
-  Freq [cm^-1]                1809.2464           3923.1516           4020.1816       
+  Freq [cm^-1]                1809.2459           3923.1507           4020.1808       
   Irrep                           A1                  A1                  B2          
   Reduced mass [u]              1.0818              1.0460              1.0819        
-  Force const [mDyne/A]         2.0864              9.4849             10.3018        
+  Force const [mDyne/A]         2.0864              9.4849             10.3017        
   Turning point v=0 [a0]        0.2480              0.1713              0.1664        
   RMS dev v=0 [a0 u^1/2]        0.1824              0.1239              0.1224        
-  Char temp [K]               2603.0988           5644.5331           5784.1374       
+  Char temp [K]               2603.1021           5644.5405           5784.1450       
   ----------------------------------------------------------------------------------
-      1   O               -0.00 -0.00 -0.07   -0.00 -0.00  0.05    0.00 -0.07 -0.00   
-      2   H               -0.00  0.43  0.56    0.00  0.58 -0.40    0.00  0.56 -0.43   
-      3   H               -0.00 -0.43  0.56   -0.00 -0.58 -0.40   -0.00  0.56  0.43   
+      1   O               -0.00  0.00 -0.07   -0.00  0.00  0.05    0.00 -0.07 -0.00   
+      2   H                0.00  0.43  0.56    0.00  0.58 -0.40   -0.00  0.56 -0.43   
+      3   H                0.00 -0.43  0.56    0.00 -0.58 -0.40   -0.00  0.56  0.43   
 
   ==> Thermochemistry Components <==
 
   Entropy, S
     Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
-    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
-    Rotational S           10.463 [cal/(mol K)]       43.779 [J/(mol K)]       0.01667448 [mEh/K] (symmetry no. = 2)
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515177 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.463 [cal/(mol K)]       43.779 [J/(mol K)]       0.01667445 [mEh/K] (symmetry no. = 2)
     Vibrational S           0.003 [cal/(mol K)]        0.013 [J/(mol K)]       0.00000498 [mEh/K]
-  Total S                  45.075 [cal/(mol K)]      188.593 [J/(mol K)]       0.07183131 [mEh/K]
+  Total S                  45.075 [cal/(mol K)]      188.593 [J/(mol K)]       0.07183120 [mEh/K]
   Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant volume heat capacity, Cv
@@ -2154,28 +2154,28 @@ Total time:
     Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cv          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
-  Total Cv                  5.986 [cal/(mol K)]       25.046 [J/(mol K)]       0.00953946 [mEh/K]
+  Total Cv                  5.986 [cal/(mol K)]       25.046 [J/(mol K)]       0.00953945 [mEh/K]
   Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant pressure heat capacity, Cp
     Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
-    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
     Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cp          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
-  Total Cp                  7.973 [cal/(mol K)]       33.360 [J/(mol K)]       0.01270628 [mEh/K]
+  Total Cp                  7.973 [cal/(mol K)]       33.360 [J/(mol K)]       0.01270626 [mEh/K]
   Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   ==> Thermochemistry Energy Analysis <==
 
   Raw electronic energy, E0
-  Total E0, Electronic energy at well bottom at 0 [K]                  -76.02663273 [Eh]
+  Total E0, Electronic energy at well bottom at 0 [K]                  -76.02663274 [Eh]
 
   Zero-point energy, ZPE_vib = Sum_i nu_i / 2
     Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Vibrational ZPE        13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.288 [cm^-1]
-  Correction ZPE           13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.288 [cm^-1]
+    Vibrational ZPE        13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.289 [cm^-1]
+  Correction ZPE           13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.289 [cm^-1]
   Total ZPE, Electronic energy at 0 [K]                                -76.00441473 [Eh]
 
   Thermal Energy, E (includes ZPE)
@@ -2183,7 +2183,7 @@ Total time:
     Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Vibrational E          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
-  Correction E             15.720 [kcal/mol]       65.774 [kJ/mol]       0.02505190 [Eh]
+  Correction E             15.720 [kcal/mol]       65.774 [kJ/mol]       0.02505189 [Eh]
   Total E, Electronic energy at  298.15 [K]                            -76.00158084 [Eh]
 
   Enthalpy, H_trans = E_trans + k_B * T
@@ -2192,30 +2192,30 @@ Total time:
     Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Vibrational H          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
   Correction H             16.313 [kcal/mol]       68.253 [kJ/mol]       0.02599608 [Eh]
-  Total H, Enthalpy at  298.15 [K]                                     -76.00063665 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.00063666 [Eh]
 
   Gibbs free energy, G = H - T * S
     Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
-    Rotational G           -2.231 [kcal/mol]       -9.334 [kJ/mol]      -0.00355522 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408304 [Eh]
+    Rotational G           -2.231 [kcal/mol]       -9.334 [kJ/mol]      -0.00355521 [Eh]
     Vibrational G          13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221785 [Eh]
-  Correction G              2.874 [kcal/mol]       12.024 [kJ/mol]       0.00457958 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                                -76.02205316 [Eh]
+  Correction G              2.874 [kcal/mol]       12.024 [kJ/mol]       0.00457960 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.02205313 [Eh]
 	SCF/cc-pVDZ Frequency 1...........................................PASSED
 	SCF/cc-pVDZ Frequency 2...........................................PASSED
 	SCF/cc-pVDZ Frequency 3...........................................PASSED
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:32 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:06 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2223,7 +2223,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2242,8 +2242,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     29.38939  B =     14.82055  C =      9.85224 [cm^-1]
-  Rotational constants: A = 881071.62781  B = 444308.76784  C = 295362.63749 [MHz]
-  Nuclear repulsion =    9.353677802986757
+  Rotational constants: A = 881071.63453  B = 444308.77123  C = 295362.63974 [MHz]
+  Nuclear repulsion =    9.353677839752608
 
   Charge       = 0
   Multiplicity = 1
@@ -2277,8 +2277,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2302,7 +2302,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2319,7 +2319,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3474054466E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3474054182E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -2328,17 +2328,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15347657941527   -7.61535e+01   9.81852e-02 
-   @DF-RHF iter   1:   -76.00793896105995    1.45538e-01   1.84569e-02 
-   @DF-RHF iter   2:   -76.04631497044016   -3.83760e-02   1.12829e-02 DIIS
-   @DF-RHF iter   3:   -76.05687689488875   -1.05619e-02   1.94969e-03 DIIS
-   @DF-RHF iter   4:   -76.05767028195160   -7.93387e-04   4.22642e-04 DIIS
-   @DF-RHF iter   5:   -76.05775930899149   -8.90270e-05   9.01147e-05 DIIS
-   @DF-RHF iter   6:   -76.05776302330433   -3.71431e-06   1.66785e-05 DIIS
-   @DF-RHF iter   7:   -76.05776311541881   -9.21145e-08   2.66779e-06 DIIS
-   @DF-RHF iter   8:   -76.05776311845361   -3.03480e-09   4.83629e-07 DIIS
-   @DF-RHF iter   9:   -76.05776311854483   -9.12195e-11   5.57321e-08 DIIS
-   @DF-RHF iter  10:   -76.05776311854611   -1.27898e-12   5.95904e-09 DIIS
+   @DF-RHF iter   0:   -75.94710806905404   -7.59471e+01   5.55730e-02 
+   @DF-RHF iter   1:   -76.03440231261533   -8.72942e-02   7.81576e-03 
+   @DF-RHF iter   2:   -76.05209349341780   -1.76912e-02   4.21713e-03 DIIS
+   @DF-RHF iter   3:   -76.05749806224043   -5.40457e-03   5.87784e-04 DIIS
+   @DF-RHF iter   4:   -76.05773197621663   -2.33914e-04   1.57910e-04 DIIS
+   @DF-RHF iter   5:   -76.05776122366373   -2.92474e-05   3.76317e-05 DIIS
+   @DF-RHF iter   6:   -76.05776307194347   -1.84828e-06   6.25426e-06 DIIS
+   @DF-RHF iter   7:   -76.05776311756114   -4.56177e-08   9.14904e-07 DIIS
+   @DF-RHF iter   8:   -76.05776311852399   -9.62856e-10   1.34231e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854618   -2.21831e-11   2.37416e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854677   -5.96856e-13   2.54948e-09 DIIS
   Energy converged.
 
 
@@ -2358,7 +2358,7 @@ gradient() will perform analytic gradient computation.
        5A1     0.606501     6A1     0.666793     2B1     0.787514  
        4B2     0.805097     7A1     0.811469     1A2     0.861557  
        3B1     0.963988     8A1     1.118808     5B2     1.202677  
-       6B2     1.546259     9A1     1.589176     7B2     2.031142  
+       6B2     1.546259     9A1     1.589177     7B2     2.031142  
        4B1     2.037085     2A2     2.075917    10A1     2.171714  
       11A1     2.232214    12A1     2.609949     8B2     2.973570  
        5B1     3.371299    13A1     3.508424     3A2     3.582881  
@@ -2369,7 +2369,7 @@ gradient() will perform analytic gradient computation.
       13B2     4.910416    17A1     5.211746    18A1     5.270269  
       14B2     5.547693     9B1     6.083565    19A1     6.616731  
       10B1     6.966231     6A2     6.974972    11B1     7.038442  
-      20A1     7.063988    15B2     7.158417    21A1     7.176967  
+      20A1     7.063988    15B2     7.158418    21A1     7.176967  
        7A2     7.280150    22A1     7.488141    16B2     7.838859  
       17B2     8.357375    23A1    13.167130  
 
@@ -2377,14 +2377,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05776311854611
+  @DF-RHF Final Energy:   -76.05776311854677
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3536778029867573
-    One-Electron Energy =                -123.4037988369638157
-    Two-Electron Energy =                  37.9923579154309650
-    Total Energy =                        -76.0577631185460916
+    Nuclear Repulsion Energy =              9.3536778397526081
+    One-Electron Energy =                -123.4037989783759031
+    Two-Electron Energy =                  37.9923580200765230
+    Total Energy =                        -76.0577631185467737
 
 Computation Completed
 
@@ -2406,18 +2406,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:34 2018
+*** tstop() called on dream at Wed Oct 17 20:15:07 2018
 Module time:
-	user time   =      10.69 seconds =       0.18 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     134.55 seconds =       2.24 minutes
-	system time =       2.46 seconds =       0.04 minutes
-	total time  =         21 seconds =       0.35 minutes
+	user time   =       4.06 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:34 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:07 2018
 
 
          ------------------------------------------------------------
@@ -2439,7 +2439,7 @@ Total time:
          H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
          H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
 
-  Nuclear repulsion =    9.353677802986757
+  Nuclear repulsion =    9.353677839752608
 
   ==> Basis Set <==
 
@@ -2457,8 +2457,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2477,22 +2477,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.000000197633
-       2       -0.000000000000     0.000000172869    -0.000000098817
-       3        0.000000000000    -0.000000172869    -0.000000098817
+       1        0.000000000000     0.000000000000     0.000000202204
+       2       -0.000000000000     0.000000176416    -0.000000101102
+       3        0.000000000000    -0.000000176416    -0.000000101102
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:37 2018
+*** tstop() called on dream at Wed Oct 17 20:15:07 2018
 Module time:
-	user time   =      10.81 seconds =       0.18 minutes
-	system time =       0.43 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     145.37 seconds =       2.42 minutes
-	system time =       2.89 seconds =       0.05 minutes
-	total time  =         24 seconds =       0.40 minutes
+	user time   =       4.29 seconds =       0.07 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-  Based on options and gradient (rms=1.40E-07), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=1.17E-07), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -2530,16 +2530,16 @@ hessian() will perform frequency computation by finite difference of analytic gr
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:37 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:07 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2547,7 +2547,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2559,15 +2559,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063572679962    15.994914619560
-         H            0.000000000000    -0.751205204049     0.504472282279     1.007825032070
-         H            0.000000000000     0.751205204049     0.504472282279     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063572679963    15.994914619560
+         H            0.000000000000    -0.751205204049     0.504472282286     1.007825032070
+         H            0.000000000000     0.751205204049     0.504472282286     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     29.18511  B =     14.82055  C =      9.82917 [cm^-1]
-  Rotational constants: A = 874947.58619  B = 444308.76784  C = 294671.22350 [MHz]
-  Nuclear repulsion =    9.342290153252501
+  Rotational constants: A = 874947.59284  B = 444308.77123  C = 294671.22574 [MHz]
+  Nuclear repulsion =    9.342290189928836
 
   Charge       = 0
   Multiplicity = 1
@@ -2601,8 +2601,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2626,7 +2626,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2643,7 +2643,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3581937959E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3581937672E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -2652,17 +2652,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05720258816422   -7.60572e+01   9.87457e-02 
-   @DF-RHF iter   1:   -76.02240815304293    3.47944e-02   1.59432e-02 
-   @DF-RHF iter   2:   -76.04928834023821   -2.68802e-02   8.86949e-03 DIIS
-   @DF-RHF iter   3:   -76.05723791249567   -7.94957e-03   1.27620e-03 DIIS
-   @DF-RHF iter   4:   -76.05769607664327   -4.58164e-04   3.94804e-04 DIIS
-   @DF-RHF iter   5:   -76.05775566684947   -5.95902e-05   8.64764e-05 DIIS
-   @DF-RHF iter   6:   -76.05775934350825   -3.67666e-06   1.34224e-05 DIIS
-   @DF-RHF iter   7:   -76.05775943727865   -9.37704e-08   1.87649e-06 DIIS
-   @DF-RHF iter   8:   -76.05775943834119   -1.06255e-09   1.69902e-07 DIIS
-   @DF-RHF iter   9:   -76.05775943835189   -1.07008e-11   4.49964e-08 DIIS
-   @DF-RHF iter  10:   -76.05775943835255   -6.53699e-13   5.18958e-09 DIIS
+   @DF-RHF iter   0:   -75.94771312648975   -7.59477e+01   5.54485e-02 
+   @DF-RHF iter   1:   -76.03449412772294   -8.67810e-02   7.78131e-03 
+   @DF-RHF iter   2:   -76.05212839025712   -1.76343e-02   4.18818e-03 DIIS
+   @DF-RHF iter   3:   -76.05748030095769   -5.35191e-03   5.99208e-04 DIIS
+   @DF-RHF iter   4:   -76.05772619523374   -2.45894e-04   1.62144e-04 DIIS
+   @DF-RHF iter   5:   -76.05775744410293   -3.12489e-05   3.85157e-05 DIIS
+   @DF-RHF iter   6:   -76.05775939110492   -1.94700e-06   6.31205e-06 DIIS
+   @DF-RHF iter   7:   -76.05775943736855   -4.62636e-08   9.23351e-07 DIIS
+   @DF-RHF iter   8:   -76.05775943834824   -9.79696e-10   1.36615e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943837114   -2.28937e-11   2.39606e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943837179   -6.53699e-13   2.57612e-09 DIIS
   Energy converged.
 
 
@@ -2701,14 +2701,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775943835255
+  @DF-RHF Final Energy:   -76.05775943837179
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3422901532525007
-    One-Electron Energy =                -123.3832392415439898
-    Two-Electron Energy =                  37.9831896499389430
-    Total Energy =                        -76.0577594383525479
+    Nuclear Repulsion Energy =              9.3422901899288355
+    One-Electron Energy =                -123.3832394150091432
+    Two-Electron Energy =                  37.9831897867085289
+    Total Energy =                        -76.0577594383717894
 
 Computation Completed
 
@@ -2730,18 +2730,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9919     Total:     1.9919
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:38 2018
+*** tstop() called on dream at Wed Oct 17 20:15:08 2018
 Module time:
-	user time   =      10.15 seconds =       0.17 minutes
-	system time =       0.15 seconds =       0.00 minutes
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     155.65 seconds =       2.59 minutes
-	system time =       3.05 seconds =       0.05 minutes
-	total time  =         25 seconds =       0.42 minutes
+	user time   =       4.76 seconds =       0.08 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:38 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:08 2018
 
 
          ------------------------------------------------------------
@@ -2759,11 +2759,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063572679962    15.994914619560
-         H            0.000000000000    -0.751205204049     0.504472282279     1.007825032070
-         H            0.000000000000     0.751205204049     0.504472282279     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063572679963    15.994914619560
+         H            0.000000000000    -0.751205204049     0.504472282286     1.007825032070
+         H            0.000000000000     0.751205204049     0.504472282286     1.007825032070
 
-  Nuclear repulsion =    9.342290153252501
+  Nuclear repulsion =    9.342290189928836
 
   ==> Basis Set <==
 
@@ -2781,8 +2781,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2801,36 +2801,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.001968921420
-       2        0.000000000000    -0.000882093202     0.000984460710
-       3       -0.000000000000     0.000882093202     0.000984460710
+       1        0.000000000000     0.000000000000    -0.001968921400
+       2        0.000000000000    -0.000882091432     0.000984460700
+       3       -0.000000000000     0.000882091432     0.000984460700
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:41 2018
+*** tstop() called on dream at Wed Oct 17 20:15:08 2018
 Module time:
-	user time   =      10.82 seconds =       0.18 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     166.49 seconds =       2.77 minutes
-	system time =       3.45 seconds =       0.06 minutes
-	total time  =         28 seconds =       0.47 minutes
+	user time   =       5.01 seconds =       0.08 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:41 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:08 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2838,7 +2838,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2850,15 +2850,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063130036482    15.994914619560
-         H            0.000000000000    -0.751205204049     0.500959745656     1.007825032070
-         H            0.000000000000     0.751205204049     0.500959745656     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063130036481    15.994914619560
+         H            0.000000000000    -0.751205204049     0.500959745649     1.007825032070
+         H            0.000000000000     0.751205204049     0.500959745649     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     29.59581  B =     14.82055  C =      9.87533 [cm^-1]
-  Rotational constants: A = 887260.19140  B = 444308.76784  C = 296054.87546 [MHz]
-  Nuclear repulsion =    9.365068895503725
+  Rotational constants: A = 887260.19819  B = 444308.77123  C = 296054.87772 [MHz]
+  Nuclear repulsion =    9.365068932359131
 
   Charge       = 0
   Multiplicity = 1
@@ -2892,8 +2892,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2917,7 +2917,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2934,7 +2934,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3367218974E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3367218692E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -2943,17 +2943,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05434140393025   -7.60543e+01   1.08041e-01 
-   @DF-RHF iter   1:   -76.02283326943338    3.15081e-02   1.37528e-02 
-   @DF-RHF iter   2:   -76.04938811991445   -2.65549e-02   8.08845e-03 DIIS
-   @DF-RHF iter   3:   -76.05726179215876   -7.87367e-03   1.30993e-03 DIIS
-   @DF-RHF iter   4:   -76.05769928334497   -4.37491e-04   3.61132e-04 DIIS
-   @DF-RHF iter   5:   -76.05775578899907   -5.65057e-05   8.22393e-05 DIIS
-   @DF-RHF iter   6:   -76.05775933830853   -3.54931e-06   1.41009e-05 DIIS
-   @DF-RHF iter   7:   -76.05775942973456   -9.14260e-08   1.52804e-06 DIIS
-   @DF-RHF iter   8:   -76.05775943075444   -1.01988e-09   1.68167e-07 DIIS
-   @DF-RHF iter   9:   -76.05775943076327   -8.82494e-12   3.89285e-08 DIIS
-   @DF-RHF iter  10:   -76.05775943076378   -5.11591e-13   5.06319e-09 DIIS
+   @DF-RHF iter   0:   -76.15632858869085   -7.61563e+01   5.71281e-02 
+   @DF-RHF iter   1:   -76.00802144470848    1.48307e-01   1.08138e-02 
+   @DF-RHF iter   2:   -76.04635842343876   -3.83370e-02   5.82368e-03 DIIS
+   @DF-RHF iter   3:   -76.05688043052886   -1.05220e-02   1.05060e-03 DIIS
+   @DF-RHF iter   4:   -76.05766781967779   -7.87389e-04   2.83398e-04 DIIS
+   @DF-RHF iter   5:   -76.05775566669494   -8.78470e-05   5.34448e-05 DIIS
+   @DF-RHF iter   6:   -76.05775933688983   -3.67019e-06   8.64509e-06 DIIS
+   @DF-RHF iter   7:   -76.05775942767872   -9.07889e-08   1.53605e-06 DIIS
+   @DF-RHF iter   8:   -76.05775943065763   -2.97891e-09   2.53154e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943074761   -8.99831e-11   3.53981e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943074882   -1.20792e-12   3.29515e-09 DIIS
   Energy converged.
 
 
@@ -2992,14 +2992,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775943076378
+  @DF-RHF Final Energy:   -76.05775943074882
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3650688955037253
-    One-Electron Energy =                -123.4243509418998741
-    Two-Electron Energy =                  38.0015226156323678
-    Total Energy =                        -76.0577594307637810
+    Nuclear Repulsion Energy =              9.3650689323591312
+    One-Electron Energy =                -123.4243510372807151
+    Two-Electron Energy =                  38.0015226741727545
+    Total Energy =                        -76.0577594307488312
 
 Computation Completed
 
@@ -3021,18 +3021,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9838     Total:     1.9838
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:43 2018
+*** tstop() called on dream at Wed Oct 17 20:15:08 2018
 Module time:
-	user time   =      10.27 seconds =       0.17 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     176.87 seconds =       2.95 minutes
-	system time =       3.59 seconds =       0.06 minutes
-	total time  =         30 seconds =       0.50 minutes
+	user time   =       5.48 seconds =       0.09 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:43 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:08 2018
 
 
          ------------------------------------------------------------
@@ -3050,11 +3050,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063130036482    15.994914619560
-         H            0.000000000000    -0.751205204049     0.500959745656     1.007825032070
-         H            0.000000000000     0.751205204049     0.500959745656     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063130036481    15.994914619560
+         H            0.000000000000    -0.751205204049     0.500959745649     1.007825032070
+         H            0.000000000000     0.751205204049     0.500959745649     1.007825032070
 
-  Nuclear repulsion =    9.365068895503725
+  Nuclear repulsion =    9.365068932359131
 
   ==> Basis Set <==
 
@@ -3072,8 +3072,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3092,36 +3092,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.001974206228
-       2       -0.000000000000     0.000891427016    -0.000987103114
-       3        0.000000000000    -0.000891427016    -0.000987103114
+       1       -0.000000000000     0.000000000000     0.001974206990
+       2       -0.000000000000     0.000891429066    -0.000987103495
+       3        0.000000000000    -0.000891429066    -0.000987103495
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:45 2018
+*** tstop() called on dream at Wed Oct 17 20:15:09 2018
 Module time:
-	user time   =      10.87 seconds =       0.18 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     187.76 seconds =       3.13 minutes
-	system time =       3.99 seconds =       0.07 minutes
-	total time  =         32 seconds =       0.53 minutes
+	user time   =       5.71 seconds =       0.10 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:45 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:09 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3129,7 +3129,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3142,14 +3142,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.753068850674     0.502716013968     1.007825032070
-         H            0.000000000000     0.753068850674     0.502716013968     1.007825032070
+         H            0.000000000000    -0.753068850681     0.502716013968     1.007825032070
+         H            0.000000000000     0.753068850681     0.502716013968     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     29.38939  B =     14.74728  C =      9.81981 [cm^-1]
-  Rotational constants: A = 881071.62781  B = 442112.39509  C = 294390.41046 [MHz]
-  Nuclear repulsion =    9.338578725249000
+  Rotational constants: A = 881071.63453  B = 442112.39845  C = 294390.41270 [MHz]
+  Nuclear repulsion =    9.338578761896224
 
   Charge       = 0
   Multiplicity = 1
@@ -3183,8 +3183,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3208,7 +3208,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3225,7 +3225,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3577687428E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3577687142E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -3234,17 +3234,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15053603594994   -7.61505e+01   1.08489e-01 
-   @DF-RHF iter   1:   -76.00787144634835    1.42665e-01   1.64638e-02 
-   @DF-RHF iter   2:   -76.04626774604756   -3.83963e-02   9.23703e-03 DIIS
-   @DF-RHF iter   3:   -76.05686632446407   -1.05986e-02   1.97704e-03 DIIS
-   @DF-RHF iter   4:   -76.05766372361738   -7.97399e-04   5.52884e-04 DIIS
-   @DF-RHF iter   5:   -76.05775347147349   -8.97479e-05   8.56277e-05 DIIS
-   @DF-RHF iter   6:   -76.05775721239509   -3.74092e-06   1.77172e-05 DIIS
-   @DF-RHF iter   7:   -76.05775730576686   -9.33718e-08   2.62445e-06 DIIS
-   @DF-RHF iter   8:   -76.05775730887341   -3.10655e-09   4.63636e-07 DIIS
-   @DF-RHF iter   9:   -76.05775730896659   -9.31806e-11   6.15678e-08 DIIS
-   @DF-RHF iter  10:   -76.05775730896798   -1.39266e-12   5.79885e-09 DIIS
+   @DF-RHF iter   0:   -75.94431044536876   -7.59443e+01   5.53915e-02 
+   @DF-RHF iter   1:   -76.03444180637402   -9.01314e-02   7.80634e-03 
+   @DF-RHF iter   2:   -76.05208941305065   -1.76476e-02   4.21522e-03 DIIS
+   @DF-RHF iter   3:   -76.05749253786567   -5.40312e-03   5.87875e-04 DIIS
+   @DF-RHF iter   4:   -76.05772611231714   -2.33574e-04   1.57917e-04 DIIS
+   @DF-RHF iter   5:   -76.05775540492598   -2.92926e-05   3.76911e-05 DIIS
+   @DF-RHF iter   6:   -76.05775726181093   -1.85688e-06   6.28296e-06 DIIS
+   @DF-RHF iter   7:   -76.05775730799206   -4.61811e-08   9.20997e-07 DIIS
+   @DF-RHF iter   8:   -76.05775730897115   -9.79085e-10   1.35317e-07 DIIS
+   @DF-RHF iter   9:   -76.05775730899370   -2.25526e-11   2.38841e-08 DIIS
+   @DF-RHF iter  10:   -76.05775730899431   -6.11067e-13   2.56587e-09 DIIS
   Energy converged.
 
 
@@ -3269,7 +3269,7 @@ gradient() will perform analytic gradient computation.
       11A1     2.232691    12A1     2.610069     8B2     2.971876  
        5B1     3.372579    13A1     3.508212     3A2     3.580734  
        9B2     3.667080     6B1     3.816074    14A1     3.886354  
-      10B2     3.899215     4A2     3.966782     7B1     4.026372  
+      10B2     3.899216     4A2     3.966782     7B1     4.026372  
       11B2     4.087517    15A1     4.210782     5A2     4.348259  
       16A1     4.428247    12B2     4.593000     8B1     4.702268  
       13B2     4.906862    17A1     5.204875    18A1     5.269405  
@@ -3283,14 +3283,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775730896798
+  @DF-RHF Final Energy:   -76.05775730899431
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3385787252490005
-    One-Electron Energy =                -123.3776177281716571
-    Two-Electron Energy =                  37.9812816939546778
-    Total Energy =                        -76.0577573089679788
+    Nuclear Repulsion Energy =              9.3385787618962244
+    One-Electron Energy =                -123.3776178697813322
+    Two-Electron Energy =                  37.9812817988908051
+    Total Energy =                        -76.0577573089942973
 
 Computation Completed
 
@@ -3312,18 +3312,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9869     Total:     1.9869
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:47 2018
+*** tstop() called on dream at Wed Oct 17 20:15:09 2018
 Module time:
-	user time   =      10.95 seconds =       0.18 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.49 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     198.82 seconds =       3.31 minutes
-	system time =       4.14 seconds =       0.07 minutes
-	total time  =         34 seconds =       0.57 minutes
+	user time   =       6.21 seconds =       0.10 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:47 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:09 2018
 
 
          ------------------------------------------------------------
@@ -3342,10 +3342,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.753068850674     0.502716013968     1.007825032070
-         H            0.000000000000     0.753068850674     0.502716013968     1.007825032070
+         H            0.000000000000    -0.753068850681     0.502716013968     1.007825032070
+         H            0.000000000000     0.753068850681     0.502716013968     1.007825032070
 
-  Nuclear repulsion =    9.338578725249000
+  Nuclear repulsion =    9.338578761896224
 
   ==> Basis Set <==
 
@@ -3363,8 +3363,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3383,36 +3383,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.001659364850
-       2        0.000000000000    -0.001647522925     0.000829682425
-       3       -0.000000000000     0.001647522925     0.000829682425
+       1       -0.000000000000     0.000000000000    -0.001659360505
+       2        0.000000000000    -0.001647519526     0.000829680253
+       3       -0.000000000000     0.001647519526     0.000829680253
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:50 2018
+*** tstop() called on dream at Wed Oct 17 20:15:09 2018
 Module time:
-	user time   =      10.84 seconds =       0.18 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     209.68 seconds =       3.49 minutes
-	system time =       4.56 seconds =       0.08 minutes
-	total time  =         37 seconds =       0.62 minutes
+	user time   =       6.45 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:50 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:09 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3420,7 +3420,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3433,14 +3433,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.749341557425     0.502716013968     1.007825032070
-         H            0.000000000000     0.749341557425     0.502716013968     1.007825032070
+         H            0.000000000000    -0.749341557418     0.502716013968     1.007825032070
+         H            0.000000000000     0.749341557418     0.502716013968     1.007825032070
 
   Running in c2v symmetry.
 
   Rotational constants: A =     29.38939  B =     14.89436  C =      9.88480 [cm^-1]
-  Rotational constants: A = 881071.62781  B = 446521.54840  C = 296338.87440 [MHz]
-  Nuclear repulsion =    9.368813495214249
+  Rotational constants: A = 881071.63453  B = 446521.55182  C = 296338.87667 [MHz]
+  Nuclear repulsion =    9.368813532099155
 
   Charge       = 0
   Multiplicity = 1
@@ -3474,8 +3474,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3499,7 +3499,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3516,7 +3516,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3370966868E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3370966585E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -3525,17 +3525,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15641409189925   -7.61564e+01   1.15547e-01 
-   @DF-RHF iter   1:   -76.00799400035822    1.48420e-01   1.74338e-02 
-   @DF-RHF iter   2:   -76.04635005933554   -3.83561e-02   9.77165e-03 DIIS
-   @DF-RHF iter   3:   -76.05687577841728   -1.05257e-02   1.79150e-03 DIIS
-   @DF-RHF iter   4:   -76.05766518084985   -7.89402e-04   4.55606e-04 DIIS
-   @DF-RHF iter   5:   -76.05775349264781   -8.83118e-05   9.22519e-05 DIIS
-   @DF-RHF iter   6:   -76.05775718058869   -3.68794e-06   1.47549e-05 DIIS
-   @DF-RHF iter   7:   -76.05775727147068   -9.08820e-08   2.65747e-06 DIIS
-   @DF-RHF iter   8:   -76.05775727443550   -2.96482e-09   4.28281e-07 DIIS
-   @DF-RHF iter   9:   -76.05775727452513   -8.96279e-11   6.89250e-08 DIIS
-   @DF-RHF iter  10:   -76.05775727452630   -1.16529e-12   5.36758e-09 DIIS
+   @DF-RHF iter   0:   -75.94990589536215   -7.59499e+01   5.57551e-02 
+   @DF-RHF iter   1:   -76.03435072618467   -8.44448e-02   7.82527e-03 
+   @DF-RHF iter   2:   -76.05208576850603   -1.77350e-02   4.21911e-03 DIIS
+   @DF-RHF iter   3:   -76.05749193309475   -5.40616e-03   5.87695e-04 DIIS
+   @DF-RHF iter   4:   -76.05772618750154   -2.34254e-04   1.57901e-04 DIIS
+   @DF-RHF iter   5:   -76.05775538875244   -2.92013e-05   3.75724e-05 DIIS
+   @DF-RHF iter   6:   -76.05775722846663   -1.83971e-06   6.22575e-06 DIIS
+   @DF-RHF iter   7:   -76.05775727352922   -4.50626e-08   9.08855e-07 DIIS
+   @DF-RHF iter   8:   -76.05775727447620   -9.46983e-10   1.33151e-07 DIIS
+   @DF-RHF iter   9:   -76.05775727449804   -2.18421e-11   2.36002e-08 DIIS
+   @DF-RHF iter  10:   -76.05775727449864   -5.96856e-13   2.53329e-09 DIIS
   Energy converged.
 
 
@@ -3564,7 +3564,7 @@ gradient() will perform analytic gradient computation.
       11B2     4.087792    15A1     4.214711     5A2     4.351413  
       16A1     4.429470    12B2     4.605171     8B1     4.704442  
       13B2     4.913966    17A1     5.218638    18A1     5.271139  
-      14B2     5.548517     9B1     6.087431    19A1     6.624485  
+      14B2     5.548517     9B1     6.087431    19A1     6.624486  
       10B1     6.967243     6A2     6.976005    11B1     7.042649  
       20A1     7.067252    15B2     7.160797    21A1     7.180805  
        7A2     7.285205    22A1     7.488562    16B2     7.843696  
@@ -3574,14 +3574,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775727452630
+  @DF-RHF Final Energy:   -76.05775727449864
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3688134952142494
-    One-Electron Energy =                -123.4300253298779353
-    Two-Electron Energy =                  38.0034545601373850
-    Total Energy =                        -76.0577572745262955
+    Nuclear Repulsion Energy =              9.3688135320991552
+    One-Electron Energy =                -123.4300254710734777
+    Two-Electron Energy =                  38.0034546644756830
+    Total Energy =                        -76.0577572744986412
 
 Computation Completed
 
@@ -3603,18 +3603,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9888     Total:     1.9888
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:51 2018
+*** tstop() called on dream at Wed Oct 17 20:15:10 2018
 Module time:
-	user time   =      10.20 seconds =       0.17 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     219.99 seconds =       3.67 minutes
-	system time =       4.67 seconds =       0.08 minutes
-	total time  =         38 seconds =       0.63 minutes
+	user time   =       6.92 seconds =       0.12 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:51 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:10 2018
 
 
          ------------------------------------------------------------
@@ -3633,10 +3633,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000     0.000000000000    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.749341557425     0.502716013968     1.007825032070
-         H            0.000000000000     0.749341557425     0.502716013968     1.007825032070
+         H            0.000000000000    -0.749341557418     0.502716013968     1.007825032070
+         H            0.000000000000     0.749341557418     0.502716013968     1.007825032070
 
-  Nuclear repulsion =    9.368813495214249
+  Nuclear repulsion =    9.368813532099155
 
   ==> Basis Set <==
 
@@ -3654,8 +3654,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3674,36 +3674,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.001683360761
-       2       -0.000000000000     0.001661493923    -0.000841680380
-       3        0.000000000000    -0.001661493923    -0.000841680380
+       1       -0.000000000000     0.000000000000     0.001683365286
+       2       -0.000000000000     0.001661497450    -0.000841682643
+       3        0.000000000000    -0.001661497450    -0.000841682643
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:54 2018
+*** tstop() called on dream at Wed Oct 17 20:15:10 2018
 Module time:
-	user time   =      10.66 seconds =       0.18 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     230.67 seconds =       3.84 minutes
-	system time =       5.12 seconds =       0.09 minutes
-	total time  =         41 seconds =       0.68 minutes
+	user time   =       7.15 seconds =       0.12 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:54 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:10 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3711,7 +3711,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3724,14 +3724,14 @@ gradient() will perform analytic gradient computation.
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000    -0.000180451050    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.749773259494     0.501636978456     1.007825032070
-         H            0.000000000000     0.752637148604     0.503795049479     1.007825032070
+         H            0.000000000000    -0.749773259489     0.501636978452     1.007825032070
+         H            0.000000000000     0.752637148610     0.503795049483     1.007825032070
 
   Running in cs symmetry.
 
   Rotational constants: A =     29.39024  B =     14.82024  C =      9.85220 [cm^-1]
-  Rotational constants: A = 881097.11080  B = 444299.55328  C = 295361.42902 [MHz]
-  Nuclear repulsion =    9.353715556558956
+  Rotational constants: A = 881097.11752  B = 444299.55666  C = 295361.43127 [MHz]
+  Nuclear repulsion =    9.353715593325250
 
   Charge       = 0
   Multiplicity = 1
@@ -3765,8 +3765,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3788,7 +3788,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3805,7 +3805,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3472658993E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3472658708E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -3814,17 +3814,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.06525630786143   -7.60653e+01   8.17655e-02 
-   @DF-RHF iter   1:   -76.02219553072642    4.30608e-02   1.32888e-02 
-   @DF-RHF iter   2:   -76.04927776425214   -2.70822e-02   7.12885e-03 DIIS
-   @DF-RHF iter   3:   -76.05721709647048   -7.93933e-03   1.36250e-03 DIIS
-   @DF-RHF iter   4:   -76.05768986288618   -4.72766e-04   3.35259e-04 DIIS
-   @DF-RHF iter   5:   -76.05775086856649   -6.10057e-05   7.02408e-05 DIIS
-   @DF-RHF iter   6:   -76.05775457126012   -3.70269e-06   1.14779e-05 DIIS
-   @DF-RHF iter   7:   -76.05775466538284   -9.41227e-08   1.41309e-06 DIIS
-   @DF-RHF iter   8:   -76.05775466646492   -1.08207e-09   1.48238e-07 DIIS
-   @DF-RHF iter   9:   -76.05775466647601   -1.10987e-11   3.38599e-08 DIIS
-   @DF-RHF iter  10:   -76.05775466647667   -6.53699e-13   4.35834e-09 DIIS
+   @DF-RHF iter   0:   -75.95011107000234   -7.59501e+01   3.98195e-02 
+   @DF-RHF iter   1:   -76.03446350338616   -8.43524e-02   5.57951e-03 
+   @DF-RHF iter   2:   -76.05213003691352   -1.76665e-02   2.99890e-03 DIIS
+   @DF-RHF iter   3:   -76.05747299224578   -5.34296e-03   4.30708e-04 DIIS
+   @DF-RHF iter   4:   -76.05772122356184   -2.48231e-04   1.16546e-04 DIIS
+   @DF-RHF iter   5:   -76.05775266908324   -3.14455e-05   2.76302e-05 DIIS
+   @DF-RHF iter   6:   -76.05775461933506   -1.95025e-06   4.52113e-06 DIIS
+   @DF-RHF iter   7:   -76.05775466548054   -4.61455e-08   6.61019e-07 DIIS
+   @DF-RHF iter   8:   -76.05775466645756   -9.77010e-10   9.76334e-08 DIIS
+   @DF-RHF iter   9:   -76.05775466648018   -2.26237e-11   1.71172e-08 DIIS
+   @DF-RHF iter  10:   -76.05775466648076   -5.82645e-13   1.86674e-09 DIIS
   Energy converged.
 
 
@@ -3863,14 +3863,14 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775466647667
+  @DF-RHF Final Energy:   -76.05775466648076
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3537155565589565
-    One-Electron Energy =                -123.4038503418129551
-    Two-Electron Energy =                  37.9923801187773336
-    Total Energy =                        -76.0577546664766686
+    Nuclear Repulsion Energy =              9.3537155933252496
+    One-Electron Energy =                -123.4038505127613234
+    Two-Electron Energy =                  37.9923802529553143
+    Total Energy =                        -76.0577546664807613
 
 Computation Completed
 
@@ -3892,18 +3892,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0035      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:56 2018
+*** tstop() called on dream at Wed Oct 17 20:15:11 2018
 Module time:
-	user time   =      10.06 seconds =       0.17 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     240.84 seconds =       4.01 minutes
-	system time =       5.24 seconds =       0.09 minutes
-	total time  =         43 seconds =       0.72 minutes
+	user time   =       7.62 seconds =       0.13 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:56 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:11 2018
 
 
          ------------------------------------------------------------
@@ -3922,10 +3922,10 @@ Total time:
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
          O            0.000000000000    -0.000180451050    -0.063351358222    15.994914619560
-         H            0.000000000000    -0.749773259494     0.501636978456     1.007825032070
-         H            0.000000000000     0.752637148604     0.503795049479     1.007825032070
+         H            0.000000000000    -0.749773259489     0.501636978452     1.007825032070
+         H            0.000000000000     0.752637148610     0.503795049483     1.007825032070
 
-  Nuclear repulsion =    9.353715556558956
+  Nuclear repulsion =    9.353715593325250
 
   ==> Basis Set <==
 
@@ -3943,8 +3943,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3963,36 +3963,36 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003688064045     0.000019110626
-       2        0.000000000000     0.001856011450    -0.001399120927
-       3        0.000000000000     0.001832052596     0.001380010301
+       1        0.000000000000    -0.003688064202     0.000019110659
+       2        0.000000000000     0.001856013406    -0.001399120672
+       3        0.000000000000     0.001832050796     0.001380010013
 
 
-*** tstop() called on silver at Tue Sep 25 13:51:58 2018
+*** tstop() called on dream at Wed Oct 17 20:15:11 2018
 Module time:
-	user time   =      10.78 seconds =       0.18 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     251.64 seconds =       4.19 minutes
-	system time =       5.59 seconds =       0.09 minutes
-	total time  =         45 seconds =       0.75 minutes
+	user time   =       7.85 seconds =       0.13 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:51:58 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:11 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4000,7 +4000,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4019,8 +4019,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     29.38939  B =     14.82055  C =      9.85224 [cm^-1]
-  Rotational constants: A = 881071.62781  B = 444308.76784  C = 295362.63749 [MHz]
-  Nuclear repulsion =    9.353677802986757
+  Rotational constants: A = 881071.63453  B = 444308.77123  C = 295362.63974 [MHz]
+  Nuclear repulsion =    9.353677839752608
 
   Charge       = 0
   Multiplicity = 1
@@ -4054,8 +4054,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4079,7 +4079,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4096,7 +4096,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3474054466E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3474054182E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -4105,17 +4105,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15347657941527   -7.61535e+01   9.19129e-02 
-   @DF-RHF iter   1:   -76.00793896106001    1.45538e-01   1.71858e-02 
-   @DF-RHF iter   2:   -76.04631497044015   -3.83760e-02   1.02163e-02 DIIS
-   @DF-RHF iter   3:   -76.05687689488875   -1.05619e-02   1.87621e-03 DIIS
-   @DF-RHF iter   4:   -76.05767028195150   -7.93387e-04   4.93739e-04 DIIS
-   @DF-RHF iter   5:   -76.05775930899148   -8.90270e-05   9.40851e-05 DIIS
-   @DF-RHF iter   6:   -76.05776302330437   -3.71431e-06   1.73353e-05 DIIS
-   @DF-RHF iter   7:   -76.05776311541894   -9.21146e-08   2.76053e-06 DIIS
-   @DF-RHF iter   8:   -76.05776311845355   -3.03461e-09   4.97384e-07 DIIS
-   @DF-RHF iter   9:   -76.05776311854486   -9.13047e-11   6.12345e-08 DIIS
-   @DF-RHF iter  10:   -76.05776311854615   -1.29319e-12   6.59762e-09 DIIS
+   @DF-RHF iter   0:   -75.94710806905404   -7.59471e+01   5.55730e-02 
+   @DF-RHF iter   1:   -76.03440231261533   -8.72942e-02   7.81576e-03 
+   @DF-RHF iter   2:   -76.05209349341780   -1.76912e-02   4.21713e-03 DIIS
+   @DF-RHF iter   3:   -76.05749806224043   -5.40457e-03   5.87784e-04 DIIS
+   @DF-RHF iter   4:   -76.05773197621663   -2.33914e-04   1.57910e-04 DIIS
+   @DF-RHF iter   5:   -76.05776122366373   -2.92474e-05   3.76317e-05 DIIS
+   @DF-RHF iter   6:   -76.05776307194347   -1.84828e-06   6.25426e-06 DIIS
+   @DF-RHF iter   7:   -76.05776311756114   -4.56177e-08   9.14904e-07 DIIS
+   @DF-RHF iter   8:   -76.05776311852399   -9.62856e-10   1.34231e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854618   -2.21831e-11   2.37416e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854677   -5.96856e-13   2.54948e-09 DIIS
   Energy converged.
 
 
@@ -4135,7 +4135,7 @@ gradient() will perform analytic gradient computation.
        5A1     0.606501     6A1     0.666793     2B1     0.787514  
        4B2     0.805097     7A1     0.811469     1A2     0.861557  
        3B1     0.963988     8A1     1.118808     5B2     1.202677  
-       6B2     1.546259     9A1     1.589176     7B2     2.031142  
+       6B2     1.546259     9A1     1.589177     7B2     2.031142  
        4B1     2.037085     2A2     2.075917    10A1     2.171714  
       11A1     2.232214    12A1     2.609949     8B2     2.973570  
        5B1     3.371299    13A1     3.508424     3A2     3.582881  
@@ -4146,7 +4146,7 @@ gradient() will perform analytic gradient computation.
       13B2     4.910416    17A1     5.211746    18A1     5.270269  
       14B2     5.547693     9B1     6.083565    19A1     6.616731  
       10B1     6.966231     6A2     6.974972    11B1     7.038442  
-      20A1     7.063988    15B2     7.158417    21A1     7.176967  
+      20A1     7.063988    15B2     7.158418    21A1     7.176967  
        7A2     7.280150    22A1     7.488141    16B2     7.838859  
       17B2     8.357375    23A1    13.167130  
 
@@ -4154,14 +4154,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05776311854615
+  @DF-RHF Final Energy:   -76.05776311854677
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3536778029867573
-    One-Electron Energy =                -123.4037988369638583
-    Two-Electron Energy =                  37.9923579154309508
-    Total Energy =                        -76.0577631185461485
+    Nuclear Repulsion Energy =              9.3536778397526081
+    One-Electron Energy =                -123.4037989783759031
+    Two-Electron Energy =                  37.9923580200765230
+    Total Energy =                        -76.0577631185467737
 
 Computation Completed
 
@@ -4183,18 +4183,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:00 2018
+*** tstop() called on dream at Wed Oct 17 20:15:11 2018
 Module time:
-	user time   =       9.95 seconds =       0.17 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     261.70 seconds =       4.36 minutes
-	system time =       5.74 seconds =       0.10 minutes
-	total time  =         47 seconds =       0.78 minutes
+	user time   =       8.32 seconds =       0.14 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:00 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:11 2018
 
 
          ------------------------------------------------------------
@@ -4216,7 +4216,7 @@ Total time:
          H            0.000000000000    -0.751205204049     0.502716013968     1.007825032070
          H            0.000000000000     0.751205204049     0.502716013968     1.007825032070
 
-  Nuclear repulsion =    9.353677802986757
+  Nuclear repulsion =    9.353677839752608
 
   ==> Basis Set <==
 
@@ -4234,8 +4234,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4254,20 +4254,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.000000197618
-       2       -0.000000000000     0.000000172860    -0.000000098809
-       3        0.000000000000    -0.000000172860    -0.000000098809
+       1        0.000000000000     0.000000000000     0.000000202204
+       2       -0.000000000000     0.000000176416    -0.000000101102
+       3        0.000000000000    -0.000000176416    -0.000000101102
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:02 2018
+*** tstop() called on dream at Wed Oct 17 20:15:11 2018
 Module time:
-	user time   =      10.84 seconds =       0.18 minutes
-	system time =       0.43 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     272.56 seconds =       4.54 minutes
-	system time =       6.17 seconds =       0.10 minutes
-	total time  =         49 seconds =       0.82 minutes
+	user time   =       8.55 seconds =       0.14 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -4293,43 +4293,43 @@ Total time:
   mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0000' '1753.0273'
- '4127.0329' '4227.0130']
+  pre-proj  low-frequency mode:    0.0001  [cm^-1]
+  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0001' '1753.0274'
+ '4127.0330' '4227.0129']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
-  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
-  post-proj  all modes:['0.0001i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0001' '1753.0273'
- '4127.0329' '4227.0130']
+  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
+  post-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0001' '0.0001' '1753.0274'
+ '4127.0330' '4227.0129']
 
   Vibration                       7                   8                   9           
-  Freq [cm^-1]                1753.0273           4127.0329           4227.0130       
+  Freq [cm^-1]                1753.0274           4127.0330           4227.0129       
   Irrep                           A1                  A1                  B2          
   Reduced mass [u]              1.0830              1.0448              1.0833        
   Force const [mDyne/A]         1.9610             10.4851             11.4047        
   Turning point v=0 [a0]        0.2518              0.1671              0.1621        
   RMS dev v=0 [a0 u^1/2]        0.1853              0.1208              0.1193        
-  Char temp [K]               2522.2122           5937.8724           6081.7213       
+  Char temp [K]               2522.2162           5937.8817           6081.7304       
   ----------------------------------------------------------------------------------
-      1   O               -0.00  0.00 -0.07   -0.00 -0.00  0.05   -0.00 -0.07 -0.00   
-      2   H               -0.00  0.43  0.56   -0.00  0.59 -0.39    0.00  0.56 -0.42   
+      1   O               -0.00  0.00 -0.07   -0.00  0.00  0.05   -0.00 -0.07  0.00   
+      2   H               -0.00  0.43  0.56    0.00  0.59 -0.39   -0.00  0.56 -0.42   
       3   H                0.00 -0.43  0.56    0.00 -0.59 -0.39    0.00  0.56  0.42   
 
   ==> Thermochemistry Components <==
 
   Entropy, S
     Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
-    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
-    Rotational S           10.329 [cal/(mol K)]       43.217 [J/(mol K)]       0.01646032 [mEh/K] (symmetry no. = 2)
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515177 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.329 [cal/(mol K)]       43.216 [J/(mol K)]       0.01646029 [mEh/K] (symmetry no. = 2)
     Vibrational S           0.004 [cal/(mol K)]        0.017 [J/(mol K)]       0.00000635 [mEh/K]
-  Total S                  44.941 [cal/(mol K)]      188.034 [J/(mol K)]       0.07161852 [mEh/K]
+  Total S                  44.941 [cal/(mol K)]      188.034 [J/(mol K)]       0.07161841 [mEh/K]
   Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant volume heat capacity, Cv
@@ -4337,15 +4337,15 @@ Total time:
     Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cv          0.030 [cal/(mol K)]        0.126 [J/(mol K)]       0.00004804 [mEh/K]
-  Total Cv                  5.992 [cal/(mol K)]       25.070 [J/(mol K)]       0.00954848 [mEh/K]
+  Total Cv                  5.992 [cal/(mol K)]       25.070 [J/(mol K)]       0.00954847 [mEh/K]
   Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant pressure heat capacity, Cp
     Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
-    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
     Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cp          0.030 [cal/(mol K)]        0.126 [J/(mol K)]       0.00004804 [mEh/K]
-  Total Cp                  7.979 [cal/(mol K)]       33.384 [J/(mol K)]       0.01271530 [mEh/K]
+  Total Cp                  7.979 [cal/(mol K)]       33.384 [J/(mol K)]       0.01271528 [mEh/K]
   Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   ==> Thermochemistry Energy Analysis <==
@@ -4357,15 +4357,15 @@ Total time:
     Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Vibrational ZPE        14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302560 [Eh]        5053.535 [cm^-1]
-  Correction ZPE           14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302560 [Eh]        5053.535 [cm^-1]
-  Total ZPE, Electronic energy at 0 [K]                                -76.03473752 [Eh]
+    Vibrational ZPE        14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302561 [Eh]        5053.537 [cm^-1]
+  Correction ZPE           14.449 [kcal/mol]       60.454 [kJ/mol]       0.02302561 [Eh]        5053.537 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.03473751 [Eh]
 
   Thermal Energy, E (includes ZPE)
     Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational E          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302729 [Eh]
+    Vibrational E          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302730 [Eh]
   Correction E             16.227 [kcal/mol]       67.895 [kJ/mol]       0.02585985 [Eh]
   Total E, Electronic energy at  298.15 [K]                            -76.03190327 [Eh]
 
@@ -4373,17 +4373,17 @@ Total time:
     Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
     Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational H          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302729 [Eh]
+    Vibrational H          14.450 [kcal/mol]       60.458 [kJ/mol]       0.02302730 [Eh]
   Correction H             16.820 [kcal/mol]       70.374 [kJ/mol]       0.02680404 [Eh]
   Total H, Enthalpy at  298.15 [K]                                     -76.03095908 [Eh]
 
   Gibbs free energy, G = H - T * S
     Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408304 [Eh]
     Rotational G           -2.191 [kcal/mol]       -9.167 [kJ/mol]      -0.00349136 [Eh]
-    Vibrational G          14.449 [kcal/mol]       60.453 [kJ/mol]       0.02302540 [Eh]
-  Correction G              3.421 [kcal/mol]       14.312 [kJ/mol]       0.00545098 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                                -76.05231214 [Eh]
+    Vibrational G          14.449 [kcal/mol]       60.453 [kJ/mol]       0.02302541 [Eh]
+  Correction G              3.421 [kcal/mol]       14.312 [kJ/mol]       0.00545101 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.05231211 [Eh]
 	SCF/cc-pVTZ Frequency 1...........................................PASSED
 	SCF/cc-pVTZ Frequency 2...........................................PASSED
 	SCF/cc-pVTZ Frequency 3...........................................PASSED
@@ -4410,16 +4410,16 @@ Total time:
 
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:03 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:12 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -4427,7 +4427,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4446,8 +4446,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
-  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
-  Nuclear repulsion =    9.366873138898288
+  Rotational constants: A = 890917.72003  B = 443602.62989  C = 296146.43467 [MHz]
+  Nuclear repulsion =    9.366873175716000
 
   Charge       = 0
   Multiplicity = 1
@@ -4481,8 +4481,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4506,7 +4506,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4523,7 +4523,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.3164319961E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3164319701E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -4532,17 +4532,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05275428124520   -7.60528e+01   1.99861e-01 
-   @DF-RHF iter   1:   -75.99200119240541    6.07531e-02   3.02136e-02 
-   @DF-RHF iter   2:   -76.01962153001254   -2.76203e-02   1.57016e-02 DIIS
-   @DF-RHF iter   3:   -76.02634728120981   -6.72575e-03   2.66136e-03 DIIS
-   @DF-RHF iter   4:   -76.02681451124214   -4.67230e-04   8.26017e-04 DIIS
-   @DF-RHF iter   5:   -76.02686007340120   -4.55622e-05   1.43356e-04 DIIS
-   @DF-RHF iter   6:   -76.02686266200632   -2.58861e-06   2.66889e-05 DIIS
-   @DF-RHF iter   7:   -76.02686272186608   -5.98598e-08   2.96966e-06 DIIS
-   @DF-RHF iter   8:   -76.02686272244343   -5.77344e-10   4.38080e-07 DIIS
-   @DF-RHF iter   9:   -76.02686272246083   -1.74083e-11   4.64208e-08 DIIS
-   @DF-RHF iter  10:   -76.02686272246096   -1.27898e-13   6.90407e-09 DIIS
+   @DF-RHF iter   0:   -76.02721010140004   -7.60272e+01   1.26959e-01 
+   @DF-RHF iter   1:   -75.98503394146663    4.21762e-02   2.24636e-02 
+   @DF-RHF iter   2:   -76.01819442576483   -3.31605e-02   1.10506e-02 DIIS
+   @DF-RHF iter   3:   -76.02632060923138   -8.12618e-03   1.83723e-03 DIIS
+   @DF-RHF iter   4:   -76.02681392166960   -4.93312e-04   4.77044e-04 DIIS
+   @DF-RHF iter   5:   -76.02686057862269   -4.66570e-05   8.85362e-05 DIIS
+   @DF-RHF iter   6:   -76.02686264788878   -2.06927e-06   1.70052e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272073316   -7.28444e-08   2.50825e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272232705   -1.59389e-09   3.76539e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272235775   -3.06954e-11   3.22492e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272235789   -1.42109e-13   3.22605e-09 DIIS
   Energy converged.
 
 
@@ -4570,14 +4570,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02686272246096
+  @DF-RHF Final Energy:   -76.02686272235789
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3668731388982884
-    One-Electron Energy =                -123.4604615511582466
-    Two-Electron Energy =                  38.0667256897990001
-    Total Energy =                        -76.0268627224609617
+    Nuclear Repulsion Energy =              9.3668731757160000
+    One-Electron Energy =                -123.4604615816829494
+    Two-Electron Energy =                  38.0667256836090715
+    Total Energy =                        -76.0268627223578903
 
 Computation Completed
 
@@ -4599,18 +4599,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:04 2018
+*** tstop() called on dream at Wed Oct 17 20:15:12 2018
 Module time:
-	user time   =       7.34 seconds =       0.12 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     281.54 seconds =       4.69 minutes
-	system time =       6.30 seconds =       0.10 minutes
-	total time  =         51 seconds =       0.85 minutes
+	user time   =       9.05 seconds =       0.15 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:04 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:12 2018
 
 
          ------------------------------------------------------------
@@ -4632,7 +4632,7 @@ Total time:
          H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
          H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
 
-  Nuclear repulsion =    9.366873138898287
+  Nuclear repulsion =    9.366873175716002
 
   ==> Basis Set <==
 
@@ -4650,8 +4650,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4670,34 +4670,69 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.013215498853
-       2       -0.000000000000     0.004499298742    -0.006607749426
-       3        0.000000000000    -0.004499298742    -0.006607749426
+       1       -0.000000000000     0.000000000000     0.013215500528
+       2       -0.000000000000     0.004499300530    -0.006607750264
+       3        0.000000000000    -0.004499300530    -0.006607750264
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:05 2018
+*** tstop() called on dream at Wed Oct 17 20:15:12 2018
 Module time:
-	user time   =       9.25 seconds =       0.15 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     290.81 seconds =       4.85 minutes
-	system time =       6.54 seconds =       0.11 minutes
-	total time  =         52 seconds =       0.87 minutes
+	user time   =       9.16 seconds =       0.15 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
 
   Based on options and gradient (rms=5.80E-03), recommend projecting translations and projecting rotations.
-hessian() will perform analytic frequency computation.
+hessian() will perform frequency computation by finite difference of analytic gradients.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:05 2018
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes.  Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 3.
+    Number of irreps is 4.
+    Number of SALCs is 3.
+    Translations projected? 1. Rotations projected? 1.
+    Index of SALCs per irrep:
+     1 :  0  1 
+     2 : 
+     3 : 
+     4 :  2 
+    Number of SALCs per irrep:
+     Irrep 1: 2
+     Irrep 2: 0
+     Irrep 3: 0
+     Irrep 4: 1
+    Number of geometries (including reference) is 6.
+    Number of displacements per irrep:
+      Irrep 1: 4
+      Irrep 2: 0
+      Irrep 3: 0
+      Irrep 4: 1
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:12 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -4705,7 +4740,7 @@ hessian() will perform analytic frequency computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4717,15 +4752,15 @@ hessian() will perform analytic frequency computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
-         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
-         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063221639759    15.994914619560
+         H            0.000000000000    -0.751802862943     0.501686650894     1.007825032070
+         H            0.000000000000     0.751802862943     0.501686650894     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
-  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
-  Nuclear repulsion =    9.366873138898288
+  Rotational constants: A =     29.51011  B =     14.79699  C =      9.85532 [cm^-1]
+  Rotational constants: A = 884690.91776  B = 443602.62989  C = 295455.18643 [MHz]
+  Nuclear repulsion =    9.355497525821443
 
   Charge       = 0
   Multiplicity = 1
@@ -4759,8 +4794,8 @@ hessian() will perform analytic frequency computation.
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4784,7 +4819,7 @@ hessian() will perform analytic frequency computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4801,7 +4836,7 @@ hessian() will perform analytic frequency computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.3164319961E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3221109742E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -4810,17 +4845,1415 @@ hessian() will perform analytic frequency computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05275428124524   -7.60528e+01   1.86953e-01 
-   @DF-RHF iter   1:   -75.99200119240544    6.07531e-02   3.02136e-02 
-   @DF-RHF iter   2:   -76.01962153001251   -2.76203e-02   1.57016e-02 DIIS
-   @DF-RHF iter   3:   -76.02634728120981   -6.72575e-03   2.79125e-03 DIIS
-   @DF-RHF iter   4:   -76.02681451124209   -4.67230e-04   7.04973e-04 DIIS
-   @DF-RHF iter   5:   -76.02686007340120   -4.55622e-05   1.45986e-04 DIIS
-   @DF-RHF iter   6:   -76.02686266200634   -2.58861e-06   2.36572e-05 DIIS
-   @DF-RHF iter   7:   -76.02686272186614   -5.98598e-08   2.72636e-06 DIIS
-   @DF-RHF iter   8:   -76.02686272244347   -5.77330e-10   4.56617e-07 DIIS
-   @DF-RHF iter   9:   -76.02686272246086   -1.73941e-11   4.34226e-08 DIIS
-   @DF-RHF iter  10:   -76.02686272246095   -8.52651e-14   6.52021e-09 DIIS
+   @DF-RHF iter   0:   -76.04271559718455   -7.60427e+01   1.26906e-01 
+   @DF-RHF iter   1:   -75.99200807640335    5.07075e-02   2.06370e-02 
+   @DF-RHF iter   2:   -76.01961748416147   -2.76094e-02   1.00766e-02 DIIS
+   @DF-RHF iter   3:   -76.02641833065843   -6.80085e-03   1.66065e-03 DIIS
+   @DF-RHF iter   4:   -76.02686197156841   -4.43641e-04   4.53456e-04 DIIS
+   @DF-RHF iter   5:   -76.02690574261538   -4.37710e-05   9.42969e-05 DIIS
+   @DF-RHF iter   6:   -76.02690826629885   -2.52368e-06   1.44152e-05 DIIS
+   @DF-RHF iter   7:   -76.02690832674742   -6.04486e-08   1.69912e-06 DIIS
+   @DF-RHF iter   8:   -76.02690832736378   -6.16367e-10   3.05004e-07 DIIS
+   @DF-RHF iter   9:   -76.02690832738223   -1.84457e-11   2.91119e-08 DIIS
+   @DF-RHF iter  10:   -76.02690832738234   -1.13687e-13   3.91412e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.546547     2A1    -1.344119     1B2    -0.711667  
+       3A1    -0.566310     1B1    -0.493825  
+
+    Virtual:                                                              
+
+       4A1     0.188717     2B2     0.258393     3B2     0.807687  
+       5A1     0.862863     6A1     1.161202     2B1     1.200758  
+       4B2     1.250878     7A1     1.457196     1A2     1.475804  
+       3B1     1.688189     8A1     1.867956     5B2     1.944626  
+       6B2     2.498802     9A1     2.530730     4B1     3.292188  
+       2A2     3.362738    10A1     3.524404    11A1     3.900405  
+       7B2     4.156903  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02690832738234
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3554975258214430
+    One-Electron Energy =                -123.4398743600335564
+    Two-Electron Energy =                  38.0574685068297569
+    Total Energy =                        -76.0269083273823583
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9403
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1475
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7928     Total:     0.7928
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0152     Total:     2.0152
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       9.55 seconds =       0.16 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:13 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063221639759    15.994914619560
+         H            0.000000000000    -0.751802862943     0.501686650894     1.007825032070
+         H            0.000000000000     0.751802862943     0.501686650894     1.007825032070
+
+  Nuclear repulsion =    9.355497525821443
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.011191882024
+       2       -0.000000000000     0.003569434720    -0.005595941012
+       3        0.000000000000    -0.003569434720    -0.005595941012
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.67 seconds =       0.16 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:13 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.062778996277    15.994914619560
+         H            0.000000000000    -0.751802862943     0.498174114257     1.007825032070
+         H            0.000000000000     0.751802862943     0.498174114257     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.92772  B =     14.79699  C =      9.90147 [cm^-1]
+  Rotational constants: A = 897210.49442  B = 443602.62989  C = 296838.48381 [MHz]
+  Nuclear repulsion =    9.378251932621403
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3107771752E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.14347765718151   -7.61435e+01   1.28075e-01 
+   @DF-RHF iter   1:   -75.97527053537321    1.68207e-01   2.41085e-02 
+   @DF-RHF iter   2:   -76.01659851684919   -4.13280e-02   1.17437e-02 DIIS
+   @DF-RHF iter   3:   -76.02595248011360   -9.35396e-03   2.28052e-03 DIIS
+   @DF-RHF iter   4:   -76.02674510441078   -7.92624e-04   5.63330e-04 DIIS
+   @DF-RHF iter   5:   -76.02680716251076   -6.20581e-05   9.45434e-05 DIIS
+   @DF-RHF iter   6:   -76.02680944743221   -2.28492e-06   1.93653e-05 DIIS
+   @DF-RHF iter   7:   -76.02680954374469   -9.63125e-08   3.09925e-06 DIIS
+   @DF-RHF iter   8:   -76.02680954626830   -2.52361e-09   4.16261e-07 DIIS
+   @DF-RHF iter   9:   -76.02680954630517   -3.68772e-11   3.58226e-08 DIIS
+   @DF-RHF iter  10:   -76.02680954630534   -1.70530e-13   3.57569e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.545915     2A1    -1.345062     1B2    -0.713735  
+       3A1    -0.565952     1B1    -0.493877  
+
+    Virtual:                                                              
+
+       4A1     0.189186     2B2     0.258651     3B2     0.810927  
+       5A1     0.863321     6A1     1.160765     2B1     1.200794  
+       4B2     1.250402     7A1     1.460232     1A2     1.475201  
+       3B1     1.690959     8A1     1.868443     5B2     1.944992  
+       6B2     2.505969     9A1     2.536169     4B1     3.292063  
+       2A2     3.366695    10A1     3.524956    11A1     3.907082  
+       7B2     4.157086  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02680954630534
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3782519326214029
+    One-Electron Energy =                -123.4810398800409530
+    Two-Electron Energy =                  38.0759784011142131
+    Total Energy =                        -76.0268095463053442
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9337
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1442
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7896     Total:     0.7896
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0069     Total:     2.0069
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.06 seconds =       0.17 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:13 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.062778996277    15.994914619560
+         H            0.000000000000    -0.751802862943     0.498174114257     1.007825032070
+         H            0.000000000000     0.751802862943     0.498174114257     1.007825032070
+
+  Nuclear repulsion =    9.378251932621403
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.015243673651
+       2       -0.000000000000     0.005438578134    -0.007621836825
+       3        0.000000000000    -0.005438578134    -0.007621836825
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.17 seconds =       0.17 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:13 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.753666509575     0.499930382576     1.007825032070
+         H            0.000000000000     0.753666509575     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.72390  C =      9.84575 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 441411.48463  C = 295168.27531 [MHz]
+  Nuclear repulsion =    9.351700262034790
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3288464679E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.02426514188920   -7.60243e+01   1.26542e-01 
+   @DF-RHF iter   1:   -75.98502248719596    3.92427e-02   2.24606e-02 
+   @DF-RHF iter   2:   -76.01819157318897   -3.31691e-02   1.10657e-02 DIIS
+   @DF-RHF iter   3:   -76.02634374390480   -8.15217e-03   1.83979e-03 DIIS
+   @DF-RHF iter   4:   -76.02683925011476   -4.95506e-04   4.78442e-04 DIIS
+   @DF-RHF iter   5:   -76.02688625827398   -4.70082e-05   8.88170e-05 DIIS
+   @DF-RHF iter   6:   -76.02688834466744   -2.08639e-06   1.71094e-05 DIIS
+   @DF-RHF iter   7:   -76.02688841863082   -7.39634e-08   2.53532e-06 DIIS
+   @DF-RHF iter   8:   -76.02688842026234   -1.63152e-09   3.78593e-07 DIIS
+   @DF-RHF iter   9:   -76.02688842029340   -3.10649e-11   3.24588e-08 DIIS
+   @DF-RHF iter  10:   -76.02688842029353   -1.27898e-13   3.25528e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.546421     2A1    -1.343688     1B2    -0.712127  
+       3A1    -0.565576     1B1    -0.493683  
+
+    Virtual:                                                              
+
+       4A1     0.188734     2B2     0.258303     3B2     0.808671  
+       5A1     0.860988     6A1     1.161029     2B1     1.200847  
+       4B2     1.250564     7A1     1.460094     1A2     1.474664  
+       3B1     1.689957     8A1     1.868796     5B2     1.942325  
+       6B2     2.499182     9A1     2.529312     4B1     3.290051  
+       2A2     3.363735    10A1     3.521844    11A1     3.903278  
+       7B2     4.154448  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02688842029353
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3517002620347895
+    One-Electron Energy =                -123.4341878589302439
+    Two-Electron Energy =                  38.0555991766019304
+    Total Energy =                        -76.0268884202935169
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1461
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7909     Total:     0.7909
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0104     Total:     2.0104
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      10.56 seconds =       0.18 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:14 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.753666509575     0.499930382576     1.007825032070
+         H            0.000000000000     0.753666509575     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.351700262034790
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.011466348418
+       2       -0.000000000000     0.002799958985    -0.005733174209
+       3        0.000000000000    -0.002799958985    -0.005733174209
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.68 seconds =       0.18 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:14 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.749939216312     0.499930382576     1.007825032070
+         H            0.000000000000     0.749939216312     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.87063  C =      9.91115 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 445810.13086  C = 297128.65269 [MHz]
+  Nuclear repulsion =    9.382083150685840
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3041118628E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.03015297735914   -7.60302e+01   1.27376e-01 
+   @DF-RHF iter   1:   -75.98503264197615    4.51203e-02   2.24669e-02 
+   @DF-RHF iter   2:   -76.01818490712907   -3.31523e-02   1.10356e-02 DIIS
+   @DF-RHF iter   3:   -76.02628543484566   -8.10053e-03   1.83467e-03 DIIS
+   @DF-RHF iter   4:   -76.02677657018658   -4.91135e-04   4.75650e-04 DIIS
+   @DF-RHF iter   5:   -76.02682287845101   -4.63083e-05   8.82569e-05 DIIS
+   @DF-RHF iter   6:   -76.02682493077015   -2.05232e-06   1.69020e-05 DIIS
+   @DF-RHF iter   7:   -76.02682500251629   -7.17461e-08   2.48143e-06 DIIS
+   @DF-RHF iter   8:   -76.02682500407337   -1.55708e-09   3.74480e-07 DIIS
+   @DF-RHF iter   9:   -76.02682500410386   -3.04823e-11   3.20415e-08 DIIS
+   @DF-RHF iter  10:   -76.02682500410396   -9.94760e-14   3.19702e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.546042     2A1    -1.345497     1B2    -0.713272  
+       3A1    -0.566689     1B1    -0.494019  
+
+    Virtual:                                                              
+
+       4A1     0.189167     2B2     0.258743     3B2     0.809936  
+       5A1     0.865212     6A1     1.160940     2B1     1.200704  
+       4B2     1.250716     7A1     1.457332     1A2     1.476348  
+       3B1     1.689180     8A1     1.867599     5B2     1.947311  
+       6B2     2.505576     9A1     2.537605     4B1     3.294221  
+       2A2     3.365690    10A1     3.527548    11A1     3.904168  
+       7B2     4.159564  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02682500410396
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3820831506858404
+    One-Electron Energy =                -123.4867800627388306
+    Two-Electron Energy =                  38.0778719079490244
+    Total Energy =                        -76.0268250041039551
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1456
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7915     Total:     0.7915
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0117     Total:     2.0117
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.08 seconds =       0.18 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:14 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.749939216312     0.499930382576     1.007825032070
+         H            0.000000000000     0.749939216312     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.382083150685840
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.014989309065
+       2       -0.000000000000     0.006213103188    -0.007494654532
+       3        0.000000000000    -0.006213103188    -0.007494654532
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.20 seconds =       0.19 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:14 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180834078    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.750367878922     0.498855903347     1.007825032070
+         H            0.000000000000     0.753237846965     0.501004861805     1.007825032070
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     29.71867  B =     14.79669  C =      9.87834 [cm^-1]
+  Rotational constants: A = 890943.18228  B = 443593.59171  C = 296145.21978 [MHz]
+  Nuclear repulsion =    9.366911117988488
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        18      18       0       0       0       0
+     A"         6       6       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3163424690E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.05316663949202   -7.60532e+01   9.24319e-02 
+   @DF-RHF iter   1:   -75.99181266188616    6.13540e-02   1.49628e-02 
+   @DF-RHF iter   2:   -76.01959035083536   -2.77777e-02   7.27187e-03 DIIS
+   @DF-RHF iter   3:   -76.02633527292627   -6.74492e-03   1.23556e-03 DIIS
+   @DF-RHF iter   4:   -76.02680543514855   -4.70162e-04   3.35619e-04 DIIS
+   @DF-RHF iter   5:   -76.02685124883412   -4.58137e-05   6.92933e-05 DIIS
+   @DF-RHF iter   6:   -76.02685383215902   -2.58332e-06   1.04773e-05 DIIS
+   @DF-RHF iter   7:   -76.02685389239559   -6.02366e-08   1.23324e-06 DIIS
+   @DF-RHF iter   8:   -76.02685389301080   -6.15202e-10   2.34249e-07 DIIS
+   @DF-RHF iter   9:   -76.02685389303096   -2.01652e-11   3.41832e-08 DIIS
+   @DF-RHF iter  10:   -76.02685389303132   -3.55271e-13   5.52443e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.546231     2Ap    -1.344595     3Ap    -0.712701  
+       4Ap    -0.566131     1App   -0.493851  
+
+    Virtual:                                                              
+
+       5Ap     0.188949     6Ap     0.258524     7Ap     0.809247  
+       8Ap     0.863160     9Ap     1.160977     2App    1.200773  
+      10Ap     1.250647    11Ap     1.458718     3App    1.475508  
+       4App    1.689573    12Ap     1.868196    13Ap     1.944811  
+      14Ap     2.501637    15Ap     2.534212     5App    3.292077  
+       6App    3.364774    16Ap     3.524708    17Ap     3.903701  
+      18Ap     4.157032  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     4,    1 ]
+
+  @DF-RHF Final Energy:   -76.02685389303132
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3669111179884883
+    One-Electron Energy =                -123.4605117939757406
+    Two-Electron Energy =                  38.0667467829559456
+    Total Energy =                        -76.0268538930313014
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0027      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0014      Z:    -0.1458
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0013      Z:     0.7912     Total:     0.7912
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0034      Z:     2.0110     Total:     2.0110
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+Module time:
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      11.57 seconds =       0.19 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:15 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180834078    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.750367878922     0.498855903347     1.007825032070
+         H            0.000000000000     0.753237846965     0.501004861805     1.007825032070
+
+  Nuclear repulsion =    9.366911117988488
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.003853957526     0.013235142286
+       2        0.000000000000     0.006438561424    -0.008068215399
+       3        0.000000000000    -0.002584603898    -0.005166926887
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.69 seconds =       0.19 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:15 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 443602.62989  C = 296146.43467 [MHz]
+  Nuclear repulsion =    9.366873175716002
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.3164319701E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -76.02721010139712   -7.60272e+01   1.26959e-01 
+   @DF-RHF iter   1:   -75.98503394146364    4.21762e-02   2.24636e-02 
+   @DF-RHF iter   2:   -76.01819442576191   -3.31605e-02   1.10506e-02 DIIS
+   @DF-RHF iter   3:   -76.02632060922842   -8.12618e-03   1.83723e-03 DIIS
+   @DF-RHF iter   4:   -76.02681392166660   -4.93312e-04   4.77044e-04 DIIS
+   @DF-RHF iter   5:   -76.02686057861968   -4.66570e-05   8.85362e-05 DIIS
+   @DF-RHF iter   6:   -76.02686264788574   -2.06927e-06   1.70052e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272073014   -7.28444e-08   2.50825e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272232401   -1.59388e-09   3.76539e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272235471   -3.06954e-11   3.22492e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272235482   -1.13687e-13   3.22605e-09 DIIS
   Energy converged.
 
 
@@ -4848,14 +6281,14 @@ hessian() will perform analytic frequency computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02686272246095
+  @DF-RHF Final Energy:   -76.02686272235482
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3668731388982884
-    One-Electron Energy =                -123.4604615511582608
-    Two-Electron Energy =                  38.0667256897990356
-    Total Energy =                        -76.0268627224609475
+    Nuclear Repulsion Energy =              9.3668731757160018
+    One-Electron Energy =                -123.4604615816806472
+    Two-Electron Energy =                  38.0667256836098318
+    Total Energy =                        -76.0268627223548208
 
 Computation Completed
 
@@ -4877,22 +6310,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:07 2018
+*** tstop() called on dream at Wed Oct 17 20:15:15 2018
 Module time:
-	user time   =       8.31 seconds =       0.14 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     299.21 seconds =       4.99 minutes
-	system time =       6.64 seconds =       0.11 minutes
-	total time  =         54 seconds =       0.90 minutes
+	user time   =      12.07 seconds =       0.20 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:07 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:15 2018
 
 
          ------------------------------------------------------------
-                                   SCF HESS                          
+                                   SCF GRAD                          
                           Rob Parrish, Justin Turney,                
                        Andy Simmonett, and Alex Sokolov              
          ------------------------------------------------------------
@@ -4910,7 +6343,7 @@ Total time:
          H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
          H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
 
-  Nuclear repulsion =    9.366873138898287
+  Nuclear repulsion =    9.366873175716002
 
   ==> Basis Set <==
 
@@ -4924,12 +6357,12 @@ Total time:
 
   ==> DFJKGrad: Density-Fitted SCF Gradients <==
 
-    Gradient:                    2
+    Gradient:                    1
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4944,119 +6377,39 @@ Total time:
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  DFHelper Memory: AOs need 0.001 [GiB]; user supplied 0.439 [GiB]. Using in-core AOs.
 
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               8
-    Memory (MB):                450
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVDZ AUX)
-    Blend: CC-PVDZ-JKFIT
-    Number of shells: 42
-    Number of basis function: 116
-    Number of Cartesian functions: 131
-    Spherical Harmonics?: true
-    Max angular momentum: 3
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.013215500512
+       2       -0.000000000000     0.004499300517    -0.006607750256
+       3        0.000000000000    -0.004499300517    -0.006607750256
 
 
-         ------------------------------------------------------------
-                                     CPHF                           
-                                  Rob Parrish                       
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c2v
-    Full point group: C2v
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
-         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
-         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
-
-  Nuclear repulsion =    9.366873138898287
-  Reference energy  =  -76.026862722460947
-
-  ==> Basis Set <==
-
-  Basis Set: CC-PVDZ
-    Blend: CC-PVDZ
-    Number of shells: 12
-    Number of basis function: 24
-    Number of Cartesian functions: 25
-    Spherical Harmonics?: true
-    Max angular momentum: 2
-
-  ==> CGRSolver (by Rob Parrish) <==
-
-   Number of roots    =         9
-   Preconditioning    =    JACOBI
-   Convergence cutoff =     1E-06
-   Maximum iterations =       100
-
-  ==> CPHFRHamiltonian (by Rob Parrish) <== 
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               8
-    Memory (MB):                450
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVDZ AUX)
-    Blend: CC-PVDZ-JKFIT
-    Number of shells: 42
-    Number of basis function: 116
-    Number of Cartesian functions: 131
-    Spherical Harmonics?: true
-    Max angular momentum: 3
-
-  ==> CPHF Iterations <==
-
-  => Iterations <=
-
-             Iter  Converged  Remaining    Residual
-  CGR           1          0          9   1.105E-01
-  CGR           2          0          9   2.301E-02
-  CGR           3          0          9   5.351E-03
-  CGR           4          0          9   8.369E-04
-  CGR           5          0          9   1.388E-04
-  CGR           6          0          9   2.599E-05
-  CGR           7          4          5   4.864E-06
-  CGR           8          9          0   8.335E-07
-
-    CGRSolver converged.
-
-
-*** tstop() called on silver at Tue Sep 25 13:52:12 2018
+*** tstop() called on dream at Wed Oct 17 20:15:15 2018
 Module time:
-	user time   =      32.94 seconds =       0.55 minutes
-	system time =       0.47 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     332.17 seconds =       5.54 minutes
-	system time =       7.11 seconds =       0.12 minutes
-	total time  =         59 seconds =       0.98 minutes
+	user time   =      12.19 seconds =       0.20 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing second-derivative from gradients using projected, 
+  symmetry-adapted, cartesian coordinates.
+
+  6 gradients passed in, including the reference geometry.
+  Generating complete list of displacements from unique ones.
+
+    Operation 2 takes plus displacements of irrep B2 to minus ones.
+
+-------------------------------------------------------------
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: SCF / CC-PVTZ, HESSIAN //
@@ -5064,16 +6417,16 @@ Total time:
 
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:12 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:15 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5081,7 +6434,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5100,8 +6453,8 @@ gradient() will perform analytic gradient computation.
   Running in c2v symmetry.
 
   Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
-  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
-  Nuclear repulsion =    9.366873138898288
+  Rotational constants: A = 890917.72003  B = 443602.62989  C = 296146.43467 [MHz]
+  Nuclear repulsion =    9.366873175716000
 
   Charge       = 0
   Multiplicity = 1
@@ -5135,8 +6488,8 @@ gradient() will perform analytic gradient computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -5160,7 +6513,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5177,7 +6530,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3337883263E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3337882983E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -5186,17 +6539,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15705386304175   -7.61571e+01   1.11607e-01 
-   @DF-RHF iter   1:   -76.00804928770357    1.49005e-01   1.92765e-02 
-   @DF-RHF iter   2:   -76.04636975319131   -3.83205e-02   1.11355e-02 DIIS
-   @DF-RHF iter   3:   -76.05688013370900   -1.05104e-02   1.84203e-03 DIIS
-   @DF-RHF iter   4:   -76.05766529844000   -7.85165e-04   5.36020e-04 DIIS
-   @DF-RHF iter   5:   -76.05775268794596   -8.73895e-05   9.76128e-05 DIIS
-   @DF-RHF iter   6:   -76.05775634090108   -3.65296e-06   1.59778e-05 DIIS
-   @DF-RHF iter   7:   -76.05775643131149   -9.04104e-08   2.76460e-06 DIIS
-   @DF-RHF iter   8:   -76.05775643428072   -2.96923e-09   4.88989e-07 DIIS
-   @DF-RHF iter   9:   -76.05775643437045   -8.97273e-11   6.37665e-08 DIIS
-   @DF-RHF iter  10:   -76.05775643437173   -1.27898e-12   5.39548e-09 DIIS
+   @DF-RHF iter   0:   -75.95139982935255   -7.59514e+01   5.56992e-02 
+   @DF-RHF iter   1:   -76.03440601355707   -8.30062e-02   7.80589e-03 
+   @DF-RHF iter   2:   -76.05211980911487   -1.77138e-02   4.19583e-03 DIIS
+   @DF-RHF iter   3:   -76.05747970577814   -5.35990e-03   5.96959e-04 DIIS
+   @DF-RHF iter   4:   -76.05772386500179   -2.44159e-04   1.60958e-04 DIIS
+   @DF-RHF iter   5:   -76.05775448086195   -3.06159e-05   3.81765e-05 DIIS
+   @DF-RHF iter   6:   -76.05775638746832   -1.90661e-06   6.28655e-06 DIIS
+   @DF-RHF iter   7:   -76.05775643335552   -4.58872e-08   9.19066e-07 DIIS
+   @DF-RHF iter   8:   -76.05775643432585   -9.70331e-10   1.34858e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643434822   -2.23679e-11   2.36299e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643434882   -5.96856e-13   2.56450e-09 DIIS
   Energy converged.
 
 
@@ -5235,14 +6588,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775643437173
+  @DF-RHF Final Energy:   -76.05775643434882
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3668731388982884
-    One-Electron Energy =                -123.4279505909431407
-    Two-Electron Energy =                  38.0033210176731302
-    Total Energy =                        -76.0577564343717256
+    Nuclear Repulsion Energy =              9.3668731757160000
+    One-Electron Energy =                -123.4279507369144397
+    Two-Electron Energy =                  38.0033211268496203
+    Total Energy =                        -76.0577564343488177
 
 Computation Completed
 
@@ -5264,18 +6617,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:14 2018
+*** tstop() called on dream at Wed Oct 17 20:15:16 2018
 Module time:
-	user time   =       9.89 seconds =       0.16 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     342.21 seconds =       5.70 minutes
-	system time =       7.28 seconds =       0.12 minutes
-	total time  =         61 seconds =       1.02 minutes
+	user time   =      12.67 seconds =       0.21 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:14 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:16 2018
 
 
          ------------------------------------------------------------
@@ -5297,7 +6650,7 @@ Total time:
          H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
          H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
 
-  Nuclear repulsion =    9.366873138898287
+  Nuclear repulsion =    9.366873175716002
 
   ==> Basis Set <==
 
@@ -5315,8 +6668,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -5335,34 +6688,69 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.002590005743
-       2       -0.000000000000     0.000881698350    -0.001295002872
-       3        0.000000000000    -0.000881698350    -0.001295002872
+       1       -0.000000000000     0.000000000000     0.002590010257
+       2       -0.000000000000     0.000881701903    -0.001295005129
+       3        0.000000000000    -0.000881701903    -0.001295005129
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:17 2018
+*** tstop() called on dream at Wed Oct 17 20:15:16 2018
 Module time:
-	user time   =      10.95 seconds =       0.18 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     353.18 seconds =       5.89 minutes
-	system time =       7.59 seconds =       0.13 minutes
-	total time  =         64 seconds =       1.07 minutes
+	user time   =      12.90 seconds =       0.21 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
 
-  Based on options and gradient (rms=1.39E-03), recommend projecting translations and projecting rotations.
-hessian() will perform analytic frequency computation.
+  Based on options and gradient (rms=1.14E-03), recommend projecting translations and projecting rotations.
+hessian() will perform frequency computation by finite difference of analytic gradients.
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:17 2018
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes.  Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 3.
+    Number of irreps is 4.
+    Number of SALCs is 3.
+    Translations projected? 1. Rotations projected? 1.
+    Index of SALCs per irrep:
+     1 :  0  1 
+     2 : 
+     3 : 
+     4 :  2 
+    Number of SALCs per irrep:
+     Irrep 1: 2
+     Irrep 2: 0
+     Irrep 3: 0
+     Irrep 4: 1
+    Number of geometries (including reference) is 6.
+    Number of displacements per irrep:
+      Irrep 1: 4
+      Irrep 2: 0
+      Irrep 3: 0
+      Irrep 4: 1
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:16 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5370,7 +6758,7 @@ hessian() will perform analytic frequency computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        8 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5382,15 +6770,15 @@ hessian() will perform analytic frequency computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
-         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
-         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+         O            0.000000000000     0.000000000000    -0.063221639759    15.994914619560
+         H            0.000000000000    -0.751802862943     0.501686650894     1.007825032070
+         H            0.000000000000     0.751802862943     0.501686650894     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
-  Rotational constants: A = 890917.71324  B = 443602.62651  C = 296146.43241 [MHz]
-  Nuclear repulsion =    9.366873138898288
+  Rotational constants: A =     29.51011  B =     14.79699  C =      9.85532 [cm^-1]
+  Rotational constants: A = 884690.91776  B = 443602.62989  C = 295455.18643 [MHz]
+  Nuclear repulsion =    9.355497525821443
 
   Charge       = 0
   Multiplicity = 1
@@ -5424,8 +6812,8 @@ hessian() will perform analytic frequency computation.
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -5449,7 +6837,7 @@ hessian() will perform analytic frequency computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               8
+    OpenMP threads:               1
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5466,7 +6854,7 @@ hessian() will perform analytic frequency computation.
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 2.3337883263E-03.
+  Minimum eigenvalue in the overlap matrix is 2.3444345369E-03.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -5475,17 +6863,1468 @@ hessian() will perform analytic frequency computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15705386304181   -7.61571e+01   1.06208e-01 
-   @DF-RHF iter   1:   -76.00804928770353    1.49005e-01   1.85731e-02 
-   @DF-RHF iter   2:   -76.04636975319127   -3.83205e-02   1.03756e-02 DIIS
-   @DF-RHF iter   3:   -76.05688013370886   -1.05104e-02   1.85069e-03 DIIS
-   @DF-RHF iter   4:   -76.05766529843999   -7.85165e-04   4.70449e-04 DIIS
-   @DF-RHF iter   5:   -76.05775268794584   -8.73895e-05   8.55563e-05 DIIS
-   @DF-RHF iter   6:   -76.05775634090102   -3.65296e-06   1.43308e-05 DIIS
-   @DF-RHF iter   7:   -76.05775643131153   -9.04105e-08   2.37188e-06 DIIS
-   @DF-RHF iter   8:   -76.05775643428069   -2.96916e-09   3.99763e-07 DIIS
-   @DF-RHF iter   9:   -76.05775643437036   -8.96705e-11   5.99446e-08 DIIS
-   @DF-RHF iter  10:   -76.05775643437175   -1.39266e-12   5.77584e-09 DIIS
+   @DF-RHF iter   0:   -75.94456690026446   -7.59446e+01   5.55910e-02 
+   @DF-RHF iter   1:   -76.03431871820544   -8.97518e-02   7.84720e-03 
+   @DF-RHF iter   2:   -76.05204811508717   -1.77294e-02   4.24838e-03 DIIS
+   @DF-RHF iter   3:   -76.05751273040305   -5.46462e-03   5.75263e-04 DIIS
+   @DF-RHF iter   4:   -76.05773351096002   -2.20781e-04   1.53219e-04 DIIS
+   @DF-RHF iter   5:   -76.05776064188237   -2.71309e-05   3.66319e-05 DIIS
+   @DF-RHF iter   6:   -76.05776238245166   -1.74057e-06   6.19456e-06 DIIS
+   @DF-RHF iter   7:   -76.05776242746474   -4.50131e-08   9.07830e-07 DIIS
+   @DF-RHF iter   8:   -76.05776242841586   -9.51118e-10   1.32161e-07 DIIS
+   @DF-RHF iter   9:   -76.05776242843758   -2.17284e-11   2.36194e-08 DIIS
+   @DF-RHF iter  10:   -76.05776242843824   -6.53699e-13   2.52931e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550912     2A1    -1.353297     1B2    -0.722365  
+       3A1    -0.577620     1B1    -0.505352  
+
+    Virtual:                                                              
+
+       4A1     0.144370     2B2     0.205154     3B2     0.554036  
+       5A1     0.606038     6A1     0.666878     2B1     0.787533  
+       4B2     0.805011     7A1     0.812324     1A2     0.861273  
+       3B1     0.964693     8A1     1.118490     5B2     1.202347  
+       6B2     1.546885     9A1     1.589174     7B2     2.031013  
+       4B1     2.036407     2A2     2.076339    10A1     2.171226  
+      11A1     2.232336    12A1     2.611262     8B2     2.973222  
+       5B1     3.372845    13A1     3.509308     3A2     3.581789  
+       9B2     3.669323     6B1     3.817477    14A1     3.886835  
+      10B2     3.901196     4A2     3.967861     7B1     4.026786  
+      11B2     4.088181    15A1     4.212883     5A2     4.351155  
+      16A1     4.430831    12B2     4.596609     8B1     4.703787  
+      13B2     4.911540    17A1     5.211316    18A1     5.270910  
+      14B2     5.548337     9B1     6.083137    19A1     6.615093  
+      10B1     6.965969     6A2     6.975542    11B1     7.039927  
+      20A1     7.063958    15B2     7.162576    21A1     7.175861  
+       7A2     7.280129    22A1     7.489623    16B2     7.838819  
+      17B2     8.357037    23A1    13.171731  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05776242843824
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3554975258214430
+    One-Electron Energy =                -123.4074292968897311
+    Two-Electron Energy =                  37.9941693426300588
+    Total Energy =                        -76.0577624284382239
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9403
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1593
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7810     Total:     0.7810
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9851     Total:     1.9851
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:16 2018
+Module time:
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      13.37 seconds =       0.22 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:16 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063221639759    15.994914619560
+         H            0.000000000000    -0.751802862943     0.501686650894     1.007825032070
+         H            0.000000000000     0.751802862943     0.501686650894     1.007825032070
+
+  Nuclear repulsion =    9.355497525821443
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.000618647625
+       2        0.000000000000    -0.000010787432    -0.000309323813
+       3       -0.000000000000     0.000010787432    -0.000309323813
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+Module time:
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      13.61 seconds =       0.23 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:17 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.062778996277    15.994914619560
+         H            0.000000000000    -0.751802862943     0.498174114257     1.007825032070
+         H            0.000000000000     0.751802862943     0.498174114257     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.92772  B =     14.79699  C =      9.90147 [cm^-1]
+  Rotational constants: A = 897210.49442  B = 443602.62989  C = 296838.48381 [MHz]
+  Nuclear repulsion =    9.378251932621403
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3232455654E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95940374094587   -7.59594e+01   5.62794e-02 
+   @DF-RHF iter   1:   -76.02817776806802   -6.87740e-02   8.82581e-03 
+   @DF-RHF iter   2:   -76.05028112525785   -2.21034e-02   4.96222e-03 DIIS
+   @DF-RHF iter   3:   -76.05753519500736   -7.25407e-03   5.33576e-04 DIIS
+   @DF-RHF iter   4:   -76.05772022871201   -1.85034e-04   1.47072e-04 DIIS
+   @DF-RHF iter   5:   -76.05774128208827   -2.10534e-05   3.49381e-05 DIIS
+   @DF-RHF iter   6:   -76.05774299594265   -1.71385e-06   6.76455e-06 DIIS
+   @DF-RHF iter   7:   -76.05774306346490   -6.75223e-08   8.67513e-07 DIIS
+   @DF-RHF iter   8:   -76.05774306432801   -8.63110e-10   5.71353e-08 DIIS
+   @DF-RHF iter   9:   -76.05774306433000   -1.98952e-12   8.39519e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550295     2A1    -1.354275     1B2    -0.724465  
+       3A1    -0.577294     1B1    -0.505434  
+
+    Virtual:                                                              
+
+       4A1     0.144675     2B2     0.205257     3B2     0.555682  
+       5A1     0.605931     6A1     0.666830     2B1     0.787516  
+       4B2     0.804891     7A1     0.814766     1A2     0.860957  
+       3B1     0.966721     8A1     1.116529     5B2     1.202608  
+       6B2     1.550150     9A1     1.592039     7B2     2.028248  
+       4B1     2.035454     2A2     2.078040    10A1     2.170381  
+      11A1     2.232243    12A1     2.615754     8B2     2.973852  
+       5B1     3.376745    13A1     3.512563     3A2     3.580408  
+       9B2     3.669815     6B1     3.819901    14A1     3.886815  
+      10B2     3.904738     4A2     3.967884     7B1     4.028230  
+      11B2     4.090117    15A1     4.215463     5A2     4.357439  
+      16A1     4.438167    12B2     4.594709     8B1     4.706417  
+      13B2     4.919489    17A1     5.217315    18A1     5.274161  
+      14B2     5.551418     9B1     6.085838    19A1     6.617801  
+      10B1     6.965707     6A2     6.978535    11B1     7.050094  
+      20A1     7.067218    21A1     7.176487    15B2     7.179399  
+       7A2     7.285598    22A1     7.495284    16B2     7.844010  
+      17B2     8.364212    23A1    13.214364  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05774306433000
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3782519326214029
+    One-Electron Energy =                -123.4484635710815326
+    Two-Electron Energy =                  38.0124685741301249
+    Total Energy =                        -76.0577430643300119
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9337
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1559
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7778     Total:     0.7778
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9770     Total:     1.9770
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+Module time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.10 seconds =       0.23 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:17 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.062778996277    15.994914619560
+         H            0.000000000000    -0.751802862943     0.498174114257     1.007825032070
+         H            0.000000000000     0.751802862943     0.498174114257     1.007825032070
+
+  Nuclear repulsion =    9.378251932621403
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.004566035691
+       2       -0.000000000000     0.001783200654    -0.002283017846
+       3        0.000000000000    -0.001783200654    -0.002283017846
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+Module time:
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.33 seconds =       0.24 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:17 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.753666509575     0.499930382576     1.007825032070
+         H            0.000000000000     0.753666509575     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.72390  C =      9.84575 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 441411.48463  C = 295168.27531 [MHz]
+  Nuclear repulsion =    9.351700262034790
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3440516833E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.94860658995196   -7.59486e+01   5.55170e-02 
+   @DF-RHF iter   1:   -76.03445239898700   -8.58458e-02   7.79633e-03 
+   @DF-RHF iter   2:   -76.05212220305479   -1.76698e-02   4.19376e-03 DIIS
+   @DF-RHF iter   3:   -76.05748029984673   -5.35810e-03   5.97081e-04 DIIS
+   @DF-RHF iter   4:   -76.05772413910996   -2.43839e-04   1.60991e-04 DIIS
+   @DF-RHF iter   5:   -76.05775481546218   -3.06764e-05   3.82439e-05 DIIS
+   @DF-RHF iter   6:   -76.05775673179265   -1.91633e-06   6.31611e-06 DIIS
+   @DF-RHF iter   7:   -76.05775677825653   -4.64639e-08   9.25308e-07 DIIS
+   @DF-RHF iter   8:   -76.05775677924345   -9.86915e-10   1.35946e-07 DIIS
+   @DF-RHF iter   9:   -76.05775677926623   -2.27800e-11   2.37717e-08 DIIS
+   @DF-RHF iter  10:   -76.05775677926677   -5.40012e-13   2.58116e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550805     2A1    -1.352877     1B2    -0.722825  
+       3A1    -0.576905     1B1    -0.505217  
+
+    Virtual:                                                              
+
+       4A1     0.144399     2B2     0.205054     3B2     0.554495  
+       5A1     0.604629     6A1     0.667177     2B1     0.787597  
+       4B2     0.804793     7A1     0.814000     1A2     0.860520  
+       3B1     0.966058     8A1     1.118327     5B2     1.201205  
+       6B2     1.547489     9A1     1.587969     7B2     2.031786  
+       4B1     2.034668     2A2     2.076948    10A1     2.169965  
+      11A1     2.232747    12A1     2.613651     8B2     2.971847  
+       5B1     3.376047    13A1     3.510700     3A2     3.578960  
+       9B2     3.666506     6B1     3.817677    14A1     3.886113  
+      10B2     3.901556     4A2     3.966317     7B1     4.027505  
+      11B2     4.089031    15A1     4.212193     5A2     4.352722  
+      16A1     4.433883    12B2     4.589644     8B1     4.703993  
+      13B2     4.911877    17A1     5.207412    18A1     5.271641  
+      14B2     5.549097     9B1     6.080584    19A1     6.608645  
+      10B1     6.965019     6A2     6.976025    11B1     7.040634  
+      20A1     7.062351    15B2     7.168542    21A1     7.172369  
+       7A2     7.277762    22A1     7.492030    16B2     7.836515  
+      17B2     8.352938    23A1    13.168329  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05775677926677
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3517002620347895
+    One-Electron Energy =                -123.4016551561628745
+    Two-Electron Energy =                  37.9921981148613241
+    Total Energy =                        -76.0577567792667679
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1580
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7790     Total:     0.7790
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9801     Total:     1.9801
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:18 2018
+Module time:
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      14.80 seconds =       0.25 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:18 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.753666509575     0.499930382576     1.007825032070
+         H            0.000000000000     0.753666509575     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.351700262034790
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.000911283222
+       2        0.000000000000    -0.000781469692    -0.000455641611
+       3       -0.000000000000     0.000781469692    -0.000455641611
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:18 2018
+Module time:
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      15.03 seconds =       0.25 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:18 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.749939216312     0.499930382576     1.007825032070
+         H            0.000000000000     0.749939216312     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.87063  C =      9.91115 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 445810.13086  C = 297128.65269 [MHz]
+  Nuclear repulsion =    9.382083150685840
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3235794306E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95419315214608   -7.59542e+01   5.58820e-02 
+   @DF-RHF iter   1:   -76.03434742709115   -8.01543e-02   7.81553e-03 
+   @DF-RHF iter   2:   -76.05210550268124   -1.77581e-02   4.19797e-03 DIIS
+   @DF-RHF iter   3:   -76.05746734843848   -5.36185e-03   5.96839e-04 DIIS
+   @DF-RHF iter   4:   -76.05771182855788   -2.44480e-04   1.60923e-04 DIIS
+   @DF-RHF iter   5:   -76.05774238294600   -3.05544e-05   3.81093e-05 DIIS
+   @DF-RHF iter   6:   -76.05774427988561   -1.89694e-06   6.25720e-06 DIIS
+   @DF-RHF iter   7:   -76.05774432520511   -4.53195e-08   9.12871e-07 DIIS
+   @DF-RHF iter   8:   -76.05774432615922   -9.54117e-10   1.33774e-07 DIIS
+   @DF-RHF iter   9:   -76.05774432618114   -2.19131e-11   2.34891e-08 DIIS
+   @DF-RHF iter  10:   -76.05774432618166   -5.25802e-13   2.54803e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.550401     2A1    -1.354699     1B2    -0.724001  
+       3A1    -0.578011     1B1    -0.505569  
+
+    Virtual:                                                              
+
+       4A1     0.144645     2B2     0.205359     3B2     0.555223  
+       5A1     0.607344     6A1     0.666537     2B1     0.787452  
+       4B2     0.805111     7A1     0.813089     1A2     0.861712  
+       3B1     0.965351     8A1     1.116692     5B2     1.203754  
+       6B2     1.549539     9A1     1.593252     7B2     2.027467  
+       4B1     2.037203     2A2     2.077431    10A1     2.171658  
+      11A1     2.231835    12A1     2.613341     8B2     2.975236  
+       5B1     3.373508    13A1     3.511161     3A2     3.583241  
+       9B2     3.672663     6B1     3.819698    14A1     3.887551  
+      10B2     3.904332     4A2     3.969468     7B1     4.027522  
+      11B2     4.089277    15A1     4.216134     5A2     4.355849  
+      16A1     4.435121    12B2     4.601764     8B1     4.706190  
+      13B2     4.919063    17A1     5.221263    18A1     5.273392  
+      14B2     5.550706     9B1     6.088418    19A1     6.624296  
+      10B1     6.966724     6A2     6.978020    11B1     7.049322  
+      20A1     7.068804    15B2     7.173427    21A1     7.180067  
+       7A2     7.288028    22A1     7.492837    16B2     7.846291  
+      17B2     8.368374    23A1    13.217804  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05774432618166
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3820831506858404
+    One-Electron Energy =                -123.4542923330242132
+    Two-Electron Energy =                  38.0144648561567138
+    Total Energy =                        -76.0577443261816484
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1572
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7798     Total:     0.7798
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9821     Total:     1.9821
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+Module time:
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      15.50 seconds =       0.26 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:19 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.749939216312     0.499930382576     1.007825032070
+         H            0.000000000000     0.749939216312     0.499930382576     1.007825032070
+
+  Nuclear repulsion =    9.382083150685840
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.004292589546
+       2       -0.000000000000     0.002558683069    -0.002146294773
+       3        0.000000000000    -0.002558683069    -0.002146294773
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+Module time:
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      15.73 seconds =       0.26 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:19 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180834078    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.750367878922     0.498855903347     1.007825032070
+         H            0.000000000000     0.753237846965     0.501004861805     1.007825032070
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     29.71867  B =     14.79669  C =      9.87834 [cm^-1]
+  Rotational constants: A = 890943.18228  B = 443593.59171  C = 296145.21978 [MHz]
+  Nuclear repulsion =    9.366911117988488
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        40      40       0       0       0       0
+     A"        18      18       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3336502442E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95481362019882   -7.59548e+01   4.02336e-02 
+   @DF-RHF iter   1:   -76.02837153960000   -7.35579e-02   6.30697e-03 
+   @DF-RHF iter   2:   -76.05031039528025   -2.19389e-02   3.55203e-03 DIIS
+   @DF-RHF iter   3:   -76.05754807444603   -7.23768e-03   3.77416e-04 DIIS
+   @DF-RHF iter   4:   -76.05772618876968   -1.78114e-04   1.03237e-04 DIIS
+   @DF-RHF iter   5:   -76.05774620005710   -2.00113e-05   2.44759e-05 DIIS
+   @DF-RHF iter   6:   -76.05774782961221   -1.62956e-06   4.79893e-06 DIIS
+   @DF-RHF iter   7:   -76.05774789585294   -6.62407e-08   6.22474e-07 DIIS
+   @DF-RHF iter   8:   -76.05774789672536   -8.72419e-10   4.17486e-08 DIIS
+   @DF-RHF iter   9:   -76.05774789672762   -2.25953e-12   6.46812e-09 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.550602     2Ap    -1.353790     3Ap    -0.723415  
+       4Ap    -0.577457     1App   -0.505393  
+
+    Virtual:                                                              
+
+       5Ap     0.144521     6Ap     0.205207     7Ap     0.554839  
+       8Ap     0.606003     9Ap     0.666856     2App    0.787520  
+      10Ap     0.804956    11Ap     0.813543     3App    0.861120  
+       4App    0.965706    12Ap     1.117499    13Ap     1.202481  
+      14Ap     1.548338    15Ap     1.590797    16Ap     2.029640  
+       5App    2.035915     6App    2.077208    17Ap     2.170823  
+      18Ap     2.232293    19Ap     2.613480    20Ap     2.973548  
+       7App    3.374788    21Ap     3.510931     8App    3.581097  
+      22Ap     3.669578     9App    3.818691    23Ap     3.886748  
+      24Ap     3.903010    10App    3.967878    11App    4.027503  
+      25Ap     4.089122    26Ap     4.214204    12App    4.354292  
+      27Ap     4.434519    28Ap     4.595684    13App    4.705103  
+      29Ap     4.915341    30Ap     5.214512    31Ap     5.272514  
+      32Ap     5.549889    14App    6.084511    33Ap     6.616494  
+      15App    6.965815    16App    6.976767    17App    7.045144  
+      34Ap     7.065382    35Ap     7.170107    36Ap     7.177306  
+      18App    7.283053    37Ap     7.492394    38Ap     7.841465  
+      39Ap     8.360636    40Ap    13.193114  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     4,    1 ]
+
+  @DF-RHF Final Energy:   -76.05774789672762
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.3669111179884883
+    One-Electron Energy =                -123.4280019115075078
+    Two-Electron Energy =                  38.0033428967913949
+    Total Energy =                        -76.0577478967276193
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0027      Z:     0.9370
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0013      Z:    -0.1576
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0014      Z:     0.7794     Total:     0.7794
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0036      Z:     1.9811     Total:     1.9811
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+Module time:
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      16.19 seconds =       0.27 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:19 2018
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000    -0.000180834078    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.750367878922     0.498855903347     1.007825032070
+         H            0.000000000000     0.753237846965     0.501004861805     1.007825032070
+
+  Nuclear repulsion =    9.366911117988488
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory (MB):               375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.003731956628     0.002609024479
+       2        0.000000000000     0.002759623173    -0.002703236251
+       3        0.000000000000     0.000972333455     0.000094211773
+
+
+*** tstop() called on dream at Wed Oct 17 20:15:20 2018
+Module time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      16.43 seconds =       0.27 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         17 seconds =       0.28 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 6 of 6    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:20 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
+         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
+         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     29.71782  B =     14.79699  C =      9.87838 [cm^-1]
+  Rotational constants: A = 890917.72003  B = 443602.62989  C = 296146.43467 [MHz]
+  Nuclear repulsion =    9.366873175716002
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.366 [GiB]. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory (MB):                375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-12
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.3337882983E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -75.95139982935481   -7.59514e+01   5.56992e-02 
+   @DF-RHF iter   1:   -76.03440601355928   -8.30062e-02   7.80589e-03 
+   @DF-RHF iter   2:   -76.05211980911726   -1.77138e-02   4.19583e-03 DIIS
+   @DF-RHF iter   3:   -76.05747970578048   -5.35990e-03   5.96959e-04 DIIS
+   @DF-RHF iter   4:   -76.05772386500411   -2.44159e-04   1.60958e-04 DIIS
+   @DF-RHF iter   5:   -76.05775448086416   -3.06159e-05   3.81765e-05 DIIS
+   @DF-RHF iter   6:   -76.05775638747068   -1.90661e-06   6.28655e-06 DIIS
+   @DF-RHF iter   7:   -76.05775643335777   -4.58871e-08   9.19066e-07 DIIS
+   @DF-RHF iter   8:   -76.05775643432824   -9.70473e-10   1.34858e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643435051   -2.22684e-11   2.36299e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643435115   -6.39488e-13   2.56450e-09 DIIS
   Energy converged.
 
 
@@ -5524,14 +8363,14 @@ hessian() will perform analytic frequency computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775643437175
+  @DF-RHF Final Energy:   -76.05775643435115
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.3668731388982884
-    One-Electron Energy =                -123.4279505909431549
-    Two-Electron Energy =                  38.0033210176731160
-    Total Energy =                        -76.0577564343717540
+    Nuclear Repulsion Energy =              9.3668731757160018
+    One-Electron Energy =                -123.4279507369165572
+    Two-Electron Energy =                  38.0033211268494071
+    Total Energy =                        -76.0577564343511483
 
 Computation Completed
 
@@ -5553,22 +8392,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
 
 
-*** tstop() called on silver at Tue Sep 25 13:52:18 2018
+*** tstop() called on dream at Wed Oct 17 20:15:20 2018
 Module time:
-	user time   =      10.11 seconds =       0.17 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =     363.37 seconds =       6.06 minutes
-	system time =       7.73 seconds =       0.13 minutes
-	total time  =         65 seconds =       1.08 minutes
+	user time   =      16.90 seconds =       0.28 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         17 seconds =       0.28 minutes
 
-*** tstart() called on silver
-*** at Tue Sep 25 13:52:18 2018
+*** tstart() called on dream
+*** at Wed Oct 17 20:15:20 2018
 
 
          ------------------------------------------------------------
-                                   SCF HESS                          
+                                   SCF GRAD                          
                           Rob Parrish, Justin Turney,                
                        Andy Simmonett, and Alex Sokolov              
          ------------------------------------------------------------
@@ -5586,7 +8425,7 @@ Total time:
          H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
          H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
 
-  Nuclear repulsion =    9.366873138898287
+  Nuclear repulsion =    9.366873175716002
 
   ==> Basis Set <==
 
@@ -5600,12 +8439,12 @@ Total time:
 
   ==> DFJKGrad: Density-Fitted SCF Gradients <==
 
-    Gradient:                    2
+    Gradient:                    1
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              8
-    Integrals threads:           8
+    OpenMP threads:              1
+    Integrals threads:           1
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -5620,120 +8459,39 @@ Total time:
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  DFHelper Memory: AOs need 0.005 [GiB]; user supplied 0.439 [GiB]. Using in-core AOs.
 
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               8
-    Memory (MB):                450
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVTZ AUX)
-    Blend: CC-PVTZ-JKFIT
-    Number of shells: 45
-    Number of basis function: 139
-    Number of Cartesian functions: 166
-    Spherical Harmonics?: true
-    Max angular momentum: 4
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.002590010221
+       2       -0.000000000000     0.000881701881    -0.001295005111
+       3        0.000000000000    -0.000881701881    -0.001295005111
 
 
-         ------------------------------------------------------------
-                                     CPHF                           
-                                  Rob Parrish                       
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c2v
-    Full point group: C2v
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.063000318018    15.994914619560
-         H            0.000000000000    -0.751802862943     0.499930382576     1.007825032070
-         H            0.000000000000     0.751802862943     0.499930382576     1.007825032070
-
-  Nuclear repulsion =    9.366873138898287
-  Reference energy  =  -76.057756434371754
-
-  ==> Basis Set <==
-
-  Basis Set: CC-PVTZ
-    Blend: CC-PVTZ
-    Number of shells: 22
-    Number of basis function: 58
-    Number of Cartesian functions: 65
-    Spherical Harmonics?: true
-    Max angular momentum: 3
-
-  ==> CGRSolver (by Rob Parrish) <==
-
-   Number of roots    =         9
-   Preconditioning    =    JACOBI
-   Convergence cutoff =     1E-06
-   Maximum iterations =       100
-
-  ==> CPHFRHamiltonian (by Rob Parrish) <== 
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               8
-    Memory (MB):                450
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (CC-PVTZ AUX)
-    Blend: CC-PVTZ-JKFIT
-    Number of shells: 45
-    Number of basis function: 139
-    Number of Cartesian functions: 166
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-  ==> CPHF Iterations <==
-
-  => Iterations <=
-
-             Iter  Converged  Remaining    Residual
-  CGR           1          0          9   1.038E-01
-  CGR           2          0          9   2.200E-02
-  CGR           3          0          9   5.774E-03
-  CGR           4          0          9   9.836E-04
-  CGR           5          0          9   1.407E-04
-  CGR           6          0          9   2.927E-05
-  CGR           7          2          7   5.625E-06
-  CGR           8          7          2   1.088E-06
-  CGR           9          9          0   1.597E-07
-
-    CGRSolver converged.
-
-
-*** tstop() called on silver at Tue Sep 25 13:54:11 2018
+*** tstop() called on dream at Wed Oct 17 20:15:20 2018
 Module time:
-	user time   =     860.68 seconds =      14.34 minutes
-	system time =       9.03 seconds =       0.15 minutes
-	total time  =        113 seconds =       1.88 minutes
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =    1224.08 seconds =      20.40 minutes
-	system time =      16.76 seconds =       0.28 minutes
-	total time  =        178 seconds =       2.97 minutes
+	user time   =      17.14 seconds =       0.29 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         17 seconds =       0.28 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing second-derivative from gradients using projected, 
+  symmetry-adapted, cartesian coordinates.
+
+  6 gradients passed in, including the reference geometry.
+  Generating complete list of displacements from unique ones.
+
+    Operation 2 takes plus displacements of irrep B2 to minus ones.
+
+-------------------------------------------------------------
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: scf/cc-pv[dt]z    //
@@ -5742,10 +8500,10 @@ Total time:
 
    ==> Helgaker 2-point exponential SCF extrapolation for method: SCF <==
 
-   LO-zeta (2) Energy:               -76.026862722461
-   HI-zeta (3) Energy:               -76.057756434372
+   LO-zeta (2) Energy:               -76.026862722355
+   HI-zeta (3) Energy:               -76.057756434351
    Alpha (exponent) Value:             1.630000000000
-   Beta (coefficient) Value:           1.000866180368
+   Beta (coefficient) Value:           1.000866183139
 
    @Extrapolated SCF/(D,T):         -76.065284371755
 
@@ -5780,34 +8538,34 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/psi4bin/cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
 
 CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
 
                  1                   2                   3                   4                   5
 
-    1    -0.00000082421446    -0.00000000000000    -0.00000000000000     0.00000041209022     0.00000000000000
-    2    -0.00000000000000     0.80941676397245     0.00000000002091     0.00000000000000    -0.40470838202950
-    3    -0.00000000000000     0.00000000002091     0.52473604249242     0.00000000000000     0.23757205981746
-    4     0.00000041209022     0.00000000000000     0.00000000000000    -0.00000027386642    -0.00000000000000
-    5     0.00000000000000    -0.40470838202950     0.23757205981746    -0.00000000000000     0.43819678972030
-    6     0.00000000000000     0.30303556098622    -0.26236802124400    -0.00000000000000    -0.27030381038891
-    7     0.00000041209582     0.00000000000000     0.00000000000000    -0.00000013822968     0.00000000000000
-    8     0.00000000000000    -0.40470838200368    -0.23757205980965    -0.00000000000000    -0.03348840770598
-    9     0.00000000000000    -0.30303556100137    -0.26236802124729    -0.00000000000000     0.03273175058690
+    1     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    2     0.00000000000000     0.80944036631429     0.00000000000000     0.00000000000000    -0.40472018315714
+    3     0.00000000000000     0.00000000000000     0.52473094730562     0.00000000000000     0.23757575166632
+    4     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    5     0.00000000000000    -0.40472018315714     0.23757575166632     0.00000000000000     0.43820426333237
+    6     0.00000000000000     0.30304409237966    -0.26236547365281     0.00000000000000    -0.27030992202299
+    7     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    8     0.00000000000000    -0.40472018315714    -0.23757575166632     0.00000000000000    -0.03348408017522
+    9     0.00000000000000    -0.30304409237966    -0.26236547365281     0.00000000000000     0.03273417035667
 
                  6                   7                   8                   9
 
-    1     0.00000000000000     0.00000041209582     0.00000000000000     0.00000000000000
-    2     0.30303556098622     0.00000000000000    -0.40470838200368    -0.30303556100137
-    3    -0.26236802124400     0.00000000000000    -0.23757205980965    -0.26236802124729
-    4    -0.00000000000000    -0.00000013822968    -0.00000000000000    -0.00000000000000
-    5    -0.27030381038891     0.00000000000000    -0.03348840770598     0.03273175058690
-    6     0.24463657064502    -0.00000000000000    -0.03273175058859     0.01773145059490
-    7    -0.00000000000000    -0.00000027386242    -0.00000000000000    -0.00000000000000
-    8    -0.03273175058859    -0.00000000000000     0.43819678973381     0.27030381039509
-    9     0.01773145059490    -0.00000000000000     0.27030381039509     0.24463657065052
+    1     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    2     0.30304409237966     0.00000000000000    -0.40472018315714    -0.30304409237966
+    3    -0.26236547365281     0.00000000000000    -0.23757575166632    -0.26236547365281
+    4     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    5    -0.27030992202299     0.00000000000000    -0.03348408017522     0.03273417035667
+    6     0.24463855858679     0.00000000000000    -0.03273417035667     0.01772691506602
+    7     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
+    8    -0.03273417035667     0.00000000000000     0.43820426333237     0.27030992202299
+    9     0.01772691506602     0.00000000000000     0.27030992202299     0.24463855858679
 
 
 
@@ -5815,49 +8573,49 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
 
   ==> Harmonic Vibrational Analysis <==
 
-  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
   projection of translations (True) and rotations (True) removed 6 degrees of freedom (6)
   total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
-  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
-  pre-proj  low-frequency mode:    0.0000i [cm^-1]
-  pre-proj  low-frequency mode:    0.0000i [cm^-1]
-  pre-proj  low-frequency mode:    0.0000i [cm^-1]
-  pre-proj  low-frequency mode:    0.0014  [cm^-1]
-  pre-proj  all modes:['3.4880i' '2.5233i' '1.8858i' '0.0092i' '0.0067i' '0.0014' '1747.7410'
- '4130.2255' '4230.5752']
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0001  [cm^-1]
+  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0001' '1747.7069'
+ '4130.2408' '4230.6358']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
-  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj  all modes:['0.0000i' '0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0000' '1747.7410'
- '4130.2255' '4230.5752']
+  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
+  post-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0001' '1747.7069'
+ '4130.2408' '4230.6358']
 
   Vibration                       7                   8                   9           
-  Freq [cm^-1]                1747.7410           4130.2255           4230.5752       
+  Freq [cm^-1]                1747.7069           4130.2408           4230.6358       
   Irrep                           A1                  A1                  B2          
   Reduced mass [u]              1.0834              1.0445              1.0837        
-  Force const [mDyne/A]         1.9498             10.4982             11.4276        
+  Force const [mDyne/A]         1.9497             10.4983             11.4279        
   Turning point v=0 [a0]        0.2522              0.1671              0.1621        
   RMS dev v=0 [a0 u^1/2]        0.1856              0.1207              0.1193        
-  Char temp [K]               2514.6064           5942.4659           6086.8465       
+  Char temp [K]               2514.5611           5942.4970           6086.9430       
   ----------------------------------------------------------------------------------
-      1   O               -0.00 -0.00 -0.07   -0.00 -0.00  0.05   -0.00 -0.07 -0.00   
-      2   H               -0.00  0.42  0.56   -0.00  0.59 -0.39    0.00  0.56 -0.42   
-      3   H               -0.00 -0.42  0.56    0.00 -0.59 -0.39    0.00  0.56  0.42   
+      1   O                0.00 -0.00 -0.07    0.00  0.00  0.05    0.00 -0.07 -0.00   
+      2   H                0.00  0.42  0.56   -0.00  0.59 -0.39   -0.00  0.56 -0.42   
+      3   H               -0.00 -0.42  0.56   -0.00 -0.59 -0.39    0.00  0.56  0.42   
 
   ==> Thermochemistry Components <==
 
   Entropy, S
     Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
-    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515186 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
-    Rotational S           10.317 [cal/(mol K)]       43.166 [J/(mol K)]       0.01644104 [mEh/K] (symmetry no. = 2)
-    Vibrational S           0.004 [cal/(mol K)]        0.017 [J/(mol K)]       0.00000649 [mEh/K]
-  Total S                  44.929 [cal/(mol K)]      187.984 [J/(mol K)]       0.07159939 [mEh/K]
+    Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515177 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
+    Rotational S           10.317 [cal/(mol K)]       43.166 [J/(mol K)]       0.01644101 [mEh/K] (symmetry no. = 2)
+    Vibrational S           0.004 [cal/(mol K)]        0.017 [J/(mol K)]       0.00000650 [mEh/K]
+  Total S                  44.929 [cal/(mol K)]      187.984 [J/(mol K)]       0.07159928 [mEh/K]
   Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant volume heat capacity, Cv
@@ -5865,15 +8623,15 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
     Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cv          0.031 [cal/(mol K)]        0.129 [J/(mol K)]       0.00004899 [mEh/K]
-  Total Cv                  5.992 [cal/(mol K)]       25.072 [J/(mol K)]       0.00954943 [mEh/K]
+  Total Cv                  5.992 [cal/(mol K)]       25.072 [J/(mol K)]       0.00954942 [mEh/K]
   Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant pressure heat capacity, Cp
     Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
-    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791704 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
     Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Vibrational Cp          0.031 [cal/(mol K)]        0.129 [J/(mol K)]       0.00004899 [mEh/K]
-  Total Cp                  7.980 [cal/(mol K)]       33.386 [J/(mol K)]       0.01271624 [mEh/K]
+  Total Cp                  7.980 [cal/(mol K)]       33.386 [J/(mol K)]       0.01271623 [mEh/K]
   Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   ==> Thermochemistry Energy Analysis <==
@@ -5885,38 +8643,38 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
     Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Vibrational ZPE        14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302895 [Eh]        5054.269 [cm^-1]
-  Correction ZPE           14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302895 [Eh]        5054.269 [cm^-1]
-  Total ZPE, Electronic energy at 0 [K]                                -76.04225542 [Eh]
+    Vibrational ZPE        14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302905 [Eh]        5054.292 [cm^-1]
+  Correction ZPE           14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302905 [Eh]        5054.292 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.04225532 [Eh]
 
   Thermal Energy, E (includes ZPE)
     Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational E          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303068 [Eh]
-  Correction E             16.229 [kcal/mol]       67.904 [kJ/mol]       0.02586324 [Eh]
-  Total E, Electronic energy at  298.15 [K]                            -76.03942114 [Eh]
+    Vibrational E          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303078 [Eh]
+  Correction E             16.229 [kcal/mol]       67.904 [kJ/mol]       0.02586333 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.03942104 [Eh]
 
   Enthalpy, H_trans = E_trans + k_B * T
     Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
     Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational H          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303068 [Eh]
-  Correction H             16.822 [kcal/mol]       70.383 [kJ/mol]       0.02680742 [Eh]
-  Total H, Enthalpy at  298.15 [K]                                     -76.03847695 [Eh]
+    Vibrational H          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303078 [Eh]
+  Correction H             16.822 [kcal/mol]       70.383 [kJ/mol]       0.02680752 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.03847685 [Eh]
 
   Gibbs free energy, G = H - T * S
     Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408306 [Eh]
-    Rotational G           -2.187 [kcal/mol]       -9.151 [kJ/mol]      -0.00348562 [Eh]
-    Vibrational G          14.451 [kcal/mol]       60.462 [kJ/mol]       0.02302874 [Eh]
-  Correction G              3.426 [kcal/mol]       14.335 [kJ/mol]       0.00546006 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                                -76.05982431 [Eh]
+    Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408304 [Eh]
+    Rotational G           -2.187 [kcal/mol]       -9.151 [kJ/mol]      -0.00348561 [Eh]
+    Vibrational G          14.451 [kcal/mol]       60.462 [kJ/mol]       0.02302884 [Eh]
+  Correction G              3.426 [kcal/mol]       14.336 [kJ/mol]       0.00546019 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.05982418 [Eh]
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 
-    Psi4 stopped on: Tuesday, 25 September 2018 01:54PM
-    Psi4 wall time for execution: 0:02:58.34
+    Psi4 stopped on: Wednesday, 17 October 2018 08:15PM
+    Psi4 wall time for execution: 0:00:17.84
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cbs-xtpl-freq/output.ref
+++ b/tests/cbs-xtpl-freq/output.ref
@@ -22,13 +22,13 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 17 October 2018 08:15PM
+    Psi4 started on: Wednesday, 17 October 2018 09:44PM
 
-    Process ID: 4839
+    Process ID: 25077
     Host:       dream
     PSIDATADIR: /home/kraus/Applications/psi4-cbs_dict/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    4
     
   ==> Input File <==
 
@@ -36,12 +36,12 @@
 #! Various gradients for a strained helium dimer and water molecule
 import numpy as np
 
-nucenergy_ref = 9.1681932964
+nucenergy_ref = 9.3008469403
 
 molecule h2o_dz {
-  O
-  H 1 0.96
-  H 1 0.96 2 104.5
+    O       
+    H             1    0.946279
+    H             1    0.946279      2  104.619334
 }
 
 molecule h2o_tz {
@@ -71,12 +71,12 @@ clean()
 
 # reference frequencies: CFOUR v1.0 with:
 # *ACES2(CALC=HF,BASIS=PVDZ,ABCDTYPE=AOBASIS,CC_PROG=ECC,VIB=ANALYTIC,SCF_CONV=10,LINEQ_CONV=10)
-# 1808.8119, 3923.3122, 4020.3029
+# 1775.7236, 4113.8382, 4212.2220
 
 scf_dz, wfn_dz = freq('SCF/cc-pVDZ', return_wfn=True, dertype=1, molecule=h2o_dz)
-compare_values(wfn_dz.frequencies().get(0), 1809.2462, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
-compare_values(wfn_dz.frequencies().get(1), 3923.1513, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
-compare_values(wfn_dz.frequencies().get(2), 4020.1774, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
+compare_values(wfn_dz.frequencies().get(0), 1776.1550, 2, "SCF/cc-pVDZ Frequency 1")            #TEST
+compare_values(wfn_dz.frequencies().get(1), 4113.6950, 2, "SCF/cc-pVDZ Frequency 2")            #TEST
+compare_values(wfn_dz.frequencies().get(2), 4212.1246, 2, "SCF/cc-pVDZ Frequency 3")            #TEST
 
 # reference frequencies: G09.D01 with:
 # freq=noraman hf/cc-pvtz
@@ -101,7 +101,7 @@ compare_values(wfn_dtz.frequencies().get(2), 4230.6358, 2, "SCF/cc-pV[DT]Z Frequ
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:03 2018
+*** at Wed Oct 17 21:44:01 2018
 
    => Loading Basis Set <=
 
@@ -117,7 +117,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -129,15 +129,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.748815837541     0.513800640630     1.007825032070
+         H            0.000000000000     0.748815837541     0.513800640630     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
-  Rotational constants: A = 817323.21137  B = 435158.60148  C = 283968.37540 [MHz]
-  Nuclear repulsion =    9.168193296424349
+  Rotational constants: A =     28.13498  B =     14.91528  C =      9.74770 [cm^-1]
+  Rotational constants: A = 843465.60301  B = 447148.74918  C = 292228.72713 [MHz]
+  Nuclear repulsion =    9.300846940321923
 
   Charge       = 0
   Multiplicity = 1
@@ -196,7 +196,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -213,7 +213,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4377086613E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3424849922E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -222,17 +222,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.97345163006347   -7.59735e+01   1.21984e-01 
-   @DF-RHF iter   1:   -75.99199115726702   -1.85395e-02   2.06083e-02 
-   @DF-RHF iter   2:   -76.01906078469820   -2.70696e-02   1.03784e-02 DIIS
-   @DF-RHF iter   3:   -76.02620700522111   -7.14622e-03   1.55130e-03 DIIS
-   @DF-RHF iter   4:   -76.02658850207993   -3.81497e-04   4.43026e-04 DIIS
-   @DF-RHF iter   5:   -76.02663012198339   -4.16199e-05   9.43404e-05 DIIS
-   @DF-RHF iter   6:   -76.02663266836080   -2.54638e-06   1.49995e-05 DIIS
-   @DF-RHF iter   7:   -76.02663273428202   -6.59212e-08   1.92575e-06 DIIS
-   @DF-RHF iter   8:   -76.02663273509880   -8.16783e-10   3.41824e-07 DIIS
-   @DF-RHF iter   9:   -76.02663273512229   -2.34905e-11   2.82526e-08 DIIS
-   @DF-RHF iter  10:   -76.02663273512246   -1.70530e-13   3.50369e-09 DIIS
+   @DF-RHF iter   0:   -75.93575834893241   -7.59358e+01   1.54038e-01 
+   @DF-RHF iter   1:   -75.99746433151326   -6.17060e-02   2.73964e-02 
+   @DF-RHF iter   2:   -76.02055941367479   -2.30951e-02   1.21050e-02 DIIS
+   @DF-RHF iter   3:   -76.02682554268820   -6.26613e-03   1.62190e-03 DIIS
+   @DF-RHF iter   4:   -76.02701332295462   -1.87780e-04   3.92110e-04 DIIS
+   @DF-RHF iter   5:   -76.02703135271233   -1.80298e-05   8.74783e-05 DIIS
+   @DF-RHF iter   6:   -76.02703273974871   -1.38704e-06   1.68503e-05 DIIS
+   @DF-RHF iter   7:   -76.02703278344681   -4.36981e-08   1.30585e-06 DIIS
+   @DF-RHF iter   8:   -76.02703278370359   -2.56776e-10   2.50920e-07 DIIS
+   @DF-RHF iter   9:   -76.02703278371310   -9.50706e-12   3.72131e-08 DIIS
+   @DF-RHF iter  10:   -76.02703278371317   -7.10543e-14   3.46904e-09 DIIS
   Energy converged.
 
 
@@ -243,31 +243,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.550925     2A1    -1.335311     1B2    -0.697803  
-       3A1    -0.566087     1B1    -0.492948  
+       1A1   -20.548431     2A1    -1.342275     1B2    -0.705443  
+       3A1    -0.568387     1B1    -0.493917  
 
     Virtual:                                                              
 
-       4A1     0.185107     2B2     0.255846     3B2     0.787336  
-       5A1     0.851826     6A1     1.163855     2B1     1.200424  
-       4B2     1.253573     7A1     1.445291     1A2     1.476011  
-       3B1     1.674661     8A1     1.868110     5B2     1.932579  
-       6B2     2.446529     9A1     2.483817     4B1     3.283958  
-       2A2     3.336669    10A1     3.507634    11A1     3.863421  
-       7B2     4.144760  
+       4A1     0.187420     2B2     0.257808     3B2     0.797730  
+       5A1     0.864391     6A1     1.162772     2B1     1.200473  
+       4B2     1.252689     7A1     1.444301     1A2     1.479253  
+       3B1     1.678115     8A1     1.865535     5B2     1.947189  
+       6B2     2.479567     9A1     2.518469     4B1     3.295526  
+       2A2     3.350729    10A1     3.525283    11A1     3.879553  
+       7B2     4.159744  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02663273512246
+  @DF-RHF Final Energy:   -76.02703278371317
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1681932964243487
-    One-Electron Energy =                -123.1035072040179301
-    Two-Electron Energy =                  37.9086811724711268
-    Total Energy =                        -76.0266327351224618
+    Nuclear Repulsion Energy =              9.3008469403219234
+    One-Electron Energy =                -123.3388522515630967
+    Two-Electron Energy =                  38.0109725275280113
+    Total Energy =                        -76.0270327837131674
 
 Computation Completed
 
@@ -277,30 +277,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9783
+     X:     0.0000      Y:     0.0000      Z:     0.9630
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1680
+     X:     0.0000      Y:     0.0000      Z:    -0.1587
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8103     Total:     0.8103
+     X:     0.0000      Y:     0.0000      Z:     0.8044     Total:     0.8044
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
+     X:     0.0000      Y:     0.0000      Z:     2.0445     Total:     2.0445
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:03 2018
+*** tstop() called on dream at Wed Oct 17 21:44:02 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:03 2018
+*** at Wed Oct 17 21:44:02 2018
 
 
          ------------------------------------------------------------
@@ -318,11 +318,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.748815837541     0.513800640630     1.007825032070
+         H            0.000000000000     0.748815837541     0.513800640630     1.007825032070
 
-  Nuclear repulsion =    9.168193296424349
+  Nuclear repulsion =    9.300846940321923
 
   ==> Basis Set <==
 
@@ -340,8 +340,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -360,22 +360,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.017641624495
-       2        0.000000000000    -0.012438412634     0.008820812248
-       3       -0.000000000000     0.012438412634     0.008820812248
+       1        0.000000000000     0.000000000000     0.000000519714
+       2       -0.000000000000     0.000001304175    -0.000000259857
+       3        0.000000000000    -0.000001304175    -0.000000259857
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:03 2018
+*** tstop() called on dream at Wed Oct 17 21:44:02 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.43 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-  Based on options and gradient (rms=9.29E-03), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=7.97E-07), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -414,7 +414,7 @@ hessian() will perform frequency computation by finite difference of analytic gr
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:03 2018
+*** at Wed Oct 17 21:44:02 2018
 
    => Loading Basis Set <=
 
@@ -430,7 +430,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -442,15 +442,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065996892279    15.994914619560
-         H            0.000000000000    -0.759061990794     0.523709286614     1.007825032070
-         H            0.000000000000     0.759061990794     0.523709286614     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064969544465    15.994914619560
+         H            0.000000000000    -0.748815837541     0.515556908949     1.007825032070
+         H            0.000000000000     0.748815837541     0.515556908949     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.08042  B =     14.51533  C =      9.45003 [cm^-1]
-  Rotational constants: A = 811850.58748  B = 435158.60148  C = 283304.86205 [MHz]
-  Nuclear repulsion =    9.157072688150697
+  Rotational constants: A =     27.94362  B =     14.91528  C =      9.72463 [cm^-1]
+  Rotational constants: A = 837728.78233  B = 447148.74918  C = 291537.02822 [MHz]
+  Nuclear repulsion =    9.289416877156286
 
   Charge       = 0
   Multiplicity = 1
@@ -509,7 +509,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -526,7 +526,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4436783875E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3483987235E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -535,17 +535,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.01024944333068   -7.60102e+01   1.21984e-01 
-   @DF-RHF iter   1:   -75.99010936736278    2.01401e-02   2.07780e-02 
-   @DF-RHF iter   2:   -76.01871392338774   -2.86046e-02   1.04125e-02 DIIS
-   @DF-RHF iter   3:   -76.02601039154391   -7.29647e-03   1.72268e-03 DIIS
-   @DF-RHF iter   4:   -76.02650762493073   -4.97233e-04   4.91158e-04 DIIS
-   @DF-RHF iter   5:   -76.02656024267506   -5.26177e-05   1.00962e-04 DIIS
-   @DF-RHF iter   6:   -76.02656319308875   -2.95041e-06   1.60189e-05 DIIS
-   @DF-RHF iter   7:   -76.02656326792095   -7.48322e-08   2.11245e-06 DIIS
-   @DF-RHF iter   8:   -76.02656326889166   -9.70715e-10   3.61271e-07 DIIS
-   @DF-RHF iter   9:   -76.02656326891703   -2.53664e-11   3.11391e-08 DIIS
-   @DF-RHF iter  10:   -76.02656326891726   -2.27374e-13   4.32135e-09 DIIS
+   @DF-RHF iter   0:   -75.96586678392289   -7.59659e+01   1.79565e-01 
+   @DF-RHF iter   1:   -75.99566657670653   -2.97998e-02   2.67991e-02 
+   @DF-RHF iter   2:   -76.02024299279228   -2.45764e-02   1.59938e-02 DIIS
+   @DF-RHF iter   3:   -76.02671388361664   -6.47089e-03   2.49168e-03 DIIS
+   @DF-RHF iter   4:   -76.02699648702270   -2.82603e-04   6.61253e-04 DIIS
+   @DF-RHF iter   5:   -76.02702687183763   -3.03848e-05   1.42679e-04 DIIS
+   @DF-RHF iter   6:   -76.02702897730734   -2.10547e-06   1.99380e-05 DIIS
+   @DF-RHF iter   7:   -76.02702902623940   -4.89321e-08   2.28039e-06 DIIS
+   @DF-RHF iter   8:   -76.02702902659190   -3.52500e-10   3.90412e-07 DIIS
+   @DF-RHF iter   9:   -76.02702902660495   -1.30456e-11   3.16335e-08 DIIS
+   @DF-RHF iter  10:   -76.02702902660506   -1.13687e-13   3.84840e-09 DIIS
   Energy converged.
 
 
@@ -556,31 +556,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.551241     2A1    -1.334848     1B2    -0.696804  
-       3A1    -0.566244     1B1    -0.492930  
+       1A1   -20.548749     2A1    -1.341796     1B2    -0.704416  
+       3A1    -0.568553     1B1    -0.493893  
 
     Virtual:                                                              
 
-       4A1     0.184865     2B2     0.255688     3B2     0.785834  
-       5A1     0.851533     6A1     1.164082     2B1     1.200358  
-       4B2     1.253844     7A1     1.443781     1A2     1.476308  
-       3B1     1.673401     8A1     1.867961     5B2     1.932335  
-       6B2     2.443168     9A1     2.481133     4B1     3.283863  
-       2A2     3.334769    10A1     3.506857    11A1     3.860644  
-       7B2     4.144448  
+       4A1     0.187180     2B2     0.257664     3B2     0.796172  
+       5A1     0.864094     6A1     1.163015     2B1     1.200437  
+       4B2     1.252942     7A1     1.442748     1A2     1.479556  
+       3B1     1.676776     8A1     1.865352     5B2     1.946958  
+       6B2     2.476097     9A1     2.515724     4B1     3.295472  
+       2A2     3.348781    10A1     3.524567    11A1     3.876610  
+       7B2     4.159488  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02656326891726
+  @DF-RHF Final Energy:   -76.02702902660506
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1570726881506967
-    One-Electron Energy =                -123.0831370350583853
-    Two-Electron Energy =                  37.8995010779904362
-    Total Energy =                        -76.0265632689172577
+    Nuclear Repulsion Energy =              9.2894168771562864
+    One-Electron Energy =                -123.3180796668309824
+    Two-Electron Energy =                  38.0016337630696341
+    Total Energy =                        -76.0270290266050637
 
 Computation Completed
 
@@ -590,30 +590,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9816
+     X:     0.0000      Y:     0.0000      Z:     0.9663
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1698
+     X:     0.0000      Y:     0.0000      Z:    -0.1604
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8119     Total:     0.8119
+     X:     0.0000      Y:     0.0000      Z:     0.8059     Total:     0.8059
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0635     Total:     2.0635
+     X:     0.0000      Y:     0.0000      Z:     2.0485     Total:     2.0485
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:04 2018
+*** tstop() called on dream at Wed Oct 17 21:44:03 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.86 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.92 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       4.32 seconds =       0.07 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:04 2018
+*** at Wed Oct 17 21:44:03 2018
 
 
          ------------------------------------------------------------
@@ -631,11 +631,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065996892279    15.994914619560
-         H            0.000000000000    -0.759061990794     0.523709286614     1.007825032070
-         H            0.000000000000     0.759061990794     0.523709286614     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064969544465    15.994914619560
+         H            0.000000000000    -0.748815837541     0.515556908949     1.007825032070
+         H            0.000000000000     0.748815837541     0.515556908949     1.007825032070
 
-  Nuclear repulsion =    9.157072688150697
+  Nuclear repulsion =    9.289416877156286
 
   ==> Basis Set <==
 
@@ -653,8 +653,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -673,20 +673,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.019533900491
-       2        0.000000000000    -0.013209286890     0.009766950246
-       3       -0.000000000000     0.013209286890     0.009766950246
+       1        0.000000000000     0.000000000000    -0.002010268388
+       2        0.000000000000    -0.000875279135     0.001005134194
+       3       -0.000000000000     0.000875279135     0.001005134194
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:04 2018
+*** tstop() called on dream at Wed Oct 17 21:44:03 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.04 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       5.33 seconds =       0.09 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
@@ -694,7 +694,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:04 2018
+*** at Wed Oct 17 21:44:03 2018
 
    => Loading Basis Set <=
 
@@ -710,7 +710,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -722,15 +722,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065554248797    15.994914619560
-         H            0.000000000000    -0.759061990794     0.520196749977     1.007825032070
-         H            0.000000000000     0.759061990794     0.520196749977     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064526900983    15.994914619560
+         H            0.000000000000    -0.748815837541     0.512044372312     1.007825032070
+         H            0.000000000000     0.748815837541     0.512044372312     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.44737  B =     14.51533  C =      9.49433 [cm^-1]
-  Rotational constants: A = 822851.35817  B = 435158.60148  C = 284632.75946 [MHz]
-  Nuclear repulsion =    9.179318561553005
+  Rotational constants: A =     28.32832  B =     14.91528  C =      9.77080 [cm^-1]
+  Rotational constants: A = 849261.55528  B = 447148.74918  C = 292921.33892 [MHz]
+  Nuclear repulsion =    9.312281747696547
 
   Charge       = 0
   Multiplicity = 1
@@ -789,7 +789,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -806,7 +806,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4317699805E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3365994908E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -815,17 +815,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.06320548962216   -7.60632e+01   1.22791e-01 
-   @DF-RHF iter   1:   -75.97589024105974    8.73152e-02   2.38889e-02 
-   @DF-RHF iter   2:   -76.01607835751466   -4.01881e-02   1.20866e-02 DIIS
-   @DF-RHF iter   3:   -76.02589104611341   -9.81269e-03   2.17891e-03 DIIS
-   @DF-RHF iter   4:   -76.02662966683096   -7.38621e-04   5.70809e-04 DIIS
-   @DF-RHF iter   5:   -76.02669279804179   -6.31312e-05   9.36617e-05 DIIS
-   @DF-RHF iter   6:   -76.02669501917308   -2.22113e-06   1.91953e-05 DIIS
-   @DF-RHF iter   7:   -76.02669511591461   -9.67415e-08   3.29890e-06 DIIS
-   @DF-RHF iter   8:   -76.02669511885554   -2.94094e-09   4.41256e-07 DIIS
-   @DF-RHF iter   9:   -76.02669511889823   -4.26894e-11   3.53567e-08 DIIS
-   @DF-RHF iter  10:   -76.02669511889833   -9.94760e-14   3.46559e-09 DIIS
+   @DF-RHF iter   0:   -75.92675949724757   -7.59268e+01   1.78692e-01 
+   @DF-RHF iter   1:   -76.00541576181675   -7.86563e-02   2.50049e-02 
+   @DF-RHF iter   2:   -76.02255186148660   -1.71361e-02   1.37911e-02 DIIS
+   @DF-RHF iter   3:   -76.02682300853506   -4.27115e-03   2.04090e-03 DIIS
+   @DF-RHF iter   4:   -76.02700954933613   -1.86541e-04   4.44915e-04 DIIS
+   @DF-RHF iter   5:   -76.02702778013216   -1.82308e-05   1.06854e-04 DIIS
+   @DF-RHF iter   6:   -76.02702898551480   -1.20538e-06   1.86498e-05 DIIS
+   @DF-RHF iter   7:   -76.02702901523371   -2.97189e-08   1.86073e-06 DIIS
+   @DF-RHF iter   8:   -76.02702901562532   -3.91609e-10   3.57209e-07 DIIS
+   @DF-RHF iter   9:   -76.02702901563586   -1.05445e-11   4.01159e-08 DIIS
+   @DF-RHF iter  10:   -76.02702901563595   -8.52651e-14   3.83685e-09 DIIS
   Energy converged.
 
 
@@ -836,31 +836,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.550608     2A1    -1.335773     1B2    -0.698803  
-       3A1    -0.565927     1B1    -0.492966  
+       1A1   -20.548114     2A1    -1.342753     1B2    -0.706473  
+       3A1    -0.568220     1B1    -0.493942  
 
     Virtual:                                                              
 
-       4A1     0.185349     2B2     0.256002     3B2     0.788846  
-       5A1     0.852111     6A1     1.163631     2B1     1.200488  
-       4B2     1.253305     7A1     1.446799     1A2     1.475713  
-       3B1     1.675928     8A1     1.868266     5B2     1.932818  
-       6B2     2.449906     9A1     2.486500     4B1     3.284041  
-       2A2     3.338574    10A1     3.508366    11A1     3.866243  
-       7B2     4.145052  
+       4A1     0.187660     2B2     0.257950     3B2     0.799296  
+       5A1     0.864680     6A1     1.162530     2B1     1.200506  
+       4B2     1.252438     7A1     1.445853     1A2     1.478951  
+       3B1     1.679461     8A1     1.865726     5B2     1.947415  
+       6B2     2.483052     9A1     2.521213     4B1     3.295567  
+       2A2     3.352682    10A1     3.525950    11A1     3.882544  
+       7B2     4.159981  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02669511889833
+  @DF-RHF Final Energy:   -76.02702901563595
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1793185615530053
-    One-Electron Energy =                -123.1238719501144772
-    Two-Electron Energy =                  37.9178582696631281
-    Total Energy =                        -76.0266951188983455
+    Nuclear Repulsion Energy =              9.3122817476965469
+    One-Electron Energy =                -123.3596188034795773
+    Two-Electron Energy =                  38.0203080401470856
+    Total Energy =                        -76.0270290156359465
 
 Computation Completed
 
@@ -870,30 +870,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9750
+     X:     0.0000      Y:     0.0000      Z:     0.9597
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1663
+     X:     0.0000      Y:     0.0000      Z:    -0.1570
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8087     Total:     0.8087
+     X:     0.0000      Y:     0.0000      Z:     0.8028     Total:     0.8028
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0555     Total:     2.0555
+     X:     0.0000      Y:     0.0000      Z:     2.0404     Total:     2.0404
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:04 2018
+*** tstop() called on dream at Wed Oct 17 21:44:03 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.42 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       7.35 seconds =       0.12 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:04 2018
+*** at Wed Oct 17 21:44:03 2018
 
 
          ------------------------------------------------------------
@@ -911,11 +911,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065554248797    15.994914619560
-         H            0.000000000000    -0.759061990794     0.520196749977     1.007825032070
-         H            0.000000000000     0.759061990794     0.520196749977     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064526900983    15.994914619560
+         H            0.000000000000    -0.748815837541     0.512044372312     1.007825032070
+         H            0.000000000000     0.748815837541     0.512044372312     1.007825032070
 
-  Nuclear repulsion =    9.179318561553005
+  Nuclear repulsion =    9.312281747696547
 
   ==> Basis Set <==
 
@@ -933,8 +933,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -953,20 +953,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.015743587634
-       2        0.000000000000    -0.011659058987     0.007871793817
-       3       -0.000000000000     0.011659058987     0.007871793817
+       1        0.000000000000     0.000000000000     0.002016990671
+       2       -0.000000000000     0.000887151175    -0.001008495336
+       3        0.000000000000    -0.000887151175    -0.001008495336
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:04 2018
+*** tstop() called on dream at Wed Oct 17 21:44:04 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.54 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.07 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.42 seconds =       0.14 minutes
+	system time =       0.44 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
@@ -974,7 +974,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:04 2018
+*** at Wed Oct 17 21:44:04 2018
 
    => Loading Basis Set <=
 
@@ -990,7 +990,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1002,15 +1002,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.760925637426     0.521953018295     1.007825032070
-         H            0.000000000000     0.760925637426     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.750679484173     0.513800640630     1.007825032070
+         H            0.000000000000     0.750679484173     0.513800640630     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.26297  B =     14.44431  C =      9.44187 [cm^-1]
-  Rotational constants: A = 817323.21137  B = 433029.64512  C = 283060.24042 [MHz]
-  Nuclear repulsion =    9.153816320429554
+  Rotational constants: A =     28.13498  B =     14.84131  C =      9.71606 [cm^-1]
+  Rotational constants: A = 843465.60301  B = 444931.31054  C = 291280.00246 [MHz]
+  Nuclear repulsion =    9.286040496564581
 
   Charge       = 0
   Multiplicity = 1
@@ -1069,7 +1069,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1086,7 +1086,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4503039213E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3546228043E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1095,17 +1095,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.97011702146608   -7.59701e+01   1.21582e-01 
-   @DF-RHF iter   1:   -75.99186913749836   -2.17521e-02   2.05996e-02 
-   @DF-RHF iter   2:   -76.01894156733934   -2.70724e-02   1.03915e-02 DIIS
-   @DF-RHF iter   3:   -76.02611008440884   -7.16852e-03   1.55417e-03 DIIS
-   @DF-RHF iter   4:   -76.02649499053453   -3.84906e-04   4.45396e-04 DIIS
-   @DF-RHF iter   5:   -76.02653720190094   -4.22114e-05   9.48795e-05 DIIS
-   @DF-RHF iter   6:   -76.02653978365447   -2.58175e-06   1.50974e-05 DIIS
-   @DF-RHF iter   7:   -76.02653985052302   -6.68686e-08   1.94586e-06 DIIS
-   @DF-RHF iter   8:   -76.02653985135767   -8.34646e-10   3.44396e-07 DIIS
-   @DF-RHF iter   9:   -76.02653985138151   -2.38458e-11   2.83674e-08 DIIS
-   @DF-RHF iter  10:   -76.02653985138163   -1.13687e-13   3.52381e-09 DIIS
+   @DF-RHF iter   0:   -76.03464870380427   -7.60346e+01   1.79985e-01 
+   @DF-RHF iter   1:   -75.98177809252151    5.28706e-02   3.71556e-02 
+   @DF-RHF iter   2:   -76.01757786651061   -3.57998e-02   1.69936e-02 DIIS
+   @DF-RHF iter   3:   -76.02639543131498   -8.81756e-03   3.07480e-03 DIIS
+   @DF-RHF iter   4:   -76.02697170573528   -5.76274e-04   7.14833e-04 DIIS
+   @DF-RHF iter   5:   -76.02702486631054   -5.31606e-05   1.53879e-04 DIIS
+   @DF-RHF iter   6:   -76.02702699084482   -2.12453e-06   2.93220e-05 DIIS
+   @DF-RHF iter   7:   -76.02702707183545   -8.09906e-08   3.71440e-06 DIIS
+   @DF-RHF iter   8:   -76.02702707391634   -2.08090e-09   7.53600e-07 DIIS
+   @DF-RHF iter   9:   -76.02702707395214   -3.57971e-11   5.35295e-08 DIIS
+   @DF-RHF iter  10:   -76.02702707395235   -2.13163e-13   5.64185e-09 DIIS
   Energy converged.
 
 
@@ -1116,31 +1116,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.551108     2A1    -1.334459     1B2    -0.697272  
-       3A1    -0.565535     1B1    -0.492793  
+       1A1   -20.548619     2A1    -1.341391     1B2    -0.704905  
+       3A1    -0.567829     1B1    -0.493756  
 
     Virtual:                                                              
 
-       4A1     0.184884     2B2     0.255612     3B2     0.786753  
-       5A1     0.849825     6A1     1.163856     2B1     1.200440  
-       4B2     1.253521     7A1     1.446771     1A2     1.475189  
-       3B1     1.675136     8A1     1.868732     5B2     1.930166  
-       6B2     2.443433     9A1     2.479885     4B1     3.281943  
-       2A2     3.335741    10A1     3.505045    11A1     3.862917  
-       7B2     4.142293  
+       4A1     0.187207     2B2     0.257581     3B2     0.797124  
+       5A1     0.862319     6A1     1.162773     2B1     1.200521  
+       4B2     1.252623     7A1     1.445762     1A2     1.478396  
+       3B1     1.678577     8A1     1.866138     5B2     1.944697  
+       6B2     2.476428     9A1     2.514394     4B1     3.293456  
+       2A2     3.349794    10A1     3.522656    11A1     3.879059  
+       7B2     4.157226  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02653985138163
+  @DF-RHF Final Energy:   -76.02702707395235
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1538163204295540
-    One-Electron Energy =                -123.0783780667240421
-    Two-Electron Energy =                  37.8980218949128584
-    Total Energy =                        -76.0265398513816280
+    Nuclear Repulsion Energy =              9.2860404965645813
+    One-Electron Energy =                -123.3131367142551511
+    Two-Electron Energy =                  38.0000691437382301
+    Total Energy =                        -76.0270270739523397
 
 Computation Completed
 
@@ -1150,30 +1150,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9783
+     X:     0.0000      Y:     0.0000      Z:     0.9630
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1683
+     X:     0.0000      Y:     0.0000      Z:    -0.1589
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8100     Total:     0.8100
+     X:     0.0000      Y:     0.0000      Z:     0.8041     Total:     0.8041
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0589     Total:     2.0589
+     X:     0.0000      Y:     0.0000      Z:     2.0438     Total:     2.0438
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:05 2018
+*** tstop() called on dream at Wed Oct 17 21:44:04 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.88 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.93 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      10.32 seconds =       0.17 minutes
+	system time =       0.56 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:05 2018
+*** at Wed Oct 17 21:44:04 2018
 
 
          ------------------------------------------------------------
@@ -1191,11 +1191,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.760925637426     0.521953018295     1.007825032070
-         H            0.000000000000     0.760925637426     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.750679484173     0.513800640630     1.007825032070
+         H            0.000000000000     0.750679484173     0.513800640630     1.007825032070
 
-  Nuclear repulsion =    9.153816320429554
+  Nuclear repulsion =    9.286040496564581
 
   ==> Basis Set <==
 
@@ -1213,8 +1213,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1233,20 +1233,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.019091958545
-       2        0.000000000000    -0.013933549919     0.009545979273
-       3       -0.000000000000     0.013933549919     0.009545979273
+       1        0.000000000000     0.000000000000    -0.001648712250
+       2        0.000000000000    -0.001620327170     0.000824356125
+       3       -0.000000000000     0.001620327170     0.000824356125
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:05 2018
+*** tstop() called on dream at Wed Oct 17 21:44:05 2018
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.04 seconds =       0.03 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      11.40 seconds =       0.19 minutes
+	system time =       0.63 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
@@ -1254,7 +1254,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:05 2018
+*** at Wed Oct 17 21:44:05 2018
 
    => Loading Basis Set <=
 
@@ -1270,7 +1270,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1282,15 +1282,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757198344162     0.521953018295     1.007825032070
-         H            0.000000000000     0.757198344162     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.746952190909     0.513800640630     1.007825032070
+         H            0.000000000000     0.746952190909     0.513800640630     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.26297  B =     14.58687  C =      9.50258 [cm^-1]
-  Rotational constants: A = 817323.21137  B = 437303.29680  C = 284880.10779 [MHz]
-  Nuclear repulsion =    9.182603576944995
+  Rotational constants: A =     28.13498  B =     14.98980  C =      9.77947 [cm^-1]
+  Rotational constants: A = 843465.60301  B = 449382.80605  C = 293181.27077 [MHz]
+  Nuclear repulsion =    9.315688252806257
 
   Charge       = 0
   Multiplicity = 1
@@ -1349,7 +1349,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1366,7 +1366,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4252101960E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3304418460E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1375,17 +1375,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.97679026553163   -7.59768e+01   1.22387e-01 
-   @DF-RHF iter   1:   -75.99210182724842   -1.53116e-02   2.06172e-02 
-   @DF-RHF iter   2:   -76.01916909472179   -2.70673e-02   1.03655e-02 DIIS
-   @DF-RHF iter   3:   -76.02629331264002   -7.12422e-03   1.54844e-03 DIIS
-   @DF-RHF iter   4:   -76.02667143033523   -3.78118e-04   4.40664e-04 DIIS
-   @DF-RHF iter   5:   -76.02671246581976   -4.10355e-05   9.38033e-05 DIIS
-   @DF-RHF iter   6:   -76.02671497723530   -2.51142e-06   1.49026e-05 DIIS
-   @DF-RHF iter   7:   -76.02671504222577   -6.49905e-08   1.90586e-06 DIIS
-   @DF-RHF iter   8:   -76.02671504302501   -7.99233e-10   3.39251e-07 DIIS
-   @DF-RHF iter   9:   -76.02671504304820   -2.31921e-11   2.81390e-08 DIIS
-   @DF-RHF iter  10:   -76.02671504304828   -8.52651e-14   3.48376e-09 DIIS
+   @DF-RHF iter   0:   -76.04053636801947   -7.60405e+01   1.68774e-01 
+   @DF-RHF iter   1:   -75.98187947471294    5.86569e-02   4.13331e-02 
+   @DF-RHF iter   2:   -76.01764423839272   -3.57648e-02   1.94518e-02 DIIS
+   @DF-RHF iter   3:   -76.02640140732264   -8.75717e-03   3.14895e-03 DIIS
+   @DF-RHF iter   4:   -76.02697243653512   -5.71029e-04   8.05998e-04 DIIS
+   @DF-RHF iter   5:   -76.02702485070654   -5.24142e-05   1.27531e-04 DIIS
+   @DF-RHF iter   6:   -76.02702694323871   -2.09253e-06   2.83689e-05 DIIS
+   @DF-RHF iter   7:   -76.02702702181139   -7.85727e-08   4.69830e-06 DIIS
+   @DF-RHF iter   8:   -76.02702702380171   -1.99032e-09   7.02960e-07 DIIS
+   @DF-RHF iter   9:   -76.02702702383701   -3.52998e-11   4.39033e-08 DIIS
+   @DF-RHF iter  10:   -76.02702702383709   -8.52651e-14   5.14495e-09 DIIS
   Energy converged.
 
 
@@ -1396,31 +1396,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.550740     2A1    -1.336166     1B2    -0.698332  
-       3A1    -0.566639     1B1    -0.493103  
+       1A1   -20.548243     2A1    -1.343162     1B2    -0.705980  
+       3A1    -0.568947     1B1    -0.494079  
 
     Virtual:                                                              
 
-       4A1     0.185329     2B2     0.256080     3B2     0.787921  
-       5A1     0.853833     6A1     1.163858     2B1     1.200406  
-       4B2     1.253627     7A1     1.443806     1A2     1.476840  
-       3B1     1.674180     8A1     1.867491     5B2     1.935005  
-       6B2     2.449628     9A1     2.487765     4B1     3.285980  
-       2A2     3.337595    10A1     3.510206    11A1     3.863931  
-       7B2     4.147230  
+       4A1     0.187631     2B2     0.258034     3B2     0.798337  
+       5A1     0.866469     6A1     1.162774     2B1     1.200421  
+       4B2     1.252756     7A1     1.442837     1A2     1.480118  
+       3B1     1.677648     8A1     1.864936     5B2     1.949693  
+       6B2     2.482708     9A1     2.522560     4B1     3.297604  
+       2A2     3.351662    10A1     3.527891    11A1     3.880053  
+       7B2     4.162267  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02671504304828
+  @DF-RHF Final Energy:   -76.02702702383709
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1826035769449952
-    One-Electron Energy =                -123.1286766128514358
-    Two-Electron Energy =                  37.9193579928581457
-    Total Energy =                        -76.0267150430482843
+    Nuclear Repulsion Energy =              9.3156882528062575
+    One-Electron Energy =                -123.3646094283658385
+    Two-Electron Energy =                  38.0218941517224920
+    Total Energy =                        -76.0270270238370927
 
 Computation Completed
 
@@ -1430,30 +1430,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9783
+     X:     0.0000      Y:     0.0000      Z:     0.9630
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1678
+     X:     0.0000      Y:     0.0000      Z:    -0.1584
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8105     Total:     0.8105
+     X:     0.0000      Y:     0.0000      Z:     0.8046     Total:     0.8046
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0602     Total:     2.0602
+     X:     0.0000      Y:     0.0000      Z:     2.0451     Total:     2.0451
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:05 2018
+*** tstop() called on dream at Wed Oct 17 21:44:05 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.84 seconds =       0.03 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.43 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      13.26 seconds =       0.22 minutes
+	system time =       0.78 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:05 2018
+*** at Wed Oct 17 21:44:05 2018
 
 
          ------------------------------------------------------------
@@ -1471,11 +1471,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757198344162     0.521953018295     1.007825032070
-         H            0.000000000000     0.757198344162     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.746952190909     0.513800640630     1.007825032070
+         H            0.000000000000     0.746952190909     0.513800640630     1.007825032070
 
-  Nuclear repulsion =    9.182603576944995
+  Nuclear repulsion =    9.315688252806257
 
   ==> Basis Set <==
 
@@ -1493,8 +1493,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1513,20 +1513,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.016170093615
-       2        0.000000000000    -0.010930568854     0.008085046807
-       3       -0.000000000000     0.010930568854     0.008085046807
+       1        0.000000000000     0.000000000000     0.001673108747
+       2       -0.000000000000     0.001636451726    -0.000836554373
+       3        0.000000000000    -0.001636451726    -0.000836554373
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:05 2018
+*** tstop() called on dream at Wed Oct 17 21:44:05 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.55 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      14.30 seconds =       0.24 minutes
+	system time =       0.85 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
@@ -1534,7 +1534,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:05 2018
+*** at Wed Oct 17 21:44:05 2018
 
    => Loading Basis Set <=
 
@@ -1550,7 +1550,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1562,15 +1562,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757643253225     0.520854514300     1.007825032070
-         H            0.000000000000     0.760480728363     0.523051522291     1.007825032070
+         O            0.000000000000    -0.000178920260    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.747396040358     0.512703679261     1.007825032070
+         H            0.000000000000     0.750235634724     0.514897601999     1.007825032070
 
   Running in cs symmetry.
 
-  Rotational constants: A =     27.26378  B =     14.51501  C =      9.47213 [cm^-1]
-  Rotational constants: A = 817347.49964  B = 435149.09376  C = 283967.25838 [MHz]
-  Nuclear repulsion =    9.168228730864485
+  Rotational constants: A =     28.13584  B =     14.91494  C =      9.74766 [cm^-1]
+  Rotational constants: A = 843491.25513  B = 447138.77065  C = 292227.54418 [MHz]
+  Nuclear repulsion =    9.300883945084580
 
   Charge       = 0
   Multiplicity = 1
@@ -1627,7 +1627,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1644,7 +1644,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4376244940E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3423993640E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1653,17 +1653,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.90152223128959   -7.59015e+01   8.76191e-02 
-   @DF-RHF iter   1:   -76.00548744597455   -1.03965e-01   1.21882e-02 
-   @DF-RHF iter   2:   -76.02217195056069   -1.66845e-02   5.73058e-03 DIIS
-   @DF-RHF iter   3:   -76.02641539245131   -4.24344e-03   9.29089e-04 DIIS
-   @DF-RHF iter   4:   -76.02660431866110   -1.88926e-04   2.09796e-04 DIIS
-   @DF-RHF iter   5:   -76.02662372700206   -1.94083e-05   5.00420e-05 DIIS
-   @DF-RHF iter   6:   -76.02662505700734   -1.33001e-06   8.25567e-06 DIIS
-   @DF-RHF iter   7:   -76.02662508949743   -3.24901e-08   1.01817e-06 DIIS
-   @DF-RHF iter   8:   -76.02662508994646   -4.49035e-10   1.74414e-07 DIIS
-   @DF-RHF iter   9:   -76.02662508995832   -1.18519e-11   1.92345e-08 DIIS
-   @DF-RHF iter  10:   -76.02662508995840   -8.52651e-14   1.76309e-09 DIIS
+   @DF-RHF iter   0:   -76.12564395142743   -7.61256e+01   1.23687e-01 
+   @DF-RHF iter   1:   -75.97447353964155    1.51170e-01   3.29044e-02 
+   @DF-RHF iter   2:   -76.01644309143589   -4.19696e-02   1.53697e-02 DIIS
+   @DF-RHF iter   3:   -76.02609796328238   -9.65487e-03   3.00684e-03 DIIS
+   @DF-RHF iter   4:   -76.02695148987674   -8.53527e-04   5.98574e-04 DIIS
+   @DF-RHF iter   5:   -76.02702169380814   -7.02039e-05   1.36151e-04 DIIS
+   @DF-RHF iter   6:   -76.02702427818613   -2.58438e-06   2.08582e-05 DIIS
+   @DF-RHF iter   7:   -76.02702438821565   -1.10030e-07   4.25154e-06 DIIS
+   @DF-RHF iter   8:   -76.02702439103354   -2.81788e-09   5.56908e-07 DIIS
+   @DF-RHF iter   9:   -76.02702439107210   -3.85683e-11   5.16578e-08 DIIS
+   @DF-RHF iter  10:   -76.02702439107229   -1.84741e-13   7.09349e-09 DIIS
   Energy converged.
 
 
@@ -1674,31 +1674,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1Ap   -20.550924     2Ap    -1.335315     3Ap    -0.697804  
-       4Ap    -0.566085     1App   -0.492948  
+       1Ap   -20.548431     2Ap    -1.342279     3Ap    -0.705445  
+       4Ap    -0.568386     1App   -0.493918  
 
     Virtual:                                                              
 
-       5Ap     0.185105     6Ap     0.255847     7Ap     0.787295  
-       8Ap     0.851875     9Ap     1.163850     2App    1.200420  
-      10Ap     1.253581    11Ap     1.445293     3App    1.476016  
-       4App    1.674663    12Ap     1.868110    13Ap     1.932579  
-      14Ap     2.445954    15Ap     2.484412     5App    3.283886  
-       6App    3.336747    16Ap     3.507640    17Ap     3.863403  
-      18Ap     4.144784  
+       5Ap     0.187418     6Ap     0.257808     7Ap     0.797687  
+       8Ap     0.864442     9Ap     1.162766     2App    1.200468  
+      10Ap     1.252697    11Ap     1.444304     3App    1.479258  
+       4App    1.678117    12Ap     1.865535    13Ap     1.947189  
+      14Ap     2.478983    15Ap     2.519072     5App    3.295454  
+       6App    3.350806    16Ap     3.525288    17Ap     3.879535  
+      18Ap     4.159770  
 
     Final Occupation by Irrep:
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.02662508995840
+  @DF-RHF Final Energy:   -76.02702439107229
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1682287308644845
-    One-Electron Energy =                -123.1035548200775622
-    Two-Electron Energy =                  37.9087009992546768
-    Total Energy =                        -76.0266250899584008
+    Nuclear Repulsion Energy =              9.3008839450845802
+    One-Electron Energy =                -123.3389014704243323
+    Two-Electron Energy =                  38.0109931342674798
+    Total Energy =                        -76.0270243910722741
 
 Computation Completed
 
@@ -1708,30 +1708,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0027      Z:     0.9783
+     X:     0.0000      Y:     0.0027      Z:     0.9630
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0015      Z:    -0.1680
+     X:     0.0000      Y:    -0.0014      Z:    -0.1587
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0012      Z:     0.8103     Total:     0.8103
+     X:     0.0000      Y:     0.0012      Z:     0.8044     Total:     0.8044
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0031      Z:     2.0595     Total:     2.0595
+     X:     0.0000      Y:     0.0032      Z:     2.0445     Total:     2.0445
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:06 2018
+*** tstop() called on dream at Wed Oct 17 21:44:06 2018
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.81 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.93 seconds =       0.05 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      16.14 seconds =       0.27 minutes
+	system time =       0.97 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:06 2018
+*** at Wed Oct 17 21:44:06 2018
 
 
          ------------------------------------------------------------
@@ -1749,11 +1749,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000    -0.000178786729    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.757643253225     0.520854514300     1.007825032070
-         H            0.000000000000     0.760480728363     0.523051522291     1.007825032070
+         O            0.000000000000    -0.000178920260    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.747396040358     0.512703679261     1.007825032070
+         H            0.000000000000     0.750235634724     0.514897601999     1.007825032070
 
-  Nuclear repulsion =    9.168228730864485
+  Nuclear repulsion =    9.300883945084580
 
   ==> Basis Set <==
 
@@ -1771,8 +1771,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -1791,20 +1791,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003305710470    -0.017624072787
-       2        0.000000000000    -0.010774931247     0.007532819991
-       3        0.000000000000     0.014080641717     0.010091252796
+       1        0.000000000000    -0.003631065976     0.000019611943
+       2        0.000000000000     0.001828417940    -0.001412520391
+       3        0.000000000000     0.001802648035     0.001392908448
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:06 2018
+*** tstop() called on dream at Wed Oct 17 21:44:06 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.05 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.05 seconds =       0.05 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      17.19 seconds =       0.29 minutes
+	system time =       1.04 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
@@ -1812,7 +1812,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:06 2018
+*** at Wed Oct 17 21:44:06 2018
 
    => Loading Basis Set <=
 
@@ -1828,7 +1828,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1840,15 +1840,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.748815837541     0.513800640630     1.007825032070
+         H            0.000000000000     0.748815837541     0.513800640630     1.007825032070
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
-  Rotational constants: A = 817323.21137  B = 435158.60148  C = 283968.37540 [MHz]
-  Nuclear repulsion =    9.168193296424349
+  Rotational constants: A =     28.13498  B =     14.91528  C =      9.74770 [cm^-1]
+  Rotational constants: A = 843465.60301  B = 447148.74918  C = 292228.72713 [MHz]
+  Nuclear repulsion =    9.300846940321930
 
   Charge       = 0
   Multiplicity = 1
@@ -1907,7 +1907,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1924,7 +1924,7 @@ gradient() will perform analytic gradient computation.
     Spherical Harmonics?: true
     Max angular momentum: 3
 
-  Minimum eigenvalue in the overlap matrix is 3.4377086613E-02.
+  Minimum eigenvalue in the overlap matrix is 3.3424849922E-02.
   Using Symmetric Orthogonalization.
 
   SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
@@ -1933,17 +1933,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.97345163006347   -7.59735e+01   1.21984e-01 
-   @DF-RHF iter   1:   -75.99199115726702   -1.85395e-02   2.06083e-02 
-   @DF-RHF iter   2:   -76.01906078469820   -2.70696e-02   1.03784e-02 DIIS
-   @DF-RHF iter   3:   -76.02620700522111   -7.14622e-03   1.55130e-03 DIIS
-   @DF-RHF iter   4:   -76.02658850207993   -3.81497e-04   4.43026e-04 DIIS
-   @DF-RHF iter   5:   -76.02663012198339   -4.16199e-05   9.43404e-05 DIIS
-   @DF-RHF iter   6:   -76.02663266836080   -2.54638e-06   1.49995e-05 DIIS
-   @DF-RHF iter   7:   -76.02663273428202   -6.59212e-08   1.92575e-06 DIIS
-   @DF-RHF iter   8:   -76.02663273509880   -8.16783e-10   3.41824e-07 DIIS
-   @DF-RHF iter   9:   -76.02663273512229   -2.34905e-11   2.82526e-08 DIIS
-   @DF-RHF iter  10:   -76.02663273512246   -1.70530e-13   3.50369e-09 DIIS
+   @DF-RHF iter   0:   -76.03759341975142   -7.60376e+01   1.46380e-01 
+   @DF-RHF iter   1:   -75.98183490128710    5.57585e-02   3.61791e-02 
+   @DF-RHF iter   2:   -76.01761697958418   -3.57821e-02   1.80359e-02 DIIS
+   @DF-RHF iter   3:   -76.02640416475506   -8.78719e-03   2.52344e-03 DIIS
+   @DF-RHF iter   4:   -76.02697780728666   -5.73643e-04   6.17325e-04 DIIS
+   @DF-RHF iter   5:   -76.02703059342042   -5.27861e-05   1.57051e-04 DIIS
+   @DF-RHF iter   6:   -76.02703270187085   -2.10845e-06   2.85402e-05 DIIS
+   @DF-RHF iter   7:   -76.02703278164145   -7.97706e-08   4.51326e-06 DIIS
+   @DF-RHF iter   8:   -76.02703278367656   -2.03511e-09   7.24111e-07 DIIS
+   @DF-RHF iter   9:   -76.02703278371219   -3.56266e-11   5.32153e-08 DIIS
+   @DF-RHF iter  10:   -76.02703278371227   -8.52651e-14   5.77622e-09 DIIS
   Energy converged.
 
 
@@ -1954,31 +1954,31 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A1   -20.550925     2A1    -1.335311     1B2    -0.697803  
-       3A1    -0.566087     1B1    -0.492948  
+       1A1   -20.548431     2A1    -1.342275     1B2    -0.705443  
+       3A1    -0.568387     1B1    -0.493917  
 
     Virtual:                                                              
 
-       4A1     0.185107     2B2     0.255846     3B2     0.787336  
-       5A1     0.851826     6A1     1.163855     2B1     1.200424  
-       4B2     1.253573     7A1     1.445291     1A2     1.476011  
-       3B1     1.674661     8A1     1.868110     5B2     1.932579  
-       6B2     2.446529     9A1     2.483817     4B1     3.283958  
-       2A2     3.336669    10A1     3.507634    11A1     3.863421  
-       7B2     4.144760  
+       4A1     0.187420     2B2     0.257808     3B2     0.797730  
+       5A1     0.864391     6A1     1.162772     2B1     1.200473  
+       4B2     1.252689     7A1     1.444301     1A2     1.479253  
+       3B1     1.678115     8A1     1.865535     5B2     1.947189  
+       6B2     2.479567     9A1     2.518469     4B1     3.295526  
+       2A2     3.350729    10A1     3.525283    11A1     3.879553  
+       7B2     4.159744  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02663273512246
+  @DF-RHF Final Energy:   -76.02703278371227
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1681932964243487
-    One-Electron Energy =                -123.1035072040179301
-    Two-Electron Energy =                  37.9086811724711268
-    Total Energy =                        -76.0266327351224618
+    Nuclear Repulsion Energy =              9.3008469403219305
+    One-Electron Energy =                -123.3388522427659808
+    Two-Electron Energy =                  38.0109725187317835
+    Total Energy =                        -76.0270327837122579
 
 Computation Completed
 
@@ -1988,30 +1988,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9783
+     X:     0.0000      Y:     0.0000      Z:     0.9630
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.1680
+     X:     0.0000      Y:     0.0000      Z:    -0.1587
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.8103     Total:     0.8103
+     X:     0.0000      Y:     0.0000      Z:     0.8044     Total:     0.8044
 
   Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.0595     Total:     2.0595
+     X:     0.0000      Y:     0.0000      Z:     2.0445     Total:     2.0445
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:06 2018
+*** tstop() called on dream at Wed Oct 17 21:44:07 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.83 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.44 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      19.05 seconds =       0.32 minutes
+	system time =       1.15 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:06 2018
+*** at Wed Oct 17 21:44:07 2018
 
 
          ------------------------------------------------------------
@@ -2029,11 +2029,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.065775570538    15.994914619560
-         H            0.000000000000    -0.759061990794     0.521953018295     1.007825032070
-         H            0.000000000000     0.759061990794     0.521953018295     1.007825032070
+         O            0.000000000000     0.000000000000    -0.064748222724    15.994914619560
+         H            0.000000000000    -0.748815837541     0.513800640630     1.007825032070
+         H            0.000000000000     0.748815837541     0.513800640630     1.007825032070
 
-  Nuclear repulsion =    9.168193296424349
+  Nuclear repulsion =    9.300846940321930
 
   ==> Basis Set <==
 
@@ -2051,8 +2051,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2071,20 +2071,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.017641624495
-       2        0.000000000000    -0.012438412634     0.008820812248
-       3       -0.000000000000     0.012438412634     0.008820812248
+       1       -0.000000000000     0.000000000000     0.000000517151
+       2       -0.000000000000     0.000001302824    -0.000000258576
+       3        0.000000000000    -0.000001302824    -0.000000258576
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:06 2018
+*** tstop() called on dream at Wed Oct 17 21:44:07 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.03 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.56 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      20.08 seconds =       0.33 minutes
+	system time =       1.24 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -2113,101 +2113,101 @@ Total time:
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '1809.2459'
- '3923.1507' '4020.1808']
+  pre-proj  low-frequency mode:    0.0001  [cm^-1]
+  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0001' '1776.1550'
+ '4113.6950' '4212.1246']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
-  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
-  post-proj  all modes:['0.0001i' '0.0001i' '0.0000i' '0.0000' '0.0000' '0.0001' '1809.2459'
- '3923.1507' '4020.1808']
+  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
+  post-proj  all modes:['0.0001i' '0.0000i' '0.0000' '0.0000' '0.0001' '0.0001' '1776.1550'
+ '4113.6950' '4212.1246']
 
   Vibration                       7                   8                   9           
-  Freq [cm^-1]                1809.2459           3923.1507           4020.1808       
+  Freq [cm^-1]                1776.1550           4113.6950           4212.1246       
   Irrep                           A1                  A1                  B2          
-  Reduced mass [u]              1.0818              1.0460              1.0819        
-  Force const [mDyne/A]         2.0864              9.4849             10.3017        
-  Turning point v=0 [a0]        0.2480              0.1713              0.1664        
-  RMS dev v=0 [a0 u^1/2]        0.1824              0.1239              0.1224        
-  Char temp [K]               2603.1021           5644.5405           5784.1450       
+  Reduced mass [u]              1.0817              1.0461              1.0820        
+  Force const [mDyne/A]         2.0106             10.4297             11.3102        
+  Turning point v=0 [a0]        0.2503              0.1673              0.1625        
+  RMS dev v=0 [a0 u^1/2]        0.1841              0.1210              0.1195        
+  Char temp [K]               2555.4916           5918.6912           6060.3094       
   ----------------------------------------------------------------------------------
-      1   O               -0.00  0.00 -0.07   -0.00  0.00  0.05    0.00 -0.07 -0.00   
-      2   H                0.00  0.43  0.56    0.00  0.58 -0.40   -0.00  0.56 -0.43   
-      3   H                0.00 -0.43  0.56    0.00 -0.58 -0.40   -0.00  0.56  0.43   
+      1   O               -0.00 -0.00 -0.07    0.00  0.00  0.05   -0.00 -0.07  0.00   
+      2   H               -0.00  0.43  0.56   -0.00  0.58 -0.40    0.00  0.56 -0.43   
+      3   H                0.00 -0.43  0.56   -0.00 -0.58 -0.40   -0.00  0.56  0.43   
 
   ==> Thermochemistry Components <==
 
   Entropy, S
     Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
     Translational S        34.608 [cal/(mol K)]      144.801 [J/(mol K)]       0.05515177 [mEh/K] (mol. weight = 18.0106 [u], P = 101325.00 [Pa])
-    Rotational S           10.463 [cal/(mol K)]       43.779 [J/(mol K)]       0.01667445 [mEh/K] (symmetry no. = 2)
-    Vibrational S           0.003 [cal/(mol K)]        0.013 [J/(mol K)]       0.00000498 [mEh/K]
-  Total S                  45.075 [cal/(mol K)]      188.593 [J/(mol K)]       0.07183120 [mEh/K]
+    Rotational S           10.377 [cal/(mol K)]       43.416 [J/(mol K)]       0.01653616 [mEh/K] (symmetry no. = 2)
+    Vibrational S           0.004 [cal/(mol K)]        0.015 [J/(mol K)]       0.00000574 [mEh/K]
+  Total S                  44.988 [cal/(mol K)]      188.232 [J/(mol K)]       0.07169367 [mEh/K]
   Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant volume heat capacity, Cv
     Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
     Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
     Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
-    Vibrational Cv          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
-  Total Cv                  5.986 [cal/(mol K)]       25.046 [J/(mol K)]       0.00953945 [mEh/K]
+    Vibrational Cv          0.028 [cal/(mol K)]        0.116 [J/(mol K)]       0.00004411 [mEh/K]
+  Total Cv                  5.989 [cal/(mol K)]       25.059 [J/(mol K)]       0.00954454 [mEh/K]
   Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   Constant pressure heat capacity, Cp
     Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
     Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
     Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
-    Vibrational Cp          0.024 [cal/(mol K)]        0.102 [J/(mol K)]       0.00003902 [mEh/K]
-  Total Cp                  7.973 [cal/(mol K)]       33.360 [J/(mol K)]       0.01270626 [mEh/K]
+    Vibrational Cp          0.028 [cal/(mol K)]        0.116 [J/(mol K)]       0.00004411 [mEh/K]
+  Total Cp                  7.976 [cal/(mol K)]       33.374 [J/(mol K)]       0.01271135 [mEh/K]
   Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
 
   ==> Thermochemistry Energy Analysis <==
 
   Raw electronic energy, E0
-  Total E0, Electronic energy at well bottom at 0 [K]                  -76.02663274 [Eh]
+  Total E0, Electronic energy at well bottom at 0 [K]                  -76.02703278 [Eh]
 
   Zero-point energy, ZPE_vib = Sum_i nu_i / 2
     Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Vibrational ZPE        13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.289 [cm^-1]
-  Correction ZPE           13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221801 [Eh]        4876.289 [cm^-1]
-  Total ZPE, Electronic energy at 0 [K]                                -76.00441473 [Eh]
+    Vibrational ZPE        14.441 [kcal/mol]       60.423 [kJ/mol]       0.02301399 [Eh]        5050.987 [cm^-1]
+  Correction ZPE           14.441 [kcal/mol]       60.423 [kJ/mol]       0.02301399 [Eh]        5050.987 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.00401879 [Eh]
 
   Thermal Energy, E (includes ZPE)
     Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational E          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
-  Correction E             15.720 [kcal/mol]       65.774 [kJ/mol]       0.02505189 [Eh]
-  Total E, Electronic energy at  298.15 [K]                            -76.00158084 [Eh]
+    Vibrational E          14.442 [kcal/mol]       60.427 [kJ/mol]       0.02301553 [Eh]
+  Correction E             16.220 [kcal/mol]       67.864 [kJ/mol]       0.02584808 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.00118471 [Eh]
 
   Enthalpy, H_trans = E_trans + k_B * T
     Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
     Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational H          13.943 [kcal/mol]       58.337 [kJ/mol]       0.02221934 [Eh]
-  Correction H             16.313 [kcal/mol]       68.253 [kJ/mol]       0.02599608 [Eh]
-  Total H, Enthalpy at  298.15 [K]                                     -76.00063666 [Eh]
+    Vibrational H          14.442 [kcal/mol]       60.427 [kJ/mol]       0.02301553 [Eh]
+  Correction H             16.812 [kcal/mol]       70.343 [kJ/mol]       0.02679226 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.00024052 [Eh]
 
   Gibbs free energy, G = H - T * S
     Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408304 [Eh]
-    Rotational G           -2.231 [kcal/mol]       -9.334 [kJ/mol]      -0.00355521 [Eh]
-    Vibrational G          13.942 [kcal/mol]       58.333 [kJ/mol]       0.02221785 [Eh]
-  Correction G              2.874 [kcal/mol]       12.024 [kJ/mol]       0.00457960 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                                -76.02205313 [Eh]
+    Rotational G           -2.205 [kcal/mol]       -9.226 [kJ/mol]      -0.00351398 [Eh]
+    Vibrational G          14.441 [kcal/mol]       60.423 [kJ/mol]       0.02301381 [Eh]
+  Correction G              3.399 [kcal/mol]       14.222 [kJ/mol]       0.00541679 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.02161599 [Eh]
 	SCF/cc-pVDZ Frequency 1...........................................PASSED
 	SCF/cc-pVDZ Frequency 2...........................................PASSED
 	SCF/cc-pVDZ Frequency 3...........................................PASSED
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:06 2018
+*** at Wed Oct 17 21:44:07 2018
 
    => Loading Basis Set <=
 
@@ -2223,7 +2223,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2302,7 +2302,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2328,17 +2328,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94710806905404   -7.59471e+01   5.55730e-02 
-   @DF-RHF iter   1:   -76.03440231261533   -8.72942e-02   7.81576e-03 
-   @DF-RHF iter   2:   -76.05209349341780   -1.76912e-02   4.21713e-03 DIIS
-   @DF-RHF iter   3:   -76.05749806224043   -5.40457e-03   5.87784e-04 DIIS
-   @DF-RHF iter   4:   -76.05773197621663   -2.33914e-04   1.57910e-04 DIIS
-   @DF-RHF iter   5:   -76.05776122366373   -2.92474e-05   3.76317e-05 DIIS
-   @DF-RHF iter   6:   -76.05776307194347   -1.84828e-06   6.25426e-06 DIIS
-   @DF-RHF iter   7:   -76.05776311756114   -4.56177e-08   9.14904e-07 DIIS
-   @DF-RHF iter   8:   -76.05776311852399   -9.62856e-10   1.34231e-07 DIIS
-   @DF-RHF iter   9:   -76.05776311854618   -2.21831e-11   2.37416e-08 DIIS
-   @DF-RHF iter  10:   -76.05776311854677   -5.96856e-13   2.54948e-09 DIIS
+   @DF-RHF iter   0:   -75.94710806905320   -7.59471e+01   8.77799e-02 
+   @DF-RHF iter   1:   -76.03440231261433   -8.72942e-02   1.48414e-02 
+   @DF-RHF iter   2:   -76.05209349341675   -1.76912e-02   6.58670e-03 DIIS
+   @DF-RHF iter   3:   -76.05749806223936   -5.40457e-03   1.13068e-03 DIIS
+   @DF-RHF iter   4:   -76.05773197621565   -2.33914e-04   2.86568e-04 DIIS
+   @DF-RHF iter   5:   -76.05776122366271   -2.92474e-05   7.23897e-05 DIIS
+   @DF-RHF iter   6:   -76.05776307194246   -1.84828e-06   1.20309e-05 DIIS
+   @DF-RHF iter   7:   -76.05776311756007   -4.56176e-08   1.75994e-06 DIIS
+   @DF-RHF iter   8:   -76.05776311852294   -9.62871e-10   2.19942e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854510   -2.21547e-11   4.62809e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854567   -5.68434e-13   4.90427e-09 DIIS
   Energy converged.
 
 
@@ -2377,14 +2377,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05776311854677
+  @DF-RHF Final Energy:   -76.05776311854567
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3536778397526081
-    One-Electron Energy =                -123.4037989783759031
-    Two-Electron Energy =                  37.9923580200765230
-    Total Energy =                        -76.0577631185467737
+    One-Electron Energy =                -123.4037989783746525
+    Two-Electron Energy =                  37.9923580200763809
+    Total Energy =                        -76.0577631185456653
 
 Computation Completed
 
@@ -2406,18 +2406,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:07 2018
+*** tstop() called on dream at Wed Oct 17 21:44:08 2018
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.06 seconds =       0.07 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      22.26 seconds =       0.37 minutes
+	system time =       1.35 seconds =       0.02 minutes
+	total time  =          7 seconds =       0.12 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:07 2018
+*** at Wed Oct 17 21:44:08 2018
 
 
          ------------------------------------------------------------
@@ -2457,8 +2457,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2477,22 +2477,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.000000202204
-       2       -0.000000000000     0.000000176416    -0.000000101102
-       3        0.000000000000    -0.000000176416    -0.000000101102
+       1       -0.000000000000     0.000000000000     0.000000202136
+       2       -0.000000000000     0.000000176370    -0.000000101068
+       3        0.000000000000    -0.000000176370    -0.000000101068
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:07 2018
+*** tstop() called on dream at Wed Oct 17 21:44:08 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.79 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.29 seconds =       0.07 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      24.06 seconds =       0.40 minutes
+	system time =       1.48 seconds =       0.02 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-  Based on options and gradient (rms=1.17E-07), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=1.43E-07), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -2531,7 +2531,7 @@ hessian() will perform frequency computation by finite difference of analytic gr
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:07 2018
+*** at Wed Oct 17 21:44:08 2018
 
    => Loading Basis Set <=
 
@@ -2547,7 +2547,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2626,7 +2626,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2652,17 +2652,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94771312648975   -7.59477e+01   5.54485e-02 
-   @DF-RHF iter   1:   -76.03449412772294   -8.67810e-02   7.78131e-03 
-   @DF-RHF iter   2:   -76.05212839025712   -1.76343e-02   4.18818e-03 DIIS
-   @DF-RHF iter   3:   -76.05748030095769   -5.35191e-03   5.99208e-04 DIIS
-   @DF-RHF iter   4:   -76.05772619523374   -2.45894e-04   1.62144e-04 DIIS
-   @DF-RHF iter   5:   -76.05775744410293   -3.12489e-05   3.85157e-05 DIIS
-   @DF-RHF iter   6:   -76.05775939110492   -1.94700e-06   6.31205e-06 DIIS
-   @DF-RHF iter   7:   -76.05775943736855   -4.62636e-08   9.23351e-07 DIIS
-   @DF-RHF iter   8:   -76.05775943834824   -9.79696e-10   1.36615e-07 DIIS
-   @DF-RHF iter   9:   -76.05775943837114   -2.28937e-11   2.39606e-08 DIIS
-   @DF-RHF iter  10:   -76.05775943837179   -6.53699e-13   2.57612e-09 DIIS
+   @DF-RHF iter   0:   -75.94771312648845   -7.59477e+01   1.08089e-01 
+   @DF-RHF iter   1:   -76.03449412772163   -8.67810e-02   1.51686e-02 
+   @DF-RHF iter   2:   -76.05212839025569   -1.76343e-02   7.69077e-03 DIIS
+   @DF-RHF iter   3:   -76.05748030095626   -5.35191e-03   8.99952e-04 DIIS
+   @DF-RHF iter   4:   -76.05772619523241   -2.45894e-04   3.11905e-04 DIIS
+   @DF-RHF iter   5:   -76.05775744410150   -3.12489e-05   7.86397e-05 DIIS
+   @DF-RHF iter   6:   -76.05775939110356   -1.94700e-06   1.21421e-05 DIIS
+   @DF-RHF iter   7:   -76.05775943736718   -4.62636e-08   1.77619e-06 DIIS
+   @DF-RHF iter   8:   -76.05775943834689   -9.79711e-10   2.66311e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943836981   -2.29221e-11   3.88920e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943837031   -4.97380e-13   4.22105e-09 DIIS
   Energy converged.
 
 
@@ -2701,14 +2701,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775943837179
+  @DF-RHF Final Energy:   -76.05775943837031
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3422901899288355
-    One-Electron Energy =                -123.3832394150091432
-    Two-Electron Energy =                  37.9831897867085289
-    Total Energy =                        -76.0577594383717894
+    One-Electron Energy =                -123.3832394150081768
+    Two-Electron Energy =                  37.9831897867090333
+    Total Energy =                        -76.0577594383703115
 
 Computation Completed
 
@@ -2730,18 +2730,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9919     Total:     1.9919
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:08 2018
+*** tstop() called on dream at Wed Oct 17 21:44:09 2018
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.20 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.76 seconds =       0.08 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      26.28 seconds =       0.44 minutes
+	system time =       1.59 seconds =       0.03 minutes
+	total time  =          8 seconds =       0.13 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:08 2018
+*** at Wed Oct 17 21:44:09 2018
 
 
          ------------------------------------------------------------
@@ -2781,8 +2781,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -2801,20 +2801,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.001968921400
-       2        0.000000000000    -0.000882091432     0.000984460700
-       3       -0.000000000000     0.000882091432     0.000984460700
+       1       -0.000000000000     0.000000000000    -0.001968921413
+       2        0.000000000000    -0.000882091440     0.000984460706
+       3       -0.000000000000     0.000882091440     0.000984460706
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:08 2018
+*** tstop() called on dream at Wed Oct 17 21:44:09 2018
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.65 seconds =       0.03 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.01 seconds =       0.08 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      27.93 seconds =       0.47 minutes
+	system time =       1.74 seconds =       0.03 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
@@ -2822,7 +2822,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:08 2018
+*** at Wed Oct 17 21:44:09 2018
 
    => Loading Basis Set <=
 
@@ -2838,7 +2838,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2917,7 +2917,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2943,17 +2943,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.15632858869085   -7.61563e+01   5.71281e-02 
-   @DF-RHF iter   1:   -76.00802144470848    1.48307e-01   1.08138e-02 
-   @DF-RHF iter   2:   -76.04635842343876   -3.83370e-02   5.82368e-03 DIIS
-   @DF-RHF iter   3:   -76.05688043052886   -1.05220e-02   1.05060e-03 DIIS
-   @DF-RHF iter   4:   -76.05766781967779   -7.87389e-04   2.83398e-04 DIIS
-   @DF-RHF iter   5:   -76.05775566669494   -8.78470e-05   5.34448e-05 DIIS
-   @DF-RHF iter   6:   -76.05775933688983   -3.67019e-06   8.64509e-06 DIIS
-   @DF-RHF iter   7:   -76.05775942767872   -9.07889e-08   1.53605e-06 DIIS
-   @DF-RHF iter   8:   -76.05775943065763   -2.97891e-09   2.53154e-07 DIIS
-   @DF-RHF iter   9:   -76.05775943074761   -8.99831e-11   3.53981e-08 DIIS
-   @DF-RHF iter  10:   -76.05775943074882   -1.20792e-12   3.29515e-09 DIIS
+   @DF-RHF iter   0:   -76.15632858868942   -7.61563e+01   1.03673e-01 
+   @DF-RHF iter   1:   -76.00802144470698    1.48307e-01   2.10800e-02 
+   @DF-RHF iter   2:   -76.04635842343727   -3.83370e-02   1.13524e-02 DIIS
+   @DF-RHF iter   3:   -76.05688043052731   -1.05220e-02   2.02098e-03 DIIS
+   @DF-RHF iter   4:   -76.05766781967623   -7.87389e-04   5.14298e-04 DIIS
+   @DF-RHF iter   5:   -76.05775566669331   -8.78470e-05   1.00573e-04 DIIS
+   @DF-RHF iter   6:   -76.05775933688814   -3.67019e-06   1.66300e-05 DIIS
+   @DF-RHF iter   7:   -76.05775942767708   -9.07889e-08   3.01762e-06 DIIS
+   @DF-RHF iter   8:   -76.05775943065602   -2.97894e-09   4.86976e-07 DIIS
+   @DF-RHF iter   9:   -76.05775943074605   -9.00258e-11   6.90036e-08 DIIS
+   @DF-RHF iter  10:   -76.05775943074732   -1.27898e-12   6.33867e-09 DIIS
   Energy converged.
 
 
@@ -2992,14 +2992,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775943074882
+  @DF-RHF Final Energy:   -76.05775943074732
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3650689323591312
-    One-Electron Energy =                -123.4243510372807151
-    Two-Electron Energy =                  38.0015226741727545
-    Total Energy =                        -76.0577594307488312
+    One-Electron Energy =                -123.4243510372795498
+    Two-Electron Energy =                  38.0015226741730956
+    Total Energy =                        -76.0577594307473248
 
 Computation Completed
 
@@ -3021,18 +3021,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9838     Total:     1.9838
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:08 2018
+*** tstop() called on dream at Wed Oct 17 21:44:10 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.48 seconds =       0.09 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      30.10 seconds =       0.50 minutes
+	system time =       1.87 seconds =       0.03 minutes
+	total time  =          9 seconds =       0.15 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:08 2018
+*** at Wed Oct 17 21:44:10 2018
 
 
          ------------------------------------------------------------
@@ -3072,8 +3072,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3092,20 +3092,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.001974206990
-       2       -0.000000000000     0.000891429066    -0.000987103495
-       3        0.000000000000    -0.000891429066    -0.000987103495
+       1        0.000000000000     0.000000000000     0.001974206999
+       2       -0.000000000000     0.000891429065    -0.000987103500
+       3        0.000000000000    -0.000891429065    -0.000987103500
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:09 2018
+*** tstop() called on dream at Wed Oct 17 21:44:10 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       5.71 seconds =       0.10 minutes
+	user time   =       1.72 seconds =       0.03 minutes
 	system time =       0.09 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      31.82 seconds =       0.53 minutes
+	system time =       1.96 seconds =       0.03 minutes
+	total time  =          9 seconds =       0.15 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
@@ -3113,7 +3113,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:09 2018
+*** at Wed Oct 17 21:44:10 2018
 
    => Loading Basis Set <=
 
@@ -3129,7 +3129,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3208,7 +3208,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3234,17 +3234,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94431044536876   -7.59443e+01   5.53915e-02 
-   @DF-RHF iter   1:   -76.03444180637402   -9.01314e-02   7.80634e-03 
-   @DF-RHF iter   2:   -76.05208941305065   -1.76476e-02   4.21522e-03 DIIS
-   @DF-RHF iter   3:   -76.05749253786567   -5.40312e-03   5.87875e-04 DIIS
-   @DF-RHF iter   4:   -76.05772611231714   -2.33574e-04   1.57917e-04 DIIS
-   @DF-RHF iter   5:   -76.05775540492598   -2.92926e-05   3.76911e-05 DIIS
-   @DF-RHF iter   6:   -76.05775726181093   -1.85688e-06   6.28296e-06 DIIS
-   @DF-RHF iter   7:   -76.05775730799206   -4.61811e-08   9.20997e-07 DIIS
-   @DF-RHF iter   8:   -76.05775730897115   -9.79085e-10   1.35317e-07 DIIS
-   @DF-RHF iter   9:   -76.05775730899370   -2.25526e-11   2.38841e-08 DIIS
-   @DF-RHF iter  10:   -76.05775730899431   -6.11067e-13   2.56587e-09 DIIS
+   @DF-RHF iter   0:   -75.94431044536664   -7.59443e+01   1.06553e-01 
+   @DF-RHF iter   1:   -76.03444180637186   -9.01314e-02   1.41666e-02 
+   @DF-RHF iter   2:   -76.05208941304856   -1.76476e-02   6.77902e-03 DIIS
+   @DF-RHF iter   3:   -76.05749253786345   -5.40312e-03   9.18198e-04 DIIS
+   @DF-RHF iter   4:   -76.05772611231488   -2.33574e-04   2.53966e-04 DIIS
+   @DF-RHF iter   5:   -76.05775540492378   -2.92926e-05   7.44830e-05 DIIS
+   @DF-RHF iter   6:   -76.05775726180883   -1.85689e-06   1.10921e-05 DIIS
+   @DF-RHF iter   7:   -76.05775730798977   -4.61809e-08   1.77166e-06 DIIS
+   @DF-RHF iter   8:   -76.05775730896890   -9.79128e-10   2.67405e-07 DIIS
+   @DF-RHF iter   9:   -76.05775730899144   -2.25384e-11   4.59443e-08 DIIS
+   @DF-RHF iter  10:   -76.05775730899208   -6.39488e-13   4.12649e-09 DIIS
   Energy converged.
 
 
@@ -3283,14 +3283,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775730899431
+  @DF-RHF Final Energy:   -76.05775730899208
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3385787618962244
-    One-Electron Energy =                -123.3776178697813322
-    Two-Electron Energy =                  37.9812817988908051
-    Total Energy =                        -76.0577573089942973
+    One-Electron Energy =                -123.3776178697794279
+    Two-Electron Energy =                  37.9812817988911107
+    Total Energy =                        -76.0577573089920804
 
 Computation Completed
 
@@ -3312,18 +3312,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9869     Total:     1.9869
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:09 2018
+*** tstop() called on dream at Wed Oct 17 21:44:11 2018
 Module time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.21 seconds =       0.10 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      33.99 seconds =       0.57 minutes
+	system time =       2.08 seconds =       0.03 minutes
+	total time  =         10 seconds =       0.17 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:09 2018
+*** at Wed Oct 17 21:44:11 2018
 
 
          ------------------------------------------------------------
@@ -3363,8 +3363,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3383,20 +3383,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000    -0.001659360505
-       2        0.000000000000    -0.001647519526     0.000829680253
-       3       -0.000000000000     0.001647519526     0.000829680253
+       1       -0.000000000000     0.000000000000    -0.001659360494
+       2        0.000000000000    -0.001647519522     0.000829680247
+       3       -0.000000000000     0.001647519522     0.000829680247
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:09 2018
+*** tstop() called on dream at Wed Oct 17 21:44:11 2018
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.72 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.45 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      35.72 seconds =       0.60 minutes
+	system time =       2.16 seconds =       0.04 minutes
+	total time  =         10 seconds =       0.17 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
@@ -3404,7 +3404,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:09 2018
+*** at Wed Oct 17 21:44:11 2018
 
    => Loading Basis Set <=
 
@@ -3420,7 +3420,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3499,7 +3499,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3525,17 +3525,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94990589536215   -7.59499e+01   5.57551e-02 
-   @DF-RHF iter   1:   -76.03435072618467   -8.44448e-02   7.82527e-03 
-   @DF-RHF iter   2:   -76.05208576850603   -1.77350e-02   4.21911e-03 DIIS
-   @DF-RHF iter   3:   -76.05749193309475   -5.40616e-03   5.87695e-04 DIIS
-   @DF-RHF iter   4:   -76.05772618750154   -2.34254e-04   1.57901e-04 DIIS
-   @DF-RHF iter   5:   -76.05775538875244   -2.92013e-05   3.75724e-05 DIIS
-   @DF-RHF iter   6:   -76.05775722846663   -1.83971e-06   6.22575e-06 DIIS
-   @DF-RHF iter   7:   -76.05775727352922   -4.50626e-08   9.08855e-07 DIIS
-   @DF-RHF iter   8:   -76.05775727447620   -9.46983e-10   1.33151e-07 DIIS
-   @DF-RHF iter   9:   -76.05775727449804   -2.18421e-11   2.36002e-08 DIIS
-   @DF-RHF iter  10:   -76.05775727449864   -5.96856e-13   2.53329e-09 DIIS
+   @DF-RHF iter   0:   -75.94990589536162   -7.59499e+01   1.07252e-01 
+   @DF-RHF iter   1:   -76.03435072618399   -8.44448e-02   1.52543e-02 
+   @DF-RHF iter   2:   -76.05208576850545   -1.77350e-02   8.22455e-03 DIIS
+   @DF-RHF iter   3:   -76.05749193309404   -5.40616e-03   1.18259e-03 DIIS
+   @DF-RHF iter   4:   -76.05772618750086   -2.34254e-04   3.12034e-04 DIIS
+   @DF-RHF iter   5:   -76.05775538875176   -2.92013e-05   7.56054e-05 DIIS
+   @DF-RHF iter   6:   -76.05775722846602   -1.83971e-06   1.15112e-05 DIIS
+   @DF-RHF iter   7:   -76.05775727352861   -4.50626e-08   1.44472e-06 DIIS
+   @DF-RHF iter   8:   -76.05775727447551   -9.46898e-10   2.47480e-07 DIIS
+   @DF-RHF iter   9:   -76.05775727449731   -2.17995e-11   4.53981e-08 DIIS
+   @DF-RHF iter  10:   -76.05775727449787   -5.68434e-13   4.87312e-09 DIIS
   Energy converged.
 
 
@@ -3574,14 +3574,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775727449864
+  @DF-RHF Final Energy:   -76.05775727449787
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3688135320991552
-    One-Electron Energy =                -123.4300254710734777
-    Two-Electron Energy =                  38.0034546644756830
-    Total Energy =                        -76.0577572744986412
+    One-Electron Energy =                -123.4300254710731224
+    Two-Electron Energy =                  38.0034546644760951
+    Total Energy =                        -76.0577572744978738
 
 Computation Completed
 
@@ -3603,18 +3603,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9888     Total:     1.9888
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:10 2018
+*** tstop() called on dream at Wed Oct 17 21:44:12 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.12 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.92 seconds =       0.12 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      37.85 seconds =       0.63 minutes
+	system time =       2.31 seconds =       0.04 minutes
+	total time  =         11 seconds =       0.18 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:10 2018
+*** at Wed Oct 17 21:44:12 2018
 
 
          ------------------------------------------------------------
@@ -3654,8 +3654,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3674,20 +3674,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.001683365286
-       2       -0.000000000000     0.001661497450    -0.000841682643
-       3        0.000000000000    -0.001661497450    -0.000841682643
+       1       -0.000000000000     0.000000000000     0.001683365274
+       2       -0.000000000000     0.001661497446    -0.000841682637
+       3        0.000000000000    -0.001661497446    -0.000841682637
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:10 2018
+*** tstop() called on dream at Wed Oct 17 21:44:12 2018
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.72 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.15 seconds =       0.12 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      39.57 seconds =       0.66 minutes
+	system time =       2.42 seconds =       0.04 minutes
+	total time  =         11 seconds =       0.18 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
@@ -3695,7 +3695,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:10 2018
+*** at Wed Oct 17 21:44:12 2018
 
    => Loading Basis Set <=
 
@@ -3711,7 +3711,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3788,7 +3788,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3814,17 +3814,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95011107000234   -7.59501e+01   3.98195e-02 
-   @DF-RHF iter   1:   -76.03446350338616   -8.43524e-02   5.57951e-03 
-   @DF-RHF iter   2:   -76.05213003691352   -1.76665e-02   2.99890e-03 DIIS
-   @DF-RHF iter   3:   -76.05747299224578   -5.34296e-03   4.30708e-04 DIIS
-   @DF-RHF iter   4:   -76.05772122356184   -2.48231e-04   1.16546e-04 DIIS
-   @DF-RHF iter   5:   -76.05775266908324   -3.14455e-05   2.76302e-05 DIIS
-   @DF-RHF iter   6:   -76.05775461933506   -1.95025e-06   4.52113e-06 DIIS
-   @DF-RHF iter   7:   -76.05775466548054   -4.61455e-08   6.61019e-07 DIIS
-   @DF-RHF iter   8:   -76.05775466645756   -9.77010e-10   9.76334e-08 DIIS
-   @DF-RHF iter   9:   -76.05775466648018   -2.26237e-11   1.71172e-08 DIIS
-   @DF-RHF iter  10:   -76.05775466648076   -5.82645e-13   1.86674e-09 DIIS
+   @DF-RHF iter   0:   -75.95011107000217   -7.59501e+01   7.89043e-02 
+   @DF-RHF iter   1:   -76.03446350338592   -8.43524e-02   1.10561e-02 
+   @DF-RHF iter   2:   -76.05213003691331   -1.76665e-02   6.05471e-03 DIIS
+   @DF-RHF iter   3:   -76.05747299224552   -5.34296e-03   8.53467e-04 DIIS
+   @DF-RHF iter   4:   -76.05772122356167   -2.48231e-04   2.30941e-04 DIIS
+   @DF-RHF iter   5:   -76.05775266908310   -3.14455e-05   5.47506e-05 DIIS
+   @DF-RHF iter   6:   -76.05775461933479   -1.95025e-06   8.95884e-06 DIIS
+   @DF-RHF iter   7:   -76.05775466548022   -4.61454e-08   1.30984e-06 DIIS
+   @DF-RHF iter   8:   -76.05775466645721   -9.76996e-10   1.93465e-07 DIIS
+   @DF-RHF iter   9:   -76.05775466647989   -2.26805e-11   3.39185e-08 DIIS
+   @DF-RHF iter  10:   -76.05775466648036   -4.68958e-13   3.69904e-09 DIIS
   Energy converged.
 
 
@@ -3863,14 +3863,14 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775466648076
+  @DF-RHF Final Energy:   -76.05775466648036
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3537155933252496
-    One-Electron Energy =                -123.4038505127613234
-    Two-Electron Energy =                  37.9923802529553143
-    Total Energy =                        -76.0577546664807613
+    One-Electron Energy =                -123.4038505127617213
+    Two-Electron Energy =                  37.9923802529561101
+    Total Energy =                        -76.0577546664803634
 
 Computation Completed
 
@@ -3892,18 +3892,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0035      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:11 2018
+*** tstop() called on dream at Wed Oct 17 21:44:13 2018
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.62 seconds =       0.13 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      41.84 seconds =       0.70 minutes
+	system time =       2.57 seconds =       0.04 minutes
+	total time  =         12 seconds =       0.20 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:11 2018
+*** at Wed Oct 17 21:44:13 2018
 
 
          ------------------------------------------------------------
@@ -3943,8 +3943,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -3963,20 +3963,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003688064202     0.000019110659
-       2        0.000000000000     0.001856013406    -0.001399120672
-       3        0.000000000000     0.001832050796     0.001380010013
+       1        0.000000000000    -0.003688064203     0.000019110672
+       2        0.000000000000     0.001856013411    -0.001399120679
+       3        0.000000000000     0.001832050792     0.001380010007
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:11 2018
+*** tstop() called on dream at Wed Oct 17 21:44:14 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.85 seconds =       0.13 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      43.54 seconds =       0.73 minutes
+	system time =       2.69 seconds =       0.04 minutes
+	total time  =         13 seconds =       0.22 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
@@ -3984,7 +3984,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:11 2018
+*** at Wed Oct 17 21:44:14 2018
 
    => Loading Basis Set <=
 
@@ -4000,7 +4000,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4079,7 +4079,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4105,17 +4105,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94710806905404   -7.59471e+01   5.55730e-02 
-   @DF-RHF iter   1:   -76.03440231261533   -8.72942e-02   7.81576e-03 
-   @DF-RHF iter   2:   -76.05209349341780   -1.76912e-02   4.21713e-03 DIIS
-   @DF-RHF iter   3:   -76.05749806224043   -5.40457e-03   5.87784e-04 DIIS
-   @DF-RHF iter   4:   -76.05773197621663   -2.33914e-04   1.57910e-04 DIIS
-   @DF-RHF iter   5:   -76.05776122366373   -2.92474e-05   3.76317e-05 DIIS
-   @DF-RHF iter   6:   -76.05776307194347   -1.84828e-06   6.25426e-06 DIIS
-   @DF-RHF iter   7:   -76.05776311756114   -4.56177e-08   9.14904e-07 DIIS
-   @DF-RHF iter   8:   -76.05776311852399   -9.62856e-10   1.34231e-07 DIIS
-   @DF-RHF iter   9:   -76.05776311854618   -2.21831e-11   2.37416e-08 DIIS
-   @DF-RHF iter  10:   -76.05776311854677   -5.96856e-13   2.54948e-09 DIIS
+   @DF-RHF iter   0:   -75.94710806905321   -7.59471e+01   1.07103e-01 
+   @DF-RHF iter   1:   -76.03440231261432   -8.72942e-02   1.26863e-02 
+   @DF-RHF iter   2:   -76.05209349341675   -1.76912e-02   7.83813e-03 DIIS
+   @DF-RHF iter   3:   -76.05749806223935   -5.40457e-03   1.16155e-03 DIIS
+   @DF-RHF iter   4:   -76.05773197621569   -2.33914e-04   2.93498e-04 DIIS
+   @DF-RHF iter   5:   -76.05776122366269   -2.92474e-05   7.43656e-05 DIIS
+   @DF-RHF iter   6:   -76.05776307194236   -1.84828e-06   1.20309e-05 DIIS
+   @DF-RHF iter   7:   -76.05776311756013   -4.56178e-08   1.75994e-06 DIIS
+   @DF-RHF iter   8:   -76.05776311852287   -9.62743e-10   2.15874e-07 DIIS
+   @DF-RHF iter   9:   -76.05776311854514   -2.22684e-11   3.89014e-08 DIIS
+   @DF-RHF iter  10:   -76.05776311854569   -5.54223e-13   4.10013e-09 DIIS
   Energy converged.
 
 
@@ -4154,14 +4154,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05776311854677
+  @DF-RHF Final Energy:   -76.05776311854569
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3536778397526081
-    One-Electron Energy =                -123.4037989783759031
-    Two-Electron Energy =                  37.9923580200765230
-    Total Energy =                        -76.0577631185467737
+    One-Electron Energy =                -123.4037989783746667
+    Two-Electron Energy =                  37.9923580200763666
+    Total Energy =                        -76.0577631185456937
 
 Computation Completed
 
@@ -4183,18 +4183,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9878     Total:     1.9878
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:11 2018
+*** tstop() called on dream at Wed Oct 17 21:44:14 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.32 seconds =       0.14 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      45.72 seconds =       0.76 minutes
+	system time =       2.82 seconds =       0.05 minutes
+	total time  =         13 seconds =       0.22 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:11 2018
+*** at Wed Oct 17 21:44:14 2018
 
 
          ------------------------------------------------------------
@@ -4234,8 +4234,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4254,20 +4254,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.000000202204
-       2       -0.000000000000     0.000000176416    -0.000000101102
-       3        0.000000000000    -0.000000176416    -0.000000101102
+       1       -0.000000000000     0.000000000000     0.000000202147
+       2       -0.000000000000     0.000000176377    -0.000000101074
+       3        0.000000000000    -0.000000176377    -0.000000101074
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:11 2018
+*** tstop() called on dream at Wed Oct 17 21:44:15 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.75 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.55 seconds =       0.14 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      47.47 seconds =       0.79 minutes
+	system time =       2.91 seconds =       0.05 minutes
+	total time  =         14 seconds =       0.23 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -4294,19 +4294,19 @@ Total time:
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
-  pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0001  [cm^-1]
-  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0001' '1753.0274'
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '1753.0274'
  '4127.0330' '4227.0129']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
+  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
-  post-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0001' '0.0001' '1753.0274'
+  post-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0001' '0.0001' '1753.0274'
  '4127.0330' '4227.0129']
 
   Vibration                       7                   8                   9           
@@ -4316,10 +4316,10 @@ Total time:
   Force const [mDyne/A]         1.9610             10.4851             11.4047        
   Turning point v=0 [a0]        0.2518              0.1671              0.1621        
   RMS dev v=0 [a0 u^1/2]        0.1853              0.1208              0.1193        
-  Char temp [K]               2522.2162           5937.8817           6081.7304       
+  Char temp [K]               2522.2162           5937.8816           6081.7304       
   ----------------------------------------------------------------------------------
-      1   O               -0.00  0.00 -0.07   -0.00  0.00  0.05   -0.00 -0.07  0.00   
-      2   H               -0.00  0.43  0.56    0.00  0.59 -0.39   -0.00  0.56 -0.42   
+      1   O               -0.00  0.00 -0.07   -0.00 -0.00  0.05   -0.00 -0.07 -0.00   
+      2   H                0.00  0.43  0.56   -0.00  0.59 -0.39    0.00  0.56 -0.42   
       3   H                0.00 -0.43  0.56    0.00 -0.59 -0.39    0.00  0.56  0.42   
 
   ==> Thermochemistry Components <==
@@ -4411,7 +4411,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:12 2018
+*** at Wed Oct 17 21:44:15 2018
 
    => Loading Basis Set <=
 
@@ -4427,7 +4427,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4506,7 +4506,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4532,17 +4532,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.02721010140004   -7.60272e+01   1.26959e-01 
-   @DF-RHF iter   1:   -75.98503394146663    4.21762e-02   2.24636e-02 
-   @DF-RHF iter   2:   -76.01819442576483   -3.31605e-02   1.10506e-02 DIIS
-   @DF-RHF iter   3:   -76.02632060923138   -8.12618e-03   1.83723e-03 DIIS
-   @DF-RHF iter   4:   -76.02681392166960   -4.93312e-04   4.77044e-04 DIIS
-   @DF-RHF iter   5:   -76.02686057862269   -4.66570e-05   8.85362e-05 DIIS
-   @DF-RHF iter   6:   -76.02686264788878   -2.06927e-06   1.70052e-05 DIIS
-   @DF-RHF iter   7:   -76.02686272073316   -7.28444e-08   2.50825e-06 DIIS
-   @DF-RHF iter   8:   -76.02686272232705   -1.59389e-09   3.76539e-07 DIIS
-   @DF-RHF iter   9:   -76.02686272235775   -3.06954e-11   3.22492e-08 DIIS
-   @DF-RHF iter  10:   -76.02686272235789   -1.42109e-13   3.22605e-09 DIIS
+   @DF-RHF iter   0:   -76.02721010139877   -7.60272e+01   1.59091e-01 
+   @DF-RHF iter   1:   -75.98503394146519    4.21762e-02   3.44044e-02 
+   @DF-RHF iter   2:   -76.01819442576338   -3.31605e-02   1.53089e-02 DIIS
+   @DF-RHF iter   3:   -76.02632060922990   -8.12618e-03   3.11723e-03 DIIS
+   @DF-RHF iter   4:   -76.02681392166807   -4.93312e-04   8.56070e-04 DIIS
+   @DF-RHF iter   5:   -76.02686057862121   -4.66570e-05   1.39076e-04 DIIS
+   @DF-RHF iter   6:   -76.02686264788721   -2.06927e-06   2.88527e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272073164   -7.28444e-08   3.35811e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272232546   -1.59382e-09   6.07470e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272235623   -3.07665e-11   5.78722e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272235638   -1.56319e-13   5.47363e-09 DIIS
   Energy converged.
 
 
@@ -4570,14 +4570,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02686272235789
+  @DF-RHF Final Energy:   -76.02686272235638
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3668731757160000
-    One-Electron Energy =                -123.4604615816829494
-    Two-Electron Energy =                  38.0667256836090715
-    Total Energy =                        -76.0268627223578903
+    One-Electron Energy =                -123.4604615816810735
+    Two-Electron Energy =                  38.0667256836086949
+    Total Energy =                        -76.0268627223563840
 
 Computation Completed
 
@@ -4599,18 +4599,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:12 2018
+*** tstop() called on dream at Wed Oct 17 21:44:15 2018
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.54 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.05 seconds =       0.15 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      49.39 seconds =       0.82 minutes
+	system time =       3.07 seconds =       0.05 minutes
+	total time  =         14 seconds =       0.23 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:12 2018
+*** at Wed Oct 17 21:44:15 2018
 
 
          ------------------------------------------------------------
@@ -4650,8 +4650,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4670,22 +4670,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.013215500528
-       2       -0.000000000000     0.004499300530    -0.006607750264
-       3        0.000000000000    -0.004499300530    -0.006607750264
+       1        0.000000000000     0.000000000000     0.013215500508
+       2       -0.000000000000     0.004499300516    -0.006607750254
+       3        0.000000000000    -0.004499300516    -0.006607750254
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:12 2018
+*** tstop() called on dream at Wed Oct 17 21:44:16 2018
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.16 seconds =       0.15 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      50.40 seconds =       0.84 minutes
+	system time =       3.14 seconds =       0.05 minutes
+	total time  =         15 seconds =       0.25 minutes
 
-  Based on options and gradient (rms=5.80E-03), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=1.00E-02), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -4724,7 +4724,7 @@ hessian() will perform frequency computation by finite difference of analytic gr
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:12 2018
+*** at Wed Oct 17 21:44:16 2018
 
    => Loading Basis Set <=
 
@@ -4740,7 +4740,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4819,7 +4819,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4845,17 +4845,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.04271559718455   -7.60427e+01   1.26906e-01 
-   @DF-RHF iter   1:   -75.99200807640335    5.07075e-02   2.06370e-02 
-   @DF-RHF iter   2:   -76.01961748416147   -2.76094e-02   1.00766e-02 DIIS
-   @DF-RHF iter   3:   -76.02641833065843   -6.80085e-03   1.66065e-03 DIIS
-   @DF-RHF iter   4:   -76.02686197156841   -4.43641e-04   4.53456e-04 DIIS
-   @DF-RHF iter   5:   -76.02690574261538   -4.37710e-05   9.42969e-05 DIIS
-   @DF-RHF iter   6:   -76.02690826629885   -2.52368e-06   1.44152e-05 DIIS
-   @DF-RHF iter   7:   -76.02690832674742   -6.04486e-08   1.69912e-06 DIIS
-   @DF-RHF iter   8:   -76.02690832736378   -6.16367e-10   3.05004e-07 DIIS
-   @DF-RHF iter   9:   -76.02690832738223   -1.84457e-11   2.91119e-08 DIIS
-   @DF-RHF iter  10:   -76.02690832738234   -1.13687e-13   3.91412e-09 DIIS
+   @DF-RHF iter   0:   -76.04271559718340   -7.60427e+01   2.10588e-01 
+   @DF-RHF iter   1:   -75.99200807640237    5.07075e-02   3.03237e-02 
+   @DF-RHF iter   2:   -76.01961748416048   -2.76094e-02   1.80828e-02 DIIS
+   @DF-RHF iter   3:   -76.02641833065739   -6.80085e-03   2.34852e-03 DIIS
+   @DF-RHF iter   4:   -76.02686197156737   -4.43641e-04   8.66783e-04 DIIS
+   @DF-RHF iter   5:   -76.02690574261442   -4.37710e-05   1.52129e-04 DIIS
+   @DF-RHF iter   6:   -76.02690826629777   -2.52368e-06   2.58685e-05 DIIS
+   @DF-RHF iter   7:   -76.02690832674639   -6.04486e-08   2.88289e-06 DIIS
+   @DF-RHF iter   8:   -76.02690832736280   -6.16410e-10   6.06822e-07 DIIS
+   @DF-RHF iter   9:   -76.02690832738129   -1.84883e-11   5.22423e-08 DIIS
+   @DF-RHF iter  10:   -76.02690832738139   -9.94760e-14   7.48186e-09 DIIS
   Energy converged.
 
 
@@ -4883,14 +4883,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02690832738234
+  @DF-RHF Final Energy:   -76.02690832738139
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3554975258214430
-    One-Electron Energy =                -123.4398743600335564
-    Two-Electron Energy =                  38.0574685068297569
-    Total Energy =                        -76.0269083273823583
+    One-Electron Energy =                -123.4398743600319364
+    Two-Electron Energy =                  38.0574685068290961
+    Total Energy =                        -76.0269083273813919
 
 Computation Completed
 
@@ -4912,18 +4912,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0152     Total:     2.0152
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+*** tstop() called on dream at Wed Oct 17 21:44:16 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.86 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.55 seconds =       0.16 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      52.28 seconds =       0.87 minutes
+	system time =       3.25 seconds =       0.05 minutes
+	total time  =         15 seconds =       0.25 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:13 2018
+*** at Wed Oct 17 21:44:16 2018
 
 
          ------------------------------------------------------------
@@ -4963,8 +4963,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -4983,20 +4983,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.011191882024
-       2       -0.000000000000     0.003569434720    -0.005595941012
-       3        0.000000000000    -0.003569434720    -0.005595941012
+       1        0.000000000000     0.000000000000     0.011191882070
+       2       -0.000000000000     0.003569434752    -0.005595941035
+       3        0.000000000000    -0.003569434752    -0.005595941035
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+*** tstop() called on dream at Wed Oct 17 21:44:16 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.67 seconds =       0.16 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      53.28 seconds =       0.89 minutes
+	system time =       3.33 seconds =       0.06 minutes
+	total time  =         15 seconds =       0.25 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
@@ -5004,7 +5004,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:13 2018
+*** at Wed Oct 17 21:44:16 2018
 
    => Loading Basis Set <=
 
@@ -5020,7 +5020,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5099,7 +5099,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5125,17 +5125,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.14347765718151   -7.61435e+01   1.28075e-01 
-   @DF-RHF iter   1:   -75.97527053537321    1.68207e-01   2.41085e-02 
-   @DF-RHF iter   2:   -76.01659851684919   -4.13280e-02   1.17437e-02 DIIS
-   @DF-RHF iter   3:   -76.02595248011360   -9.35396e-03   2.28052e-03 DIIS
-   @DF-RHF iter   4:   -76.02674510441078   -7.92624e-04   5.63330e-04 DIIS
-   @DF-RHF iter   5:   -76.02680716251076   -6.20581e-05   9.45434e-05 DIIS
-   @DF-RHF iter   6:   -76.02680944743221   -2.28492e-06   1.93653e-05 DIIS
-   @DF-RHF iter   7:   -76.02680954374469   -9.63125e-08   3.09925e-06 DIIS
-   @DF-RHF iter   8:   -76.02680954626830   -2.52361e-09   4.16261e-07 DIIS
-   @DF-RHF iter   9:   -76.02680954630517   -3.68772e-11   3.58226e-08 DIIS
-   @DF-RHF iter  10:   -76.02680954630534   -1.70530e-13   3.57569e-09 DIIS
+   @DF-RHF iter   0:   -76.14347765717969   -7.61435e+01   2.29835e-01 
+   @DF-RHF iter   1:   -75.97527053537135    1.68207e-01   3.54247e-02 
+   @DF-RHF iter   2:   -76.01659851684727   -4.13280e-02   1.94876e-02 DIIS
+   @DF-RHF iter   3:   -76.02595248011163   -9.35396e-03   3.22515e-03 DIIS
+   @DF-RHF iter   4:   -76.02674510440887   -7.92624e-04   9.08821e-04 DIIS
+   @DF-RHF iter   5:   -76.02680716250879   -6.20581e-05   1.52527e-04 DIIS
+   @DF-RHF iter   6:   -76.02680944743027   -2.28492e-06   3.36302e-05 DIIS
+   @DF-RHF iter   7:   -76.02680954374277   -9.63125e-08   4.63366e-06 DIIS
+   @DF-RHF iter   8:   -76.02680954626635   -2.52358e-09   5.68123e-07 DIIS
+   @DF-RHF iter   9:   -76.02680954630321   -3.68630e-11   5.06608e-08 DIIS
+   @DF-RHF iter  10:   -76.02680954630337   -1.56319e-13   5.93351e-09 DIIS
   Energy converged.
 
 
@@ -5163,14 +5163,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02680954630534
+  @DF-RHF Final Energy:   -76.02680954630337
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3782519326214029
-    One-Electron Energy =                -123.4810398800409530
-    Two-Electron Energy =                  38.0759784011142131
-    Total Energy =                        -76.0268095463053442
+    One-Electron Energy =                -123.4810398800386508
+    Two-Electron Energy =                  38.0759784011138720
+    Total Energy =                        -76.0268095463033831
 
 Computation Completed
 
@@ -5192,18 +5192,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0069     Total:     2.0069
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+*** tstop() called on dream at Wed Oct 17 21:44:17 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.87 seconds =       0.03 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.06 seconds =       0.17 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      55.18 seconds =       0.92 minutes
+	system time =       3.40 seconds =       0.06 minutes
+	total time  =         16 seconds =       0.27 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:13 2018
+*** at Wed Oct 17 21:44:17 2018
 
 
          ------------------------------------------------------------
@@ -5243,8 +5243,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -5263,20 +5263,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.015243673651
-       2       -0.000000000000     0.005438578134    -0.007621836825
-       3        0.000000000000    -0.005438578134    -0.007621836825
+       1        0.000000000000     0.000000000000     0.015243673616
+       2       -0.000000000000     0.005438578107    -0.007621836808
+       3        0.000000000000    -0.005438578107    -0.007621836808
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:13 2018
+*** tstop() called on dream at Wed Oct 17 21:44:17 2018
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.03 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.17 seconds =       0.17 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      56.21 seconds =       0.94 minutes
+	system time =       3.46 seconds =       0.06 minutes
+	total time  =         16 seconds =       0.27 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
@@ -5284,7 +5284,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:13 2018
+*** at Wed Oct 17 21:44:17 2018
 
    => Loading Basis Set <=
 
@@ -5300,7 +5300,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5379,7 +5379,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5405,17 +5405,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.02426514188920   -7.60243e+01   1.26542e-01 
-   @DF-RHF iter   1:   -75.98502248719596    3.92427e-02   2.24606e-02 
-   @DF-RHF iter   2:   -76.01819157318897   -3.31691e-02   1.10657e-02 DIIS
-   @DF-RHF iter   3:   -76.02634374390480   -8.15217e-03   1.83979e-03 DIIS
-   @DF-RHF iter   4:   -76.02683925011476   -4.95506e-04   4.78442e-04 DIIS
-   @DF-RHF iter   5:   -76.02688625827398   -4.70082e-05   8.88170e-05 DIIS
-   @DF-RHF iter   6:   -76.02688834466744   -2.08639e-06   1.71094e-05 DIIS
-   @DF-RHF iter   7:   -76.02688841863082   -7.39634e-08   2.53532e-06 DIIS
-   @DF-RHF iter   8:   -76.02688842026234   -1.63152e-09   3.78593e-07 DIIS
-   @DF-RHF iter   9:   -76.02688842029340   -3.10649e-11   3.24588e-08 DIIS
-   @DF-RHF iter  10:   -76.02688842029353   -1.27898e-13   3.25528e-09 DIIS
+   @DF-RHF iter   0:   -76.02426514188996   -7.60243e+01   1.81852e-01 
+   @DF-RHF iter   1:   -75.98502248719673    3.92427e-02   3.06547e-02 
+   @DF-RHF iter   2:   -76.01819157318975   -3.31691e-02   1.98578e-02 DIIS
+   @DF-RHF iter   3:   -76.02634374390558   -8.15217e-03   3.19503e-03 DIIS
+   @DF-RHF iter   4:   -76.02683925011550   -4.95506e-04   6.40550e-04 DIIS
+   @DF-RHF iter   5:   -76.02688625827484   -4.70082e-05   1.39517e-04 DIIS
+   @DF-RHF iter   6:   -76.02688834466817   -2.08639e-06   2.29065e-05 DIIS
+   @DF-RHF iter   7:   -76.02688841863169   -7.39635e-08   4.54972e-06 DIIS
+   @DF-RHF iter   8:   -76.02688842026311   -1.63142e-09   5.06870e-07 DIIS
+   @DF-RHF iter   9:   -76.02688842029421   -3.11076e-11   4.82459e-08 DIIS
+   @DF-RHF iter  10:   -76.02688842029436   -1.42109e-13   4.60366e-09 DIIS
   Energy converged.
 
 
@@ -5443,14 +5443,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02688842029353
+  @DF-RHF Final Energy:   -76.02688842029436
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3517002620347895
-    One-Electron Energy =                -123.4341878589302439
-    Two-Electron Energy =                  38.0555991766019304
-    Total Energy =                        -76.0268884202935169
+    One-Electron Energy =                -123.4341878589317218
+    Two-Electron Energy =                  38.0555991766025699
+    Total Energy =                        -76.0268884202943553
 
 Computation Completed
 
@@ -5472,18 +5472,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0104     Total:     2.0104
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+*** tstop() called on dream at Wed Oct 17 21:44:18 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.81 seconds =       0.03 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.56 seconds =       0.18 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      58.04 seconds =       0.97 minutes
+	system time =       3.61 seconds =       0.06 minutes
+	total time  =         17 seconds =       0.28 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:14 2018
+*** at Wed Oct 17 21:44:18 2018
 
 
          ------------------------------------------------------------
@@ -5523,8 +5523,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -5543,20 +5543,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.011466348418
-       2       -0.000000000000     0.002799958985    -0.005733174209
-       3        0.000000000000    -0.002799958985    -0.005733174209
+       1       -0.000000000000     0.000000000000     0.011466348372
+       2       -0.000000000000     0.002799958952    -0.005733174186
+       3        0.000000000000    -0.002799958952    -0.005733174186
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+*** tstop() called on dream at Wed Oct 17 21:44:18 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.68 seconds =       0.18 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      59.05 seconds =       0.98 minutes
+	system time =       3.68 seconds =       0.06 minutes
+	total time  =         17 seconds =       0.28 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
@@ -5564,7 +5564,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:14 2018
+*** at Wed Oct 17 21:44:18 2018
 
    => Loading Basis Set <=
 
@@ -5580,7 +5580,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5659,7 +5659,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5685,17 +5685,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.03015297735914   -7.60302e+01   1.27376e-01 
-   @DF-RHF iter   1:   -75.98503264197615    4.51203e-02   2.24669e-02 
-   @DF-RHF iter   2:   -76.01818490712907   -3.31523e-02   1.10356e-02 DIIS
-   @DF-RHF iter   3:   -76.02628543484566   -8.10053e-03   1.83467e-03 DIIS
-   @DF-RHF iter   4:   -76.02677657018658   -4.91135e-04   4.75650e-04 DIIS
-   @DF-RHF iter   5:   -76.02682287845101   -4.63083e-05   8.82569e-05 DIIS
-   @DF-RHF iter   6:   -76.02682493077015   -2.05232e-06   1.69020e-05 DIIS
-   @DF-RHF iter   7:   -76.02682500251629   -7.17461e-08   2.48143e-06 DIIS
-   @DF-RHF iter   8:   -76.02682500407337   -1.55708e-09   3.74480e-07 DIIS
-   @DF-RHF iter   9:   -76.02682500410386   -3.04823e-11   3.20415e-08 DIIS
-   @DF-RHF iter  10:   -76.02682500410396   -9.94760e-14   3.19702e-09 DIIS
+   @DF-RHF iter   0:   -76.03015297736017   -7.60302e+01   2.05497e-01 
+   @DF-RHF iter   1:   -75.98503264197721    4.51203e-02   2.85088e-02 
+   @DF-RHF iter   2:   -76.01818490713018   -3.31523e-02   1.98038e-02 DIIS
+   @DF-RHF iter   3:   -76.02628543484673   -8.10053e-03   2.95987e-03 DIIS
+   @DF-RHF iter   4:   -76.02677657018768   -4.91135e-04   7.47170e-04 DIIS
+   @DF-RHF iter   5:   -76.02682287845209   -4.63083e-05   1.58380e-04 DIIS
+   @DF-RHF iter   6:   -76.02682493077123   -2.05232e-06   3.03312e-05 DIIS
+   @DF-RHF iter   7:   -76.02682500251741   -7.17462e-08   4.00329e-06 DIIS
+   @DF-RHF iter   8:   -76.02682500407452   -1.55711e-09   6.21414e-07 DIIS
+   @DF-RHF iter   9:   -76.02682500410492   -3.03970e-11   5.31698e-08 DIIS
+   @DF-RHF iter  10:   -76.02682500410509   -1.70530e-13   5.55203e-09 DIIS
   Energy converged.
 
 
@@ -5723,14 +5723,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02682500410396
+  @DF-RHF Final Energy:   -76.02682500410509
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3820831506858404
-    One-Electron Energy =                -123.4867800627388306
-    Two-Electron Energy =                  38.0778719079490244
-    Total Energy =                        -76.0268250041039551
+    One-Electron Energy =                -123.4867800627390579
+    Two-Electron Energy =                  38.0778719079481291
+    Total Energy =                        -76.0268250041050919
 
 Computation Completed
 
@@ -5752,18 +5752,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0117     Total:     2.0117
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+*** tstop() called on dream at Wed Oct 17 21:44:18 2018
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.84 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.08 seconds =       0.18 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      60.91 seconds =       1.02 minutes
+	system time =       3.81 seconds =       0.06 minutes
+	total time  =         17 seconds =       0.28 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:14 2018
+*** at Wed Oct 17 21:44:18 2018
 
 
          ------------------------------------------------------------
@@ -5803,8 +5803,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -5823,20 +5823,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.014989309065
-       2       -0.000000000000     0.006213103188    -0.007494654532
-       3        0.000000000000    -0.006213103188    -0.007494654532
+       1        0.000000000000     0.000000000000     0.014989309074
+       2       -0.000000000000     0.006213103196    -0.007494654537
+       3        0.000000000000    -0.006213103196    -0.007494654537
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:14 2018
+*** tstop() called on dream at Wed Oct 17 21:44:19 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.06 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      11.20 seconds =       0.19 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      61.98 seconds =       1.03 minutes
+	system time =       3.84 seconds =       0.06 minutes
+	total time  =         18 seconds =       0.30 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
@@ -5844,7 +5844,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:14 2018
+*** at Wed Oct 17 21:44:19 2018
 
    => Loading Basis Set <=
 
@@ -5860,7 +5860,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5937,7 +5937,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5963,17 +5963,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.05316663949202   -7.60532e+01   9.24319e-02 
-   @DF-RHF iter   1:   -75.99181266188616    6.13540e-02   1.49628e-02 
-   @DF-RHF iter   2:   -76.01959035083536   -2.77777e-02   7.27187e-03 DIIS
-   @DF-RHF iter   3:   -76.02633527292627   -6.74492e-03   1.23556e-03 DIIS
-   @DF-RHF iter   4:   -76.02680543514855   -4.70162e-04   3.35619e-04 DIIS
-   @DF-RHF iter   5:   -76.02685124883412   -4.58137e-05   6.92933e-05 DIIS
-   @DF-RHF iter   6:   -76.02685383215902   -2.58332e-06   1.04773e-05 DIIS
-   @DF-RHF iter   7:   -76.02685389239559   -6.02366e-08   1.23324e-06 DIIS
-   @DF-RHF iter   8:   -76.02685389301080   -6.15202e-10   2.34249e-07 DIIS
-   @DF-RHF iter   9:   -76.02685389303096   -2.01652e-11   3.41832e-08 DIIS
-   @DF-RHF iter  10:   -76.02685389303132   -3.55271e-13   5.52443e-09 DIIS
+   @DF-RHF iter   0:   -76.05316663949280   -7.60532e+01   1.78994e-01 
+   @DF-RHF iter   1:   -75.99181266188718    6.13540e-02   2.11607e-02 
+   @DF-RHF iter   2:   -76.01959035083634   -2.77777e-02   1.45437e-02 DIIS
+   @DF-RHF iter   3:   -76.02633527292723   -6.74492e-03   2.65442e-03 DIIS
+   @DF-RHF iter   4:   -76.02680543514953   -4.70162e-04   6.71239e-04 DIIS
+   @DF-RHF iter   5:   -76.02685124883511   -4.58137e-05   1.30180e-04 DIIS
+   @DF-RHF iter   6:   -76.02685383216000   -2.58332e-06   1.91289e-05 DIIS
+   @DF-RHF iter   7:   -76.02685389239663   -6.02366e-08   2.19152e-06 DIIS
+   @DF-RHF iter   8:   -76.02685389301179   -6.15159e-10   4.27679e-07 DIIS
+   @DF-RHF iter   9:   -76.02685389303193   -2.01368e-11   6.61954e-08 DIIS
+   @DF-RHF iter  10:   -76.02685389303232   -3.97904e-13   1.03786e-08 DIIS
+   @DF-RHF iter  11:   -76.02685389303225    7.10543e-14   1.98146e-09 DIIS
   Energy converged.
 
 
@@ -6001,14 +6002,14 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.02685389303132
+  @DF-RHF Final Energy:   -76.02685389303225
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3669111179884883
-    One-Electron Energy =                -123.4605117939757406
-    Two-Electron Energy =                  38.0667467829559456
-    Total Energy =                        -76.0268538930313014
+    One-Electron Energy =                -123.4605118334348930
+    Two-Electron Energy =                  38.0667468224141459
+    Total Energy =                        -76.0268538930322535
 
 Computation Completed
 
@@ -6030,18 +6031,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0034      Z:     2.0110     Total:     2.0110
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+*** tstop() called on dream at Wed Oct 17 21:44:19 2018
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.83 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.57 seconds =       0.19 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      63.83 seconds =       1.06 minutes
+	system time =       3.94 seconds =       0.07 minutes
+	total time  =         18 seconds =       0.30 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:15 2018
+*** at Wed Oct 17 21:44:19 2018
 
 
          ------------------------------------------------------------
@@ -6081,8 +6082,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -6101,20 +6102,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003853957526     0.013235142286
-       2        0.000000000000     0.006438561424    -0.008068215399
-       3        0.000000000000    -0.002584603898    -0.005166926887
+       1        0.000000000000    -0.003853958683     0.013235141507
+       2        0.000000000000     0.006438562163    -0.008068217675
+       3        0.000000000000    -0.002584603480    -0.005166923832
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+*** tstop() called on dream at Wed Oct 17 21:44:19 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.69 seconds =       0.19 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      64.85 seconds =       1.08 minutes
+	system time =       4.03 seconds =       0.07 minutes
+	total time  =         18 seconds =       0.30 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
@@ -6122,7 +6123,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:15 2018
+*** at Wed Oct 17 21:44:19 2018
 
    => Loading Basis Set <=
 
@@ -6138,7 +6139,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6217,7 +6218,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6243,17 +6244,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.02721010139712   -7.60272e+01   1.26959e-01 
-   @DF-RHF iter   1:   -75.98503394146364    4.21762e-02   2.24636e-02 
-   @DF-RHF iter   2:   -76.01819442576191   -3.31605e-02   1.10506e-02 DIIS
-   @DF-RHF iter   3:   -76.02632060922842   -8.12618e-03   1.83723e-03 DIIS
-   @DF-RHF iter   4:   -76.02681392166660   -4.93312e-04   4.77044e-04 DIIS
-   @DF-RHF iter   5:   -76.02686057861968   -4.66570e-05   8.85362e-05 DIIS
-   @DF-RHF iter   6:   -76.02686264788574   -2.06927e-06   1.70052e-05 DIIS
-   @DF-RHF iter   7:   -76.02686272073014   -7.28444e-08   2.50825e-06 DIIS
-   @DF-RHF iter   8:   -76.02686272232401   -1.59388e-09   3.76539e-07 DIIS
-   @DF-RHF iter   9:   -76.02686272235471   -3.06954e-11   3.22492e-08 DIIS
-   @DF-RHF iter  10:   -76.02686272235482   -1.13687e-13   3.22605e-09 DIIS
+   @DF-RHF iter   0:   -76.02721010139977   -7.60272e+01   2.04823e-01 
+   @DF-RHF iter   1:   -75.98503394146614    4.21762e-02   3.17684e-02 
+   @DF-RHF iter   2:   -76.01819442576445   -3.31605e-02   1.83374e-02 DIIS
+   @DF-RHF iter   3:   -76.02632060923091   -8.12618e-03   2.45973e-03 DIIS
+   @DF-RHF iter   4:   -76.02681392166907   -4.93312e-04   7.13223e-04 DIIS
+   @DF-RHF iter   5:   -76.02686057862229   -4.66570e-05   1.58881e-04 DIIS
+   @DF-RHF iter   6:   -76.02686264788827   -2.06927e-06   2.51303e-05 DIIS
+   @DF-RHF iter   7:   -76.02686272073268   -7.28444e-08   3.29648e-06 DIIS
+   @DF-RHF iter   8:   -76.02686272232654   -1.59386e-09   6.38873e-07 DIIS
+   @DF-RHF iter   9:   -76.02686272235725   -3.07097e-11   5.47172e-08 DIIS
+   @DF-RHF iter  10:   -76.02686272235738   -1.27898e-13   5.60244e-09 DIIS
   Energy converged.
 
 
@@ -6281,14 +6282,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02686272235482
+  @DF-RHF Final Energy:   -76.02686272235738
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3668731757160018
-    One-Electron Energy =                -123.4604615816806472
-    Two-Electron Energy =                  38.0667256836098318
-    Total Energy =                        -76.0268627223548208
+    One-Electron Energy =                -123.4604615816818267
+    Two-Electron Energy =                  38.0667256836084320
+    Total Energy =                        -76.0268627223573787
 
 Computation Completed
 
@@ -6310,18 +6311,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0110     Total:     2.0110
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+*** tstop() called on dream at Wed Oct 17 21:44:20 2018
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.84 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.07 seconds =       0.20 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      66.71 seconds =       1.11 minutes
+	system time =       4.15 seconds =       0.07 minutes
+	total time  =         19 seconds =       0.32 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:15 2018
+*** at Wed Oct 17 21:44:20 2018
 
 
          ------------------------------------------------------------
@@ -6361,8 +6362,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -6381,20 +6382,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.013215500512
-       2       -0.000000000000     0.004499300517    -0.006607750256
-       3        0.000000000000    -0.004499300517    -0.006607750256
+       1       -0.000000000000     0.000000000000     0.013215500499
+       2       -0.000000000000     0.004499300508    -0.006607750250
+       3        0.000000000000    -0.004499300508    -0.006607750250
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:15 2018
+*** tstop() called on dream at Wed Oct 17 21:44:20 2018
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.02 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.19 seconds =       0.20 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      67.73 seconds =       1.13 minutes
+	system time =       4.21 seconds =       0.07 minutes
+	total time  =         19 seconds =       0.32 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -6418,7 +6419,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:15 2018
+*** at Wed Oct 17 21:44:20 2018
 
    => Loading Basis Set <=
 
@@ -6434,7 +6435,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6513,7 +6514,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6539,17 +6540,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95139982935255   -7.59514e+01   5.56992e-02 
-   @DF-RHF iter   1:   -76.03440601355707   -8.30062e-02   7.80589e-03 
-   @DF-RHF iter   2:   -76.05211980911487   -1.77138e-02   4.19583e-03 DIIS
-   @DF-RHF iter   3:   -76.05747970577814   -5.35990e-03   5.96959e-04 DIIS
-   @DF-RHF iter   4:   -76.05772386500179   -2.44159e-04   1.60958e-04 DIIS
-   @DF-RHF iter   5:   -76.05775448086195   -3.06159e-05   3.81765e-05 DIIS
-   @DF-RHF iter   6:   -76.05775638746832   -1.90661e-06   6.28655e-06 DIIS
-   @DF-RHF iter   7:   -76.05775643335552   -4.58872e-08   9.19066e-07 DIIS
-   @DF-RHF iter   8:   -76.05775643432585   -9.70331e-10   1.34858e-07 DIIS
-   @DF-RHF iter   9:   -76.05775643434822   -2.23679e-11   2.36299e-08 DIIS
-   @DF-RHF iter  10:   -76.05775643434882   -5.96856e-13   2.56450e-09 DIIS
+   @DF-RHF iter   0:   -75.95139982935524   -7.59514e+01   1.07145e-01 
+   @DF-RHF iter   1:   -76.03440601355976   -8.30062e-02   1.50157e-02 
+   @DF-RHF iter   2:   -76.05211980911770   -1.77138e-02   8.40870e-03 DIIS
+   @DF-RHF iter   3:   -76.05747970578086   -5.35990e-03   1.16369e-03 DIIS
+   @DF-RHF iter   4:   -76.05772386500462   -2.44159e-04   3.01813e-04 DIIS
+   @DF-RHF iter   5:   -76.05775448086467   -3.06159e-05   6.06857e-05 DIIS
+   @DF-RHF iter   6:   -76.05775638747104   -1.90661e-06   1.20930e-05 DIIS
+   @DF-RHF iter   7:   -76.05775643335818   -4.58871e-08   1.76795e-06 DIIS
+   @DF-RHF iter   8:   -76.05775643432868   -9.70502e-10   2.10633e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643435091   -2.22258e-11   4.36909e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643435159   -6.82121e-13   4.93316e-09 DIIS
   Energy converged.
 
 
@@ -6588,14 +6589,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775643434882
+  @DF-RHF Final Energy:   -76.05775643435159
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3668731757160000
-    One-Electron Energy =                -123.4279507369144397
-    Two-Electron Energy =                  38.0033211268496203
-    Total Energy =                        -76.0577564343488177
+    One-Electron Energy =                -123.4279507369156619
+    Two-Electron Energy =                  38.0033211268480784
+    Total Energy =                        -76.0577564343515888
 
 Computation Completed
 
@@ -6617,18 +6618,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:16 2018
+*** tstop() called on dream at Wed Oct 17 21:44:21 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.67 seconds =       0.21 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      69.92 seconds =       1.17 minutes
+	system time =       4.35 seconds =       0.07 minutes
+	total time  =         20 seconds =       0.33 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:16 2018
+*** at Wed Oct 17 21:44:21 2018
 
 
          ------------------------------------------------------------
@@ -6668,8 +6669,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -6688,22 +6689,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000000000000     0.000000000000     0.002590010257
-       2       -0.000000000000     0.000881701903    -0.001295005129
-       3        0.000000000000    -0.000881701903    -0.001295005129
+       1       -0.000000000000     0.000000000000     0.002590010212
+       2       -0.000000000000     0.000881701877    -0.001295005106
+       3        0.000000000000    -0.000881701877    -0.001295005106
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:16 2018
+*** tstop() called on dream at Wed Oct 17 21:44:21 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.72 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.90 seconds =       0.21 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      71.64 seconds =       1.19 minutes
+	system time =       4.46 seconds =       0.07 minutes
+	total time  =         20 seconds =       0.33 minutes
 
-  Based on options and gradient (rms=1.14E-03), recommend projecting translations and projecting rotations.
+  Based on options and gradient (rms=1.39E-03), recommend projecting translations and projecting rotations.
 hessian() will perform frequency computation by finite difference of analytic gradients.
 
          ----------------------------------------------------------
@@ -6742,7 +6743,7 @@ hessian() will perform frequency computation by finite difference of analytic gr
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:16 2018
+*** at Wed Oct 17 21:44:21 2018
 
    => Loading Basis Set <=
 
@@ -6758,7 +6759,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6837,7 +6838,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6863,17 +6864,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94456690026446   -7.59446e+01   5.55910e-02 
-   @DF-RHF iter   1:   -76.03431871820544   -8.97518e-02   7.84720e-03 
-   @DF-RHF iter   2:   -76.05204811508717   -1.77294e-02   4.24838e-03 DIIS
-   @DF-RHF iter   3:   -76.05751273040305   -5.46462e-03   5.75263e-04 DIIS
-   @DF-RHF iter   4:   -76.05773351096002   -2.20781e-04   1.53219e-04 DIIS
-   @DF-RHF iter   5:   -76.05776064188237   -2.71309e-05   3.66319e-05 DIIS
-   @DF-RHF iter   6:   -76.05776238245166   -1.74057e-06   6.19456e-06 DIIS
-   @DF-RHF iter   7:   -76.05776242746474   -4.50131e-08   9.07830e-07 DIIS
-   @DF-RHF iter   8:   -76.05776242841586   -9.51118e-10   1.32161e-07 DIIS
-   @DF-RHF iter   9:   -76.05776242843758   -2.17284e-11   2.36194e-08 DIIS
-   @DF-RHF iter  10:   -76.05776242843824   -6.53699e-13   2.52931e-09 DIIS
+   @DF-RHF iter   0:   -75.94456690026369   -7.59446e+01   1.00884e-01 
+   @DF-RHF iter   1:   -76.03431871820470   -8.97518e-02   1.50951e-02 
+   @DF-RHF iter   2:   -76.05204811508641   -1.77294e-02   8.17234e-03 DIIS
+   @DF-RHF iter   3:   -76.05751273040221   -5.46462e-03   1.12139e-03 DIIS
+   @DF-RHF iter   4:   -76.05773351095921   -2.20781e-04   3.02783e-04 DIIS
+   @DF-RHF iter   5:   -76.05776064188157   -2.71309e-05   7.59232e-05 DIIS
+   @DF-RHF iter   6:   -76.05776238245086   -1.74057e-06   1.19161e-05 DIIS
+   @DF-RHF iter   7:   -76.05776242746397   -4.50131e-08   1.74634e-06 DIIS
+   @DF-RHF iter   8:   -76.05776242841500   -9.51033e-10   2.59634e-07 DIIS
+   @DF-RHF iter   9:   -76.05776242843683   -2.18279e-11   4.54351e-08 DIIS
+   @DF-RHF iter  10:   -76.05776242843741   -5.82645e-13   5.16423e-09 DIIS
   Energy converged.
 
 
@@ -6912,14 +6913,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05776242843824
+  @DF-RHF Final Energy:   -76.05776242843741
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3554975258214430
-    One-Electron Energy =                -123.4074292968897311
-    Two-Electron Energy =                  37.9941693426300588
-    Total Energy =                        -76.0577624284382239
+    One-Electron Energy =                -123.4074292968892337
+    Two-Electron Energy =                  37.9941693426303644
+    Total Energy =                        -76.0577624284374281
 
 Computation Completed
 
@@ -6941,18 +6942,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9851     Total:     1.9851
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:16 2018
+*** tstop() called on dream at Wed Oct 17 21:44:22 2018
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.27 seconds =       0.04 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.37 seconds =       0.22 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      73.94 seconds =       1.23 minutes
+	system time =       4.62 seconds =       0.08 minutes
+	total time  =         21 seconds =       0.35 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:16 2018
+*** at Wed Oct 17 21:44:22 2018
 
 
          ------------------------------------------------------------
@@ -6992,8 +6993,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -7012,20 +7013,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.000618647625
-       2        0.000000000000    -0.000010787432    -0.000309323813
-       3       -0.000000000000     0.000010787432    -0.000309323813
+       1        0.000000000000     0.000000000000     0.000618647603
+       2        0.000000000000    -0.000010787443    -0.000309323801
+       3       -0.000000000000     0.000010787443    -0.000309323801
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+*** tstop() called on dream at Wed Oct 17 21:44:23 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.77 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.61 seconds =       0.23 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      75.72 seconds =       1.26 minutes
+	system time =       4.74 seconds =       0.08 minutes
+	total time  =         22 seconds =       0.37 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 2 of 6    //
@@ -7033,7 +7034,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:17 2018
+*** at Wed Oct 17 21:44:23 2018
 
    => Loading Basis Set <=
 
@@ -7049,7 +7050,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7128,7 +7129,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -7154,16 +7155,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95940374094587   -7.59594e+01   5.62794e-02 
-   @DF-RHF iter   1:   -76.02817776806802   -6.87740e-02   8.82581e-03 
-   @DF-RHF iter   2:   -76.05028112525785   -2.21034e-02   4.96222e-03 DIIS
-   @DF-RHF iter   3:   -76.05753519500736   -7.25407e-03   5.33576e-04 DIIS
-   @DF-RHF iter   4:   -76.05772022871201   -1.85034e-04   1.47072e-04 DIIS
-   @DF-RHF iter   5:   -76.05774128208827   -2.10534e-05   3.49381e-05 DIIS
-   @DF-RHF iter   6:   -76.05774299594265   -1.71385e-06   6.76455e-06 DIIS
-   @DF-RHF iter   7:   -76.05774306346490   -6.75223e-08   8.67513e-07 DIIS
-   @DF-RHF iter   8:   -76.05774306432801   -8.63110e-10   5.71353e-08 DIIS
-   @DF-RHF iter   9:   -76.05774306433000   -1.98952e-12   8.39519e-09 DIIS
+   @DF-RHF iter   0:   -75.95940374094577   -7.59594e+01   1.02133e-01 
+   @DF-RHF iter   1:   -76.02817776806788   -6.87740e-02   1.76875e-02 
+   @DF-RHF iter   2:   -76.05028112525777   -2.21034e-02   9.67315e-03 DIIS
+   @DF-RHF iter   3:   -76.05753519500712   -7.25407e-03   1.08943e-03 DIIS
+   @DF-RHF iter   4:   -76.05772022871180   -1.85034e-04   2.90634e-04 DIIS
+   @DF-RHF iter   5:   -76.05774128208814   -2.10534e-05   6.34040e-05 DIIS
+   @DF-RHF iter   6:   -76.05774299594248   -1.71385e-06   1.25729e-05 DIIS
+   @DF-RHF iter   7:   -76.05774306346488   -6.75224e-08   1.30292e-06 DIIS
+   @DF-RHF iter   8:   -76.05774306432784   -8.62954e-10   1.04918e-07 DIIS
+   @DF-RHF iter   9:   -76.05774306433000   -2.16005e-12   1.52352e-08 DIIS
+   @DF-RHF iter  10:   -76.05774306433010   -9.94760e-14   3.51358e-09 DIIS
   Energy converged.
 
 
@@ -7194,7 +7196,7 @@ gradient() will perform analytic gradient computation.
       13B2     4.919489    17A1     5.217315    18A1     5.274161  
       14B2     5.551418     9B1     6.085838    19A1     6.617801  
       10B1     6.965707     6A2     6.978535    11B1     7.050094  
-      20A1     7.067218    21A1     7.176487    15B2     7.179399  
+      20A1     7.067218    21A1     7.176488    15B2     7.179399  
        7A2     7.285598    22A1     7.495284    16B2     7.844010  
       17B2     8.364212    23A1    13.214364  
 
@@ -7202,14 +7204,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05774306433000
+  @DF-RHF Final Energy:   -76.05774306433010
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3782519326214029
-    One-Electron Energy =                -123.4484635710815326
-    Two-Electron Energy =                  38.0124685741301249
-    Total Energy =                        -76.0577430643300119
+    One-Electron Energy =                -123.4484639864087967
+    Two-Electron Energy =                  38.0124689894572967
+    Total Energy =                        -76.0577430643301113
 
 Computation Completed
 
@@ -7231,18 +7233,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9770     Total:     1.9770
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+*** tstop() called on dream at Wed Oct 17 21:44:23 2018
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.21 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.10 seconds =       0.23 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      77.95 seconds =       1.30 minutes
+	system time =       4.83 seconds =       0.08 minutes
+	total time  =         22 seconds =       0.37 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:17 2018
+*** at Wed Oct 17 21:44:23 2018
 
 
          ------------------------------------------------------------
@@ -7282,8 +7284,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -7302,20 +7304,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.004566035691
-       2       -0.000000000000     0.001783200654    -0.002283017846
-       3        0.000000000000    -0.001783200654    -0.002283017846
+       1        0.000000000000     0.000000000000     0.004566036628
+       2       -0.000000000000     0.001783202134    -0.002283018314
+       3        0.000000000000    -0.001783202134    -0.002283018314
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:17 2018
+*** tstop() called on dream at Wed Oct 17 21:44:24 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.33 seconds =       0.24 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      79.66 seconds =       1.33 minutes
+	system time =       4.92 seconds =       0.08 minutes
+	total time  =         23 seconds =       0.38 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 3 of 6    //
@@ -7323,7 +7325,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:17 2018
+*** at Wed Oct 17 21:44:24 2018
 
    => Loading Basis Set <=
 
@@ -7339,7 +7341,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7418,7 +7420,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -7444,17 +7446,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.94860658995196   -7.59486e+01   5.55170e-02 
-   @DF-RHF iter   1:   -76.03445239898700   -8.58458e-02   7.79633e-03 
-   @DF-RHF iter   2:   -76.05212220305479   -1.76698e-02   4.19376e-03 DIIS
-   @DF-RHF iter   3:   -76.05748029984673   -5.35810e-03   5.97081e-04 DIIS
-   @DF-RHF iter   4:   -76.05772413910996   -2.43839e-04   1.60991e-04 DIIS
-   @DF-RHF iter   5:   -76.05775481546218   -3.06764e-05   3.82439e-05 DIIS
-   @DF-RHF iter   6:   -76.05775673179265   -1.91633e-06   6.31611e-06 DIIS
-   @DF-RHF iter   7:   -76.05775677825653   -4.64639e-08   9.25308e-07 DIIS
-   @DF-RHF iter   8:   -76.05775677924345   -9.86915e-10   1.35946e-07 DIIS
-   @DF-RHF iter   9:   -76.05775677926623   -2.27800e-11   2.37717e-08 DIIS
-   @DF-RHF iter  10:   -76.05775677926677   -5.40012e-13   2.58116e-09 DIIS
+   @DF-RHF iter   0:   -75.94860658995074   -7.59486e+01   1.09065e-01 
+   @DF-RHF iter   1:   -76.03445239898569   -8.58458e-02   1.54067e-02 
+   @DF-RHF iter   2:   -76.05212220305351   -1.76698e-02   6.74451e-03 DIIS
+   @DF-RHF iter   3:   -76.05748029984547   -5.35810e-03   9.08234e-04 DIIS
+   @DF-RHF iter   4:   -76.05772413910856   -2.43839e-04   3.09687e-04 DIIS
+   @DF-RHF iter   5:   -76.05775481546104   -3.06764e-05   6.09489e-05 DIIS
+   @DF-RHF iter   6:   -76.05775673179144   -1.91633e-06   1.21499e-05 DIIS
+   @DF-RHF iter   7:   -76.05775677825525   -4.64638e-08   1.44523e-06 DIIS
+   @DF-RHF iter   8:   -76.05775677924223   -9.86972e-10   2.61511e-07 DIIS
+   @DF-RHF iter   9:   -76.05775677926492   -2.26947e-11   4.76399e-08 DIIS
+   @DF-RHF iter  10:   -76.05775677926542   -4.97380e-13   4.96522e-09 DIIS
   Energy converged.
 
 
@@ -7493,14 +7495,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775677926677
+  @DF-RHF Final Energy:   -76.05775677926542
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3517002620347895
-    One-Electron Energy =                -123.4016551561628745
-    Two-Electron Energy =                  37.9921981148613241
-    Total Energy =                        -76.0577567792667679
+    One-Electron Energy =                -123.4016551561627324
+    Two-Electron Energy =                  37.9921981148625392
+    Total Energy =                        -76.0577567792654179
 
 Computation Completed
 
@@ -7522,18 +7524,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9801     Total:     1.9801
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:18 2018
+*** tstop() called on dream at Wed Oct 17 21:44:24 2018
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.19 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.80 seconds =       0.25 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      81.87 seconds =       1.36 minutes
+	system time =       5.03 seconds =       0.08 minutes
+	total time  =         23 seconds =       0.38 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:18 2018
+*** at Wed Oct 17 21:44:24 2018
 
 
          ------------------------------------------------------------
@@ -7573,8 +7575,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -7593,20 +7595,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.000911283222
-       2        0.000000000000    -0.000781469692    -0.000455641611
-       3       -0.000000000000     0.000781469692    -0.000455641611
+       1        0.000000000000     0.000000000000     0.000911283291
+       2        0.000000000000    -0.000781469648    -0.000455641646
+       3       -0.000000000000     0.000781469648    -0.000455641646
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:18 2018
+*** tstop() called on dream at Wed Oct 17 21:44:25 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.74 seconds =       0.03 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.03 seconds =       0.25 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      83.62 seconds =       1.39 minutes
+	system time =       5.17 seconds =       0.09 minutes
+	total time  =         24 seconds =       0.40 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 4 of 6    //
@@ -7614,7 +7616,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:18 2018
+*** at Wed Oct 17 21:44:25 2018
 
    => Loading Basis Set <=
 
@@ -7630,7 +7632,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7709,7 +7711,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -7735,17 +7737,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95419315214608   -7.59542e+01   5.58820e-02 
-   @DF-RHF iter   1:   -76.03434742709115   -8.01543e-02   7.81553e-03 
-   @DF-RHF iter   2:   -76.05210550268124   -1.77581e-02   4.19797e-03 DIIS
-   @DF-RHF iter   3:   -76.05746734843848   -5.36185e-03   5.96839e-04 DIIS
-   @DF-RHF iter   4:   -76.05771182855788   -2.44480e-04   1.60923e-04 DIIS
-   @DF-RHF iter   5:   -76.05774238294600   -3.05544e-05   3.81093e-05 DIIS
-   @DF-RHF iter   6:   -76.05774427988561   -1.89694e-06   6.25720e-06 DIIS
-   @DF-RHF iter   7:   -76.05774432520511   -4.53195e-08   9.12871e-07 DIIS
-   @DF-RHF iter   8:   -76.05774432615922   -9.54117e-10   1.33774e-07 DIIS
-   @DF-RHF iter   9:   -76.05774432618114   -2.19131e-11   2.34891e-08 DIIS
-   @DF-RHF iter  10:   -76.05774432618166   -5.25802e-13   2.54803e-09 DIIS
+   @DF-RHF iter   0:   -75.95419315214791   -7.59542e+01   1.07497e-01 
+   @DF-RHF iter   1:   -76.03434742709295   -8.01543e-02   1.50342e-02 
+   @DF-RHF iter   2:   -76.05210550268301   -1.77581e-02   8.07536e-03 DIIS
+   @DF-RHF iter   3:   -76.05746734844035   -5.36185e-03   1.14810e-03 DIIS
+   @DF-RHF iter   4:   -76.05771182855959   -2.44480e-04   2.51344e-04 DIIS
+   @DF-RHF iter   5:   -76.05774238294786   -3.05544e-05   6.91590e-05 DIIS
+   @DF-RHF iter   6:   -76.05774427988752   -1.89694e-06   1.20366e-05 DIIS
+   @DF-RHF iter   7:   -76.05774432520685   -4.53193e-08   1.75603e-06 DIIS
+   @DF-RHF iter   8:   -76.05774432616101   -9.54159e-10   2.57333e-07 DIIS
+   @DF-RHF iter   9:   -76.05774432618300   -2.19842e-11   4.64178e-08 DIIS
+   @DF-RHF iter  10:   -76.05774432618355   -5.54223e-13   4.96702e-09 DIIS
   Energy converged.
 
 
@@ -7784,14 +7786,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05774432618166
+  @DF-RHF Final Energy:   -76.05774432618355
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3820831506858404
-    One-Electron Energy =                -123.4542923330242132
-    Two-Electron Energy =                  38.0144648561567138
-    Total Energy =                        -76.0577443261816484
+    One-Electron Energy =                -123.4542923330241138
+    Two-Electron Energy =                  38.0144648561547100
+    Total Energy =                        -76.0577443261835526
 
 Computation Completed
 
@@ -7813,18 +7815,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9821     Total:     1.9821
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+*** tstop() called on dream at Wed Oct 17 21:44:25 2018
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.19 seconds =       0.04 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.50 seconds =       0.26 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      85.83 seconds =       1.43 minutes
+	system time =       5.29 seconds =       0.09 minutes
+	total time  =         24 seconds =       0.40 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:19 2018
+*** at Wed Oct 17 21:44:25 2018
 
 
          ------------------------------------------------------------
@@ -7864,8 +7866,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -7884,20 +7886,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.004292589546
-       2       -0.000000000000     0.002558683069    -0.002146294773
-       3        0.000000000000    -0.002558683069    -0.002146294773
+       1       -0.000000000000     0.000000000000     0.004292589576
+       2       -0.000000000000     0.002558683087    -0.002146294788
+       3        0.000000000000    -0.002558683087    -0.002146294788
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+*** tstop() called on dream at Wed Oct 17 21:44:26 2018
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.77 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.73 seconds =       0.26 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      87.60 seconds =       1.46 minutes
+	system time =       5.40 seconds =       0.09 minutes
+	total time  =         25 seconds =       0.42 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 5 of 6    //
@@ -7905,7 +7907,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:19 2018
+*** at Wed Oct 17 21:44:26 2018
 
    => Loading Basis Set <=
 
@@ -7921,7 +7923,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7998,7 +8000,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -8024,16 +8026,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95481362019882   -7.59548e+01   4.02336e-02 
-   @DF-RHF iter   1:   -76.02837153960000   -7.35579e-02   6.30697e-03 
-   @DF-RHF iter   2:   -76.05031039528025   -2.19389e-02   3.55203e-03 DIIS
-   @DF-RHF iter   3:   -76.05754807444603   -7.23768e-03   3.77416e-04 DIIS
-   @DF-RHF iter   4:   -76.05772618876968   -1.78114e-04   1.03237e-04 DIIS
-   @DF-RHF iter   5:   -76.05774620005710   -2.00113e-05   2.44759e-05 DIIS
-   @DF-RHF iter   6:   -76.05774782961221   -1.62956e-06   4.79893e-06 DIIS
-   @DF-RHF iter   7:   -76.05774789585294   -6.62407e-08   6.22474e-07 DIIS
-   @DF-RHF iter   8:   -76.05774789672536   -8.72419e-10   4.17486e-08 DIIS
-   @DF-RHF iter   9:   -76.05774789672762   -2.25953e-12   6.46812e-09 DIIS
+   @DF-RHF iter   0:   -75.95481362019669   -7.59548e+01   7.97248e-02 
+   @DF-RHF iter   1:   -76.02837153959779   -7.35579e-02   1.24976e-02 
+   @DF-RHF iter   2:   -76.05031039527806   -2.19389e-02   7.03851e-03 DIIS
+   @DF-RHF iter   3:   -76.05754807444376   -7.23768e-03   7.47868e-04 DIIS
+   @DF-RHF iter   4:   -76.05772618876726   -1.78114e-04   2.04568e-04 DIIS
+   @DF-RHF iter   5:   -76.05774620005472   -2.00113e-05   4.85001e-05 DIIS
+   @DF-RHF iter   6:   -76.05774782960991   -1.62956e-06   9.50931e-06 DIIS
+   @DF-RHF iter   7:   -76.05774789585061   -6.62407e-08   1.23346e-06 DIIS
+   @DF-RHF iter   8:   -76.05774789672314   -8.72532e-10   8.27268e-08 DIIS
+   @DF-RHF iter   9:   -76.05774789672520   -2.06057e-12   1.28169e-08 DIIS
+   @DF-RHF iter  10:   -76.05774789672549   -2.84217e-13   2.73404e-09 DIIS
   Energy converged.
 
 
@@ -8057,7 +8060,7 @@ gradient() will perform analytic gradient computation.
        5App    2.035915     6App    2.077208    17Ap     2.170823  
       18Ap     2.232293    19Ap     2.613480    20Ap     2.973548  
        7App    3.374788    21Ap     3.510931     8App    3.581097  
-      22Ap     3.669578     9App    3.818691    23Ap     3.886748  
+      22Ap     3.669578     9App    3.818692    23Ap     3.886748  
       24Ap     3.903010    10App    3.967878    11App    4.027503  
       25Ap     4.089122    26Ap     4.214204    12App    4.354292  
       27Ap     4.434519    28Ap     4.595684    13App    4.705103  
@@ -8072,14 +8075,14 @@ gradient() will perform analytic gradient computation.
              Ap   App 
     DOCC [     4,    1 ]
 
-  @DF-RHF Final Energy:   -76.05774789672762
+  @DF-RHF Final Energy:   -76.05774789672549
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3669111179884883
-    One-Electron Energy =                -123.4280019115075078
-    Two-Electron Energy =                  38.0033428967913949
-    Total Energy =                        -76.0577478967276193
+    One-Electron Energy =                -123.4280023332770213
+    Two-Electron Energy =                  38.0033433185630400
+    Total Energy =                        -76.0577478967254876
 
 Computation Completed
 
@@ -8101,18 +8104,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0036      Z:     1.9811     Total:     1.9811
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:19 2018
+*** tstop() called on dream at Wed Oct 17 21:44:26 2018
 Module time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.19 seconds =       0.27 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      89.77 seconds =       1.50 minutes
+	system time =       5.54 seconds =       0.09 minutes
+	total time  =         25 seconds =       0.42 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:19 2018
+*** at Wed Oct 17 21:44:26 2018
 
 
          ------------------------------------------------------------
@@ -8152,8 +8155,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -8172,20 +8175,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000    -0.003731956628     0.002609024479
-       2        0.000000000000     0.002759623173    -0.002703236251
-       3        0.000000000000     0.000972333455     0.000094211773
+       1        0.000000000000    -0.003731951355     0.002609025600
+       2        0.000000000000     0.002759622150    -0.002703234141
+       3        0.000000000000     0.000972329206     0.000094208541
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:20 2018
+*** tstop() called on dream at Wed Oct 17 21:44:27 2018
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.74 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      16.43 seconds =       0.27 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =      91.51 seconds =       1.53 minutes
+	system time =       5.67 seconds =       0.09 minutes
+	total time  =         26 seconds =       0.43 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    Loading displacement 6 of 6    //
@@ -8193,7 +8196,7 @@ Total time:
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:20 2018
+*** at Wed Oct 17 21:44:27 2018
 
    => Loading Basis Set <=
 
@@ -8209,7 +8212,7 @@ gradient() will perform analytic gradient computation.
             by Justin Turney, Rob Parrish, Andy Simmonett
                              and Daniel Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -8288,7 +8291,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory (MB):                375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -8314,17 +8317,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.95139982935481   -7.59514e+01   5.56992e-02 
-   @DF-RHF iter   1:   -76.03440601355928   -8.30062e-02   7.80589e-03 
-   @DF-RHF iter   2:   -76.05211980911726   -1.77138e-02   4.19583e-03 DIIS
-   @DF-RHF iter   3:   -76.05747970578048   -5.35990e-03   5.96959e-04 DIIS
-   @DF-RHF iter   4:   -76.05772386500411   -2.44159e-04   1.60958e-04 DIIS
-   @DF-RHF iter   5:   -76.05775448086416   -3.06159e-05   3.81765e-05 DIIS
-   @DF-RHF iter   6:   -76.05775638747068   -1.90661e-06   6.28655e-06 DIIS
-   @DF-RHF iter   7:   -76.05775643335777   -4.58871e-08   9.19066e-07 DIIS
-   @DF-RHF iter   8:   -76.05775643432824   -9.70473e-10   1.34858e-07 DIIS
-   @DF-RHF iter   9:   -76.05775643435051   -2.22684e-11   2.36299e-08 DIIS
-   @DF-RHF iter  10:   -76.05775643435115   -6.39488e-13   2.56450e-09 DIIS
+   @DF-RHF iter   0:   -75.95139982935157   -7.59514e+01   1.07145e-01 
+   @DF-RHF iter   1:   -76.03440601355607   -8.30062e-02   1.47957e-02 
+   @DF-RHF iter   2:   -76.05211980911402   -1.77138e-02   6.74784e-03 DIIS
+   @DF-RHF iter   3:   -76.05747970577715   -5.35990e-03   1.17968e-03 DIIS
+   @DF-RHF iter   4:   -76.05772386500078   -2.44159e-04   3.09624e-04 DIIS
+   @DF-RHF iter   5:   -76.05775448086092   -3.06159e-05   7.34377e-05 DIIS
+   @DF-RHF iter   6:   -76.05775638746748   -1.90661e-06   9.81891e-06 DIIS
+   @DF-RHF iter   7:   -76.05775643335451   -4.58870e-08   1.76795e-06 DIIS
+   @DF-RHF iter   8:   -76.05775643432494   -9.70431e-10   2.59417e-07 DIIS
+   @DF-RHF iter   9:   -76.05775643434723   -2.22826e-11   4.73557e-08 DIIS
+   @DF-RHF iter  10:   -76.05775643434784   -6.11067e-13   4.93316e-09 DIIS
   Energy converged.
 
 
@@ -8363,14 +8366,14 @@ gradient() will perform analytic gradient computation.
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05775643435115
+  @DF-RHF Final Energy:   -76.05775643434784
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.3668731757160018
-    One-Electron Energy =                -123.4279507369165572
-    Two-Electron Energy =                  38.0033211268494071
-    Total Energy =                        -76.0577564343511483
+    One-Electron Energy =                -123.4279507369135160
+    Two-Electron Energy =                  38.0033211268496842
+    Total Energy =                        -76.0577564343478372
 
 Computation Completed
 
@@ -8392,18 +8395,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.9811     Total:     1.9811
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:20 2018
+*** tstop() called on dream at Wed Oct 17 21:44:28 2018
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.21 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      16.90 seconds =       0.28 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =      93.74 seconds =       1.56 minutes
+	system time =       5.79 seconds =       0.10 minutes
+	total time  =         27 seconds =       0.45 minutes
 
 *** tstart() called on dream
-*** at Wed Oct 17 20:15:20 2018
+*** at Wed Oct 17 21:44:28 2018
 
 
          ------------------------------------------------------------
@@ -8443,8 +8446,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory (MB):               375
     Schwarz Cutoff:          0E+00
     Fitting Condition:       1E-12
@@ -8463,20 +8466,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.002590010221
-       2       -0.000000000000     0.000881701881    -0.001295005111
-       3        0.000000000000    -0.000881701881    -0.001295005111
+       1       -0.000000000000     0.000000000000     0.002590010232
+       2       -0.000000000000     0.000881701886    -0.001295005116
+       3        0.000000000000    -0.000881701886    -0.001295005116
 
 
-*** tstop() called on dream at Wed Oct 17 20:15:20 2018
+*** tstop() called on dream at Wed Oct 17 21:44:28 2018
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.74 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      17.14 seconds =       0.29 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =      95.48 seconds =       1.59 minutes
+	system time =       5.88 seconds =       0.10 minutes
+	total time  =         27 seconds =       0.45 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -8500,12 +8503,12 @@ Total time:
 
    ==> Helgaker 2-point exponential SCF extrapolation for method: SCF <==
 
-   LO-zeta (2) Energy:               -76.026862722355
-   HI-zeta (3) Energy:               -76.057756434351
+   LO-zeta (2) Energy:               -76.026862722357
+   HI-zeta (3) Energy:               -76.057756434348
    Alpha (exponent) Value:             1.630000000000
-   Beta (coefficient) Value:           1.000866183139
+   Beta (coefficient) Value:           1.000866182949
 
-   @Extrapolated SCF/(D,T):         -76.065284371755
+   @Extrapolated SCF/(D,T):         -76.065284371751
 
 
    ==> Components <==
@@ -8546,26 +8549,26 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
                  1                   2                   3                   4                   5
 
     1     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    2     0.00000000000000     0.80944036631429     0.00000000000000     0.00000000000000    -0.40472018315714
-    3     0.00000000000000     0.00000000000000     0.52473094730562     0.00000000000000     0.23757575166632
+    2     0.00000000000000     0.80943859707943     0.00000000000000     0.00000000000000    -0.40471929853972
+    3     0.00000000000000     0.00000000000000     0.52473110951508     0.00000000000000     0.23757587447087
     4     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    5     0.00000000000000    -0.40472018315714     0.23757575166632     0.00000000000000     0.43820426333237
-    6     0.00000000000000     0.30304409237966    -0.26236547365281     0.00000000000000    -0.27030992202299
+    5     0.00000000000000    -0.40471929853972     0.23757587447087     0.00000000000000     0.43820381802083
+    6     0.00000000000000     0.30304343000082    -0.26236555475754     0.00000000000000    -0.27030965223585
     7     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    8     0.00000000000000    -0.40472018315714    -0.23757575166632     0.00000000000000    -0.03348408017522
-    9     0.00000000000000    -0.30304409237966    -0.26236547365281     0.00000000000000     0.03273417035667
+    8     0.00000000000000    -0.40471929853972    -0.23757587447087     0.00000000000000    -0.03348451948111
+    9     0.00000000000000    -0.30304343000082    -0.26236555475754     0.00000000000000     0.03273377776498
 
                  6                   7                   8                   9
 
     1     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    2     0.30304409237966     0.00000000000000    -0.40472018315714    -0.30304409237966
-    3    -0.26236547365281     0.00000000000000    -0.23757575166632    -0.26236547365281
+    2     0.30304343000082     0.00000000000000    -0.40471929853972    -0.30304343000082
+    3    -0.26236555475754     0.00000000000000    -0.23757587447087    -0.26236555475754
     4     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    5    -0.27030992202299     0.00000000000000    -0.03348408017522     0.03273417035667
-    6     0.24463855858679     0.00000000000000    -0.03273417035667     0.01772691506602
+    5    -0.27030965223585     0.00000000000000    -0.03348451948111     0.03273377776498
+    6     0.24463835115301     0.00000000000000    -0.03273377776498     0.01772720360453
     7     0.00000000000000     0.00000000000000     0.00000000000000     0.00000000000000
-    8    -0.03273417035667     0.00000000000000     0.43820426333237     0.27030992202299
-    9     0.01772691506602     0.00000000000000     0.27030992202299     0.24463855858679
+    8    -0.03273377776498     0.00000000000000     0.43820381802083     0.27030965223585
+    9     0.01772720360453     0.00000000000000     0.27030965223585     0.24463835115301
 
 
 
@@ -8579,33 +8582,33 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
   mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (0)
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
   pre-proj  low-frequency mode:    0.0000  [cm^-1]
-  pre-proj  low-frequency mode:    0.0001  [cm^-1]
-  pre-proj  all modes:['0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '0.0001' '1747.7069'
- '4130.2408' '4230.6358']
+  pre-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '1747.7064'
+ '4130.2413' '4230.6312']
   projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  6 (6)
-  post-proj low-frequency mode:    0.0001i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
   post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
-  post-proj low-frequency mode:    0.0001  [cm^-1] (TR)
-  post-proj  all modes:['0.0001i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0001' '1747.7069'
- '4130.2408' '4230.6358']
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj  all modes:['0.0000i' '0.0000i' '0.0000i' '0.0000' '0.0000' '0.0000' '1747.7064'
+ '4130.2413' '4230.6312']
 
   Vibration                       7                   8                   9           
-  Freq [cm^-1]                1747.7069           4130.2408           4230.6358       
+  Freq [cm^-1]                1747.7064           4130.2413           4230.6312       
   Irrep                           A1                  A1                  B2          
   Reduced mass [u]              1.0834              1.0445              1.0837        
   Force const [mDyne/A]         1.9497             10.4983             11.4279        
   Turning point v=0 [a0]        0.2522              0.1671              0.1621        
   RMS dev v=0 [a0 u^1/2]        0.1856              0.1207              0.1193        
-  Char temp [K]               2514.5611           5942.4970           6086.9430       
+  Char temp [K]               2514.5604           5942.4977           6086.9364       
   ----------------------------------------------------------------------------------
-      1   O                0.00 -0.00 -0.07    0.00  0.00  0.05    0.00 -0.07 -0.00   
-      2   H                0.00  0.42  0.56   -0.00  0.59 -0.39   -0.00  0.56 -0.42   
+      1   O                0.00  0.00 -0.07    0.00 -0.00  0.05    0.00 -0.07 -0.00   
+      2   H               -0.00  0.42  0.56    0.00  0.59 -0.39   -0.00  0.56 -0.42   
       3   H               -0.00 -0.42  0.56   -0.00 -0.59 -0.39    0.00  0.56  0.42   
 
   ==> Thermochemistry Components <==
@@ -8643,38 +8646,38 @@ CURRENT HESSIAN  Irrep: 1 Size: 9 x 9
     Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
-    Vibrational ZPE        14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302905 [Eh]        5054.292 [cm^-1]
-  Correction ZPE           14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302905 [Eh]        5054.292 [cm^-1]
-  Total ZPE, Electronic energy at 0 [K]                                -76.04225532 [Eh]
+    Vibrational ZPE        14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302904 [Eh]        5054.289 [cm^-1]
+  Correction ZPE           14.451 [kcal/mol]       60.463 [kJ/mol]       0.02302904 [Eh]        5054.289 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -76.04225533 [Eh]
 
   Thermal Energy, E (includes ZPE)
     Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
     Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational E          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303078 [Eh]
-  Correction E             16.229 [kcal/mol]       67.904 [kJ/mol]       0.02586333 [Eh]
-  Total E, Electronic energy at  298.15 [K]                            -76.03942104 [Eh]
+    Vibrational E          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303077 [Eh]
+  Correction E             16.229 [kcal/mol]       67.904 [kJ/mol]       0.02586332 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -76.03942105 [Eh]
 
   Enthalpy, H_trans = E_trans + k_B * T
     Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
     Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
-    Vibrational H          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303078 [Eh]
-  Correction H             16.822 [kcal/mol]       70.383 [kJ/mol]       0.02680752 [Eh]
-  Total H, Enthalpy at  298.15 [K]                                     -76.03847685 [Eh]
+    Vibrational H          14.452 [kcal/mol]       60.467 [kJ/mol]       0.02303077 [Eh]
+  Correction H             16.822 [kcal/mol]       70.383 [kJ/mol]       0.02680751 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -76.03847687 [Eh]
 
   Gibbs free energy, G = H - T * S
     Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
     Translational G        -8.837 [kcal/mol]      -36.975 [kJ/mol]      -0.01408304 [Eh]
     Rotational G           -2.187 [kcal/mol]       -9.151 [kJ/mol]      -0.00348561 [Eh]
-    Vibrational G          14.451 [kcal/mol]       60.462 [kJ/mol]       0.02302884 [Eh]
-  Correction G              3.426 [kcal/mol]       14.336 [kJ/mol]       0.00546019 [Eh]
-  Total G, Free enthalpy at  298.15 [K]                                -76.05982418 [Eh]
+    Vibrational G          14.451 [kcal/mol]       60.462 [kJ/mol]       0.02302883 [Eh]
+  Correction G              3.426 [kcal/mol]       14.336 [kJ/mol]       0.00546018 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -76.05982419 [Eh]
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 	SCF/cc-pV[DT]Z Frequency 1........................................PASSED
 
-    Psi4 stopped on: Wednesday, 17 October 2018 08:15PM
-    Psi4 wall time for execution: 0:00:17.84
+    Psi4 stopped on: Wednesday, 17 October 2018 09:44PM
+    Psi4 wall time for execution: 0:00:26.85
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
The general idea is to allow more flexible definition of CBS functions, and clean up the `cbs()` function a little. The goal is to allow further corrections to the energy into CBS, eg differences of basis sets (eg. `\Delta E_{diff} = E(aug-cc-pvtz) - E(cc-pvtz)`) or frozen core corrections (`\Delta E_{ae} = E(freeze_core True) - E(freeze_core False)` or DKH ...

Added `frequency` to cbs-compatible calls.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Simple, dict-based interface to CBS.
- [x] Handling of an arbitrary number of correction functions.
- [x] Support for passing of arbitrary options (such as `freeze_core`). 
- [x] Fix `pywrap-cbs1` which fails on `cbs_number` checks.
- [x] Documentation.
- [x] Frequency calculations via cbs are now possible.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
