### PR TITLE
fixes amplitude memory estimate not recognizing frozen core

### DIFF
--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -64,7 +64,7 @@ void DFOCC::omp2_manager() {
     if (reference_ == "RESTRICTED") {
         // mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_amp = 3.0 * cost_ampAA;
@@ -124,13 +124,13 @@ void DFOCC::omp2_manager() {
     else if (reference_ == "UNRESTRICTED") {
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -377,7 +377,7 @@ void DFOCC::mp2_manager() {
     if (reference_ == "RESTRICTED") {
         // mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_amp = 3.0 * cost_ampAA;
@@ -439,13 +439,13 @@ void DFOCC::mp2_manager() {
     else if (reference_ == "UNRESTRICTED") {
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -601,7 +601,7 @@ void DFOCC::ccsd_manager() {
 
         // Mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_3amp = 3.0 * cost_ampAA;
@@ -714,13 +714,13 @@ void DFOCC::ccsd_manager() {
 
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -921,7 +921,7 @@ void DFOCC::ccsd_t_manager() {
 
         // Mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_3amp = 3.0 * cost_ampAA;
@@ -1064,13 +1064,13 @@ void DFOCC::ccsd_t_manager() {
 
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -1303,7 +1303,7 @@ void DFOCC::ccsdl_t_manager() {
 
         // Mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_3amp = 3.0 * cost_ampAA;
@@ -1463,13 +1463,13 @@ void DFOCC::ccsdl_t_manager() {
 
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -1668,7 +1668,7 @@ void DFOCC::ccd_manager() {
 
         // Mem for amplitudes
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
         cost_3amp = 3.0 * cost_ampAA;
@@ -1758,13 +1758,13 @@ void DFOCC::ccd_manager() {
     else if (reference_ == "UNRESTRICTED") {
         // memory requirements
         cost_ampAA = 0.0;
-        cost_ampAA = nocc2AA * nvir2AA;
+        cost_ampAA = naocc2AA * nvir2AA;
         cost_ampAA /= 1024.0 * 1024.0;
         cost_ampAA *= sizeof(double);
-        cost_ampBB = nocc2BB * nvir2BB;
+        cost_ampBB = naocc2BB * nvir2BB;
         cost_ampBB /= 1024.0 * 1024.0;
         cost_ampBB *= sizeof(double);
-        cost_ampAB = nocc2AB * nvir2AB;
+        cost_ampAB = naocc2AB * nvir2AB;
         cost_ampAB /= 1024.0 * 1024.0;
         cost_ampAB *= sizeof(double);
         cost_amp = MAX0(cost_ampAA, cost_ampBB);
@@ -1958,7 +1958,7 @@ void DFOCC::omp3_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;
@@ -2257,7 +2257,7 @@ void DFOCC::mp3_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;
@@ -2493,7 +2493,7 @@ void DFOCC::omp2_5_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;
@@ -2790,7 +2790,7 @@ void DFOCC::mp2_5_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;
@@ -3007,7 +3007,7 @@ void DFOCC::olccd_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;
@@ -3276,7 +3276,7 @@ void DFOCC::lccd_manager() {
 
     // Mem for amplitudes
     cost_ampAA = 0.0;
-    cost_ampAA = nocc2AA * nvir2AA;
+    cost_ampAA = naocc2AA * nvir2AA;
     cost_ampAA /= 1024.0 * 1024.0;
     cost_ampAA *= sizeof(double);
     cost_3amp = 3.0 * cost_ampAA;


### PR DESCRIPTION
## Description
Memory estimation for the amplitudes now recognize frozen_core settings.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] fixes #898 
- [ ]  check code for same problem in CD algorithm variant.

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
