### PR TITLE
ENH: CCLambdaWfn inherits from CCEnergyWfn

### DIFF
--- a/psi4/src/psi4/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/ccenergy/ccenergy.cc
@@ -95,8 +95,6 @@ double CCEnergyWavefunction::compute_energy()
     double **geom, *zvals, value;
     FILE *efile;
     int **cachelist, *cachefiles;
-    dpdfile2 t1;
-    dpdbuf4 t2;
     double *emp2_aa, *emp2_ab, *ecc_aa, *ecc_ab, tval;
 
     moinfo_.iter=0;

--- a/psi4/src/psi4/cclambda/L2.cc
+++ b/psi4/src/psi4/cclambda/L2.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -57,9 +58,8 @@ void GmiL2(int L_irr);
 void dijabL2(int L_irr);
 
 void BL2_AO(int L_irr);
-void status(const char *, std::string);
 
-void L2_build(struct L_Params L_params) {
+void CCLambdaWavefunction::L2_build(struct L_Params L_params) {
   dpdbuf4 L2;
   int L_irr;
   L_irr = L_params.irrep;

--- a/psi4/src/psi4/cclambda/cache.cc
+++ b/psi4/src/psi4/cclambda/cache.cc
@@ -35,6 +35,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/cclambda/cclambda.h"
 
 namespace psi {
 extern FILE* outfile;
@@ -54,7 +55,7 @@ void cache_iajb_uhf(int **cachelist);
 void cache_ijka_uhf(int **cachelist);
 void cache_ijkl_uhf(int **cachelist);
 
-int **cacheprep_uhf(int level, int *cachefiles)
+int **CCLambdaWavefunction::cacheprep_uhf(int level, int *cachefiles)
 {
   int **cachelist;
 
@@ -120,7 +121,7 @@ int **cacheprep_uhf(int level, int *cachefiles)
    }
 }
 
-int **cacheprep_rhf(int level, int *cachefiles)
+int **CCLambdaWavefunction::cacheprep_rhf(int level, int *cachefiles)
 {
   int **cachelist;
 
@@ -745,12 +746,12 @@ void cache_ijkl_uhf(int **cachelist)
   cachelist[23][23] = 1;
 }
 
-void cachedone_uhf(int **cachelist)
+void CCLambdaWavefunction::cachedone_uhf(int **cachelist)
 {
   free_int_matrix(cachelist);
 }
 
-void cachedone_rhf(int **cachelist)
+void CCLambdaWavefunction::cachedone_rhf(int **cachelist)
 {
   free_int_matrix(cachelist);
 }

--- a/psi4/src/psi4/cclambda/cc2_L2.cc
+++ b/psi4/src/psi4/cclambda/cc2_L2.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -50,9 +51,8 @@ void L1FL2(int L_irr);
 void dijabL2(int L_irr);
 
 void BL2_AO(int L_irr);
-void status(const char *, std::string );
 
-void cc2_L2_build(struct L_Params L_params) {
+void CCLambdaWavefunction::cc2_L2_build(struct L_Params L_params) {
   int L_irr;
   L_irr = L_params.irrep;
 

--- a/psi4/src/psi4/cclambda/cclambda.h
+++ b/psi4/src/psi4/cclambda/cclambda.h
@@ -30,6 +30,7 @@
 #define CCLAMBDA_H
 
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/ccenergy/ccwave.h"
 
 namespace psi {
 class Wavefunction;
@@ -38,7 +39,7 @@ class Options;
 
 namespace psi { namespace cclambda {
 
-class CCLambdaWavefunction : public Wavefunction
+class CCLambdaWavefunction final : public psi::ccenergy::CCEnergyWavefunction
 {
 public:
     CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
@@ -48,6 +49,29 @@ public:
 
 private:
     void init();
+    void init_io();
+    void init_amps(struct L_Params);
+    int **cacheprep_uhf(int level, int *cachefiles);
+    int **cacheprep_rhf(int level, int *cachefiles);
+    void cachedone_rhf(int **cachelist);
+    void cachedone_uhf(int **cachelist);
+    void cleanup();
+    void denom(struct L_Params);
+    void get_params(psi::Options&);
+    void local_init();
+    void local_done();
+    void exit_io();
+    void title();
+    void get_moinfo(std::shared_ptr<psi::Wavefunction> wfn);
+
+    int converged(int);
+    void diis(int, int);
+    void sort_amps(int);
+    void status(const char*, std::string);
+    void update();
+
+    void cc2_L2_build(struct L_Params);
+    void L2_build(struct L_Params);
 };
 
 }}

--- a/psi4/src/psi4/cclambda/converged.cc
+++ b/psi4/src/psi4/cclambda/converged.cc
@@ -34,6 +34,7 @@
 #include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -41,7 +42,7 @@
 
 namespace psi { namespace cclambda {
 
-int converged(int L_irr)
+int CCLambdaWavefunction::converged(int L_irr)
 {
   int row,col,h,nirreps;
   double rms=0.0;

--- a/psi4/src/psi4/cclambda/denom.cc
+++ b/psi4/src/psi4/cclambda/denom.cc
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cstring>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -44,7 +45,7 @@ void denom_rhf(struct L_Params);
 void denom_rohf(struct L_Params);
 void denom_uhf(struct L_Params);
 
-void denom(struct L_Params L_params) {
+void CCLambdaWavefunction::denom(struct L_Params L_params) {
   if(params.ref == 0) denom_rhf(L_params);
   else if(params.ref == 1) denom_rohf(L_params);
   else if(params.ref == 2) denom_uhf(L_params);

--- a/psi4/src/psi4/cclambda/diis.cc
+++ b/psi4/src/psi4/cclambda/diis.cc
@@ -38,6 +38,7 @@
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/cclambda/cclambda.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
@@ -60,7 +61,7 @@ namespace psi { namespace cclambda {
 ** -TDC  12/22/01
 */
 
-void diis(int iter, int L_irr)
+void CCLambdaWavefunction::diis(int iter, int L_irr)
 {
   int nvector=8;  /* Number of error vectors to keep */
   int h, nirreps;

--- a/psi4/src/psi4/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cclambda/get_moinfo.cc
@@ -38,6 +38,7 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/molecule.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -54,7 +55,7 @@ namespace psi { namespace cclambda {
 ** Modified for UHF references by TDC, June 2002.
 */
 
-void get_moinfo(std::shared_ptr<Wavefunction> wfn)
+void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn)
 {
     int i,j, h, p, q, errcod, nactive, nirreps, sym;
     double ***C, ***Ca, ***Cb;
@@ -241,7 +242,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn)
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
-void cleanup(void)
+void CCLambdaWavefunction::cleanup(void)
 {
     int i, h;
 

--- a/psi4/src/psi4/cclambda/get_params.cc
+++ b/psi4/src/psi4/cclambda/get_params.cc
@@ -42,6 +42,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/cclambda/cclambda.h"
 
 #include "MOInfo.h"
 #include "Params.h"
@@ -51,7 +52,7 @@
 
 namespace psi { namespace cclambda {
 
-void get_params(Options& options)
+void CCLambdaWavefunction::get_params(Options& options)
 {
   int errcod, iconv,i,j,k,l,prop_sym,prop_root, excited_method=0;
         int *states_per_irrep, prop_all, lambda_and_Ls = 0;

--- a/psi4/src/psi4/cclambda/init_amps.cc
+++ b/psi4/src/psi4/cclambda/init_amps.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -39,7 +40,7 @@
 
 namespace psi { namespace cclambda {
 
-void init_amps(struct L_Params L_params)
+void CCLambdaWavefunction::init_amps(struct L_Params L_params)
 {
   double norm;
   dpdfile2 T1, R1, LIA, Lia, dIA, dia, XIA, Xia;

--- a/psi4/src/psi4/cclambda/local.cc
+++ b/psi4/src/psi4/cclambda/local.cc
@@ -45,6 +45,7 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
+#include "psi4/cclambda/cclambda.h"
 #define EXTERN
 #include "globals.h"
 
@@ -64,7 +65,7 @@ namespace psi { namespace cclambda {
 ** TDC, Jan-June 2002
 */
 
-void local_init(void)
+void CCLambdaWavefunction::local_init(void)
 {
   local.nso = moinfo.nso;
   local.nocc = moinfo.occpi[0]; /* active doubly occupied orbitals */
@@ -74,7 +75,7 @@ void local_init(void)
 
 }
 
-void local_done(void)
+void CCLambdaWavefunction::local_done(void)
 {
   outfile->Printf( "\tLocal parameters free.\n");
 }

--- a/psi4/src/psi4/cclambda/sort_amps.cc
+++ b/psi4/src/psi4/cclambda/sort_amps.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/cclambda/cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
 #define EXTERN
@@ -39,7 +40,7 @@
 
 namespace psi { namespace cclambda {
 
-void sort_amps(int L_irr)
+void CCLambdaWavefunction::sort_amps(int L_irr)
 {
   dpdbuf4 L2;
 

--- a/psi4/src/psi4/cclambda/status.cc
+++ b/psi4/src/psi4/cclambda/status.cc
@@ -33,9 +33,11 @@
 #include <cstdio>
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/cclambda/cclambda.h"
+
 namespace psi { namespace cclambda {
 
-void status(const char *s, std::string out)
+void CCLambdaWavefunction::status(const char *s, std::string out)
 {
    std::shared_ptr<psi::PsiOutStream> printer=(out=="outfile"?outfile:
            std::make_shared<PsiOutStream>(out));

--- a/psi4/src/psi4/cclambda/update.cc
+++ b/psi4/src/psi4/cclambda/update.cc
@@ -33,12 +33,13 @@
 #include <cstdio>
 #include "MOInfo.h"
 #include "Params.h"
+#include "psi4/cclambda/cclambda.h"
 #define EXTERN
 #include "globals.h"
 
 namespace psi { namespace cclambda {
 
-void update(void)
+void CCLambdaWavefunction::update(void)
 {
   outfile->Printf("\t%4d      %20.15f    %4.3e\n",moinfo.iter,moinfo.lcc,
 	  moinfo.conv);


### PR DESCRIPTION
Inherit CCLambdaWavefunction from CCEnergyWavefunction and further
build a class around CCLambdaWavefunction.

## Description
This PR just contains the inheritance of the CCLambdaWavefunction from the CCEnergyWavefunction, but no other functional changes or features.
The main motivation for this was so that this can be merged before the clang-format of the cclambda module in #1206 that seems to be happening before #1061. It would be nice to have these changes in before the formatting.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
