### PR TITLE
 Fix memory error in psi::detci::CIWavefunction

### DIFF
--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -482,8 +482,10 @@ std::vector<std::vector<SharedMatrix> > CIWavefunction::opdm(SharedCIVector Ivec
 
     } /* end loop over states_vec */
 
-    if (transp_tmp != nullptr) free_block(transp_tmp);
-    if (transp_tmp2 != nullptr) free_block(transp_tmp2);
+    if (transp_tmp) free(transp_tmp[0]);
+    free(transp_tmp);
+    if (transp_tmp2) free(transp_tmp2[0]);
+    free(transp_tmp2);
 
     scratch_a.reset();
     scratch_b.reset();

--- a/psi4/src/psi4/detci/tpdm.cc
+++ b/psi4/src/psi4/detci/tpdm.cc
@@ -410,8 +410,10 @@ std::vector<SharedMatrix> CIWavefunction::tpdm(SharedCIVector Ivec, SharedCIVect
 
     // Ivec->buf_unlock();
     // Jvec->buf_unlock();
-    if (transp_tmp != nullptr) free_block(transp_tmp);
-    if (transp_tmp2 != nullptr) free_block(transp_tmp2);
+    if (transp_tmp) free(transp_tmp[0]);
+    free(transp_tmp);
+    if (transp_tmp2) free(transp_tmp2[0]);
+    free(transp_tmp2);
 
     std::vector<int> nshape{nact, nact, nact, nact};
     tpdm_aam->set_numpy_shape(nshape);


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Match `malloc` with `free`. `free_block` uses `delete[]`.

## Checklist
- [x]  ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge