### PR TITLE
Dft fixes

### DIFF
--- a/psi4/driver/procrouting/dft_funcs/dict_hyb_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_hyb_funcs.py
@@ -34,6 +34,8 @@ import copy
 funcs = []
 
 funcs.append({
+    # This should be replaced with a call to libxc's
+    # HYB_GGA_XC_LC_WPBEH_WHS once it's possible
     "name": "wPBE0",
     "alias": ["LC-WPBE0"],
     "x_functionals": {
@@ -58,6 +60,8 @@ funcs.append({
 })
 
 funcs.append({
+    # This should be replaced with a call to libxc's
+    # HYB_GGA_XC_LC_WPBE_WHS once it's possible
     "name": "wPBE",
     "alias": ["LC-WPBE", "LCWPBE"],
     "x_functionals": {

--- a/psi4/driver/procrouting/dft_funcs/dict_hyb_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_hyb_funcs.py
@@ -44,7 +44,7 @@ funcs.append({
     },
     "x_hf": {
         "alpha": 0.25,
-        "beta": 1.0,
+        "beta": 0.75,
         "omega": 0.3
     },
     "c_functionals": {

--- a/psi4/driver/procrouting/dft_funcs/dict_xc_funcs.py
+++ b/psi4/driver/procrouting/dft_funcs/dict_xc_funcs.py
@@ -104,7 +104,7 @@ funcs.append({"name": "BHandHLYP"      , "xc_functionals": {"HYB_GGA_XC_BHANDHLY
 funcs.append({"name": "MB3LYP-RC04"    , "xc_functionals": {"HYB_GGA_XC_MB3LYP_RC04"    : {}}})
 funcs.append({"name": "mPWLYP1M"       , "xc_functionals": {"HYB_GGA_XC_MPWLYP1M"       : {}}})
 funcs.append({"name": "revB3LYP"       , "xc_functionals": {"HYB_GGA_XC_REVB3LYP"       : {}}})
-funcs.append({"name": "CAMY-BLYP"      , "xc_functionals": {"HYB_GGA_XC_CAMY_BLYP"      : {}}})
+#funcs.append({"name": "CAMY-BLYP"      , "xc_functionals": {"HYB_GGA_XC_CAMY_BLYP"      : {}}}) # CAMY range separation not supported by psi4
 funcs.append({"name": "PBE0-13"        , "xc_functionals": {"HYB_GGA_XC_PBE0_13"        : {}}})
 funcs.append({"name": "B3LYPs"         , "xc_functionals": {"HYB_GGA_XC_B3LYPs"         : {}}})
 funcs.append({"name": "wB97"           , "xc_functionals": {"HYB_GGA_XC_WB97"           : {}}})
@@ -112,10 +112,10 @@ funcs.append({"name": "wB97X"          , "xc_functionals": {"HYB_GGA_XC_WB97X"  
 funcs.append({"name": "wB97X-D"        , "xc_functionals": {"HYB_GGA_XC_WB97X_D"        : {}}, "dispersion": {"type": "chg", "params": {"s6": 1.0}}})
 funcs.append({"name": "LRC-wPBEh"      , "xc_functionals": {"HYB_GGA_XC_LRC_WPBEH"      : {}}})
 funcs.append({"name": "wB97X-V"        , "xc_functionals": {"HYB_GGA_XC_WB97X_V"        : {}}, "alias": ["WB97XV"]})
-funcs.append({"name": "LCY-PBE"        , "xc_functionals": {"HYB_GGA_XC_LCY_PBE"        : {}}})
-funcs.append({"name": "LCY-BLYP"       , "xc_functionals": {"HYB_GGA_XC_LCY_BLYP"       : {}}})
+#funcs.append({"name": "LCY-PBE"        , "xc_functionals": {"HYB_GGA_XC_LCY_PBE"        : {}}}) # LCY range separation not supported by psi4
+#funcs.append({"name": "LCY-BLYP"       , "xc_functionals": {"HYB_GGA_XC_LCY_BLYP"       : {}}}) # LCY range separation not supported by psi4
 funcs.append({"name": "LC-VV10"        , "xc_functionals": {"HYB_GGA_XC_LC_VV10"        : {}}})
-funcs.append({"name": "CAMY-B3LYP"     , "xc_functionals": {"HYB_GGA_XC_CAMY_B3LYP"     : {}}})
+#funcs.append({"name": "CAMY-B3LYP"     , "xc_functionals": {"HYB_GGA_XC_CAMY_B3LYP"     : {}}}) # CAMY range separation not supported by psi4
 funcs.append({"name": "HPBEINT"        , "xc_functionals": {"HYB_GGA_XC_HPBEINT"        : {}}})
 funcs.append({"name": "LRC-WPBE"       , "xc_functionals": {"HYB_GGA_XC_LRC_WPBE"       : {}}})
 funcs.append({"name": "B3LYP5"         , "xc_functionals": {"HYB_GGA_XC_B3LYP5"         : {}}})

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -98,7 +98,7 @@ void export_functional(py::module &m) {
         .def("set_x_omega", &SuperFunctional::set_x_omega, "Sets the range-seperation exchange parameter.")
         .def("set_c_omega", &SuperFunctional::set_c_omega, "Sets the range-seperation correlation parameter.")
         .def("set_x_alpha", &SuperFunctional::set_x_alpha, "Sets the amount of exact global HF exchange.")
-        .def("set_x_beta", &SuperFunctional::set_x_beta, "Sets the additional amount of exact HF exchange at long range.")
+        .def("set_x_beta", &SuperFunctional::set_x_beta, "Sets how much more long-range exchange than short-range exchange.")
         .def("set_c_alpha", &SuperFunctional::set_c_alpha, "Sets the amount of MP2 correlation.")
         .def("set_c_ss_alpha", &SuperFunctional::set_c_ss_alpha, "Sets the amount of SS MP2 correlation.")
         .def("set_c_os_alpha", &SuperFunctional::set_c_os_alpha, "Sets the amount of OS MP2 correlation.")

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -98,7 +98,7 @@ void export_functional(py::module &m) {
         .def("set_x_omega", &SuperFunctional::set_x_omega, "Sets the range-seperation exchange parameter.")
         .def("set_c_omega", &SuperFunctional::set_c_omega, "Sets the range-seperation correlation parameter.")
         .def("set_x_alpha", &SuperFunctional::set_x_alpha, "Sets the amount of exact global HF exchange.")
-        .def("set_x_beta", &SuperFunctional::set_x_beta, "Sets the amount of exact HF exchange at long range.")
+        .def("set_x_beta", &SuperFunctional::set_x_beta, "Sets the additional amount of exact HF exchange at long range.")
         .def("set_c_alpha", &SuperFunctional::set_c_alpha, "Sets the amount of MP2 correlation.")
         .def("set_c_ss_alpha", &SuperFunctional::set_c_ss_alpha, "Sets the amount of SS MP2 correlation.")
         .def("set_c_os_alpha", &SuperFunctional::set_c_os_alpha, "Sets the amount of OS MP2 correlation.")

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -109,17 +109,22 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
             xc_hyb_cam_coef(xc_functional_.get(), &omega_, &alpha, &beta);
 
             /*
-              The values alpha and beta have a different meaning in psi4 and libxc.
+              The values alpha and beta have a different meaning in
+              psi4 and libxc.
 
               In libxc, alpha is the contribution from full exact
-              exchange, and beta is the contribution from short-range
-              exchange, yielding alpha exact exchange in the long
-              range, and alpha+beta in the short range.
+              exchange (at all ranges), and beta is the contribution
+              from short-range only exchange, yielding alpha exact
+              exchange at the long range and alpha+beta in the short
+              range in total.
 
-              In Psi4, alpha is the amount of exchange in the short
-              range, while beta is the difference between the amount
-              of exchange in the long range and in the short
-              range. This means
+              In Psi4, alpha is the amount of exchange at all ranges,
+              while beta is the difference between the amount of
+              exchange in the long range and in the short range,
+              meaning alpha+beta at the long range, and alpha only at
+              the short range.
+
+              These differences amount to the transform
 
               SR      = LibXC_ALPHA + LibXC_BETA = Psi4_ALPHA
               LR      = LibXC_ALPHA              = Psi4_ALPHA + Psi4_BETA

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -90,7 +90,7 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
     if (xc_functional_->info->family == XC_FAMILY_HYB_GGA ||
         xc_functional_->info->family == XC_FAMILY_HYB_MGGA) {
         /* Range separation? */
-        int rangesep = 0;
+        lrc_ = false;
         if (xc_functional_->info->flags & XC_FLAGS_HYB_CAMY) {
             outfile->Printf("Functional '%d' is a HYB_CAMY functional which is not supported in Psi4\n", xc_name.c_str());
             throw PSIEXCEPTION("HYB_CAMY functionals not supported in Psi4 at present");
@@ -128,8 +128,10 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
 
             global_exch_ = alpha + beta;
             lr_exch_ = -1.0 * beta;
+        }
 
-        } else {
+        if(!lrc) {
+            // Global hybrid
             global_exch_ = xc_hyb_exx_coef(xc_functional_.get());
         }
     }

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -130,7 +130,7 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
             lr_exch_ = -1.0 * beta;
         }
 
-        if(!lrc) {
+        if(!lrc_) {
             // Global hybrid
             global_exch_ = xc_hyb_exx_coef(xc_functional_.get());
         }

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -91,19 +91,40 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
         xc_functional_->info->family == XC_FAMILY_HYB_MGGA) {
         /* Range separation? */
         int rangesep = 0;
-        if (xc_functional_->info->flags & XC_FLAGS_HYB_CAM) rangesep++;
-        if (xc_functional_->info->flags & XC_FLAGS_HYB_CAMY) rangesep++;
-        if (xc_functional_->info->flags & XC_FLAGS_HYB_LC) rangesep++;
-        if (xc_functional_->info->flags & XC_FLAGS_HYB_LCY) rangesep++;
-        if (rangesep) {
+        if (xc_functional_->info->flags & XC_FLAGS_HYB_CAMY) {
+            outfile->Printf("Functional '%d' is a HYB_CAMY functional which is not supported in Psi4\n", xc_name.c_str());
+            throw PSIEXCEPTION("HYB_CAMY functionals not supported in Psi4 at present");
+        }
+        if (xc_functional_->info->flags & XC_FLAGS_HYB_LC ) {
+            outfile->Printf("Functional '%d' is a HYB_LC functional which is not supported in Psi4\n", xc_name.c_str());
+            throw PSIEXCEPTION("HYB_LC functionals not supported in Psi4 at present");
+        }
+        if (xc_functional_->info->flags & XC_FLAGS_HYB_LCY) {
+            outfile->Printf("Functional '%d' is a HYB_LCY functional which is not supported in Psi4\n", xc_name.c_str());
+            throw PSIEXCEPTION("HYB_LCY functionals not supported in Psi4 at present");
+        }
+        if (xc_functional_->info->flags & XC_FLAGS_HYB_CAM) {
             lrc_ = true;
-
-            // SR      = LibXC_ALPHA + LibXC_BETA = psi4.set_x_alpha
-            // LR      = LibXC_ALPHA              = psi4.set_x_alpha + psi4.set_x_beta
-            // LR - SR =             - LibXC_BETA =                    psi4.set_x_beta
-
             double alpha, beta;
             xc_hyb_cam_coef(xc_functional_.get(), &omega_, &alpha, &beta);
+
+            /*
+              The values alpha and beta have a different meaning in psi4 and libxc.
+
+              In libxc, alpha is the contribution from full exact
+              exchange, and beta is the contribution from short-range
+              exchange, yielding alpha exact exchange in the long
+              range, and alpha+beta in the short range.
+
+              In Psi4, alpha is the amount of exchange in the short
+              range, while beta is the difference between the amount
+              of exchange in the long range and in the short
+              range. This means
+
+              SR      = LibXC_ALPHA + LibXC_BETA = Psi4_ALPHA
+              LR      = LibXC_ALPHA              = Psi4_ALPHA + Psi4_BETA
+              LR - SR =             - LibXC_BETA =              Psi4_BETA
+            */
 
             global_exch_ = alpha + beta;
             lr_exch_ = -1.0 * beta;
@@ -200,9 +221,11 @@ std::map<std::string, double> LibXCFunctional::query_libxc(const std::string& fu
     if (functional == "XC_HYB_CAM_COEF") {
         double omega, alpha, beta;
         xc_hyb_cam_coef(xc_functional_.get(), &omega, &alpha, &beta);
+        // LibXC and Psi4 conventions for alpha and beta differ, see
+        // above for full description
         params["OMEGA"] = omega;
         params["ALPHA"] = alpha + beta;
-        params["BETA"] = -1.0 * beta;
+        params["BETA"] = -beta;
     }
     else if (functional == "XC_NLC_COEF") {
         double nlc_b, nlc_c;


### PR DESCRIPTION
## Description
This PR clarifies the libxc interface code and function descriptions as to the meaning of the alpha and beta parameters in psi4 vs libxc. See #1258 .

Also, the definition of wPBE0 is fixed. See #1259 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
