### PR TITLE
Timers in CC modules

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/G.cc
+++ b/psi4/src/psi4/cc/ccdensity/G.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void G_build(void) {
+void G_build() {
     dpdbuf4 LIJAB, Lijab, LiJaB, LIjAb, LijAB, LIJab;
     dpdbuf4 tIJAB, tijab, tiJaB, tIjAb, tijAB, tIJab;
     dpdfile2 GAE, Gae, GMI, Gmi;

--- a/psi4/src/psi4/cc/ccdensity/G_norm.cc
+++ b/psi4/src/psi4/cc/ccdensity/G_norm.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void G_norm(void) {
+void G_norm() {
     dpdfile2 G1;
     dpdbuf4 G;
     double value, value1, dot_IA, dot_ia, dot_AI, dot_ai;

--- a/psi4/src/psi4/cc/ccdensity/Gabcd.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gabcd.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gabcd(void) {
+void Gabcd() {
     dpdbuf4 G, L, T;
     int G_irr;
     G_irr = params.G_irr;

--- a/psi4/src/psi4/cc/ccdensity/Gciab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gciab.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gciab(void) {
+void Gciab() {
     int h, nirreps, a, b, c, i, A, B, C, I, Asym, Bsym, Csym, Isym, row, col;
     double value;
     dpdfile2 L1, T1, g;

--- a/psi4/src/psi4/cc/ccdensity/Gibja.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gibja.cc
@@ -68,7 +68,7 @@ namespace ccdensity {
 ** backtransformation) after all contributions have been accounted
 ** for.  */
 
-void Gibja(void) {
+void Gibja() {
     int h, nirreps, row, col;
     int i, j, a, b, I, J, A, B, Isym, Jsym, Asym, Bsym;
     dpdfile2 T1, L1, T1A, T1B, L1A, L1B;

--- a/psi4/src/psi4/cc/ccdensity/Gijab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab.cc
@@ -39,11 +39,11 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijab_RHF(void);
-void Gijab_ROHF(void);
-void Gijab_UHF(void);
+void Gijab_RHF();
+void Gijab_ROHF();
+void Gijab_UHF();
 
-void Gijab(void) {
+void Gijab() {
     if (params.ref == 0)
         Gijab_RHF();
     else if (params.ref == 1)

--- a/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijab_RHF(void) {
+void Gijab_RHF() {
     int h, nirreps, i, a, m, e, I, A, M, E, Isym, Asym, Msym, Esym, row, col;
     int j, b, J, B, Jsym, Bsym;
     double value;

--- a/psi4/src/psi4/cc/ccdensity/Gijab_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_ROHF.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijab_ROHF(void) {
+void Gijab_ROHF() {
     int h, nirreps, i, a, m, e, I, A, M, E, Isym, Asym, Msym, Esym, row, col;
     int j, b, J, B, Jsym, Bsym;
     double value;

--- a/psi4/src/psi4/cc/ccdensity/Gijab_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_UHF.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijab_UHF(void) {
+void Gijab_UHF() {
     int h, nirreps, i, a, m, e, I, A, M, E, Isym, Asym, Msym, Esym, row, col;
     int j, b, J, B, Jsym, Bsym;
     double value;

--- a/psi4/src/psi4/cc/ccdensity/Gijka.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijka.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijka(void) {
+void Gijka() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     double value;
     dpdfile2 L1, T1, g;

--- a/psi4/src/psi4/cc/ccdensity/Gijkl.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijkl.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void Gijkl(void) {
+void Gijkl() {
     dpdbuf4 V, G;
     int G_irr;
     G_irr = params.G_irr;

--- a/psi4/src/psi4/cc/ccdensity/V.cc
+++ b/psi4/src/psi4/cc/ccdensity/V.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void V_build(void) {
+void V_build() {
     dpdbuf4 V, L, T;
     int G_irr;
     G_irr = params.G_irr;

--- a/psi4/src/psi4/cc/ccdensity/V_cc2.cc
+++ b/psi4/src/psi4/cc/ccdensity/V_cc2.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void V_cc2(void) {
+void V_cc2() {
     dpdbuf4 V, L, T;
     int G_irr;
     G_irr = params.G_irr;

--- a/psi4/src/psi4/cc/ccdensity/build_A.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A.cc
@@ -42,11 +42,11 @@ namespace ccdensity {
 /* BUILD_A(): Construct the molecular orbital Hessian, A.
 ** */
 
-void build_A_RHF(void);
-void build_A_ROHF(void);
-void build_A_UHF(void);
+void build_A_RHF();
+void build_A_ROHF();
+void build_A_UHF();
 
-void build_A(void) {
+void build_A() {
     if (params.ref == 0)
         build_A_RHF();
     else if (params.ref == 1)

--- a/psi4/src/psi4/cc/ccdensity/build_A_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_RHF.cc
@@ -51,7 +51,7 @@ namespace ccdensity {
 **
 ** */
 
-void build_A_RHF(void) {
+void build_A_RHF() {
     int h, nirreps, e, m, a, i, em, ai, E, M, A, I;
     int Esym, Msym, Asym, Isym;
     dpdfile2 fIJ, fAB;

--- a/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
@@ -53,7 +53,7 @@ namespace ccdensity {
 **
 ** */
 
-void build_A_ROHF(void) {
+void build_A_ROHF() {
     int h, nirreps, e, m, a, i, em, ai, E, M, A, I;
     int Esym, Msym, Asym, Isym;
     int *virtpi, *openpi, *occpi, *occ_off, *vir_off;

--- a/psi4/src/psi4/cc/ccdensity/build_A_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_UHF.cc
@@ -54,7 +54,7 @@ namespace ccdensity {
 ** TDC, January 2003
 */
 
-void build_A_UHF(void) {
+void build_A_UHF() {
     int h, nirreps, row, col;
     int a, i, b, j;
     int A, I, B, J;

--- a/psi4/src/psi4/cc/ccdensity/build_X.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_X.cc
@@ -50,7 +50,7 @@ namespace ccdensity {
 **  Xai = I'ia - I'ai
 ** */
 
-void build_X(void) {
+void build_X() {
     dpdfile2 X, I, I1, I2, I3, F, F1, X2;
     dpdbuf4 E, Fi;
 

--- a/psi4/src/psi4/cc/ccdensity/build_Z.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z.cc
@@ -49,11 +49,11 @@ namespace ccdensity {
 **
 */
 
-void build_Z_RHF(void);
-void build_Z_ROHF(void);
-void build_Z_UHF(void);
+void build_Z_RHF();
+void build_Z_ROHF();
+void build_Z_UHF();
 
-void build_Z(void) {
+void build_Z() {
     if (params.ref == 0)
         build_Z_RHF();
     else if (params.ref == 1)

--- a/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
@@ -54,7 +54,7 @@ namespace ccdensity {
 **
 */
 
-void build_Z_RHF(void) {
+void build_Z_RHF() {
     dpdbuf4 A;
     dpdfile2 X1, D;
     double *X;

--- a/psi4/src/psi4/cc/ccdensity/build_Z_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_ROHF.cc
@@ -53,7 +53,7 @@ namespace ccdensity {
 **
 */
 
-void build_Z_ROHF(void) {
+void build_Z_ROHF() {
     dpdbuf4 A;
     dpdfile2 X1, D;
     double **X, **T, **Y, **Z;

--- a/psi4/src/psi4/cc/ccdensity/build_Z_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_UHF.cc
@@ -60,7 +60,7 @@ namespace ccdensity {
 **
 */
 
-void build_Z_UHF(void) {
+void build_Z_UHF() {
     dpdbuf4 A_AA, A_BB, A_AB;
     dpdfile2 X, D;
     double **A, *Z;

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -58,25 +58,25 @@ namespace psi {
 class Molecule;
 namespace ccdensity {
 
-void init_io(void);
-void title(void);
+void init_io();
+void title();
 void get_moinfo(std::shared_ptr<Wavefunction> wfn);
-void get_frozen(void);
+void get_frozen();
 void get_params(Options &options);
-void exit_io(void);
+void exit_io();
 void onepdm(struct RHO_Params);
 void sortone(struct RHO_Params);
-void twopdm(void);
+void twopdm();
 void energy(struct RHO_Params);
-// void resort_tei(void);
-// void resort_gamma(void);
+// void resort_tei();
+// void resort_gamma();
 void lag(struct RHO_Params rho_params);
-void build_X(void);
-void build_A(void);
-void build_Z(void);
-void relax_I(void);
+void build_X();
+void build_A();
+void build_Z();
+void relax_I();
 void relax_D(struct RHO_Params rho_params);
-void sortI(void);
+void sortI();
 void fold(struct RHO_Params rho_params);
 void deanti(struct RHO_Params rho_params);
 void add_ref_RHF(struct iwlbuf *);
@@ -88,45 +88,45 @@ void dump_RHF(struct iwlbuf *, struct RHO_Params rho_params);
 void dump_ROHF(struct iwlbuf *, struct RHO_Params rho_params);
 void dump_UHF(struct iwlbuf *, struct iwlbuf *, struct iwlbuf *, struct RHO_Params rho_params);
 void kinetic(std::shared_ptr<Wavefunction> wfn);
-void probable(void);
+void probable();
 int **cacheprep_rhf(int level, int *cachefiles);
 int **cacheprep_uhf(int level, int *cachefiles);
 void cachedone_rhf(int **cachelist);
 void cachedone_uhf(int **cachelist);
 void setup_LR(struct RHO_Params);
-void G_build(void);
+void G_build();
 void x_oe_intermediates(struct RHO_Params);
 void x_onepdm(struct RHO_Params);
-void x_te_intermediates(void);
-void x_Gijkl(void);
-void x_Gabcd(void);
-void x_Gibja(void);
-void x_Gijka(void);
-void x_Gijab(void);
-void x_Gciab(void);
-void V_build_x(void);
-void x_xi1(void);
-void x_xi_zero(void);
-void x_xi2(void);
-void x_xi_oe_intermediates(void);
-// void G_norm(void);
+void x_te_intermediates();
+void x_Gijkl();
+void x_Gabcd();
+void x_Gibja();
+void x_Gijka();
+void x_Gijab();
+void x_Gciab();
+void V_build_x();
+void x_xi1();
+void x_xi_zero();
+void x_xi2();
+void x_xi_oe_intermediates();
+// void G_norm();
 void zero_onepdm(struct RHO_Params rho_params);
-void zero_twopdm(void);
+void zero_twopdm();
 void get_rho_params(Options &options);
 void get_td_params(Options &options);
 void td_setup(struct TD_Params S);
 void tdensity(struct TD_Params S);
-void td_print(void);
+void td_print();
 void oscillator_strength(std::shared_ptr<Wavefunction> wfn, struct TD_Params *S);
 void rotational_strength(MintsHelper &mints, struct TD_Params *S);
 void ael(struct RHO_Params *rho_params);
-void cleanup(void);
-void td_cleanup(void);
+void cleanup();
+void td_cleanup();
 void x_oe_intermediates_rhf(struct RHO_Params rho_params);
-void x_te_intermediates_rhf(void);
-void x_xi_intermediates(void);
-void V_build(void);
-void V_cc2(void);
+void x_te_intermediates_rhf();
+void x_xi_intermediates();
+void V_build();
+void V_cc2();
 void ex_tdensity(char hand, struct TD_Params S, struct TD_Params U);
 void ex_td_setup(struct TD_Params S, struct TD_Params U);
 void ex_td_cleanup();
@@ -544,7 +544,7 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 }
 
 // must be fixed with options for excited state densities
-void init_io(void) {
+void init_io() {
     int i, num_unparsed;
     char *argv_unparsed[100];
 
@@ -596,7 +596,7 @@ void init_io(void) {
     psio_open(PSIF_EOM_TMP0, PSIO_OPEN_NEW);
 }
 
-void title(void) {
+void title() {
     outfile->Printf("\n");
     outfile->Printf("\t\t\t**************************\n");
     outfile->Printf("\t\t\t*                        *\n");
@@ -606,7 +606,7 @@ void title(void) {
     outfile->Printf("\n");
 }
 
-void exit_io(void) {
+void exit_io() {
     int i;
 
     /* delete temporary EOM files */

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -584,7 +584,7 @@ void init_io() {
       }
     */
 
-    tstart();
+    timer_on("CCDensity");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, PSIO_OPEN_OLD);
     // erase old files
@@ -628,7 +628,7 @@ void exit_io() {
     /* Close all dpd data files here */
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    tstop();
+    timer_off("CCDensity");
 }
 
 }  // namespace ccdensity

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -584,7 +584,7 @@ void init_io() {
       }
     */
 
-    timer_on("CCDensity");
+    timer_on("ccdensity");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, PSIO_OPEN_OLD);
     // erase old files
@@ -628,7 +628,7 @@ void exit_io() {
     /* Close all dpd data files here */
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    timer_off("CCDensity");
+    timer_off("ccdensity");
 }
 
 }  // namespace ccdensity

--- a/psi4/src/psi4/cc/ccdensity/distribute.cc
+++ b/psi4/src/psi4/cc/ccdensity/distribute.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 void classify(int p, int q, int r, int s, double value, struct iwlbuf *ABuf, struct iwlbuf *BBuf, struct iwlbuf *CBuf,
               struct iwlbuf *DBuf, struct iwlbuf *EBuf, struct iwlbuf *FBuf);
 
-void distribute(void) {
+void distribute() {
     double tolerance;
     struct iwlbuf InBuf;
     struct iwlbuf ABuf, BBuf, CBuf, DBuf, EBuf, FBuf;

--- a/psi4/src/psi4/cc/ccdensity/ex_td_cleanup.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_td_cleanup.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void ex_td_cleanup(void) {
+void ex_td_cleanup() {
     /*
      *  Clean out these files between computing x_ltd and x_rtd,
      *  because LHS and RHS eigenvectors change (get swapped).

--- a/psi4/src/psi4/cc/ccdensity/get_frozen.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_frozen.cc
@@ -49,7 +49,7 @@ namespace ccdensity {
 ** TDC, March 2000.
 */
 
-void get_frozen(void) {
+void get_frozen() {
     int i, nfzc;
 
     frozen.nfzc = moinfo.nfzc;

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -249,7 +249,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 }
 
 /* Frees memory allocated in get_moinfo(). */
-void cleanup(void) {
+void cleanup() {
     int i;
 
     free(moinfo.orbspi);

--- a/psi4/src/psi4/cc/ccdensity/relax_I.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I.cc
@@ -47,11 +47,11 @@ namespace ccdensity {
 ** with both RHF and ROHF cases.
 ** */
 
-void relax_I_RHF(void);
-void relax_I_ROHF(void);
-void relax_I_UHF(void);
+void relax_I_RHF();
+void relax_I_ROHF();
+void relax_I_UHF();
 
-void relax_I(void) {
+void relax_I() {
     if (params.ref == 0)
         relax_I_RHF();
     else if (params.ref == 1)

--- a/psi4/src/psi4/cc/ccdensity/relax_I_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_RHF.cc
@@ -46,7 +46,7 @@ namespace ccdensity {
 ** equations.  I *think* the following code is general enough to deal
 ** with both RHF and ROHF cases. */
 
-void relax_I_RHF(void) {
+void relax_I_RHF() {
     dpdfile2 I, D, f, I1, I2, I3;
     dpdbuf4 E, A, C, D4;
     int h, nirreps, i, j, e, *occpi, *virtpi, *openpi;

--- a/psi4/src/psi4/cc/ccdensity/relax_I_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_ROHF.cc
@@ -46,7 +46,7 @@ namespace ccdensity {
 ** equations.  I *think* the following code is general enough to deal
 ** with both RHF and ROHF cases. */
 
-void relax_I_ROHF(void) {
+void relax_I_ROHF() {
     dpdfile2 I, D, f;
     dpdbuf4 E;
     int h, nirreps, i, j, e, *occpi, *virtpi, *openpi;

--- a/psi4/src/psi4/cc/ccdensity/relax_I_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_UHF.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 ** Lagrangian.  These terms arise from the first-order CPHF equations.
 */
 
-void relax_I_UHF(void) {
+void relax_I_UHF() {
     dpdfile2 I, D, f;
     dpdbuf4 E;
     int h, nirreps, i, a;

--- a/psi4/src/psi4/cc/ccdensity/resort_gamma.cc
+++ b/psi4/src/psi4/cc/ccdensity/resort_gamma.cc
@@ -46,7 +46,7 @@ namespace ccdensity {
 ** all orbitals.
 */
 
-void resort_gamma(void) {
+void resort_gamma() {
     int h, nirreps, row, col, nfzc, nfzv;
     int i, j, k, l, I, J, K, L, ij, kl, ib, ja, ci;
     int a, b, c, d, A, B, C, D, ab, cd;

--- a/psi4/src/psi4/cc/ccdensity/resort_tei.cc
+++ b/psi4/src/psi4/cc/ccdensity/resort_tei.cc
@@ -42,11 +42,11 @@
 namespace psi {
 namespace ccdensity {
 
-void distribute(void);
+void distribute();
 
 int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int perm_qs, int perm_prqs, int keep);
 
-void resort_tei(void) {
+void resort_tei() {
     double tolerance;
     dpdfile4 A, B, C, D, E, F;
 

--- a/psi4/src/psi4/cc/ccdensity/sortI.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI.cc
@@ -48,11 +48,11 @@ namespace ccdensity {
 ** my sortone.c code here, so don't let some of the variable names
 ** confuse you. */
 
-void sortI_RHF(void);
-void sortI_ROHF(void);
-void sortI_UHF(void);
+void sortI_RHF();
+void sortI_ROHF();
+void sortI_UHF();
 
-void sortI(void) {
+void sortI() {
     if (params.ref == 0)
         sortI_RHF();
     else if (params.ref == 1)

--- a/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
@@ -60,7 +60,7 @@ namespace ccdensity {
 ** TDC, 2/2008
 */
 
-void sortI_RHF(void) {
+void sortI_RHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
     int *occpi, *virtpi, *occ_off, *vir_off;

--- a/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
@@ -53,7 +53,7 @@ namespace ccdensity {
 ** my sortone.c code here, so don't let some of the variable names
 ** confuse you. */
 
-void sortI_ROHF(void) {
+void sortI_ROHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
     int *occpi, *virtpi, *occ_off, *vir_off;

--- a/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
@@ -53,7 +53,7 @@ namespace ccdensity {
 ** my sortone.c code here, so don't let some of the variable names
 ** confuse you. */
 
-void sortI_UHF(void) {
+void sortI_UHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
     int *aoccpi, *avirtpi, *aocc_off, *avir_off;

--- a/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccdensity {
 
-void td_cleanup(void) {
+void td_cleanup() {
     psio_close(PSIF_CC_TMP, 0);
     psio_close(PSIF_EOM_TMP, 0);
     psio_close(PSIF_EOM_TMP0, 0);

--- a/psi4/src/psi4/cc/ccdensity/td_print.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_print.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 
 #define _hartree2nm 0.02194746313710
 
-void td_print(void) {
+void td_print() {
     int i;
 
     outfile->Printf("\n\t                   Ground State -> Excited State Transitions\n");

--- a/psi4/src/psi4/cc/ccdensity/twopdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/twopdm.cc
@@ -36,13 +36,13 @@
 namespace psi {
 namespace ccdensity {
 
-void V_build(void);
-void Gijkl(void);
-void Gabcd(void);
-void Gibja(void);
-void Gijka(void);
-void Gciab(void);
-void Gijab(void);
+void V_build();
+void Gijkl();
+void Gabcd();
+void Gibja();
+void Gijka();
+void Gciab();
+void Gijab();
 
 /* twopdm(): Computes all contributions to the two-particle density
 ** matrix for CC-like wave functions.
@@ -58,7 +58,7 @@ void Gijab(void);
 ** TDC, July 2002
 */
 
-void twopdm(void) {
+void twopdm() {
     /*  V_build(); */
     Gijkl();
     Gabcd();

--- a/psi4/src/psi4/cc/ccdensity/x_Gabcd.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gabcd.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 /* Gabcd = 0.5 Lmnab * Rmncd + P(cd) Lmnab * Rmc * Tnd */
 /* Gabcd = 0.5 Lmnab * Rmncd + Lmnab (Rmc * Tnd + tmc * Rnd) */
 
-void x_Gabcd(void) {
+void x_Gabcd() {
     dpdfile2 R1, T1;
     dpdbuf4 L2, I2, I3, R2, GABCD, Gabcd, GAbCd;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_Gciab.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gciab.cc
@@ -41,22 +41,22 @@
 namespace psi {
 namespace ccdensity {
 
-void x_Gciab_rohf(void);
-void x_Gciab_6(void);
-void x_Gciab_7(void);
-void x_Gciab_8_rohf(void);
-extern void x_Gciab_uhf(void);
+void x_Gciab_rohf();
+void x_Gciab_6();
+void x_Gciab_7();
+void x_Gciab_8_rohf();
+extern void x_Gciab_uhf();
 
 /* This function computes the non-R0 parts of the 2pdm density matrix
    Gciab = 0.5 *(rho_abci + rho_ciab) */
-void x_Gciab(void) {
+void x_Gciab() {
     if (params.ref == 0 || params.ref == 1)
         x_Gciab_rohf();
     else
         x_Gciab_uhf();
 }
 
-void x_Gciab_rohf(void) {
+void x_Gciab_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -466,7 +466,7 @@ void x_Gciab_rohf(void) {
    rho_ciab += P(ab) LR1_VV(c,a) T(i,b)
 */
 
-void x_Gciab_6(void) {
+void x_Gciab_6() {
     int h, nirreps, c, i, a, b, C, I, A, B, Csym, Isym, Asym, Bsym, row, col;
     int AA, BB, AAsym, BBsym;
     int L_irr, R_irr, G_irr;
@@ -647,7 +647,7 @@ void x_Gciab_6(void) {
    rho_ciab += P(ab) LT_VV(c,a) R(i,b)
 */
 
-void x_Gciab_7(void) {
+void x_Gciab_7() {
     int h, nirreps, c, i, a, b, C, I, A, B, Csym, Isym, Asym, Bsym, row, col;
     int AA, BB, AAsym, BBsym;
     int L_irr, R_irr, G_irr;
@@ -829,7 +829,7 @@ void x_Gciab_7(void) {
    term 9, +P(AB) LMNCE TINAE RMB
 */
 
-void x_Gciab_8_rohf(void) {
+void x_Gciab_8_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_Gciab_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gciab_uhf.cc
@@ -41,15 +41,15 @@
 namespace psi {
 namespace ccdensity {
 
-void x_Gciab_uhf(void);
-extern void x_Gciab_6(void);
-extern void x_Gciab_7(void);
-void x_Gciab_8_uhf(void);
+void x_Gciab_uhf();
+extern void x_Gciab_6();
+extern void x_Gciab_7();
+void x_Gciab_8_uhf();
 
 /* This function computes the non-R0 parts of the 2pdm density matrix
    Gciab = 0.5 *(rho_abci + rho_ciab) */
 
-void x_Gciab_uhf(void) {
+void x_Gciab_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -473,7 +473,7 @@ void x_Gciab_uhf(void) {
    term 9, +P(AB) LMNCE TINAE RMB
 */
 
-void x_Gciab_8_uhf(void) {
+void x_Gciab_8_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_Gibja.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gibja.cc
@@ -41,10 +41,10 @@
 namespace psi {
 namespace ccdensity {
 
-void x_Gibja_rohf(void);
-extern void x_Gibja_uhf(void);
+void x_Gibja_rohf();
+extern void x_Gibja_uhf();
 
-void x_Gibja(void) {
+void x_Gibja() {
     if (params.ref == 0 || params.ref == 1)
         x_Gibja_rohf();
     else
@@ -57,7 +57,7 @@ void x_Gibja(void) {
    and arranged as G(ia,jb) until final sort
 */
 
-void x_Gibja_rohf(void) {
+void x_Gibja_rohf() {
     int h, nirreps, row, col, L_irr, R_irr, G_irr;
     int i, j, a, b, I, J, A, B, Isym, Jsym, Asym, Bsym;
     dpdfile2 L1, T1A, T1B, L1A, L1B, R1A, R1B, I1A, I1B;

--- a/psi4/src/psi4/cc/ccdensity/x_Gibja_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gibja_uhf.cc
@@ -46,7 +46,7 @@ namespace ccdensity {
    and arranged as G(ia,jb) until final sort
 */
 
-void x_Gibja_uhf(void) {
+void x_Gibja_uhf() {
     int h, nirreps, row, col, L_irr, R_irr, G_irr;
     int i, j, a, b, I, J, A, B, Isym, Jsym, Asym, Bsym;
     dpdfile2 L1, T1A, T1B, L1A, L1B, R1A, R1B, I1A, I1B;

--- a/psi4/src/psi4/cc/ccdensity/x_Gijab.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijab.cc
@@ -43,12 +43,12 @@ namespace ccdensity {
 
 /* computes non R0 parts of EOM CCSD Gijab */
 
-extern void x_Gijab_uhf(void);
-void x_Gijab_rohf(void);
-void x_Gijab_rohf_2(void);
-void x_Gijab_rohf_3(void);
+extern void x_Gijab_uhf();
+void x_Gijab_rohf();
+void x_Gijab_rohf_2();
+void x_Gijab_rohf_3();
 
-void x_Gijab(void) {
+void x_Gijab() {
     if (params.ref == 0 || params.ref == 1)
         x_Gijab_rohf();
     else
@@ -56,7 +56,7 @@ void x_Gijab(void) {
     return;
 }
 
-void x_Gijab_rohf(void) {
+void x_Gijab_rohf() {
     int h, nirreps;
     int R_irr, L_irr, G_irr;
     double value, tval;
@@ -1026,7 +1026,7 @@ void x_Gijab_rohf(void) {
    P(ij) P(ab) [ Z(i,a) * T(j,b) ]
  */
 
-void x_Gijab_rohf_2(void) {
+void x_Gijab_rohf_2() {
     int h, nirreps, row, col;
     int i, j, a, b;
     int I1, I2, I3, I4, J1, J2, J3, J4, A1, A2, A3, A4, B1, B2, B3, B4;
@@ -1299,7 +1299,7 @@ void x_Gijab_rohf_2(void) {
    Z(i,a) += Lme Tma Tie ; term 19
  */
 
-void x_Gijab_rohf_3(void) {
+void x_Gijab_rohf_3() {
     int h, nirreps, row, col;
     int i, j, a, b;
     int I1, I2, I3, I4, J1, J2, J3, J4, A1, A2, A3, A4, B1, B2, B3, B4;

--- a/psi4/src/psi4/cc/ccdensity/x_Gijab_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijab_uhf.cc
@@ -42,10 +42,10 @@ namespace psi {
 namespace ccdensity {
 
 /* computes non R0 parts of EOM CCSD Gijab */
-void x_Gijab_uhf_2(void);
-void x_Gijab_uhf_3(void);
+void x_Gijab_uhf_2();
+void x_Gijab_uhf_3();
 
-void x_Gijab_uhf(void) {
+void x_Gijab_uhf() {
     int h, nirreps, II;
     int R_irr, L_irr, G_irr;
     double value, tval;
@@ -1016,7 +1016,7 @@ void x_Gijab_uhf(void) {
    P(ij) P(ab) [ Z(i,a) * T(j,b) ]
  */
 
-void x_Gijab_uhf_2(void) {
+void x_Gijab_uhf_2() {
     int h, nirreps, row, col;
     int i, j, a, b;
     int I1, I2, I3, I4, J1, J2, J3, J4, A1, A2, A3, A4, B1, B2, B3, B4;
@@ -1289,7 +1289,7 @@ void x_Gijab_uhf_2(void) {
    Z(i,a) += Lme Tma Tie ; term 19
  */
 
-void x_Gijab_uhf_3(void) {
+void x_Gijab_uhf_3() {
     int h, nirreps, row, col;
     int i, j, a, b;
     int I1, I2, I3, I4, J1, J2, J3, J4, A1, A2, A3, A4, B1, B2, B3, B4;

--- a/psi4/src/psi4/cc/ccdensity/x_Gijka.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijka.cc
@@ -41,13 +41,13 @@
 namespace psi {
 namespace ccdensity {
 
-void x_Gijka_rohf(void);
-void x_Gijka_6_rohf(void);
-void x_Gijka_7_rohf(void);
-void x_Gijka_8_rohf(void);
-extern void x_Gijka_uhf(void);
+void x_Gijka_rohf();
+void x_Gijka_6_rohf();
+void x_Gijka_7_rohf();
+void x_Gijka_8_rohf();
+extern void x_Gijka_uhf();
 
-void x_Gijka(void) {
+void x_Gijka() {
     if (params.ref == 0 || params.ref == 1)
         x_Gijka_rohf();
     else
@@ -58,7 +58,7 @@ void x_Gijka(void) {
 /* This function computes the non-R0 parts of the 2pdm density matrix
    Gijka = 0.5 *(rho_kaij + rho_Gijka) */
 
-void x_Gijka_rohf(void) {
+void x_Gijka_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -325,7 +325,7 @@ void x_Gijka_rohf(void) {
    rho_ijka -= P(ij) lke rie tja or
    rho_ijka -= P(ij) LR1_OO(k,i) T(j,a) */
 
-void x_Gijka_6_rohf(void) {
+void x_Gijka_6_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -490,7 +490,7 @@ void x_Gijka_6_rohf(void) {
 /* This function computes
    Gijka -= P(ij) LT_OO(k,i) * R(j,a) */
 
-void x_Gijka_7_rohf(void) {
+void x_Gijka_7_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -657,7 +657,7 @@ void x_Gijka_7_rohf(void) {
 /* term 8, +P(ij) Lkmfe rimae tjf */
 /* term 9, +P(ij) Lkmfe rimae tjf */
 
-void x_Gijka_8_rohf(void) {
+void x_Gijka_8_rohf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_Gijka_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijka_uhf.cc
@@ -41,14 +41,14 @@
 namespace psi {
 namespace ccdensity {
 
-void x_Gijka_6_uhf(void);
-void x_Gijka_7_uhf(void);
-void x_Gijka_8_uhf(void);
+void x_Gijka_6_uhf();
+void x_Gijka_7_uhf();
+void x_Gijka_8_uhf();
 
 /* This function computes the non-R0 parts of the 2pdm density matrix
    Gijka = 0.5 *(rho_kaij + rho_Gijka) */
 
-void x_Gijka_uhf(void) {
+void x_Gijka_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -315,7 +315,7 @@ void x_Gijka_uhf(void) {
    rho_ijka -= P(ij) Lke Rie Tja + P(ij) Lmkef Rmief Tja or
    rho_ijka -= P(ij) LR_OO(k,i) T(j,a) */
 
-void x_Gijka_6_uhf(void) {
+void x_Gijka_6_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -480,7 +480,7 @@ void x_Gijka_6_uhf(void) {
 /* This function computes
    Gijka -= P(ij) Lke Tie Rja + Lmkef Tmief Rja or
          -= P(ij) LT_OO(k,i) * R(j,a) */
-void x_Gijka_7_uhf(void) {
+void x_Gijka_7_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;
@@ -647,7 +647,7 @@ void x_Gijka_7_uhf(void) {
 /* term 8, +P(ij) Lkmfe Rimae Tjf */
 /* term 9, +P(ij) Lkmfe Timae Rjf */
 
-void x_Gijka_8_uhf(void) {
+void x_Gijka_8_uhf() {
     int h, nirreps, i, j, k, a, I, J, K, A, Isym, Jsym, Ksym, Asym, row, col;
     int II, JJ, IIsym, JJsym;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_Gijkl.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijkl.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 /* Dijkl = 0.5 Lklef * Rijef + P(ij) Lklef * Rie * tjf */
 /* Dijkl = R2L2_OOOO + P(ij) Lklef * Rie * tjf */
 
-void x_Gijkl(void) {
+void x_Gijkl() {
     dpdfile2 R1, T1;
     dpdbuf4 L2, I2, GIJKL, Gijkl, GIjKl;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_V.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_V.cc
@@ -44,7 +44,7 @@ namespace ccdensity {
 /* compute intermediates for excited state pdm that look like
    ground state intermediates, only use GL */
 
-void V_build_x(void) {
+void V_build_x() {
     int L_irr;
     dpdbuf4 V, L, T;
     L_irr = params.L_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_te_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_te_intermediates.cc
@@ -45,7 +45,7 @@ namespace ccdensity {
 
 extern void c_clean_CIJAB(dpdbuf4 *CMNEF);
 
-void x_te_intermediates(void) {
+void x_te_intermediates() {
     dpdfile2 R1, L1;
     dpdbuf4 V, L, R, T2;
     int G_irr, L_irr, R_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_te_intermediates_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_te_intermediates_rhf.cc
@@ -44,7 +44,7 @@ namespace ccdensity {
 /* this file is intended to replace x_te_intermediates.c when the density
    code gets spin-adapted */
 
-void x_te_intermediates_rhf(void) {
+void x_te_intermediates_rhf() {
     dpdfile2 R1, L1;
     dpdbuf4 V, L, R, T2;
     int G_irr, L_irr, R_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_xi1.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1.cc
@@ -67,7 +67,6 @@ void x_xi1_rohf() {
     R_irr = params.R_irr;
     G_irr = params.G_irr;
 
-
 #ifdef DEBUG_XI
     x_xi_check("begin xi1");
 #endif

--- a/psi4/src/psi4/cc/ccdensity/x_xi1.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1.cc
@@ -41,15 +41,15 @@
 namespace psi {
 namespace ccdensity {
 
-void x_xi1_rohf(void);
+void x_xi1_rohf();
 extern void x_xi_check(char *term_lbl);
-extern void x_xi1_connected(void);
-extern void x_xi1_uhf(void);
-extern void x_xi1_rhf(void);
+extern void x_xi1_connected();
+extern void x_xi1_uhf();
+extern void x_xi1_rhf();
 
 /* compute xi_1 amplitudes for zeta equations */
 
-void x_xi1(void) {
+void x_xi1() {
     if (params.ref == 0)
         x_xi1_rhf();
     else if (params.ref == 1)
@@ -58,7 +58,7 @@ void x_xi1(void) {
         x_xi1_uhf();
 }
 
-void x_xi1_rohf(void) {
+void x_xi1_rohf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     dpdbuf4 D, R2, L2, H2, I2;
@@ -659,7 +659,7 @@ void x_xi1_rohf(void) {
     return;
 }
 
-void x_xi_zero(void) {
+void x_xi_zero() {
     dpdfile2 XIA, Xia;
     dpdbuf4 XIJAB, Xijab, XIjAb;
     int G_irr;

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_connected.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_connected.cc
@@ -79,7 +79,7 @@ namespace ccdensity {
 
 /* double aug_xi_check(dpdfile2 *HIA, dpdfile2 *Hia); */
 
-void x_xi1_connected(void) {
+void x_xi1_connected() {
     dpdfile2 L1, XIA, Xia, HIA, Hia, I1, R1, F1, IME, Ime;
     int L_irr, R_irr, G_irr;
     dpdbuf4 D, R2, L2, H2, I2;

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_rhf.cc
@@ -42,11 +42,11 @@ namespace psi {
 namespace ccdensity {
 
 extern void x_xi_check(char *term_lbl);
-extern void x_xi1_connected(void);
+extern void x_xi1_connected();
 
 /* compute xi_1 amplitudes for zeta equations */
 
-void x_xi1_rhf(void) {
+void x_xi1_rhf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     dpdbuf4 D, R2, L2, H2, I2, Z2;

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_uhf.cc
@@ -42,9 +42,9 @@ namespace psi {
 namespace ccdensity {
 
 extern void x_xi_check(char *term_lbl);
-extern void x_xi1_connected(void);
+extern void x_xi1_connected();
 
-void x_xi1_uhf(void) {
+void x_xi1_uhf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     dpdbuf4 D, R2, L2, H2, I2;

--- a/psi4/src/psi4/cc/ccdensity/x_xi2.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2.cc
@@ -42,16 +42,16 @@
 namespace psi {
 namespace ccdensity {
 
-void x_xi2_4_rohf(void);
-void x_xi2_14(void);
-void x_xi2_rohf(void);
+void x_xi2_4_rohf();
+void x_xi2_14();
+void x_xi2_rohf();
 extern void x_xi_check(char *term_lbl);
-extern void x_xi2_uhf(void);
-extern void x_xi2_rhf(void);
+extern void x_xi2_uhf();
+extern void x_xi2_rhf();
 
 /* compute xi_2 amplitudes for zeta equations */
 
-void x_xi2(void) {
+void x_xi2() {
     if (params.ref == 0)
         x_xi2_rhf();
     else if (params.ref == 1)
@@ -61,7 +61,7 @@ void x_xi2(void) {
     return;
 }
 
-void x_xi2_rohf(void) {
+void x_xi2_rohf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     double tval;
@@ -847,7 +847,7 @@ void x_xi2_rohf(void) {
 
 /* compute terms 4 and 6 of xi2 amplitudes */
 /* Xijab += P(ij) P(ab) (Rme Lia + Rmnef Linaf) <mj||eb> */
-void x_xi2_4_rohf(void) {
+void x_xi2_4_rohf() {
     dpdfile2 RIA, Ria, LIA, Lia;
     int L_irr, R_irr, G_irr, nirreps;
     int I, A, M, E, i, a, m, e, h, row, col, Isym, Esym, Asym, Msym;
@@ -1107,7 +1107,7 @@ void x_xi2_4_rohf(void) {
 /* compute term 14 of Xi2 amplitudes for all spin cases */
 /* Xijab += P(ij) P(ab) (Lmjeb Rme) Fia */
 
-void x_xi2_14(void) {
+void x_xi2_14() {
     dpdfile2 IIA, Iia, FME, Fme;
     int L_irr, R_irr, G_irr, nirreps;
     int I, A, J, B, i, a, j, b, h, row, col, Isym, Asym, Jsym, Bsym;

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
@@ -42,14 +42,14 @@
 namespace psi {
 namespace ccdensity {
 
-void x_xi2_4_rhf(void);
-extern void x_xi2_14(void);
+void x_xi2_4_rhf();
+extern void x_xi2_14();
 extern void x_xi_check(char *term_lbl);
 extern double norm_C_rhf(dpdfile2 *CME, dpdbuf4 *CMnEf, dpdbuf4 *CMnfE);
 
 /* compute xi_2 amplitudes for RHF wavefunctions for zeta equations */
 
-void x_xi2_rhf(void) {
+void x_xi2_rhf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     double tval;
@@ -418,7 +418,7 @@ void x_xi2_rhf(void) {
 
 /* compute terms 4 and 6 of xi2 amplitudes */
 /* Xijab += P(ij) P(ab) (Rme Lia + Rmnef Linaf) <mj||eb> */
-void x_xi2_4_rhf(void) {
+void x_xi2_4_rhf() {
     dpdfile2 RIA, LIA;
     int L_irr, R_irr, G_irr, nirreps;
     int I, A, M, E, i, a, m, e, h, row, col, Isym, Esym, Asym, Msym;

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
@@ -43,12 +43,12 @@ namespace psi {
 namespace ccdensity {
 
 extern void x_xi_check(char *term_lbl);
-extern void x_xi2_14(void); /* in x_xi2.c */
-void x_xi2_4_uhf(void);     /* in x_xi2.c */
+extern void x_xi2_14(); /* in x_xi2.c */
+void x_xi2_4_uhf();     /* in x_xi2.c */
 
 /* compute UHF xi_2 amplitudes for zeta equations */
 
-void x_xi2_uhf(void) {
+void x_xi2_uhf() {
     dpdfile2 L1, XIA, Xia, I1, R1, F1, Z1A, Z1B;
     int L_irr, R_irr, G_irr;
     double tval;
@@ -839,7 +839,7 @@ void x_xi2_uhf(void) {
 /* compute terms 4 and 6 of xi2 amplitudes */
 /* Xijab += P(ij) P(ab) (Rme Lia + Rmnef Linaf) <mj||eb> */
 /* Xijab += P(ij) P(ab) Z2(me,ia) <mj||eb>(me,jb) */
-void x_xi2_4_uhf(void) {
+void x_xi2_4_uhf() {
     dpdfile2 RIA, Ria, LIA, Lia;
     int L_irr, R_irr, G_irr, nirreps;
     int I, A, M, E, i, a, m, e, h, row, col, Isym, Esym, Asym, Msym;

--- a/psi4/src/psi4/cc/ccdensity/x_xi_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi_intermediates.cc
@@ -41,7 +41,7 @@ namespace ccdensity {
 
 /* build one-electron intermediates for the construction of the xi amplitudes */
 
-void x_xi_intermediates(void) {
+void x_xi_intermediates() {
     dpdfile2 L1, R1, T1, I, LR1, LR2, LT1, LT2;
     dpdbuf4 L2, T2, R2, D, H2, I2;
     int L_irr, R_irr, G_irr;

--- a/psi4/src/psi4/cc/ccdensity/zero_pdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/zero_pdm.cc
@@ -105,7 +105,7 @@ void zero_onepdm(struct RHO_Params rho_params) {
     }
 }
 
-void zero_twopdm(void) {
+void zero_twopdm() {
     dpdbuf4 G;
     int G_irr;
     G_irr = params.G_irr;

--- a/psi4/src/psi4/cc/ccenergy/BT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2.cc
@@ -80,9 +80,7 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_close(&B);
             global_dpd_->buf4_close(&tauIjAb);
         } else if (params_.abcd == "OLD") {
-#ifdef TIME_CCENERGY
             timer_on("ABCD:old");
-#endif
             global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tauIjAb");
             global_dpd_->buf4_init(&B, PSIF_CC_BINTS, 0, 5, 5, 5, 5, 0, "B <ab|cd>");
             global_dpd_->buf4_init(&Z1, PSIF_CC_TMP0, 0, 5, 0, 5, 0, 0, "Z(Ab,Ij)");
@@ -91,13 +89,9 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_close(&Z1);
             global_dpd_->buf4_close(&B);
             global_dpd_->buf4_close(&tauIjAb);
-#ifdef TIME_CCENERGY
             timer_off("ABCD:old");
-#endif
         } else if (params_.abcd == "NEW") {
-#ifdef TIME_CCENERGY
             timer_on("ABCD:new");
-#endif
             /* tau(-)(ij,ab) (i>j, a>b) = tau(ij,ab) - tau(ij,ba) */
             global_dpd_->buf4_init(&tau_a, PSIF_CC_TAMPS, 0, 4, 9, 0, 5, 1, "tauIjAb");
             global_dpd_->buf4_copy(&tau_a, PSIF_CC_TAMPS, "tau(-)(ij,ab)");
@@ -112,9 +106,7 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_copy(&tau_a, PSIF_CC_TAMPS, "tau(+)(ij,ab)");
             global_dpd_->buf4_close(&tau_a);
 
-#ifdef TIME_CCENERGY
             timer_on("ABCD:S");
-#endif
             global_dpd_->buf4_init(&tau_s, PSIF_CC_TAMPS, 0, 3, 8, 3, 8, 0, "tau(+)(ij,ab)");
             global_dpd_->buf4_init(&B_s, PSIF_CC_BINTS, 0, 8, 8, 8, 8, 0, "B(+) <ab|cd> + <ab|dc>");
             global_dpd_->buf4_init(&S, PSIF_CC_TMP0, 0, 8, 3, 8, 3, 0, "S(ab,ij)");
@@ -122,9 +114,7 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_close(&S);
             global_dpd_->buf4_close(&B_s);
             global_dpd_->buf4_close(&tau_s);
-#ifdef TIME_CCENERGY
             timer_off("ABCD:S");
-#endif
 
             /* tau_diag(ij,c)  = 2 * tau(ij,cc)*/
             global_dpd_->buf4_init(&tau, PSIF_CC_TAMPS, 0, 3, 8, 3, 8, 0, "tau(+)(ij,ab)");
@@ -182,9 +172,7 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->free_dpd_block(tau_diag, tau.params->rowtot[0], moinfo_.nvirt);
             global_dpd_->buf4_close(&tau);
 
-#ifdef TIME_CCENERGY
             timer_on("ABCD:A");
-#endif
             global_dpd_->buf4_init(&tau_a, PSIF_CC_TAMPS, 0, 4, 9, 4, 9, 0, "tau(-)(ij,ab)");
             global_dpd_->buf4_init(&B_a, PSIF_CC_BINTS, 0, 9, 9, 9, 9, 0, "B(-) <ab|cd> - <ab|dc>");
             global_dpd_->buf4_init(&A, PSIF_CC_TMP0, 0, 9, 4, 9, 4, 0, "A(ab,ij)");
@@ -192,23 +180,17 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_close(&A);
             global_dpd_->buf4_close(&B_a);
             global_dpd_->buf4_close(&tau_a);
-#ifdef TIME_CCENERGY
             timer_off("ABCD:A");
-#endif
 
-#ifdef TIME_CCENERGY
             timer_on("ABCD:axpy");
-#endif
             global_dpd_->buf4_init(&S, PSIF_CC_TMP0, 0, 5, 0, 8, 3, 0, "S(ab,ij)");
             global_dpd_->buf4_sort_axpy(&S, PSIF_CC_TAMPS, rspq, 0, 5, "New tIjAb", 1);
             global_dpd_->buf4_close(&S);
             global_dpd_->buf4_init(&A, PSIF_CC_TMP0, 0, 5, 0, 9, 4, 0, "A(ab,ij)");
             global_dpd_->buf4_sort_axpy(&A, PSIF_CC_TAMPS, rspq, 0, 5, "New tIjAb", 1);
             global_dpd_->buf4_close(&A);
-#ifdef TIME_CCENERGY
             timer_off("ABCD:axpy");
             timer_off("ABCD:new");
-#endif
         }
     } else if (params_.ref == 1) { /** ROHF **/
 

--- a/psi4/src/psi4/cc/ccenergy/BT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2.cc
@@ -45,7 +45,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::BT2(void) {
+void CCEnergyWavefunction::BT2() {
     int h;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 B_anti, B;

--- a/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
@@ -50,7 +50,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::BT2_AO(void) {
+void CCEnergyWavefunction::BT2_AO() {
     int h, nirreps, i, Gc, Gd, Ga, Gb, ij;
     double ***C, **X;
     double ***Ca, ***Cb;

--- a/psi4/src/psi4/cc/ccenergy/CT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/CT2.cc
@@ -74,7 +74,7 @@ namespace ccenergy {
 ** May 2000
 */
 
-void CCEnergyWavefunction::CT2(void) {
+void CCEnergyWavefunction::CT2() {
     dpdfile2 tIA, tia;
     dpdbuf4 Y, C, D, T2new, T2;
 

--- a/psi4/src/psi4/cc/ccenergy/DT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/DT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::DT2(void) {
+void CCEnergyWavefunction::DT2() {
     dpdbuf4 D;
 
     if (params_.ref == 0) { /*** RHF ***/

--- a/psi4/src/psi4/cc/ccenergy/ET2.cc
+++ b/psi4/src/psi4/cc/ccenergy/ET2.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::ET2(void) {
+void CCEnergyWavefunction::ET2() {
     dpdfile2 tIA, tia;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 E, t2, t2a, t2b;

--- a/psi4/src/psi4/cc/ccenergy/FT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/FT2.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::FT2(void) {
+void CCEnergyWavefunction::FT2() {
     dpdfile2 tIA, tia, t1;
     dpdbuf4 newtIJAB, newtijab, newtIjAb, t2, t2a, t2b;
     dpdbuf4 F_anti, F;

--- a/psi4/src/psi4/cc/ccenergy/FT2_cc2.cc
+++ b/psi4/src/psi4/cc/ccenergy/FT2_cc2.cc
@@ -37,7 +37,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::FT2_CC2(void) {
+void CCEnergyWavefunction::FT2_CC2() {
     dpdbuf4 newT2, T2, Z;
     dpdfile2 F;
 

--- a/psi4/src/psi4/cc/ccenergy/Fae.cc
+++ b/psi4/src/psi4/cc/ccenergy/Fae.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::Fae_build(void) {
+void CCEnergyWavefunction::Fae_build() {
     int h, a, e, nirreps;
     int ma, fe, ef, m, f, M, A, Gm, Ga, Ge, Gf, Gma, nrows, ncols;
     double *X;

--- a/psi4/src/psi4/cc/ccenergy/FaetT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/FaetT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::FaetT2(void) {
+void CCEnergyWavefunction::FaetT2() {
     dpdfile2 FAEt, Faet;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 tIJAB, tijab, tIjAb;

--- a/psi4/src/psi4/cc/ccenergy/Fme.cc
+++ b/psi4/src/psi4/cc/ccenergy/Fme.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::Fme_build(void) {
+void CCEnergyWavefunction::Fme_build() {
     dpdfile2 FME, Fme, fIA, fia, tIA, tia;
     dpdbuf4 D_anti, D;
 

--- a/psi4/src/psi4/cc/ccenergy/Fmi.cc
+++ b/psi4/src/psi4/cc/ccenergy/Fmi.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::Fmi_build(void) {
+void CCEnergyWavefunction::Fmi_build() {
     int h, m, i;
     dpdfile2 FMI, Fmi, FMIt, Fmit, fIJ, fij, fIA, fia;
     dpdfile2 tIA, tia, FME, Fme;

--- a/psi4/src/psi4/cc/ccenergy/FmitT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/FmitT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::FmitT2(void) {
+void CCEnergyWavefunction::FmitT2() {
     dpdfile2 FMIt, Fmit;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 tIJAB, tijab, tIjAb;

--- a/psi4/src/psi4/cc/ccenergy/Wmbej.cc
+++ b/psi4/src/psi4/cc/ccenergy/Wmbej.cc
@@ -60,9 +60,7 @@ void CCEnergyWavefunction::Wmbej_build() {
     dpdfile2 tIA, tia;
     int Gmb, mb, Gj, Ge, Gf, nrows, ncols, nlinks;
 
-#ifdef TIME_CCENERGY
     timer_on("C->Wmbej");
-#endif
 
     /* W(mb,je) <-- <mb||ej> */
 
@@ -118,10 +116,8 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->buf4_close(&C);
     }
 
-#ifdef TIME_CCENERGY
     timer_off("C->Wmbej");
     timer_on("F->Wmbej");
-#endif
 
     if (params_.ref == 0) { /** RHF **/
         global_dpd_->file2_init(&tIA, PSIF_CC_OEI, 0, 0, 1, "tIA");
@@ -264,10 +260,8 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->file2_close(&tia);
     }
 
-#ifdef TIME_CCENERGY
     timer_off("F->Wmbej");
     timer_on("E->Wmbej");
-#endif
 
     if (params_.ref == 0) { /** RHF **/
         global_dpd_->file2_init(&tIA, PSIF_CC_OEI, 0, 0, 1, "tIA");
@@ -364,9 +358,7 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->file2_close(&tia);
     }
 
-#ifdef TIME_CCENERGY
     timer_off("E->Wmbej");
-#endif
 
     /* Convert to (ME,JB) for remaining terms */
 
@@ -432,9 +424,7 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->buf4_close(&W);
     }
 
-#ifdef TIME_CCENERGY
     timer_on("X->Wmbej");
-#endif
 
     if (params_.ref == 0) { /** RHF **/
         global_dpd_->file2_init(&tIA, PSIF_CC_OEI, 0, 0, 1, "tIA");
@@ -767,9 +757,7 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->file2_close(&tia);
     }
 
-#ifdef TIME_CCENERGY
     timer_off("X->Wmbej");
-#endif
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/Wmbej.cc
+++ b/psi4/src/psi4/cc/ccenergy/Wmbej.cc
@@ -54,7 +54,7 @@ namespace ccenergy {
 ** May 2000
 */
 
-void CCEnergyWavefunction::Wmbej_build(void) {
+void CCEnergyWavefunction::Wmbej_build() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ, W;
     dpdbuf4 C, D, E, F, X, tIAjb, tiaJB, t2, Y, Z;
     dpdfile2 tIA, tia;

--- a/psi4/src/psi4/cc/ccenergy/WmbejT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/WmbejT2.cc
@@ -117,7 +117,7 @@ namespace ccenergy {
 ** Last revised October 2001
 */
 
-void CCEnergyWavefunction::WmbejT2(void) {
+void CCEnergyWavefunction::WmbejT2() {
     dpdbuf4 T2new, T2, W, T2B, W1, W2, Z;
 
     if (params_.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/ccenergy/Wmnij.cc
+++ b/psi4/src/psi4/cc/ccenergy/Wmnij.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::Wmnij_build(void) {
+void CCEnergyWavefunction::Wmnij_build() {
     dpdbuf4 A_anti, A;
     dpdbuf4 WMNIJ, Wmnij, WMnIj, W;
     dpdfile2 tIA, tia;

--- a/psi4/src/psi4/cc/ccenergy/WmnijT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/WmnijT2.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::WmnijT2(void) {
+void CCEnergyWavefunction::WmnijT2() {
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 WMNIJ, Wmnij, WMnIj;
     dpdbuf4 tauIJAB, tauijab, tauIjAb;

--- a/psi4/src/psi4/cc/ccenergy/Z.cc
+++ b/psi4/src/psi4/cc/ccenergy/Z.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::Z_build(void) {
+void CCEnergyWavefunction::Z_build() {
     dpdbuf4 ZIJMA, Zijma, ZIjMa, ZIjmA, ZIjAm, ZMaIj, ZmAIj, Z;
     dpdbuf4 tauIJAB, tauijab, tauIjAb, tauIjbA, F_anti, F, tau;
     int Gmb, Gij, mb, nrows, ncols;

--- a/psi4/src/psi4/cc/ccenergy/Z.cc
+++ b/psi4/src/psi4/cc/ccenergy/Z.cc
@@ -45,9 +45,7 @@ void CCEnergyWavefunction::Z_build() {
     dpdbuf4 tauIJAB, tauijab, tauIjAb, tauIjbA, F_anti, F, tau;
     int Gmb, Gij, mb, nrows, ncols;
 
-#ifdef TIME_CCENERGY
     timer_on("Z");
-#endif
 
     if (params_.ref == 0) { /** RHF **/
         /* ZMbIj = <Mb|Ef> * tau(Ij,Ef) */
@@ -158,9 +156,7 @@ void CCEnergyWavefunction::Z_build() {
         global_dpd_->buf4_close(&ZIjAm);
     }
 
-#ifdef TIME_CCENERGY
     timer_off("Z");
-#endif
 }
 
 }  // namespace ccenergy

--- a/psi4/src/psi4/cc/ccenergy/ZT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/ZT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::ZT2(void) {
+void CCEnergyWavefunction::ZT2() {
     dpdbuf4 ZIJMA, ZIJAM, Zijma, Zijam, ZIjMa, ZIjAm, Z;
     dpdbuf4 newtIJAB, newtijab, newtIjAb, T2;
     dpdfile2 tIA, tia, T1;

--- a/psi4/src/psi4/cc/ccenergy/amp_write.cc
+++ b/psi4/src/psi4/cc/ccenergy/amp_write.cc
@@ -61,7 +61,7 @@ void twostack_insert(struct twostack *stack, double value, int i, int j, int a, 
 void amp_write_T1(dpdfile2 *T1, int length, const char *label, std::string out_fname);
 void amp_write_T2(dpdbuf4 *T2, int length, const char *label, std::string out_fname);
 
-void CCEnergyWavefunction::amp_write(void) {
+void CCEnergyWavefunction::amp_write() {
     dpdfile2 T1;
     dpdbuf4 T2;
 

--- a/psi4/src/psi4/cc/ccenergy/analyze.cc
+++ b/psi4/src/psi4/cc/ccenergy/analyze.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::analyze(void) {
+void CCEnergyWavefunction::analyze() {
     int nirreps, h, i, j, a, b, ij, ab, u, v;
     int position, num_div, tot1, tot2, nvir, nso, nocc;
     double width, max, min, value, value2;

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
@@ -54,9 +54,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_cc2_Wabei(void);
+void purge_cc2_Wabei();
 
-void CCEnergyWavefunction::cc2_Wabei_build(void) {
+void CCEnergyWavefunction::cc2_Wabei_build() {
     int omit = 0;
     int e, E;
     int Gef, Gab, Gei, Ge, Gf, Gi;
@@ -321,7 +321,7 @@ void CCEnergyWavefunction::cc2_Wabei_build(void) {
 #endif
 }
 
-void CCEnergyWavefunction::purge_cc2_Wabei(void) {
+void CCEnergyWavefunction::purge_cc2_Wabei() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
@@ -65,9 +65,7 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
     dpdbuf4 Z, Z1, Z2, Z3;
     dpdbuf4 B, C, D, F, W;
 
-#ifdef TIME_CCENERGY
     timer_on("F->Wabei");
-#endif
     if (params_.ref == 0) { /** RHF **/
         global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 11, 5, 11, 5, 0, "F <ai|bc>");
         global_dpd_->buf4_copy(&F, PSIF_CC_TMP0, "CC2 WAbEi (Ei,Ab)");
@@ -113,10 +111,8 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
         global_dpd_->buf4_sort(&F, PSIF_CC_TMP0, psrq, 29, 25, "CC2 WaBeI (aB,eI)");
         global_dpd_->buf4_close(&F);
     }
-#ifdef TIME_CCENERGY
     timer_off("F->Wabei");
     timer_on("B->Wabei");
-#endif
     if (params_.ref == 0) { /** RHF **/
 
         global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
@@ -267,10 +263,8 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
         global_dpd_->file2_close(&tIA);
         global_dpd_->file2_close(&tia);
     }
-#ifdef TIME_CCENERGY
     timer_off("B->Wabei");
     timer_on("Wabei_sort");
-#endif
     if (params_.ref == 0) { /* RHF */
 
         global_dpd_->buf4_init(&W, PSIF_CC2_HET1, 0, 5, 11, 5, 11, 0, "CC2 WAbEi");
@@ -316,9 +310,7 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
         global_dpd_->buf4_sort(&W, PSIF_CC2_HET1, rspq, 25, 29, "CC2 WaBeI (eI,aB)");
         global_dpd_->buf4_close(&W);
     }
-#ifdef TIME_CCENERGY
     timer_off("Wabei_sort");
-#endif
 }
 
 void CCEnergyWavefunction::purge_cc2_Wabei() {

--- a/psi4/src/psi4/cc/ccenergy/cc2_WabeiT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_WabeiT2.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_WabeiT2(void) {
+void CCEnergyWavefunction::cc2_WabeiT2() {
     int rowx, colx, rowz, colz, ab;
     int GX, GZ, Ge, Gi, Gj, hxbuf, hzbuf;
     dpdfile2 t1, tia, tIA;

--- a/psi4/src/psi4/cc/ccenergy/cc2_WabijT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_WabijT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_WabijT2(void) {
+void CCEnergyWavefunction::cc2_WabijT2() {
     dpdbuf4 W;
 
     if (params_.ref == 0) { /*** RHF ***/

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wmbij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wmbij.cc
@@ -42,9 +42,9 @@
 namespace psi {
 namespace ccenergy {
 
-void purge_cc2_Wmbij(void);
+void purge_cc2_Wmbij();
 
-void CCEnergyWavefunction::cc2_Wmbij_build(void) {
+void CCEnergyWavefunction::cc2_Wmbij_build() {
     dpdfile2 t1, tIA, tia;
     dpdbuf4 E, D, C, F;
     dpdbuf4 W, W1;
@@ -489,7 +489,7 @@ void CCEnergyWavefunction::cc2_Wmbij_build(void) {
     }
 }
 
-void CCEnergyWavefunction::purge_cc2_Wmbij(void) {
+void CCEnergyWavefunction::purge_cc2_Wmbij() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/ccenergy/cc2_WmbijT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_WmbijT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_WmbijT2(void) {
+void CCEnergyWavefunction::cc2_WmbijT2() {
     dpdfile2 t1, tia, tIA;
     dpdbuf4 Z, W;
     dpdbuf4 t2, t2a, t2b, tIJAB, tijab, tIjAb;

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wmnij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wmnij.cc
@@ -46,7 +46,7 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void CCEnergyWavefunction::cc2_Wmnij_build(void) {
+void CCEnergyWavefunction::cc2_Wmnij_build() {
     dpdbuf4 A, E, D, Z, W, Z1, X;
     dpdfile2 t1, tIA, tia;
 
@@ -320,7 +320,7 @@ void CCEnergyWavefunction::cc2_Wmnij_build(void) {
     timer_off("D->Wmnij");
 }
 
-void CCEnergyWavefunction::purge_cc2_Wmnij(void) {
+void CCEnergyWavefunction::purge_cc2_Wmnij() {
     dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;

--- a/psi4/src/psi4/cc/ccenergy/cc2_faeT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_faeT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_faeT2(void) {
+void CCEnergyWavefunction::cc2_faeT2() {
     dpdfile2 fme, fME, Fae, FAE, fAE, tIA, tia;
     dpdbuf4 tIjAb, tIJAB, tijab, t2;
     dpdbuf4 newtIjAb, newtIJAB, newtijab;

--- a/psi4/src/psi4/cc/ccenergy/cc2_fmiT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_fmiT2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_fmiT2(void) {
+void CCEnergyWavefunction::cc2_fmiT2() {
     dpdfile2 fia, fIA, Fmi, FMI, fMI, tIA, tia;
     dpdbuf4 tIjAb, tIJAB, tijab, t2;
     dpdbuf4 newtIjAb, newtIJAB, newtijab;

--- a/psi4/src/psi4/cc/ccenergy/cc2_t2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_t2.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::cc2_t2_build(void) {
+void CCEnergyWavefunction::cc2_t2_build() {
     DT2();
 
     if ((params_.ref == 0) || params_.t2_coupled) { /** RHF or ROHF with coupled T2's **/

--- a/psi4/src/psi4/cc/ccenergy/cc2_t2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_t2.cc
@@ -35,6 +35,7 @@
 #include "psi4/libdpd/dpd.h"
 #include "Params.h"
 #include "psi4/cc/ccwave.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace ccenergy {
@@ -43,34 +44,22 @@ void CCEnergyWavefunction::cc2_t2_build() {
     DT2();
 
     if ((params_.ref == 0) || params_.t2_coupled) { /** RHF or ROHF with coupled T2's **/
-#ifdef TIME_CCENERGY
-        timer_on("fT2", "outfile");
-#endif
+        timer_on("fT2");
         cc2_faeT2();
         cc2_fmiT2();
         if (params_.print & 2) status("f -> T2", "outfile");
-#ifdef TIME_CCENERGY
-        timer_off("fT2", "outfile");
-#endif
+        timer_off("fT2");
     }
 
-#ifdef TIME_CCENERGY
-    timer_on("WmbijT2", "outfile");
-#endif
+    timer_on("WmbijT2");
     cc2_WmbijT2();
     if (params_.print & 2) status("Wmbij -> T2", "outfile");
-#ifdef TIME_CCENERGY
-    timer_off("WmbijT2", "outfile");
-#endif
+    timer_off("WmbijT2");
 
-#ifdef TIME_CCENERGY
-    timer_on("WabeiT2", "outfile");
-#endif
+    timer_on("WabeiT2");
     cc2_WabeiT2();
     if (params_.print & 2) status("Wabei -> T2", "outfile");
-#ifdef TIME_CCENERGY
-    timer_off("WabeiT2", "outfile");
-#endif
+    timer_off("WabeiT2");
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/cc3.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3.cc
@@ -47,7 +47,7 @@ namespace ccenergy {
  * Denominators are subsequently applied in denom()
  */
 
-void CCEnergyWavefunction::cc3(void) {
+void CCEnergyWavefunction::cc3() {
     dpdfile2 TIA_new, Tia_new, FME, Fme;
     dpdbuf4 TIJAB_new, Tijab_new, TIjAb_new;
     dpdbuf4 TIJAB, Tijab, TIjAb, TiJaB;

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wabei.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wabei.cc
@@ -54,9 +54,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_Wabei(void);
+void purge_Wabei();
 
-void CCEnergyWavefunction::cc3_Wabei(void) {
+void CCEnergyWavefunction::cc3_Wabei() {
     int omit = 0;
     dpdfile2 T1, t1, tIA, tia;
     dpdbuf4 Z, Z1, Z2, Z3;
@@ -1032,7 +1032,7 @@ void CCEnergyWavefunction::cc3_Wabei(void) {
     }
 }
 
-void CCEnergyWavefunction::purge_Wabei(void) {
+void CCEnergyWavefunction::purge_Wabei() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wamef.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wamef.cc
@@ -46,9 +46,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_Wamef(void);
+void purge_Wamef();
 
-void CCEnergyWavefunction::cc3_Wamef(void) {
+void CCEnergyWavefunction::cc3_Wamef() {
     dpdbuf4 F, D, W;
     dpdfile2 t1, tia, tIA;
 
@@ -198,7 +198,7 @@ void CCEnergyWavefunction::cc3_Wamef(void) {
     }
 }
 
-void CCEnergyWavefunction::purge_Wamef(void) {
+void CCEnergyWavefunction::purge_Wamef() {
     dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmbij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmbij.cc
@@ -49,9 +49,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_Wmbij(void);
+void purge_Wmbij();
 
-void CCEnergyWavefunction::cc3_Wmbij(void) {
+void CCEnergyWavefunction::cc3_Wmbij() {
     dpdbuf4 C, D, E, F, W, W1, Z, X, Z1;
     dpdfile2 t1, tia, tIA;
 
@@ -479,7 +479,7 @@ void CCEnergyWavefunction::cc3_Wmbij(void) {
     }
 }
 
-void CCEnergyWavefunction::purge_Wmbij(void) {
+void CCEnergyWavefunction::purge_Wmbij() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmnie.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmnie.cc
@@ -46,9 +46,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_Wmnie(void);
+void purge_Wmnie();
 
-void CCEnergyWavefunction::cc3_Wmnie(void) {
+void CCEnergyWavefunction::cc3_Wmnie() {
     dpdbuf4 E, D, W, Z;
     dpdfile2 tIA, tia;
 
@@ -218,7 +218,7 @@ void CCEnergyWavefunction::cc3_Wmnie(void) {
 }
 
 /* Purge Wmnie matrix elements */
-void CCEnergyWavefunction::purge_Wmnie(void) {
+void CCEnergyWavefunction::purge_Wmnie() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmnij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmnij.cc
@@ -47,9 +47,9 @@ namespace ccenergy {
 ** TDC, Feb 2004
 */
 
-void purge_Wmnij(void);
+void purge_Wmnij();
 
-void CCEnergyWavefunction::cc3_Wmnij(void) {
+void CCEnergyWavefunction::cc3_Wmnij() {
     dpdbuf4 A, E, D, Z, W, Z1, X;
     dpdfile2 t1, tIA, tia;
 
@@ -295,7 +295,7 @@ void CCEnergyWavefunction::cc3_Wmnij(void) {
     }
 }
 
-void CCEnergyWavefunction::purge_Wmnij(void) {
+void CCEnergyWavefunction::purge_Wmnij() {
     dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -545,7 +545,7 @@ void CCEnergyWavefunction::init_io() {
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
-void CCEnergyWavefunction::title(void) {
+void CCEnergyWavefunction::title() {
     outfile->Printf("            **************************\n");
     outfile->Printf("            *                        *\n");
     outfile->Printf("            *        CCENERGY        *\n");
@@ -553,7 +553,7 @@ void CCEnergyWavefunction::title(void) {
     outfile->Printf("            **************************\n");
 }
 
-void CCEnergyWavefunction::exit_io(void) {
+void CCEnergyWavefunction::exit_io() {
     int i;
     for (i = PSIF_CC_MIN; i < PSIF_CC_TMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* delete CC_TMP files */
@@ -561,14 +561,14 @@ void CCEnergyWavefunction::exit_io(void) {
     tstop();
 }
 
-void CCEnergyWavefunction::init_ioff(void) {
+void CCEnergyWavefunction::init_ioff() {
     int i;
     ioff_ = init_int_array(IOFF_MAX);
     ioff_[0] = 0;
     for (i = 1; i < IOFF_MAX; i++) ioff_[i] = ioff_[i - 1] + i;
 }
 
-void CCEnergyWavefunction::checkpoint(void) {
+void CCEnergyWavefunction::checkpoint() {
     int i;
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
@@ -576,7 +576,7 @@ void CCEnergyWavefunction::checkpoint(void) {
 }
 
 /* just use T's on disk and don't iterate */
-void CCEnergyWavefunction::one_step(void) {
+void CCEnergyWavefunction::one_step() {
     dpdfile2 t1;
     dpdbuf4 t2;
     double tval;

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -100,10 +100,6 @@ double CCEnergyWavefunction::compute_energy() {
     init_ioff();
     title();
 
-#ifdef TIME_CCENERGY
-    timer_on("CCEnergy");
-#endif
-
     get_moinfo();
     get_params(options_);
 
@@ -218,16 +214,12 @@ double CCEnergyWavefunction::compute_energy() {
     for (moinfo_.iter = 1; moinfo_.iter <= params_.maxiter; moinfo_.iter++) {
         sort_amps();
 
-#ifdef TIME_CCENERGY
         timer_on("F build");
-#endif
         Fme_build();
         Fae_build();
         Fmi_build();
         if (params_.print & 2) status("F intermediates", "outfile");
-#ifdef TIME_CCENERGY
         timer_off("F build");
-#endif
 
         t1_build();
         if (params_.print & 2) status("T1 amplitudes", "outfile");
@@ -236,58 +228,35 @@ double CCEnergyWavefunction::compute_energy() {
             cc2_Wmnij_build();
             if (params_.print & 2) status("Wmnij", "outfile");
 
-#ifdef TIME_CCENERGY
             timer_on("Wmbij build");
-#endif
             cc2_Wmbij_build();
             if (params_.print & 2) status("Wmbij", "outfile");
-#ifdef TIME_CCENERGY
             timer_off("Wmbij build");
-#endif
 
-#ifdef TIME_CCENERGY
             timer_on("Wabei build");
-#endif
             cc2_Wabei_build();
             if (params_.print & 2) status("Wabei", "outfile");
-#ifdef TIME_CCENERGY
             timer_off("Wabei build");
-#endif
 
-#ifdef TIME_CCENERGY
             timer_on("T2 Build");
-#endif
             cc2_t2_build();
             if (params_.print & 2) status("T2 amplitudes", "outfile");
-#ifdef TIME_CCENERGY
             timer_off("T2 Build");
-#endif
-
-        }
-
-        else {
-#ifdef TIME_CCENERGY
+        } else {
             timer_on("Wmbej build");
-#endif
             Wmbej_build();
             if (params_.print & 2) status("Wmbej", "outfile");
-#ifdef TIME_CCENERGY
             timer_off("Wmbej build");
-#endif
 
             Z_build();
             if (params_.print & 2) status("Z", "outfile");
             Wmnij_build();
             if (params_.print & 2) status("Wmnij", "outfile");
 
-#ifdef TIME_CCENERGY
             timer_on("T2 Build");
-#endif
             t2_build();
             if (params_.print & 2) status("T2 amplitudes", "outfile");
-#ifdef TIME_CCENERGY
             timer_off("T2 Build");
-#endif
 
             if (params_.wfn == "CC3" || params_.wfn == "EOM_CC3") {
                 /* step1: build cc3 intermediates, Wabei, Wmnie, Wmbij, Wamef */
@@ -352,9 +321,7 @@ double CCEnergyWavefunction::compute_energy() {
         if (params_.aobasis != "NONE") dpd_close(1);
         dpd_close(0);
         cleanup();
-#ifdef TIME_CCENERGY
         timer_off("CCEnergy");
-#endif
         free(ioff_);
         exit_io();
         return Failure;
@@ -510,10 +477,6 @@ double CCEnergyWavefunction::compute_energy() {
 
     cleanup();
 
-#ifdef TIME_CCENERGY
-    timer_off("CCEnergy");
-#endif
-
     energy_ = moinfo_.ecc + moinfo_.eref;
     name_ = "CCSD";
     Process::environment.globals["CURRENT ENERGY"] = moinfo_.ecc + moinfo_.eref;
@@ -541,7 +504,7 @@ double CCEnergyWavefunction::compute_energy() {
 void CCEnergyWavefunction::init_io() {
     params_.just_energy = 0;
     params_.just_residuals = 0;
-    tstart();
+    timer_on("CCEnergy");
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
@@ -558,7 +521,7 @@ void CCEnergyWavefunction::exit_io() {
     for (i = PSIF_CC_MIN; i < PSIF_CC_TMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* delete CC_TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    tstop();
+    timer_off("CCEnergy");
 }
 
 void CCEnergyWavefunction::init_ioff() {

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -321,7 +321,7 @@ double CCEnergyWavefunction::compute_energy() {
         if (params_.aobasis != "NONE") dpd_close(1);
         dpd_close(0);
         cleanup();
-        timer_off("CCEnergy");
+        timer_off("ccenergy");
         free(ioff_);
         exit_io();
         return Failure;
@@ -504,7 +504,7 @@ double CCEnergyWavefunction::compute_energy() {
 void CCEnergyWavefunction::init_io() {
     params_.just_energy = 0;
     params_.just_residuals = 0;
-    timer_on("CCEnergy");
+    timer_on("ccenergy");
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
@@ -521,7 +521,7 @@ void CCEnergyWavefunction::exit_io() {
     for (i = PSIF_CC_MIN; i < PSIF_CC_TMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* delete CC_TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    timer_off("CCEnergy");
+    timer_off("ccenergy");
 }
 
 void CCEnergyWavefunction::init_ioff() {

--- a/psi4/src/psi4/cc/ccenergy/d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d1diag.cc
@@ -55,7 +55,7 @@ namespace ccenergy {
  *
  * */
 
-double CCEnergyWavefunction::d1diag_t1_rhf(void) {
+double CCEnergyWavefunction::d1diag_t1_rhf() {
     int h, nirreps, i;
     double **T, **C, *E, max;
     dpdfile2 T1;
@@ -205,7 +205,7 @@ double CCEnergyWavefunction::d1diag_t1_rohf() {
     return max;
 }
 
-double CCEnergyWavefunction::d1diag(void) {
+double CCEnergyWavefunction::d1diag() {
     double norm = 0.0;
 
     if (params_.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/ccenergy/d2diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d2diag.cc
@@ -49,7 +49,7 @@ namespace ccenergy {
  *
  * */
 
-double CCEnergyWavefunction::d2diag_rhf(void) {
+double CCEnergyWavefunction::d2diag_rhf() {
     int h, nirreps, i;
     double **Co, *Eo, max;
     double **Cv, *Ev;
@@ -176,7 +176,7 @@ double CCEnergyWavefunction::d2diag_rhf(void) {
     return max;
 }
 
-double CCEnergyWavefunction::d2diag(void) {
+double CCEnergyWavefunction::d2diag() {
     double norm = 0.0;
 
     if (params_.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/ccenergy/denom.cc
+++ b/psi4/src/psi4/cc/ccenergy/denom.cc
@@ -41,11 +41,11 @@ namespace psi {
 namespace ccenergy {
 
 void local_filter_T1(dpdfile2 *T1);
-void dijabT2(void);
+void dijabT2();
 
 /* apply denominators to t1 and t2 */
 
-void CCEnergyWavefunction::denom(void) {
+void CCEnergyWavefunction::denom() {
     dpdfile2 newtIA, dIA, tIA, newtia, dia, tia;
 
     if (params_.ref == 0) {

--- a/psi4/src/psi4/cc/ccenergy/diagnostic.cc
+++ b/psi4/src/psi4/cc/ccenergy/diagnostic.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccenergy {
 
-double CCEnergyWavefunction::diagnostic(void) {
+double CCEnergyWavefunction::diagnostic() {
     int h, nirreps, Gi, Ga;
     int i, a, I, A, row, col;
     int num_elec, num_elec_a, num_elec_b;

--- a/psi4/src/psi4/cc/ccenergy/dijabT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/dijabT2.cc
@@ -41,7 +41,7 @@ namespace ccenergy {
 
 void local_filter_T2(dpdbuf4 *T2);
 
-void CCEnergyWavefunction::dijabT2(void) {
+void CCEnergyWavefunction::dijabT2() {
     dpdbuf4 newtIJAB, newtijab, newtIjAb, tIjAb;
     dpdbuf4 dIJAB, dijab, dIjAb;
 

--- a/psi4/src/psi4/cc/ccenergy/energy.cc
+++ b/psi4/src/psi4/cc/ccenergy/energy.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-double CCEnergyWavefunction::energy(void) {
+double CCEnergyWavefunction::energy() {
     double e = 0.0;
     if (params_.ref == 0)
         e = rhf_energy();
@@ -53,7 +53,7 @@ double CCEnergyWavefunction::energy(void) {
     return e;
 }
 
-double CCEnergyWavefunction::rhf_energy(void) {
+double CCEnergyWavefunction::rhf_energy() {
     double tauIjAb_energy, tIA_energy;
     dpdfile2 fIA, tIA;
     dpdbuf4 tauIjAb, D, E;
@@ -89,7 +89,7 @@ double CCEnergyWavefunction::rhf_energy(void) {
     return (tauIjAb_energy + tIA_energy);
 }
 
-double CCEnergyWavefunction::rohf_energy(void) {
+double CCEnergyWavefunction::rohf_energy() {
     double tIA_energy, tia_energy, tauIJAB_energy, tauijab_energy, tauIjAb_energy;
     dpdfile2 tIA, tia, fIA, fia;
     dpdbuf4 tauIJAB, tauijab, tauIjAb, D;
@@ -142,7 +142,7 @@ double CCEnergyWavefunction::rohf_energy(void) {
     return (tIA_energy + tia_energy + tauIJAB_energy + tauijab_energy + tauIjAb_energy);
 }
 
-double CCEnergyWavefunction::uhf_energy(void) {
+double CCEnergyWavefunction::uhf_energy() {
     double E2AA, E2BB, E2AB, T1A, T1B;
     dpdbuf4 T2, D;
     dpdfile2 T1, F;

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 ** Modified by TDC, March 1999
 */
 
-void CCEnergyWavefunction::get_moinfo(void) {
+void CCEnergyWavefunction::get_moinfo() {
     int i, j, h, p, q, errcod, nactive, nirreps;
     double ***Co, ***Cv, ***Ca, ***Cb;
     psio_address next;
@@ -282,7 +282,7 @@ void CCEnergyWavefunction::get_moinfo(void) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps out the energy. */
-void CCEnergyWavefunction::cleanup(void) {
+void CCEnergyWavefunction::cleanup() {
     int i, h;
     char *keyw = nullptr;
 

--- a/psi4/src/psi4/cc/ccenergy/init_amps.cc
+++ b/psi4/src/psi4/cc/ccenergy/init_amps.cc
@@ -44,7 +44,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::init_amps(void) {
+void CCEnergyWavefunction::init_amps() {
     dpdfile2 tIA, tia, fIA, fia, dIA, dia;
     dpdbuf4 tIJAB, tijab, tIjAb, D, dIJAB, dijab, dIjAb;
 

--- a/psi4/src/psi4/cc/ccenergy/lmp2.cc
+++ b/psi4/src/psi4/cc/ccenergy/lmp2.cc
@@ -73,7 +73,7 @@ namespace ccenergy {
 ** TDC, June 2002
 */
 
-void CCEnergyWavefunction::lmp2(void) {
+void CCEnergyWavefunction::lmp2() {
     int i, j, k, ij, ab, iter, conv, row, col, nocc, nvir, natom, weak;
     double energy, rms, weak_pair_energy;
     dpdbuf4 T2, newT2, D;

--- a/psi4/src/psi4/cc/ccenergy/local.cc
+++ b/psi4/src/psi4/cc/ccenergy/local.cc
@@ -66,7 +66,7 @@ namespace ccenergy {
 ** TDC, Jan-June 2002
 */
 
-void CCEnergyWavefunction::local_init(void) {
+void CCEnergyWavefunction::local_init() {
     int i, k, ij, nocc;
 
     local_.nso = moinfo_.nso;
@@ -83,7 +83,7 @@ void CCEnergyWavefunction::local_init(void) {
     outfile->Printf("    Localization parameters ready.\n\n");
 }
 
-void CCEnergyWavefunction::local_done(void) { outfile->Printf("    Local parameters free.\n"); }
+void CCEnergyWavefunction::local_done() { outfile->Printf("    Local parameters free.\n"); }
 
 void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
     int i, a, ij, ii;

--- a/psi4/src/psi4/cc/ccenergy/mp2_energy.cc
+++ b/psi4/src/psi4/cc/ccenergy/mp2_energy.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-double CCEnergyWavefunction::mp2_energy(void) {
+double CCEnergyWavefunction::mp2_energy() {
     /* Note that if we reach this point and ref=1 (ROHF), then we aren't using
      * semicanonical orbitals and so we can't compute a non-iterative MBPT(2)
      * energy */
@@ -53,7 +53,7 @@ double CCEnergyWavefunction::mp2_energy(void) {
         return 0.0;
 }
 
-double CCEnergyWavefunction::rhf_mp2_energy(void) {
+double CCEnergyWavefunction::rhf_mp2_energy() {
     double T2_energy, T1_energy;
     dpdfile2 F, T1, D1;
     dpdbuf4 T2, D;
@@ -104,7 +104,7 @@ double CCEnergyWavefunction::rhf_mp2_energy(void) {
     return (T2_energy + T1_energy);
 }
 
-double CCEnergyWavefunction::uhf_mp2_energy(void) {
+double CCEnergyWavefunction::uhf_mp2_energy() {
     double E2AA, E2BB, E2AB, T1A, T1B;
     dpdbuf4 T2, D;
     dpdfile2 T1, F, D1;

--- a/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
@@ -47,7 +47,7 @@ namespace ccenergy {
  * published.
  * */
 
-double CCEnergyWavefunction::new_d1diag_t1_rohf(void) {
+double CCEnergyWavefunction::new_d1diag_t1_rohf() {
     int h, nirreps, i, j;
     int nclsd, nuocc, nopen;
     double **T1_hp, **T1_hx, **T1_xp, **T1_sq;
@@ -152,7 +152,7 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf(void) {
     return max;
 }
 
-double CCEnergyWavefunction::new_d1diag(void) {
+double CCEnergyWavefunction::new_d1diag() {
     double norm = 0.0;
 
     if (params_.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/ccenergy/priority.cc
+++ b/psi4/src/psi4/cc/ccenergy/priority.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::init_priority_list(void) {
+void CCEnergyWavefunction::init_priority_list() {
     if (!cache_priority_list_)
         throw PSIEXCEPTION(
             "Cache priority list must be allocated before calling *CCEnergyWavefunction::init_priority_list().");

--- a/psi4/src/psi4/cc/ccenergy/rotate.cc
+++ b/psi4/src/psi4/cc/ccenergy/rotate.cc
@@ -61,7 +61,7 @@ namespace ccenergy {
 ** TDC, 5/03
 */
 
-int CCEnergyWavefunction::rotate(void) {
+int CCEnergyWavefunction::rotate() {
     int i, a, ii, aa, j, ij, b, p, q, I, J, A, B;
     int h, nirreps, nso, nmo, ntri, stat;
     dpdfile2 T1;

--- a/psi4/src/psi4/cc/ccenergy/sort_amps.cc
+++ b/psi4/src/psi4/cc/ccenergy/sort_amps.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::sort_amps(void) {
+void CCEnergyWavefunction::sort_amps() {
     dpdbuf4 t2, t2B;
 
     if (params_.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/ccenergy/spinad_amps.cc
+++ b/psi4/src/psi4/cc/ccenergy/spinad_amps.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 ** FME = Fme
 */
 
-void CCEnergyWavefunction::spinad_amps(void) {
+void CCEnergyWavefunction::spinad_amps() {
     dpdfile2 T1, F;
     dpdbuf4 T2AB1, T2AB2, T2, W, W1, W2;
 

--- a/psi4/src/psi4/cc/ccenergy/t1.cc
+++ b/psi4/src/psi4/cc/ccenergy/t1.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::t1_build(void) {
+void CCEnergyWavefunction::t1_build() {
     dpdfile2 newtIA, newtia, tIA, tia, fIA, fia;
     dpdfile2 FAE, Fae, FMI, Fmi, FME, Fme;
     dpdfile2 dIA, dia;

--- a/psi4/src/psi4/cc/ccenergy/t1_ijab.cc
+++ b/psi4/src/psi4/cc/ccenergy/t1_ijab.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::t1_ijab(void) {
+void CCEnergyWavefunction::t1_ijab() {
     int h, ij, ab, i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
     int nirreps;

--- a/psi4/src/psi4/cc/ccenergy/t2.cc
+++ b/psi4/src/psi4/cc/ccenergy/t2.cc
@@ -37,6 +37,7 @@
 #include "Params.h"
 #include "MOInfo.h"
 #include "psi4/cc/ccwave.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace ccenergy {
@@ -57,50 +58,34 @@ void CCEnergyWavefunction::t2_build() {
         WmnijT2();
         if (params_.print & 2) status("Wmnij -> T2", "outfile");
 
-#ifdef TIME_CCENERGY
-        timer_on("BT2", "outfile");
-#endif
+        timer_on("BT2");
         if (params_.aobasis == "DISK" || params_.aobasis == "DIRECT")
             BT2_AO();
         else
             BT2();
         if (params_.print & 2) status("<ab||cd> -> T2", "outfile");
-#ifdef TIME_CCENERGY
-        timer_off("BT2", "outfile");
-#endif
+        timer_off("BT2");
 
         ZT2();
         if (params_.print & 2) status("Z -> T2", "outfile");
 
-#ifdef TIME_CCENERGY
-        timer_on("FT2", "outfile");
-#endif
+        timer_on("FT2");
         FT2();
         if (params_.print & 2) status("<ia||bc> -> T2", "outfile");
-#ifdef TIME_CCENERGY
-        timer_off("FT2", "outfile");
-#endif
+        timer_off("FT2");
 
         ET2();
         if (params_.print & 2) status("<ij||ka> -> T2", "outfile");
 
-#ifdef TIME_CCENERGY
-        timer_on("WmbejT2", "outfile");
-#endif
+        timer_on("WmbejT2");
         WmbejT2();
         if (params_.print & 2) status("Wmbej -> T2", "outfile");
-#ifdef TIME_CCENERGY
-        timer_off("WmbejT2", "outfile");
-#endif
+        timer_off("WmbejT2");
 
-#ifdef TIME_CCENERGY
-        timer_on("CT2", "outfile");
-#endif
+        timer_on("CT2");
         CT2();
         if (params_.print & 2) status("<ia||jb> -> T2", "outfile");
-#ifdef TIME_CCENERGY
-        timer_off("CT2", "outfile");
-#endif
+        timer_off("CT2");
     } else { /* For CC2, just include (FT2)c->T2 */
         FT2_CC2();
     }

--- a/psi4/src/psi4/cc/ccenergy/t2.cc
+++ b/psi4/src/psi4/cc/ccenergy/t2.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::t2_build(void) {
+void CCEnergyWavefunction::t2_build() {
     dpdbuf4 tIjAb;
     double dotval;
 

--- a/psi4/src/psi4/cc/ccenergy/tau.cc
+++ b/psi4/src/psi4/cc/ccenergy/tau.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::tau_build(void) {
+void CCEnergyWavefunction::tau_build() {
     int h, ij, ab, i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
     int nirreps;

--- a/psi4/src/psi4/cc/ccenergy/taut.cc
+++ b/psi4/src/psi4/cc/ccenergy/taut.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::taut_build(void) {
+void CCEnergyWavefunction::taut_build() {
     int h, ij, ab, i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
     int nirreps;

--- a/psi4/src/psi4/cc/ccenergy/tsave.cc
+++ b/psi4/src/psi4/cc/ccenergy/tsave.cc
@@ -39,7 +39,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::tsave(void) {
+void CCEnergyWavefunction::tsave() {
     dpdfile2 t1;
     dpdbuf4 t2;
 

--- a/psi4/src/psi4/cc/ccenergy/update.cc
+++ b/psi4/src/psi4/cc/ccenergy/update.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::update(void) {
+void CCEnergyWavefunction::update() {
     outfile->Printf("  %4d      %20.15f    %4.3e    %7.6f    %7.6f    %7.6f    %7.6f\n", moinfo_.iter, moinfo_.ecc,
                     moinfo_.conv, moinfo_.t1diag, moinfo_.d1diag, moinfo_.new_d1diag, moinfo_.d2diag);
 }

--- a/psi4/src/psi4/cc/cceom/WabefDD.cc
+++ b/psi4/src/psi4/cc/cceom/WabefDD.cc
@@ -72,11 +72,9 @@ void WabefDD(int i, int C_irr) {
         sprintf(SIjAb_lbl, "%s %d", "SIjAb", i);
         sprintf(CMnEf_lbl, "%s %d", "CMnEf", i);
 
-/* SIjAb += <Ab|Ef> CIjEf -- allow out of core algorithm */
+        /* SIjAb += <Ab|Ef> CIjEf -- allow out of core algorithm */
 
-#ifdef TIME_CCEOM
         timer_on("WabefDD Z");
-#endif
 
         if (params.abcd == "OLD") {
             global_dpd_->buf4_init(&CMnEf, PSIF_EOM_CMnEf, C_irr, 0, 5, 0, 5, 0, CMnEf_lbl);
@@ -200,9 +198,7 @@ void WabefDD(int i, int C_irr) {
             timer_off("ABCD:axpy");
         }
 
-#ifdef TIME_CCEOM
         timer_off("WabefDD Z");
-#endif
 
         /* construct XIjMb = CIjEf * <mb|ef> */
         global_dpd_->buf4_init(&X, PSIF_EOM_TMP, C_irr, 10, 0, 10, 0, 0, "WabefDD X(Mb,Ij)");

--- a/psi4/src/psi4/cc/cceom/amp_write.cc
+++ b/psi4/src/psi4/cc/cceom/amp_write.cc
@@ -64,7 +64,7 @@ class R1_amp {
         i = a = Gi = Ga = 0;
         value = 0.0;
     }
-    void zero(void) {
+    void zero() {
         i = a = Gi = Ga = 0;
         value = 0.0;
     }
@@ -83,7 +83,7 @@ class R2_amp {
         i = j = a = b = Gi = Gj = Ga = Gb = 0;
         value = 0.0;
     }
-    void zero(void) {
+    void zero() {
         i = j = a = b = Gi = Gj = Ga = Gb = 0;
         value = 0.0;
     }

--- a/psi4/src/psi4/cc/cceom/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/cceom/cc2_hbar_extra.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cceom {
 
-void cc2_hbar_extra(void) {
+void cc2_hbar_extra() {
     dpdbuf4 W1, W2, W;
 
     if (params.ref == 0) { /** RHF **/

--- a/psi4/src/psi4/cc/cceom/cceom.cc
+++ b/psi4/src/psi4/cc/cceom/cceom.cc
@@ -87,9 +87,6 @@ PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
 
     get_params(options);
     get_eom_params(ref_wfn, options);
-#ifdef TIME_CCEOM
-    timer_on("CCEOM");
-#endif
 
     form_dpd_dp();
 
@@ -128,15 +125,12 @@ PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
     dpd_close(0);
     if (params.local) local_done();
     cleanup();
-#ifdef TIME_CCEOM
-    timer_off("CCEOM");
-#endif
     exit_io();
     return Success;
 }
 
 void init_io() {
-    tstart();
+    timer_on("CCEOM");
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
@@ -145,7 +139,7 @@ void exit_io() {
     for (i = PSIF_CC_MIN; i <= PSIF_CC_DIIS_AMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0);
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    tstop();
+    timer_off("CCEOM");
 }
 
 void form_dpd_dp() {

--- a/psi4/src/psi4/cc/cceom/cceom.cc
+++ b/psi4/src/psi4/cc/cceom/cceom.cc
@@ -53,22 +53,22 @@
 namespace psi {
 namespace cceom {
 
-void init_io(void);
+void init_io();
 void get_moinfo(std::shared_ptr<Wavefunction>);
-void cleanup(void);
-void exit_io(void);
-void diag(void);
+void cleanup();
+void exit_io();
+void diag();
 void get_params(Options &);
 void get_eom_params(std::shared_ptr<Wavefunction>, Options &);
-void form_dpd_dp(void);
+void form_dpd_dp();
 int **cacheprep_uhf(int level, int *cachefiles);
 int **cacheprep_rhf(int level, int *cachefiles);
-void sort_amps(void);
-void hbar_norms(void);
+void sort_amps();
+void hbar_norms();
 
 /* local correlation functions */
-void local_init(void);
-void local_done(void);
+void local_init();
+void local_done();
 
 }  // namespace cceom
 }  // namespace psi
@@ -135,12 +135,12 @@ PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
     return Success;
 }
 
-void init_io(void) {
+void init_io() {
     tstart();
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
-void exit_io(void) {
+void exit_io() {
     int i;
     for (i = PSIF_CC_MIN; i <= PSIF_CC_DIIS_AMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0);
@@ -148,7 +148,7 @@ void exit_io(void) {
     tstop();
 }
 
-void form_dpd_dp(void) {
+void form_dpd_dp() {
     int h, h0, h1, cnt, nirreps;
     nirreps = moinfo.nirreps;
 

--- a/psi4/src/psi4/cc/cceom/cceom.cc
+++ b/psi4/src/psi4/cc/cceom/cceom.cc
@@ -130,7 +130,7 @@ PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
 }
 
 void init_io() {
-    timer_on("CCEOM");
+    timer_on("cceom");
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
@@ -139,7 +139,7 @@ void exit_io() {
     for (i = PSIF_CC_MIN; i <= PSIF_CC_DIIS_AMP; i++) psio_close(i, 1);
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0);
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    timer_off("CCEOM");
+    timer_off("cceom");
 }
 
 void form_dpd_dp() {

--- a/psi4/src/psi4/cc/cceom/dgeev_eom.cc
+++ b/psi4/src/psi4/cc/cceom/dgeev_eom.cc
@@ -45,7 +45,7 @@
 namespace psi {
 namespace cceom {
 
-void cleanup(void);
+void cleanup();
 
 /* This routine transposes matrices and calls lapack dgeev() in libqt *
  * to diagonalize a square nonsymmetric matrix.  The eigenvalues      *

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -148,20 +148,14 @@ void diag() {
     int L_start_iter, L_old;
     char *keyw;
 
-#ifdef TIME_CCEOM
     timer_on("HBAR_EXTRA");
-#endif
     if (params.wfn == "EOM_CC2")
         cc2_hbar_extra();
     else
         hbar_extra(); /* sort hbar matrix elements for sigma equations */
-#ifdef TIME_CCEOM
     timer_off("HBAR_EXTRA");
-#endif
 
-#ifdef EOM_DEBUG
     hbar_norms();
-#endif
 
     //  if(eom_params.guess == "INPUT")
     //    read_guess_init();
@@ -177,9 +171,7 @@ void diag() {
         keep_going = 1;
         num_converged = 0;
         if (eom_params.cs_per_irrep[C_irr] == 0) continue;
-#ifdef TIME_CCEOM
         timer_on("INIT GUESS");
-#endif
         outfile->Printf("Symmetry of excited state: %s\n", moinfo.irr_labs[moinfo.sym ^ C_irr].c_str());
         outfile->Printf("Symmetry of right eigenvector: %s\n", moinfo.irr_labs[C_irr].c_str());
         if (params.eom_ref == 0) outfile->Printf("Seeking states with multiplicity of %d\n", eom_params.mult);
@@ -265,9 +257,7 @@ void diag() {
             }
         }
 
-#ifdef TIME_CCEOM
         timer_off("INIT GUESS");
-#endif
 
 #ifdef EOM_DEBUG
         /* printout initial guesses */
@@ -337,7 +327,6 @@ void diag() {
 #ifdef EOM_DEBUG
                 check_sum("reset", 0, 0);
 #endif
-#ifdef TIME_CCEOM
                 timer_on("SIGMA ALL");
                 if (params.wfn == "EOM_CC2") {
                     timer_on("sigmacc2");
@@ -369,21 +358,6 @@ void diag() {
                     }
                 }
                 timer_off("SIGMA ALL");
-#else
-                if (params.wfn == "EOM_CC2")
-                    cc2_sigma(i, C_irr);
-                else {
-                    sigmaSS(i, C_irr);
-                    sigmaSD(i, C_irr);
-                    sigmaDS(i, C_irr);
-                    sigmaDD(i, C_irr);
-                }
-                if (((params.wfn == "EOM_CC3") && (cc3_stage > 0)) || eom_params.restart_eom_cc3) {
-                    cc3_HC1(i, C_irr);
-                    cc3_HC1ET1(i, C_irr);
-                    sigmaCC3(i, C_irr, cc3_eval);
-                }
-#endif
                 if (params.full_matrix) {
                     sigma00(i, C_irr);
                     sigma0S(i, C_irr);
@@ -428,9 +402,7 @@ void diag() {
                 }
             }
 
-#ifdef TIME_CCEOM
             timer_on("BUILD G");
-#endif /*timing*/
             /* Form G = C'*S matrix */
             G = block_matrix(L, L);
 
@@ -567,9 +539,7 @@ void diag() {
             ignore_G_old = 0;
             already_sigma = L;
 
-#ifdef TIME_CCEOM
             timer_off("BUILD G");
-#endif /* timing */
 #ifdef EOM_DEBUG
             outfile->Printf("The G Matrix\n");
             mat_print(G, L, L, outfile);
@@ -605,9 +575,7 @@ void diag() {
             }
             outfile->Printf("  Root    EOM Energy     Delta E   Res. Norm    Conv?\n");
             for (k = 0; k < eom_params.cs_per_irrep[C_irr]; ++k) {
-#ifdef TIME_CCEOM
                 timer_on("CALC RES");
-#endif /* timing */
 
                 /* rezero residual vector for each root */
                 if (params.full_matrix) {
@@ -758,9 +726,7 @@ void diag() {
                     norm = norm_C(&RIA, &Ria, &RIJAB, &Rijab, &RIjAb);
                 outfile->Printf("Norm of residual vector %d  before precondition %18.13lf\n", k, norm);
 #endif
-#ifdef TIME_CCEOM
                 timer_off("CALC RES");
-#endif          /* timing */
                 /* moved back down 8-06 why was this ever before residual norm?
                     if(params.eom_ref == 0) precondition_RHF(&RIA, &RIjAb, lambda[k]);
                     else precondition(&RIA, &Ria, &RIJAB, &Rijab, &RIjAb, lambda[k]); */

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -100,8 +100,8 @@ void sigmaDS_full(int index, int irrep);
 void sigmaDD_full(int index, int irrep);
 void sigmaCC3(int i, int C_irr, double omega);
 void diagSS(int irrep);
-void hbar_extra(void);
-void hbar_norms(void);
+void hbar_extra();
+void hbar_norms();
 extern void sort_C(int index, int irrep);
 
 void dgeev_eom(int L, double **G, double *evals, double **alpha);
@@ -110,10 +110,10 @@ double local_G1_dot(dpdfile2 *, dpdfile2 *);
 double local_G2_dot(dpdbuf4 *, dpdbuf4 *);
 void local_filter_T1_nodenom(dpdfile2 *);
 void local_filter_T2_nodenom(dpdbuf4 *);
-void local_guess(void);
+void local_guess();
 
 void read_guess(int);
-void read_guess_init(void);
+void read_guess_init();
 extern double norm_C1_rhf(dpdfile2 *C1A);
 void cc3_HC1(int i, int C_irr); /* compute [H,C1] */
 void cc3_HC1ET1(int i, int C_irr);
@@ -122,7 +122,7 @@ extern void restart_with_root(int i, int C_irr);
 extern void save_C_ccsd(int i, int C_irr);
 extern int follow_root(int L, double **alpha, int C_irr);
 
-void cc2_hbar_extra(void);
+void cc2_hbar_extra();
 void cc2_sigma(int index, int irrep);
 void amp_write_RHF(dpdfile2 *RIA, dpdbuf4 *RIjAb, int length);
 void amp_write_UHF(dpdfile2 *, dpdfile2 *, dpdbuf4 *, dpdbuf4 *, dpdbuf4 *, int length);
@@ -131,7 +131,7 @@ void amp_write_ROHF(dpdfile2 *, dpdfile2 *, dpdbuf4 *, dpdbuf4 *, dpdbuf4 *, int
 void overlap(int C_irr, int current);
 void overlap_stash(int C_irr);
 
-void diag(void) {
+void diag() {
     dpdfile2 CME, CME2, Cme, SIA, Sia, RIA, Ria, DIA, Dia, tIA, tia, LIA, Lia;
     dpdbuf4 CMNEF, Cmnef, CMnEf, SIJAB, Sijab, SIjAb, RIJAB, Rijab, RIjAb, RIjbA;
     dpdbuf4 CMnEf1, CMnfE1, CMnfE, CMneF, C2;

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -231,7 +231,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps out the energy. */
-void cleanup(void) {
+void cleanup() {
     int i, h;
 
     if (params.ref == 0 || params.ref == 1) {

--- a/psi4/src/psi4/cc/cceom/globals.h
+++ b/psi4/src/psi4/cc/cceom/globals.h
@@ -50,7 +50,6 @@ namespace cceom {
 EXTERN void check_sum(char *term_lbl, int index, int irrep);
 
 // #define EOM_DEBUG (0)
-#define TIME_CCEOM (1)
 
 #define H_IRR (0)
 #define MAX(I, J) ((I > J) ? I : J)

--- a/psi4/src/psi4/cc/cceom/hbar_extra.cc
+++ b/psi4/src/psi4/cc/cceom/hbar_extra.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cceom {
 
-void hbar_extra(void) {
+void hbar_extra() {
     dpdbuf4 W, W1, W2, WAmEf, WmBeJ, WmBEj, WmNIe, WMnIe;
 
     if (params.eom_ref == 2) {

--- a/psi4/src/psi4/cc/cceom/local.cc
+++ b/psi4/src/psi4/cc/cceom/local.cc
@@ -65,7 +65,7 @@ namespace cceom {
 ** TDC, Jan-June 2002
 */
 
-void local_init(void) {
+void local_init() {
     int i, ij, a;
     int nso, nocc, nvir;
     double **X, **Y;
@@ -172,7 +172,7 @@ void local_init(void) {
     outfile->Printf("\tLocalization parameters ready.\n\n");
 }
 
-void local_done(void) { outfile->Printf("\tLocal parameters free.\n"); }
+void local_done() { outfile->Printf("\tLocal parameters free.\n"); }
 
 void local_filter_T1(dpdfile2 *T1) {
     int i, a, ij, ii;

--- a/psi4/src/psi4/cc/cceom/local_guess.cc
+++ b/psi4/src/psi4/cc/cceom/local_guess.cc
@@ -54,7 +54,7 @@ struct onestack {
 
 void stack_insert(struct onestack *stack, double value, int i, int a, int level, int stacklen);
 
-void local_guess(void) {
+void local_guess() {
     int nso, nocc, nvir, nroot, i, ii, ij, a, m;
     double *T1bar, *T1tilde;
     double fii, value, norm;

--- a/psi4/src/psi4/cc/cceom/read_guess.cc
+++ b/psi4/src/psi4/cc/cceom/read_guess.cc
@@ -47,7 +47,7 @@ namespace cceom {
 /* counts the number of states and Cs for each irrep based on the orbital numbers given
  * in input -- overrides the "roots_per_irrep" keyword */
 
-void read_guess_init(void) {
+void read_guess_init() {
     int i, a, k, l, spin, errcod, C_irrep;
     int num_vectors, vector_len, this_irrep, useit;
     char lbl[32];

--- a/psi4/src/psi4/cc/cceom/restart.cc
+++ b/psi4/src/psi4/cc/cceom/restart.cc
@@ -55,9 +55,7 @@ void restart(double **alpha, int L, int num, int C_irr, int ortho, double **alph
     dpdbuf4 C2, CMNEF, Cmnef, CMnEf, SIJAB, Sijab, SIjAb;
     double dotval, norm;
 
-#ifdef TIME_CCEOM
     timer_on("RESTART");
-#endif
 
     A_OCC = 0;
     A_VIR = 1;
@@ -359,9 +357,7 @@ void restart(double **alpha, int L, int num, int C_irr, int ortho, double **alph
 
     free_block(alpha_tot);
 
-#ifdef TIME_CCEOM
     timer_off("RESTART");
-#endif
 
     return;
 }

--- a/psi4/src/psi4/cc/cceom/sigmaDD.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaDD.cc
@@ -51,7 +51,6 @@ void WmnefDD(int i, int C_irr);
 to a Sigma vector stored at Sigma plus 'i' */
 
 void sigmaDD(int i, int C_irr) {
-#ifdef TIME_CCEOM
     timer_on("FDD");
     FDD(i, C_irr);
     timer_off("FDD");
@@ -67,13 +66,6 @@ void sigmaDD(int i, int C_irr) {
     timer_on("WmnefDD");
     WmnefDD(i, C_irr);
     timer_off("WmnefDD");
-#else
-    FDD(i, C_irr);
-    WmnijDD(i, C_irr);
-    WabefDD(i, C_irr);
-    WmbejDD(i, C_irr);
-    WmnefDD(i, C_irr);
-#endif
 
     return;
 }

--- a/psi4/src/psi4/cc/cceom/sigmaDS.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaDS.cc
@@ -50,7 +50,6 @@ void WnmjeDS(int i, int C_irr);
 to a Sigma vector stored at Sigma plus 'i' */
 
 void sigmaDS(int i, int C_irr) {
-#ifdef TIME_CCEOM
     timer_on("WmaijDS");
     WmaijDS(i, C_irr);
     timer_off("WmaijDS");
@@ -63,12 +62,6 @@ void sigmaDS(int i, int C_irr) {
     timer_on("WbmfeDS");
     WbmfeDS(i, C_irr);
     timer_off("WbmfeDS");
-#else
-    WmaijDS(i, C_irr);
-    WabejDS(i, C_irr);
-    WnmjeDS(i, C_irr);
-    WbmfeDS(i, C_irr);
-#endif
 
     return;
 }

--- a/psi4/src/psi4/cc/cceom/sigmaSD.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaSD.cc
@@ -49,7 +49,6 @@ void WmnieSD(int i, int C_irr);
 to a Sigma vector stored at Sigma plus 'i' */
 
 void sigmaSD(int i, int C_irr) {
-#ifdef TIME_CCEOM
     timer_on("FSD");
     FSD(i, C_irr);
     timer_off("FSD");
@@ -59,11 +58,6 @@ void sigmaSD(int i, int C_irr) {
     timer_on("WmnieSD");
     WmnieSD(i, C_irr);
     timer_off("WmnieSD");
-#else
-    FSD(i, C_irr);
-    WamefSD(i, C_irr);
-    WmnieSD(i, C_irr);
-#endif
 
     return;
 }

--- a/psi4/src/psi4/cc/cceom/sort_amps.cc
+++ b/psi4/src/psi4/cc/cceom/sort_amps.cc
@@ -47,7 +47,7 @@ namespace cceom {
  cceom_density is written
 */
 
-void sort_amps(void) {
+void sort_amps() {
     dpdbuf4 R2;
     int R_irr;
 

--- a/psi4/src/psi4/cc/cchbar/F.cc
+++ b/psi4/src/psi4/cc/cchbar/F.cc
@@ -65,7 +65,7 @@ namespace cchbar {
 ** TDC, revised June 2002
 */
 
-void F_build(void) {
+void F_build() {
     int h, e, a, m;
     dpdfile2 Faet, FAEt, Fmit, FMIt;
     dpdfile2 Fae, FAE, FMI, Fmi;

--- a/psi4/src/psi4/cc/cchbar/Fai.cc
+++ b/psi4/src/psi4/cc/cchbar/Fai.cc
@@ -50,7 +50,7 @@ void Fme_for_Fai();
 void Fae_for_Fai();
 void Fmi_for_Fai();
 
-void Fai_build(void) {
+void Fai_build() {
     dpdfile2 newtIA, newtia, tIA, tia, fIA, fia;
     dpdfile2 FAE, Fae, FMI, Fmi, FME, Fme;
     dpdfile2 dIA, dia;
@@ -414,7 +414,7 @@ void Fai_build(void) {
     }
 }
 
-void Fae_for_Fai(void) {
+void Fae_for_Fai() {
     int h, a, e, nirreps;
     int ma, fe, ef, m, f, M, A, Gm, Ga, Ge, Gf, Gma, nrows, ncols;
     double *X;
@@ -699,7 +699,7 @@ void Fae_for_Fai(void) {
     }
 }
 
-void Fme_for_Fai(void) {
+void Fme_for_Fai() {
     dpdfile2 FME, Fme, fIA, fia, tIA, tia;
     dpdbuf4 D_anti, D;
 
@@ -793,7 +793,7 @@ void Fme_for_Fai(void) {
     }
 }
 
-void Fmi_for_Fai(void) {
+void Fmi_for_Fai() {
     int h, m, i;
     dpdfile2 FMI, Fmi, FMIt, Fmit, fIJ, fij, fIA, fia;
     dpdfile2 tIA, tia, FME, Fme;

--- a/psi4/src/psi4/cc/cchbar/HET1_Wabef.cc
+++ b/psi4/src/psi4/cc/cchbar/HET1_Wabef.cc
@@ -71,7 +71,7 @@ namespace cchbar {
  * TDC, 7/04
  */
 
-void HET1_Wabef(void) {
+void HET1_Wabef() {
     dpdbuf4 Bints, Fints, Z, D, W;
     dpdfile2 T1;
     int Gab, nirreps, ab, ba, A, B, Ga, Gb, a, b;

--- a/psi4/src/psi4/cc/cchbar/Wabei.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei.cc
@@ -61,15 +61,15 @@ namespace cchbar {
 **  [cf. Gauss and Stanton, JCP 103, 3561-3577 (1995)]
 */
 
-void Wabei_RHF(void);
-void Wabei_ROHF(void);
-void WABEI_UHF(void);
-void Wabei_UHF(void);
-void WAbEi_UHF(void);
-void WaBeI_UHF(void);
+void Wabei_RHF();
+void Wabei_ROHF();
+void WABEI_UHF();
+void Wabei_UHF();
+void WAbEi_UHF();
+void WaBeI_UHF();
 void Wabei_UHF_sort_ints();
 
-void Wabei_build(void) {
+void Wabei_build() {
     if (params.ref == 0)
         Wabei_RHF();
     else if (params.ref == 1)
@@ -83,7 +83,7 @@ void Wabei_build(void) {
     }
 }
 
-void Wabei_UHF_sort_ints(void) {
+void Wabei_UHF_sort_ints() {
     dpdbuf4 F, B;
     // required in WABEI
     global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 21, 5, 21, 5, 1, "F <AI|BC>");

--- a/psi4/src/psi4/cc/cchbar/Wabei_AAAA_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_AAAA_UHF.cc
@@ -62,9 +62,9 @@ namespace cchbar {
 ** TDC, June 2002
 */
 
-void build_Z1_AAAA(void);
+void build_Z1_AAAA();
 
-void WABEI_UHF(void) {
+void WABEI_UHF() {
     dpdfile2 FME, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, E, C;
 
@@ -283,7 +283,7 @@ void WABEI_UHF(void) {
     global_dpd_->buf4_close(&W);
 }
 
-void build_Z1_AAAA(void) {
+void build_Z1_AAAA() {
     dpdbuf4 T2, Z1, Fint;
     dpdfile2 T1;
     int row, col, h;

--- a/psi4/src/psi4/cc/cchbar/Wabei_ABAB_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_ABAB_UHF.cc
@@ -64,7 +64,7 @@ namespace cchbar {
 void build_Z1A_ABAB();
 void build_Z1B_ABAB();
 
-void WAbEi_UHF(void) {
+void WAbEi_UHF() {
     dpdfile2 Fme, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, E, C;
 

--- a/psi4/src/psi4/cc/cchbar/Wabei_BABA_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_BABA_UHF.cc
@@ -63,7 +63,7 @@ namespace cchbar {
 */
 void build_Z1A_BABA();
 
-void WaBeI_UHF(void) {
+void WaBeI_UHF() {
     dpdfile2 Fme, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, E, C;
 

--- a/psi4/src/psi4/cc/cchbar/Wabei_BBBB_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_BBBB_UHF.cc
@@ -62,9 +62,9 @@ namespace cchbar {
 ** TDC, June 2002
 */
 
-void build_Z1_BBBB(void);
+void build_Z1_BBBB();
 
-void Wabei_UHF(void) {
+void Wabei_UHF() {
     dpdfile2 Fme, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, E, C;
 
@@ -283,7 +283,7 @@ void Wabei_UHF(void) {
     global_dpd_->buf4_close(&W);
 }
 
-void build_Z1_BBBB(void) {
+void build_Z1_BBBB() {
     dpdbuf4 T2, Z1, Fint;
     dpdfile2 T1;
     int row, col, h;

--- a/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
@@ -46,7 +46,7 @@
 namespace psi {
 namespace cchbar {
 
-void build_Z1(void);
+void build_Z1();
 void ZFW(dpdbuf4 *Z, dpdbuf4 *F, dpdbuf4 *W, double alpha, double beta);
 
 /* Wabei_RHF(): Builds the Wabei HBAR matrix elements for CCSD for
@@ -59,7 +59,7 @@ void ZFW(dpdbuf4 *Z, dpdbuf4 *F, dpdbuf4 *W, double alpha, double beta);
 ** -TDC, 7/05
 */
 
-void Wabei_RHF(void) {
+void Wabei_RHF() {
     dpdfile2 Fme, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, C, F1, F2, W1, W2, Tau;
     double value;
@@ -548,7 +548,7 @@ void Wabei_RHF(void) {
 **
 ** TDC, 7/10/05
 */
-void build_Z1(void) {
+void build_Z1() {
     dpdbuf4 T2, Z1;
     dpdfile2 T1;
     int h, row, col, p, q, r, s, P, Q, R, S, psym, qsym, rsym, ssym;

--- a/psi4/src/psi4/cc/cchbar/Wabei_RHF_FT2_a.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_RHF_FT2_a.cc
@@ -53,7 +53,7 @@ namespace cchbar {
 ** TDC, March 2004
 */
 
-void Wabei_RHF_FT2_a(void) {
+void Wabei_RHF_FT2_a() {
     int h, nirreps;
     int Gam, Ga, Gm;
     int Gef, Gmf, Ge, Gf, Gae;

--- a/psi4/src/psi4/cc/cchbar/Wabei_ROHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_ROHF.cc
@@ -43,7 +43,7 @@ namespace cchbar {
 
 /** Wabei intermediates are stored here as (ei,ab) **/
 
-void Wabei_ROHF(void) {
+void Wabei_ROHF() {
     dpdfile2 Fme, T1;
     dpdbuf4 F, W, T2, B, Z, Z1, Z2, D, T, E, C;
 

--- a/psi4/src/psi4/cc/cchbar/Wabij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabij.cc
@@ -47,17 +47,17 @@ namespace cchbar {
 /* function to compute matrix element <Phi_ij^ab|Hbar|0> which equals zero as long as the
 T amplitudes were determined by ccenergy with the same H */
 
-void DT2(void), FaetT2(void), FmitT2(void), WmnijT2(void), WmbejT2(void);
-void BT2(void), ZT2(void), FT2(void), ET2(void), CT2(void), dijabT2(void);
-void BT2_AO(void);
-void Z_build(void);
+void DT2(), FaetT2(void), FmitT2(void), WmnijT2(void), WmbejT2(void);
+void BT2(), ZT2(void), FT2(void), ET2(void), CT2(void), dijabT2(void);
+void BT2_AO();
+void Z_build();
 void status(const char *, std::string);
-void FT2_CC2(void);
-void Wmnij_for_Wabij(void);
-void Wmbej_for_Wabij(void);
-void purge_Wabij(void);
+void FT2_CC2();
+void Wmnij_for_Wabij();
+void Wmbej_for_Wabij();
+void purge_Wabij();
 
-void Wabij_build(void) {
+void Wabij_build() {
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     double dotval;
 
@@ -144,7 +144,7 @@ void Wabij_build(void) {
     }
 }
 
-void DT2(void) {
+void DT2() {
     dpdbuf4 D;
     if (params.ref == 0) { /*** RHF ***/
         global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
@@ -171,7 +171,7 @@ void DT2(void) {
     }
 }
 
-void FaetT2(void) {
+void FaetT2() {
     dpdfile2 FAEt, Faet;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 tIJAB, tijab, tIjAb;
@@ -247,7 +247,7 @@ void FaetT2(void) {
     }
 }
 
-void FmitT2(void) {
+void FmitT2() {
     dpdfile2 FMIt, Fmit;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 tIJAB, tijab, tIjAb;
@@ -325,7 +325,7 @@ void FmitT2(void) {
     }
 }
 
-void WmnijT2(void) {
+void WmnijT2() {
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 WMNIJ, Wmnij, WMnIj;
     dpdbuf4 tauIJAB, tauijab, tauIjAb;
@@ -389,7 +389,7 @@ void WmnijT2(void) {
     }
 }
 
-void BT2(void) {
+void BT2() {
     int h;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 B_anti, B;
@@ -491,7 +491,7 @@ void BT2(void) {
     }
 }
 
-void ZT2(void) {
+void ZT2() {
     dpdbuf4 ZIJMA, ZIJAM, Zijma, Zijam, ZIjMa, ZIjAm, Z;
     dpdbuf4 newtIJAB, newtijab, newtIjAb, T2;
     dpdfile2 tIA, tia, T1;
@@ -580,7 +580,7 @@ void ZT2(void) {
     }
 }
 
-void Z_build(void) {
+void Z_build() {
     dpdbuf4 ZIJMA, Zijma, ZIjMa, ZIjmA, ZIjAm, ZMaIj, ZmAIj, Z;
     dpdbuf4 tauIJAB, tauijab, tauIjAb, tauIjbA, F_anti, F, tau;
     int Gmb, Gij, mb, nrows, ncols;
@@ -676,7 +676,7 @@ void Z_build(void) {
     timer_off("Z");
 }
 
-void FT2(void) {
+void FT2() {
     dpdfile2 tIA, tia, t1;
     dpdbuf4 newtIJAB, newtijab, newtIjAb, t2, t2a, t2b;
     dpdbuf4 F_anti, F;
@@ -812,7 +812,7 @@ void FT2(void) {
     }
 }
 
-void ET2(void) {
+void ET2() {
     dpdfile2 tIA, tia;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 E, t2, t2a, t2b;
@@ -919,7 +919,7 @@ void ET2(void) {
     }
 }
 
-void WmbejT2(void) {
+void WmbejT2() {
     dpdbuf4 T2new, T2, W, T2B, W1, W2, Z;
 
     if (params.ref == 0) { /** RHF **/
@@ -1283,7 +1283,7 @@ void WmbejT2(void) {
     } /*** UHF ***/
 }
 
-void CT2(void) {
+void CT2() {
     dpdfile2 tIA, tia;
     dpdbuf4 Y, C, D, T2new, T2;
 
@@ -1642,7 +1642,7 @@ void CT2(void) {
     } /*** UHF ***/
 }
 
-void Wmnij_for_Wabij(void) {
+void Wmnij_for_Wabij() {
     dpdbuf4 A_anti, A;
     dpdbuf4 WMNIJ, Wmnij, WMnIj, W;
     dpdfile2 tIA, tia;
@@ -1805,7 +1805,7 @@ void Wmnij_for_Wabij(void) {
     timer_off("Wmnij");
 }
 
-void Wmbej_for_Wabij(void) {
+void Wmbej_for_Wabij() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ, W;
     dpdbuf4 C, D, E, F, X, tIAjb, tiaJB, t2, Y, Z;
     dpdfile2 tIA, tia;
@@ -2391,7 +2391,7 @@ void Wmbej_for_Wabij(void) {
     timer_off("X->Wmbej");
 }
 
-void purge_Wabij(void) {
+void purge_Wabij() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/cchbar/Wabij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabij.cc
@@ -47,8 +47,8 @@ namespace cchbar {
 /* function to compute matrix element <Phi_ij^ab|Hbar|0> which equals zero as long as the
 T amplitudes were determined by ccenergy with the same H */
 
-void DT2(), FaetT2(void), FmitT2(void), WmnijT2(void), WmbejT2(void);
-void BT2(), ZT2(void), FT2(void), ET2(void), CT2(void), dijabT2(void);
+void DT2(), FaetT2(), FmitT2(), WmnijT2(), WmbejT2();
+void BT2(), ZT2(), FT2(), ET2(), CT2(), dijabT2();
 void BT2_AO();
 void Z_build();
 void status(const char *, std::string);

--- a/psi4/src/psi4/cc/cchbar/Wamef.cc
+++ b/psi4/src/psi4/cc/cchbar/Wamef.cc
@@ -76,7 +76,7 @@ namespace cchbar {
 ** RAK, July 2006
 */
 
-void Wamef_build(void) {
+void Wamef_build() {
     dpdbuf4 Wamef, WAMEF, WAmEf, WaMeF, W;
     dpdbuf4 F, D;
     dpdfile2 tia, tIA;

--- a/psi4/src/psi4/cc/cchbar/Wmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbej.cc
@@ -66,7 +66,7 @@ namespace cchbar {
 ** TDC, June 2002
 */
 
-void Wmbej_build(void) {
+void Wmbej_build() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ;
     dpdbuf4 tIAJB, tjAIb, tiajb, tIAjb, tiaJB, tIbjA;
     dpdbuf4 D, C, F, E, X, Y, t2, W, Z;

--- a/psi4/src/psi4/cc/cchbar/Wmbij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbij.cc
@@ -54,7 +54,7 @@ namespace cchbar {
  ** TDC, March 2004
  */
 
-void Wmbij_build(void) {
+void Wmbij_build() {
     dpdfile2 Fme, T1;
     dpdbuf4 W, E, T2, Wmnij, I, Tau, Z, Z1, Z2, C, D;
 

--- a/psi4/src/psi4/cc/cchbar/Wmnie.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmnie.cc
@@ -74,9 +74,9 @@ namespace cchbar {
 ** RAK, April 2004
 */
 
-void purge_Wmnie(void);
+void purge_Wmnie();
 
-void Wmnie_build(void) {
+void Wmnie_build() {
     dpdbuf4 W, Wmnie, WMNIE, WMnIe, WmNiE, WMniE, WmNIe;
     dpdbuf4 E, Z;
     dpdbuf4 D, D_a;

--- a/psi4/src/psi4/cc/cchbar/cc2_Wabei.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wabei.cc
@@ -56,9 +56,9 @@ namespace cchbar {
 ** TDC, Feb 2004
 */
 
-void purge_cc2_Wabei(void);
+void purge_cc2_Wabei();
 
-void cc2_Wabei_build(void) {
+void cc2_Wabei_build() {
     int omit = 0;
     int e, E;
     int Gef, Gab, Gei, Ge, Gf, Gi;
@@ -418,7 +418,7 @@ void cc2_Wabei_build(void) {
     timer_off("Wabei_sort");
 }
 
-void purge_cc2_Wabei(void) {
+void purge_cc2_Wabei() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/cchbar/cc2_Wmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wmbej.cc
@@ -64,7 +64,7 @@ namespace cchbar {
 ** TDC, June 2002
 */
 
-void cc2_Wmbej_build(void) {
+void cc2_Wmbej_build() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ;
     dpdbuf4 tIAJB, tjAIb, tiajb, tIAjb, tiaJB, tIbjA;
     dpdbuf4 D, C, F, E, X, Y, Y1, t2, W, Z;

--- a/psi4/src/psi4/cc/cchbar/cc2_Wmbij.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wmbij.cc
@@ -43,9 +43,9 @@
 namespace psi {
 namespace cchbar {
 
-void purge_cc2_Wmbij(void);
+void purge_cc2_Wmbij();
 
-void cc2_Wmbij_build(void) {
+void cc2_Wmbij_build() {
     dpdfile2 t1, tIA, tia;
     dpdbuf4 E, D, C, F;
     dpdbuf4 W, W1;
@@ -510,7 +510,7 @@ void cc2_Wmbij_build(void) {
     }
 }
 
-void purge_cc2_Wmbij(void) {
+void purge_cc2_Wmbij() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/cchbar/cc2_Zmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Zmbej.cc
@@ -64,7 +64,7 @@ namespace cchbar {
 ** TDC, June 2002
 */
 
-void cc2_Zmbej_build(void) {
+void cc2_Zmbej_build() {
     dpdbuf4 ZMBEJ, Zmbej, ZMbEj, ZmBeJ, ZmBEj, ZMbeJ;
     dpdbuf4 tIAJB, tjAIb, tiajb, tIAjb, tiaJB, tIbjA;
     dpdbuf4 D, C, F, E, X, Y, Y1, t2, W, Z;

--- a/psi4/src/psi4/cc/cchbar/cc3_HET1.cc
+++ b/psi4/src/psi4/cc/cchbar/cc3_HET1.cc
@@ -47,11 +47,11 @@ namespace cchbar {
  *
  */
 
-void HET1_Wmbej(void);
-void purge_HET1_Wmbej(void);
-void HET1_Wabef(void);
+void HET1_Wmbej();
+void purge_HET1_Wmbej();
+void HET1_Wabef();
 
-void cc3_HET1(void) {
+void cc3_HET1() {
     HET1_Wmbej();
 
     if (params.ref == 1) purge_HET1_Wmbej();
@@ -61,7 +61,7 @@ void cc3_HET1(void) {
     return;
 }
 
-void HET1_Wmbej(void) {
+void HET1_Wmbej() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ;
     dpdbuf4 D, C, F, E, X, Y, t2, W, Z;
     dpdfile2 tIA, tia;
@@ -610,7 +610,7 @@ void HET1_Wmbej(void) {
 }
 
 /* Purge Wmbej matrix elements for ROHF */
-void purge_HET1_Wmbej(void) {
+void purge_HET1_Wmbej() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/cchbar/cchbar.cc
+++ b/psi4/src/psi4/cc/cchbar/cchbar.cc
@@ -55,35 +55,35 @@ namespace psi {
 namespace cchbar {
 
 void init_io();
-void title(void);
+void title();
 void get_moinfo(std::shared_ptr<Wavefunction> ref_wfn, Options &);
 void get_params(Options &);
-void exit_io(void);
-void F_build(void);
-void Wmbej_build(void);
-void Wmnie_build(void);
-void Wmbij_build(void);
-void Wabij_build(void);
-void Wamef_build(void);
-void Wabei_build(void);
-void cc2_Zmbej_build(void);
-void cc2_Wmbej_build(void);
-void cc2_Wmbij_build(void);
-void cc2_Wabei_build(void);
-void purge(void);
-void cleanup(void);
+void exit_io();
+void F_build();
+void Wmbej_build();
+void Wmnie_build();
+void Wmbij_build();
+void Wabij_build();
+void Wamef_build();
+void Wabei_build();
+void cc2_Zmbej_build();
+void cc2_Wmbej_build();
+void cc2_Wmbij_build();
+void cc2_Wabei_build();
+void purge();
+void cleanup();
 int **cacheprep_rhf(int level, int *cachefiles);
 int **cacheprep_uhf(int level, int *cachefiles);
 void cachedone_uhf(int **cachelist);
 void cachedone_rhf(int **cachelist);
-void sort_amps(void);
-void tau_build(void);
-void taut_build(void);
+void sort_amps();
+void tau_build();
+void taut_build();
 void status(const char *, std::string);
-void cc3_HET1(void);
-void Fai_build(void);
-void reference(void);
-void norm_HET1(void);
+void cc3_HET1();
+void Fai_build();
+void reference();
+void norm_HET1();
 
 using namespace psi;
 
@@ -193,7 +193,7 @@ void init_io() {
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
-void title(void) {
+void title() {
     outfile->Printf("\n");
     outfile->Printf("\t\t\t**************************\n");
     outfile->Printf("\t\t\t*                        *\n");
@@ -203,7 +203,7 @@ void title(void) {
     outfile->Printf("\n");
 }
 
-void exit_io(void) {
+void exit_io() {
     /* Close all dpd data files here */
     for (int i = PSIF_CC_MIN; i < PSIF_CC_TMP; ++i) psio_close(i, 1);
     for (int i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; ++i) psio_close(i, 0); /* get rid of TMP files */

--- a/psi4/src/psi4/cc/cchbar/cchbar.cc
+++ b/psi4/src/psi4/cc/cchbar/cchbar.cc
@@ -46,6 +46,7 @@
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/libqt/qt.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -187,7 +188,7 @@ PsiReturnType cchbar(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
 }
 
 void init_io() {
-    tstart();
+    timer_on("CCHBAR");
 
     /* Open all dpd data files */
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
@@ -209,7 +210,7 @@ void exit_io() {
     for (int i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; ++i) psio_close(i, 0); /* get rid of TMP files */
     for (int i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; ++i) psio_close(i, 1);
 
-    tstop();
+    timer_off("CCHBAR");
 }
 
 }  // namespace cchbar

--- a/psi4/src/psi4/cc/cchbar/cchbar.cc
+++ b/psi4/src/psi4/cc/cchbar/cchbar.cc
@@ -188,7 +188,7 @@ PsiReturnType cchbar(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
 }
 
 void init_io() {
-    timer_on("CCHBAR");
+    timer_on("cchbar");
 
     /* Open all dpd data files */
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
@@ -210,7 +210,7 @@ void exit_io() {
     for (int i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; ++i) psio_close(i, 0); /* get rid of TMP files */
     for (int i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; ++i) psio_close(i, 1);
 
-    timer_off("CCHBAR");
+    timer_off("cchbar");
 }
 
 }  // namespace cchbar

--- a/psi4/src/psi4/cc/cchbar/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cchbar/get_moinfo.cc
@@ -155,7 +155,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
-void cleanup(void) {
+void cleanup() {
     int i;
 
     free(moinfo.orbspi);

--- a/psi4/src/psi4/cc/cchbar/norm_HET1.cc
+++ b/psi4/src/psi4/cc/cchbar/norm_HET1.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cchbar {
 
-void norm_HET1(void) {
+void norm_HET1() {
     int i;
     double dot;
     dpdfile2 F;

--- a/psi4/src/psi4/cc/cchbar/purge.cc
+++ b/psi4/src/psi4/cc/cchbar/purge.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cchbar {
 
-void purge(void) {
+void purge() {
     dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;
@@ -661,7 +661,7 @@ void purge(void) {
 }
 
 /* Purge Wmnie matrix elements */
-void purge_Wmnie(void) {
+void purge_Wmnie() {
     dpdfile4 W;
     int *occpi, *virtpi;
     int h, a, b, e, f, i, j, m, n;

--- a/psi4/src/psi4/cc/cchbar/reference.cc
+++ b/psi4/src/psi4/cc/cchbar/reference.cc
@@ -44,11 +44,11 @@
 namespace psi {
 namespace cchbar {
 
-double rhf_energy(void);
-double rohf_energy(void);
-double uhf_energy(void);
+double rhf_energy();
+double rohf_energy();
+double uhf_energy();
 
-void reference(void) {
+void reference() {
     double energy;
     if (params.ref == 0)
         energy = (rhf_energy());
@@ -61,7 +61,7 @@ void reference(void) {
     outfile->Printf("Reference expectation value computed: %20.15lf\n", energy);
 }
 
-double rhf_energy(void) {
+double rhf_energy() {
     double tauIjAb_energy, tIA_energy;
     dpdfile2 fIA, tIA;
     dpdbuf4 tauIjAb, D, E;
@@ -85,7 +85,7 @@ double rhf_energy(void) {
     return (tauIjAb_energy + tIA_energy);
 }
 
-double rohf_energy(void) {
+double rohf_energy() {
     double tIA_energy, tia_energy, tauIJAB_energy, tauijab_energy, tauIjAb_energy;
     dpdfile2 tIA, tia, fIA, fia;
     dpdbuf4 tauIJAB, tauijab, tauIjAb, D;
@@ -128,7 +128,7 @@ double rohf_energy(void) {
     return (tIA_energy + tia_energy + tauIJAB_energy + tauijab_energy + tauIjAb_energy);
 }
 
-double uhf_energy(void) {
+double uhf_energy() {
     double E2AA, E2BB, E2AB, T1A, T1B;
     dpdbuf4 T2, D;
     dpdfile2 T1, F;

--- a/psi4/src/psi4/cc/cchbar/sort_amps.cc
+++ b/psi4/src/psi4/cc/cchbar/sort_amps.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cchbar {
 
-void sort_amps(void) {
+void sort_amps() {
     dpdbuf4 t2;
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/

--- a/psi4/src/psi4/cc/cchbar/tau.cc
+++ b/psi4/src/psi4/cc/cchbar/tau.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cchbar {
 
-void tau_build(void) {
+void tau_build() {
     int h, ij, ab, i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
     int nirreps;

--- a/psi4/src/psi4/cc/cchbar/taut.cc
+++ b/psi4/src/psi4/cc/cchbar/taut.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cchbar {
 
-void taut_build(void) {
+void taut_build() {
     int h, ij, ab, i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
     int nirreps;

--- a/psi4/src/psi4/cc/cclambda/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_hbar_extra.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cclambda {
 
-void cc2_hbar_extra(void) {
+void cc2_hbar_extra() {
     dpdbuf4 W1, W2, W;
 
     /* CC2 W(ME,jb) + W(Me,Jb) is constructed in CCEOM for EOM_CC2 */

--- a/psi4/src/psi4/cc/cclambda/cc3_l3l1.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_l3l1.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cclambda {
 
-void cc3_l3l1(void) {
+void cc3_l3l1() {
     dpdfile2 L1, D1, L1new;
     dpdbuf4 Z, W;
     int nirreps, Gde, Gg, Gi, Ga;

--- a/psi4/src/psi4/cc/cclambda/cc3_l3l2.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_l3l2.cc
@@ -43,8 +43,8 @@
 namespace psi {
 namespace cclambda {
 
-void cc3_l3l2_RHF_AAA(void);
-void cc3_l3l2_RHF_AAB(void);
+void cc3_l3l2_RHF_AAA();
+void cc3_l3l2_RHF_AAB();
 
 void L3_AAA(double ***W1, int nirreps, int I, int Gi, int J, int Gj, int K, int Gk, dpdbuf4 *T2, dpdbuf4 *F, dpdbuf4 *E,
             dpdfile2 *fIJ, dpdfile2 *fAB, dpdbuf4 *D, dpdbuf4 *LIJAB, dpdfile2 *LIA, dpdfile2 *FME, int *occpi,
@@ -56,14 +56,14 @@ void L3_AAB(double ***W1, int nirreps, int I, int Gi, int J, int Gj, int K, int 
             dpdbuf4 *LIjAb, dpdfile2 *LIA, dpdfile2 *Lia, dpdfile2 *FME, dpdfile2 *Fme, int *aoccpi, int *aocc_off,
             int *boccpi, int *bocc_off, int *avirtpi, int *avir_off, int *bvirtpi, int *bvir_off);
 
-void cc3_l3l2(void) {
+void cc3_l3l2() {
     if (params.ref == 0) {
         cc3_l3l2_RHF_AAA();
         cc3_l3l2_RHF_AAB();
     }
 }
 
-void cc3_l3l2_RHF_AAA(void) {
+void cc3_l3l2_RHF_AAA() {
     int h, nirreps;
     int *occ_off, *occpi;
     int *vir_off, *virtpi;
@@ -430,7 +430,7 @@ void cc3_l3l2_RHF_AAA(void) {
     global_dpd_->buf4_close(&L2new);
 }
 
-void cc3_l3l2_RHF_AAB(void) {
+void cc3_l3l2_RHF_AAB() {
     int h, nirreps;
     int *occ_off, *occpi;
     int *vir_off, *virtpi;

--- a/psi4/src/psi4/cc/cclambda/cc3_t3x.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_t3x.cc
@@ -42,7 +42,7 @@
 namespace psi {
 namespace cclambda {
 
-void cc3_t3x(void) {
+void cc3_t3x() {
     if (params.ref == 0) {
         int h, nirreps;
         int *occ_off, *occpi;

--- a/psi4/src/psi4/cc/cclambda/cc3_t3z.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_t3z.cc
@@ -62,10 +62,10 @@
 namespace psi {
 namespace cclambda {
 
-void cc3_t3z_RHF_AAA(void);
-void cc3_t3z_RHF_AAB(void);
+void cc3_t3z_RHF_AAA();
+void cc3_t3z_RHF_AAB();
 
-void cc3_t3z(void) {
+void cc3_t3z() {
     if (params.ref == 0) { /** RHF **/
         cc3_t3z_RHF_AAA();
         cc3_t3z_RHF_AAB();
@@ -74,7 +74,7 @@ void cc3_t3z(void) {
     }
 }
 
-void cc3_t3z_RHF_AAA(void) {
+void cc3_t3z_RHF_AAA() {
     int h, nirreps;
     int *occ_off, *occpi;
     int *vir_off, *virtpi;
@@ -258,7 +258,7 @@ void cc3_t3z_RHF_AAA(void) {
     global_dpd_->buf4_close(&Dints);
 }
 
-void cc3_t3z_RHF_AAB(void) {
+void cc3_t3z_RHF_AAB() {
     int h, nirreps;
     int *occ_off, *occpi;
     int *vir_off, *virtpi;

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -350,7 +350,7 @@ void CCLambdaWavefunction::init_io() {
                          }
                        }
                      */
-    tstart();
+    timer_on("CCLambda");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
@@ -378,7 +378,7 @@ void CCLambdaWavefunction::exit_io() {
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* delete CC_TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    tstop();
+    timer_off("CCLambda");
 }
 
 /* put copies of L for excited states in LAMPS with irrep and index label */

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -66,7 +66,7 @@ void L2_build(struct L_Params L_params);
 void sort_amps(int L_irr);
 void Lsave(int L_irr);
 void Lnorm(struct L_Params L_params);
-void Lmag(void);
+void Lmag();
 void overlap(int L_irr);
 void overlap_LAMPS(struct L_Params L_params);
 void Lsave_index(struct L_Params L_params);
@@ -77,19 +77,19 @@ void L_zero(int irrep);
 void c_clean(dpdfile2 *LIA, dpdfile2 *Lia, dpdbuf4 *LIJAB, dpdbuf4 *Lijab, dpdbuf4 *LIjAb);
 void L_clean(struct L_Params pL_params);
 void zeta_norm(struct L_Params pL_params);
-void spinad_amps(void);
-void hbar_extra(void);
+void spinad_amps();
+void hbar_extra();
 void ortho_Rs(struct L_Params *pL_params, int current_L);
 
 void cc2_L1_build(struct L_Params L_params);
 void cc2_L2_build(struct L_Params L_params);
 void cc2_Gai_build(int L_irr);
-void cc2_hbar_extra(void);
+void cc2_hbar_extra();
 
-void cc3_t3z(void);
-void cc3_t3x(void);
-void cc3_l3l2(void);
-void cc3_l3l1(void);
+void cc3_t3z();
+void cc3_t3x();
+void cc3_l3l2();
+void cc3_l3l1();
 
 }  // namespace cclambda
 }  // namespace psi
@@ -331,7 +331,7 @@ double CCLambdaWavefunction::compute_energy() {
 }
 
 // must be fixed with options later for excited states
-void CCLambdaWavefunction::init_io(void) {
+void CCLambdaWavefunction::init_io() {
     int i, num_unparsed;
     char *lbl, *argv_unparsed[100];
 
@@ -355,7 +355,7 @@ void CCLambdaWavefunction::init_io(void) {
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
-void CCLambdaWavefunction::title(void) {
+void CCLambdaWavefunction::title() {
     outfile->Printf("\n");
     outfile->Printf("\t\t\t**************************\n");
     outfile->Printf("\t\t\t*        CCLAMBDA        *\n");
@@ -363,7 +363,7 @@ void CCLambdaWavefunction::title(void) {
     outfile->Printf("\n");
 }
 
-void CCLambdaWavefunction::exit_io(void) {
+void CCLambdaWavefunction::exit_io() {
     int i;
 
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) {

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -350,7 +350,7 @@ void CCLambdaWavefunction::init_io() {
                          }
                        }
                      */
-    timer_on("CCLambda");
+    timer_on("cclambda");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
@@ -378,7 +378,7 @@ void CCLambdaWavefunction::exit_io() {
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* delete CC_TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    timer_off("CCLambda");
+    timer_off("cclambda");
 }
 
 /* put copies of L for excited states in LAMPS with irrep and index label */

--- a/psi4/src/psi4/cc/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cclambda/get_moinfo.cc
@@ -218,7 +218,7 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
-void CCLambdaWavefunction::cleanup(void) {
+void CCLambdaWavefunction::cleanup() {
     int i, h;
 
     psio_write_entry(PSIF_CC_INFO, "Lambda Pseudoenergy", (char *)&(moinfo.lcc), sizeof(double));

--- a/psi4/src/psi4/cc/cclambda/hbar_extra.cc
+++ b/psi4/src/psi4/cc/cclambda/hbar_extra.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cclambda {
 
-void hbar_extra(void) {
+void hbar_extra() {
     dpdbuf4 W1, W2, W;
 
     if (params.ref == 0) {

--- a/psi4/src/psi4/cc/cclambda/local.cc
+++ b/psi4/src/psi4/cc/cclambda/local.cc
@@ -66,7 +66,7 @@ namespace cclambda {
 ** TDC, Jan-June 2002
 */
 
-void CCLambdaWavefunction::local_init(void) {
+void CCLambdaWavefunction::local_init() {
     local.nso = moinfo.nso;
     local.nocc = moinfo.occpi[0];  /* active doubly occupied orbitals */
     local.nvir = moinfo.virtpi[0]; /* active virtual orbitals */
@@ -74,7 +74,7 @@ void CCLambdaWavefunction::local_init(void) {
     outfile->Printf("\tLocalization parameters ready.\n\n");
 }
 
-void CCLambdaWavefunction::local_done(void) { outfile->Printf("\tLocal parameters free.\n"); }
+void CCLambdaWavefunction::local_done() { outfile->Printf("\tLocal parameters free.\n"); }
 
 void local_filter_T1(dpdfile2 *T1) {
     int i, a, ij, ii;

--- a/psi4/src/psi4/cc/cclambda/spinad_amps.cc
+++ b/psi4/src/psi4/cc/cclambda/spinad_amps.cc
@@ -51,7 +51,7 @@ namespace cclambda {
 **
 */
 
-void spinad_amps(void) {
+void spinad_amps() {
     dpdfile2 T1;
     dpdbuf4 T2;
 

--- a/psi4/src/psi4/cc/cclambda/update.cc
+++ b/psi4/src/psi4/cc/cclambda/update.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cclambda {
 
-void CCLambdaWavefunction::update(void) {
+void CCLambdaWavefunction::update() {
     outfile->Printf("\t%4d      %20.15f    %4.3e\n", moinfo.iter, moinfo.lcc, moinfo.conv);
 }
 

--- a/psi4/src/psi4/cc/ccresponse/analyze.cc
+++ b/psi4/src/psi4/cc/ccresponse/analyze.cc
@@ -45,8 +45,8 @@
 namespace psi {
 namespace ccresponse {
 
-double **Build_R(void);
-double **Build_U(void);
+double **Build_R();
+double **Build_U();
 
 void analyze(const char *pert, int irrep, double omega) {
     int nirreps, h, i, j, a, b, ij, ab, u, v;

--- a/psi4/src/psi4/cc/ccresponse/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_hbar_extra.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccresponse {
 
-void cc2_hbar_extra(void) {
+void cc2_hbar_extra() {
     dpdfile2 t1, lt;
     dpdbuf4 A, D, E, Z, Z1;
     dpdbuf4 W1, W;

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -58,28 +58,28 @@ namespace ccresponse {
 #define IOFF_MAX 32641
 
 /* Function prototypes */
-void init_io(void);
-void init_ioff(void);
-void title(void);
+void init_io();
+void init_ioff();
+void title();
 void get_moinfo(std::shared_ptr<Wavefunction>);
 void get_params(std::shared_ptr<Wavefunction>, Options &);
-void cleanup(void);
-void exit_io(void);
+void cleanup();
+void exit_io();
 int **cacheprep_rhf(int level, int *cachefiles);
 int **cacheprep_uhf(int level, int *cachefiles);
 void cachedone_uhf(int **cachelist);
 void cachedone_rhf(int **cachelist);
-void hbar_extra(void);
-void cc2_hbar_extra(void);
-void sort_lamps(void);
-void lambda_residuals(void);
+void hbar_extra();
+void cc2_hbar_extra();
+void sort_lamps();
+void lambda_residuals();
 
-void local_init(void);
-void local_done(void);
+void local_init();
+void local_done();
 
-void polar(void);
+void polar();
 void optrot(std::shared_ptr<Molecule> molecule);
-void roa(void);
+void roa();
 
 void preppert(std::shared_ptr<BasisSet> primary);
 
@@ -156,7 +156,7 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
     return PsiReturnType::Success;
 }
 
-void init_io(void) {
+void init_io() {
     int i;
 
     tstart();
@@ -171,7 +171,7 @@ void init_io(void) {
     psio_open(PSIF_CC_DIIS_ERR, 0);
 }
 
-void title(void) {
+void title() {
     outfile->Printf("\t\t\t**************************\n");
     outfile->Printf("\t\t\t*                        *\n");
     outfile->Printf("\t\t\t*       ccresponse       *\n");
@@ -179,7 +179,7 @@ void title(void) {
     outfile->Printf("\t\t\t**************************\n");
 }
 
-void exit_io(void) {
+void exit_io() {
     int i;
 
     /* Close all dpd data files here */
@@ -190,7 +190,7 @@ void exit_io(void) {
     tstop();
 }
 
-void init_ioff(void) {
+void init_ioff() {
     int i;
     ioff = init_int_array(IOFF_MAX);
     ioff[0] = 0;

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -92,8 +92,6 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
     get_moinfo(ref_wfn);
     get_params(ref_wfn, options);
 
-    timer_on("ccresponse");
-
     cachefiles = init_int_array(PSIO_MAXUNIT);
 
     if (params.ref == 2) { /*** UHF references ***/
@@ -149,8 +147,6 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
 
     cleanup();
 
-    timer_off("ccresponse");
-
     exit_io();
 
     return PsiReturnType::Success;
@@ -159,7 +155,7 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
 void init_io() {
     int i;
 
-    tstart();
+    timer_on("CCResponse");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 
@@ -187,7 +183,7 @@ void exit_io() {
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* get rid of TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    tstop();
+    timer_off("CCResponse");
 }
 
 void init_ioff() {

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -155,7 +155,7 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
 void init_io() {
     int i;
 
-    timer_on("CCResponse");
+    timer_on("ccresponse");
 
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 
@@ -183,7 +183,7 @@ void exit_io() {
     for (i = PSIF_CC_TMP; i <= PSIF_CC_TMP11; i++) psio_close(i, 0); /* get rid of TMP files */
     for (i = PSIF_CC_TMP11 + 1; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
 
-    timer_off("CCResponse");
+    timer_off("ccresponse");
 }
 
 void init_ioff() {

--- a/psi4/src/psi4/cc/ccresponse/compute_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/compute_X.cc
@@ -61,8 +61,8 @@ void print_X(const char *pert, int irrep, double omega);
 void update_X(const char *pert, int irrep, double omega);
 void diis(int iter, const char *pert, int irrep, double omega);
 double pseudopolar(const char *pert, int irrep, double omega);
-void cleanup(void);
-void exit_io(void);
+void cleanup();
+void exit_io();
 void amp_write(const char *pert, int irrep, double omega);
 
 void analyze(const char *pert, int irrep, double omega);

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -238,7 +238,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps out the energy. */
-void cleanup(void) {
+void cleanup() {
     int i;
 
     if (params.ref == 2) { /* UHF */

--- a/psi4/src/psi4/cc/ccresponse/hbar_extra.cc
+++ b/psi4/src/psi4/cc/ccresponse/hbar_extra.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccresponse {
 
-void hbar_extra(void) {
+void hbar_extra() {
     dpdfile2 lt;
     dpdbuf4 W1, W2, W;
     dpdbuf4 t2, l2;

--- a/psi4/src/psi4/cc/ccresponse/lambda_residuals.cc
+++ b/psi4/src/psi4/cc/ccresponse/lambda_residuals.cc
@@ -54,7 +54,7 @@ namespace ccresponse {
 ** TDC, 9/10/05
 */
 
-void lambda_residuals(void) {
+void lambda_residuals() {
     dpdbuf4 L2, Z, W;
     dpdfile2 L1, F;
     int h, i, e, m, a, I, E, M, A, Isym, Esym, Msym, Asym;

--- a/psi4/src/psi4/cc/ccresponse/local.cc
+++ b/psi4/src/psi4/cc/ccresponse/local.cc
@@ -65,7 +65,7 @@ namespace ccresponse {
 ** TDC, Jan-June 2002
 */
 
-void local_init(void) {
+void local_init() {
     local.nso = moinfo.nso;
     local.nocc = moinfo.occpi[0];  /* active doubly occupied orbitals */
     local.nvir = moinfo.virtpi[0]; /* active virtual orbitals */
@@ -73,7 +73,7 @@ void local_init(void) {
     outfile->Printf("\tLocalization parameters ready.\n\n");
 }
 
-void local_done(void) { outfile->Printf("\tLocal parameters free.\n"); }
+void local_done() { outfile->Printf("\tLocal parameters free.\n"); }
 
 void local_filter_T1(dpdfile2 *T1) {
     int i, a, ij, ii;

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -56,7 +56,7 @@ void compute_X(const char *pert, int irrep, double omega);
 void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep, double omega_x, const char *pert_y,
              int y_irrep, double omega_y);
 
-void polar(void) {
+void polar() {
     double ***tensor;
     char **cartcomp, pert[32], pert_x[32], pert_y[32];
     int alpha, beta, i;

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -58,7 +58,7 @@ void compute_X(const char *pert, int irrep, double omega);
 void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep, double omega_x, const char *pert_y,
              int y_irrep, double omega_y);
 
-void roa(void) {
+void roa() {
     double ***tensor_rl, ***tensor_pl, **tensor0, ***tensor_rr;
     double ****tensor_rQ, ***tensor_rQ0, ***tensor_rQ1;
     double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;

--- a/psi4/src/psi4/cc/ccresponse/scatter2.cc
+++ b/psi4/src/psi4/cc/ccresponse/scatter2.cc
@@ -66,7 +66,7 @@ namespace ccresponse {
 std::vector<SharedMatrix> compute_tensor_deriv(std::vector<SharedMatrix> tensor_list, const double disp_size);
 
 /* Computes all the ROA data using all the tensors */
-void scatter2(void) {
+void scatter2() {
     printf("Scattering FUN-ction.\n");
 
     //* Put Python Lists of Lists (the various Tensors) into Vectors of Matrices

--- a/psi4/src/psi4/cc/ccresponse/sort_lamps.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_lamps.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccresponse {
 
-void sort_lamps(void) {
+void sort_lamps() {
     dpdbuf4 L;
 
     /* RAK fixing this for new cclambda, assuming A1 ground lambda? */

--- a/psi4/src/psi4/cc/cctriples/ET_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_AAA.cc
@@ -44,7 +44,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_AAA(void) {
+double ET_AAA() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Ge, Gm;

--- a/psi4/src/psi4/cc/cctriples/ET_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_AAB.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_AAB(void) {
+double ET_AAB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Ge, Gm;

--- a/psi4/src/psi4/cc/cctriples/ET_ABB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_ABB.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_ABB(void) {
+double ET_ABB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Ge, Gm;

--- a/psi4/src/psi4/cc/cctriples/ET_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_BBB.cc
@@ -41,7 +41,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_BBB(void) {
+double ET_BBB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Ge, Gm;

--- a/psi4/src/psi4/cc/cctriples/ET_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_RHF.cc
@@ -72,7 +72,7 @@ struct thread_data {
 
 void ET_RHF_thread(thread_data *);
 
-double ET_RHF(void) {
+double ET_RHF() {
     int i, j, k, I, J, K, Gi, Gj, Gk, h, nirreps, cnt;
     int nijk, nthreads, thread, *ijk_part;
     int *occpi, *virtpi, *occ_off, *vir_off;

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_AAA.cc
@@ -43,7 +43,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_UHF_AAA(void) {
+double ET_UHF_AAA() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_AAB.cc
@@ -44,7 +44,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_UHF_AAB(void) {
+double ET_UHF_AAB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_ABB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_ABB.cc
@@ -43,7 +43,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_UHF_ABB(void) {
+double ET_UHF_ABB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_BBB.cc
@@ -43,7 +43,7 @@
 namespace psi {
 namespace cctriples {
 
-double ET_UHF_BBB(void) {
+double ET_UHF_BBB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
@@ -73,7 +73,7 @@ struct thread_data {
 
 void EaT_RHF_thread(thread_data *);
 
-double EaT_RHF(void) {
+double EaT_RHF() {
     int i, j, k, I, J, K, Gi, Gj, Gk, h, nirreps, cnt;
     int nijk, nthreads, thread, *ijk_part;
     int *occpi, *virtpi, *occ_off, *vir_off;

--- a/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
@@ -45,7 +45,7 @@
 namespace psi {
 namespace cctriples {
 
-void T3_grad_RHF(void) {
+void T3_grad_RHF() {
     int h, nirreps;
     int I, J, K, A, B, C, D, L;
     int i, j, k, a, b, c, d, l;

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
@@ -51,7 +51,7 @@ extern void T3_UHF_AAA_abc(double ***W, double ***V, int disc, int nirreps, int 
                            dpdbuf4 *C2, dpdbuf4 *F, dpdbuf4 *E, dpdfile2 *C1, dpdbuf4 *D, dpdfile2 *fIA, dpdfile2 *fIJ,
                            dpdfile2 *fAB, int *occpi, int *occ_off, int *virtpi, int *vir_off, double omega);
 
-double T3_grad_UHF_AAA(void) {
+double T3_grad_UHF_AAA() {
     int h, nirreps;
     int *occpi, *virtpi, *occ_off, *vir_off;
     int i, j, k, a, b, c, d, l;

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
@@ -58,7 +58,7 @@ extern void T3_UHF_AAB_abc(double ***W, double ***V, int disc, int nirreps, int 
                            dpdfile2 *fab, int *aoccpi, int *aocc_off, int *boccpi, int *bocc_off, int *avirtpi,
                            int *avir_off, int *bvirtpi, int *bvir_off, double omega);
 
-double T3_grad_UHF_AAB(void) {
+double T3_grad_UHF_AAB() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
@@ -57,7 +57,7 @@ extern void T3_UHF_AAB_abc(double ***W, double ***V, int disc, int nirreps, int 
                            dpdfile2 *fab, int *aoccpi, int *aocc_off, int *boccpi, int *bocc_off, int *avirtpi,
                            int *avir_off, int *bvirtpi, int *bvir_off, double omega);
 
-double T3_grad_UHF_BBA(void) {
+double T3_grad_UHF_BBA() {
     int cnt;
     int h, nirreps;
     int Gi, Gj, Gk, Ga, Gb, Gc, Gd, Gl;

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
@@ -51,7 +51,7 @@ extern void T3_UHF_AAA_abc(double ***W, double ***V, int disc, int nirreps, int 
                            dpdbuf4 *C2, dpdbuf4 *F, dpdbuf4 *E, dpdfile2 *C1, dpdbuf4 *D, dpdfile2 *fIA, dpdfile2 *fIJ,
                            dpdfile2 *fAB, int *occpi, int *occ_off, int *virtpi, int *vir_off, double omega);
 
-double T3_grad_UHF_BBB(void) {
+double T3_grad_UHF_BBB() {
     int h, nirreps;
     int *occpi, *virtpi, *occ_off, *vir_off;
     int i, j, k, a, b, c, d, l;

--- a/psi4/src/psi4/cc/cctriples/count_ijk.cc
+++ b/psi4/src/psi4/cc/cctriples/count_ijk.cc
@@ -40,7 +40,7 @@
 namespace psi {
 namespace cctriples {
 
-void count_ijk(void) {
+void count_ijk() {
     int nirreps;
     int Gi, Gj, Gk;
     int i, j, k;

--- a/psi4/src/psi4/cc/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cctriples/get_moinfo.cc
@@ -215,7 +215,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
-void cleanup(void) {
+void cleanup() {
     int i;
 
     free(moinfo.orbspi);

--- a/psi4/src/psi4/cc/cctriples/triples.cc
+++ b/psi4/src/psi4/cc/cctriples/triples.cc
@@ -52,32 +52,32 @@ namespace psi {
 namespace cctriples {
 
 void init_io();
-void title(void);
+void title();
 void get_moinfo(std::shared_ptr<Wavefunction>, Options &);
-void exit_io(void);
-void cleanup(void);
-double ET_RHF(void);
-double EaT_RHF(void);
-double ET_AAA(void);
-double ET_AAB(void);
-double ET_ABB(void);
-double ET_BBB(void);
-double ET_UHF_AAA(void);
-double ET_UHF_BBB(void);
-double ET_UHF_AAB(void);
-double ET_UHF_ABB(void);
-void count_ijk(void);
-void setup(void);
+void exit_io();
+void cleanup();
+double ET_RHF();
+double EaT_RHF();
+double ET_AAA();
+double ET_AAB();
+double ET_ABB();
+double ET_BBB();
+double ET_UHF_AAA();
+double ET_UHF_BBB();
+double ET_UHF_AAB();
+double ET_UHF_ABB();
+void count_ijk();
+void setup();
 int **cacheprep_rhf(int level, int *cachefiles);
 int **cacheprep_uhf(int level, int *cachefiles);
 void cachedone_uhf(int **cachelist);
 void cachedone_rhf(int **cachelist);
 
-void T3_grad_RHF(void);
-double T3_grad_UHF_AAA(void);
-double T3_grad_UHF_BBB(void);
-double T3_grad_UHF_AAB(void);
-double T3_grad_UHF_BBA(void);
+void T3_grad_RHF();
+double T3_grad_UHF_AAA();
+double T3_grad_UHF_BBB();
+double T3_grad_UHF_AAB();
+double T3_grad_UHF_BBA();
 
 void T3_UHF_AAA_abc(double ***W, double ***V, int disc, int nirreps, int A, int Ga, int B, int Gb, int C, int Gc,
                     dpdbuf4 *C2, dpdbuf4 *F, dpdbuf4 *E, dpdfile2 *C1, dpdbuf4 *D, dpdfile2 *fIA, dpdfile2 *fIJ,
@@ -266,7 +266,7 @@ void init_io() {
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
 
-void title(void) {
+void title() {
     outfile->Printf("            **************************\n");
     outfile->Printf("            *                        *\n");
     outfile->Printf("            *        CCTRIPLES       *\n");
@@ -274,7 +274,7 @@ void title(void) {
     outfile->Printf("            **************************\n");
 }
 
-void exit_io(void) {
+void exit_io() {
     int i;
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
     tstop();

--- a/psi4/src/psi4/cc/cctriples/triples.cc
+++ b/psi4/src/psi4/cc/cctriples/triples.cc
@@ -108,8 +108,6 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
     init_io();
     title();
 
-    timer_on("CCtriples");
-
     get_moinfo(reference_wavefunction, options);
     memory = Process::environment.get_memory();
 
@@ -254,14 +252,12 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
 
     cleanup();
 
-    timer_off("CCtriples");
-
     exit_io();
     return Success;
 }
 
 void init_io() {
-    tstart();
+    timer_on("CCTriples");
 
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
@@ -277,7 +273,7 @@ void title() {
 void exit_io() {
     int i;
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    tstop();
+    timer_off("CCTriples");
 }
 
 }  // namespace cctriples

--- a/psi4/src/psi4/cc/cctriples/triples.cc
+++ b/psi4/src/psi4/cc/cctriples/triples.cc
@@ -257,7 +257,7 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
 }
 
 void init_io() {
-    timer_on("CCTriples");
+    timer_on("cctriples");
 
     for (int i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_open(i, 1);
 }
@@ -273,7 +273,7 @@ void title() {
 void exit_io() {
     int i;
     for (i = PSIF_CC_MIN; i <= PSIF_CC_MAX; i++) psio_close(i, 1);
-    timer_off("CCTriples");
+    timer_off("cctriples");
 }
 
 }  // namespace cctriples

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -57,130 +57,130 @@ class CCEnergyWavefunction : public Wavefunction {
     /* setup, info and teardown */
     void init();
     void init_io();
-    void init_ioff(void);
-    void exit_io(void);
-    void cleanup(void);
+    void init_ioff();
+    void exit_io();
+    void cleanup();
     void status(const char *, std::string);
-    void title(void);
+    void title();
 
     /* calculation info */
-    void get_moinfo(void);
+    void get_moinfo();
     void get_params(Options &);
 
     /* amplitude handling */
-    void init_amps(void);
-    void sort_amps(void);
-    void tsave(void);
-    void ccdump(void);
-    void spinad_amps(void);
-    void amp_write(void);
-    void checkpoint(void);
+    void init_amps();
+    void sort_amps();
+    void tsave();
+    void ccdump();
+    void spinad_amps();
+    void amp_write();
+    void checkpoint();
 
     /* intermediates */
-    void update(void);
-    void Fae_build(void);
-    void Fmi_build(void);
-    void Fme_build(void);
-    void Wmnij_build(void);
-    void Wmbej_build(void);
-    void purge_Wabei(void);
-    void purge_Wmnij(void);
-    void purge_Wmnie(void);
-    void purge_Wmbij(void);
-    void purge_Wamef(void);
-    void FaetT2(void);
-    void FmitT2(void);
-    void WmnijT2(void);
-    void WmbejT2(void);
-    void BT2(void);
-    void CT2(void);
-    void DT2(void);
-    void ET2(void);
-    void FT2(void);
-    void ZT2(void);
-    void dijabT2(void);
-    void t1_build(void);
-    void tau_build(void);
-    void taut_build(void);
-    void Z_build(void);
-    void Y_build(void);
-    void X_build(void);
-    void t2_build(void);
+    void update();
+    void Fae_build();
+    void Fmi_build();
+    void Fme_build();
+    void Wmnij_build();
+    void Wmbej_build();
+    void purge_Wabei();
+    void purge_Wmnij();
+    void purge_Wmnie();
+    void purge_Wmbij();
+    void purge_Wamef();
+    void FaetT2();
+    void FmitT2();
+    void WmnijT2();
+    void WmbejT2();
+    void BT2();
+    void CT2();
+    void DT2();
+    void ET2();
+    void FT2();
+    void ZT2();
+    void dijabT2();
+    void t1_build();
+    void tau_build();
+    void taut_build();
+    void Z_build();
+    void Y_build();
+    void X_build();
+    void t2_build();
     int converged(double);
 
     /* DPD cache */
-    void init_priority_list(void);
+    void init_priority_list();
     int **cacheprep_uhf(int level, int *cachefiles);
     int **cacheprep_rhf(int level, int *cachefiles);
     void cachedone_rhf(int **cachelist);
     void cachedone_uhf(int **cachelist);
 
     /* Brueckner */
-    int rotate(void);
+    int rotate();
     double **fock_build(double **D);
 
     /* CC2 / CC3 */
-    void cc2_fmiT2(void);
-    void cc2_faeT2(void);
-    void cc2_WmbijT2(void);
-    void cc2_WabeiT2(void);
-    void cc2_WabijT2(void);
-    void cc2_Wmnij_build(void);
-    void cc2_Wmbij_build(void);
-    void cc2_Wabei_build(void);
-    void cc2_t2_build(void);
-    void FT2_CC2(void);
-    void purge_cc2_Wmnij(void);
-    void purge_cc2_Wmbij(void);
-    void purge_cc2_Wabei(void);
-    void t1_ijab(void);
-    void cc3_Wmnie(void);
-    void cc3_Wamef(void);
-    void cc3_Wmnij(void);
-    void cc3_Wmbij(void);
-    void cc3_Wabei(void);
-    void cc3(void);
+    void cc2_fmiT2();
+    void cc2_faeT2();
+    void cc2_WmbijT2();
+    void cc2_WabeiT2();
+    void cc2_WabijT2();
+    void cc2_Wmnij_build();
+    void cc2_Wmbij_build();
+    void cc2_Wabei_build();
+    void cc2_t2_build();
+    void FT2_CC2();
+    void purge_cc2_Wmnij();
+    void purge_cc2_Wmbij();
+    void purge_cc2_Wabei();
+    void t1_ijab();
+    void cc3_Wmnie();
+    void cc3_Wamef();
+    void cc3_Wmnij();
+    void cc3_Wmbij();
+    void cc3_Wabei();
+    void cc3();
 
     /* energies */
-    double energy(void);
-    double mp2_energy(void);
-    double uhf_mp2_energy(void);
-    double rhf_mp2_energy(void);
-    void one_step(void);
-    void denom(void);
+    double energy();
+    double mp2_energy();
+    double uhf_mp2_energy();
+    double rhf_mp2_energy();
+    void one_step();
+    void denom();
     void pair_energies(double **epair_aa, double **epair_ab);
     void print_pair_energies(double *emp2_aa, double *emp2_ab, double *ecc_aa, double *ecc_ab);
 
     void form_df_ints(Options &options, int **cachelist, int *cachefiles, dpd_file4_cache_entry *priority);
 
     /* diagnostics */
-    void analyze(void);
-    double diagnostic(void);
-    double d1diag(void);
-    double new_d1diag(void);
-    double new_d1diag_t1_rohf(void);
-    double d2diag(void);
-    double d1diag_t1_rhf(void);
-    double d1diag_t1_rohf(void);
-    double d2diag_rhf(void);
+    void analyze();
+    double diagnostic();
+    double d1diag();
+    double new_d1diag();
+    double new_d1diag_t1_rohf();
+    double d2diag();
+    double d1diag_t1_rhf();
+    double d1diag_t1_rohf();
+    double d2diag_rhf();
 
     /* local correlation */
-    void lmp2(void);
+    void lmp2();
     void local_filter_T1(dpdfile2 *T1);
     void local_filter_T2(dpdbuf4 *T2);
-    void local_init(void);
-    void local_done(void);
+    void local_init();
+    void local_done();
 
     /* AO basis */
-    void BT2_AO(void);
+    void BT2_AO();
     void halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, int dpdnum2, double ***C1, double ***C2, int nirreps,
                    int **mo_row, int **so_row, int *mospi_left, int *mospi_right, int *sospi, int type, double alpha,
                    double beta);
     int AO_contribute(struct iwlbuf *InBuf, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO);
 
-    double rhf_energy(void);
-    double uhf_energy(void);
-    double rohf_energy(void);
+    double rhf_energy();
+    double uhf_energy();
+    double rohf_energy();
     void rhf_fock_build(double **fock, double **D);
     void uhf_fock_build(double **fock_a, double **fock_b, double **D_a, double **D_b);
 


### PR DESCRIPTION
## Description
Switches times in CC modules from `tstart`/`tstop` to `timer_on`/`timer_off`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Use `timer_on`/`timer_off` in CC modules
- [x] Remove `void` from argument lists 

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
