### PR TITLE
Fix MKL on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ install:
   - conda create --channel conda-forge
                  --name %CONDA_ENV%
                  deepdiff
+                 intel-openmp=2018.0.3
                  mkl-devel=2018.0.3
                  mpmath
                  networkx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - conda create --channel conda-forge
                  --name %CONDA_ENV%
                  deepdiff
-                 mkl-devel
+                 mkl-devel=2018.0.3
                  mpmath
                  networkx
                  ninja


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

Appveyor is falling, because the new version (2019.0) of MKL is not detected.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Lock MKL version

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
