### PR TITLE
ccenergy: Apply some style fixes

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/AO_contribute.cc
+++ b/psi4/src/psi4/cc/ccenergy/AO_contribute.cc
@@ -46,28 +46,22 @@ namespace psi {
 namespace ccenergy {
 
 int CCEnergyWavefunction::AO_contribute(struct iwlbuf *InBuf, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO) {
-    int idx, p, q, r, s;
-    double value;
-    Value *valptr;
-    Label *lblptr;
+    int p, q, r, s;
+    double value = 0.0;
     int Gp, Gq, Gr, Gs, Gpr, Gps, Gqr, Gqs, Grp, Gsp, Grq, Gsq;
     int pr, ps, qr, qs, rp, rq, sp, sq, pq, rs;
     int count = 0;
 
-    lblptr = InBuf->labels;
-    valptr = InBuf->values;
+    auto lblptr = InBuf->labels;
+    auto valptr = InBuf->values;
 
-    for (idx = 4 * InBuf->idx; InBuf->idx < InBuf->inbuf; InBuf->idx++) {
+    for (int idx = 4 * InBuf->idx; InBuf->idx < InBuf->inbuf; InBuf->idx++) {
         p = std::abs((int)lblptr[idx++]);
         q = (int)lblptr[idx++];
         r = (int)lblptr[idx++];
         s = (int)lblptr[idx++];
 
         value = (double)valptr[InBuf->idx];
-        /*
-        if(std::fabs(value) > 1e-8)
-            outfile->Printf(stdout, "%d %d %d %d %20.14f\n", p, q, r, s, value);
-        */
         count++;
 
         Gp = tau1_AO->params->psym[p];

--- a/psi4/src/psi4/cc/ccenergy/BT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2.cc
@@ -46,7 +46,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::BT2() {
-    int h;
     dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdbuf4 B_anti, B;
     dpdbuf4 tauIJAB, tauijab, tauIjAb;
@@ -55,8 +54,7 @@ void CCEnergyWavefunction::BT2() {
     dpdbuf4 B_a, B_s;
     dpdbuf4 S, A;
     double **B_diag, **tau_diag;
-    int ij, Gc, C, c, cc;
-    int nbuckets, rows_per_bucket, rows_left, m, row_start, ab, cd, dc, d;
+    int nbuckets, rows_per_bucket, rows_left, row_start;
     int nrows, ncols, nlinks;
     psio_address next;
 
@@ -121,11 +119,11 @@ void CCEnergyWavefunction::BT2() {
             global_dpd_->buf4_mat_irrep_init(&tau, 0);
             global_dpd_->buf4_mat_irrep_rd(&tau, 0);
             tau_diag = global_dpd_->dpd_block_matrix(tau.params->rowtot[0], moinfo_.nvirt);
-            for (ij = 0; ij < tau.params->rowtot[0]; ij++)
-                for (Gc = 0; Gc < moinfo_.nirreps; Gc++)
-                    for (C = 0; C < moinfo_.virtpi[Gc]; C++) {
-                        c = C + moinfo_.vir_off[Gc];
-                        cc = tau.params->colidx[c][c];
+            for (int ij = 0; ij < tau.params->rowtot[0]; ij++)
+                for (int Gc = 0; Gc < moinfo_.nirreps; Gc++)
+                    for (int C = 0; C < moinfo_.virtpi[Gc]; C++) {
+                        auto c = C + moinfo_.vir_off[Gc];
+                        auto cc = tau.params->colidx[c][c];
                         tau_diag[ij][c] = tau.matrix[0][ij][cc];
                     }
             global_dpd_->buf4_mat_irrep_close(&tau, 0);
@@ -144,6 +142,7 @@ void CCEnergyWavefunction::BT2() {
             next = PSIO_ZERO;
             ncols = tau.params->rowtot[0];
             nlinks = moinfo_.nvirt;
+            auto m = 0;
             for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
                 row_start = m * rows_per_bucket;
                 nrows = rows_per_bucket;

--- a/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
@@ -51,30 +51,26 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::BT2_AO() {
-    int h, nirreps, i, Gc, Gd, Ga, Gb, ij;
-    double ***C, **X;
+    double ***C;
     double ***Ca, ***Cb;
-    int *sopi, *virtpi;
+    int *virtpi;
     int *avirtpi, *bvirtpi;
-    int **T2_cd_row_start, **T2_pq_row_start, offset, cd, pq;
+    int **T2_cd_row_start, **T2_pq_row_start;
     int **T2_CD_row_start, **T2_Cd_row_start;
     dpdbuf4 tau, t2, tau1_AO, tau2_AO;
     dpdfile4 T;
-    psio_address next;
     struct iwlbuf InBuf;
     int lastbuf;
     double tolerance = 1e-14;
-    double **integrals;
-    int **tau1_cols, **tau2_cols, *num_ints;
     int counter = 0, counterAA = 0, counterBB = 0, counterAB = 0;
 
-    nirreps = moinfo_.nirreps;
-    sopi = moinfo_.sopi;
+    auto nirreps = moinfo_.nirreps;
+    auto sopi = moinfo_.sopi;
 
     T2_pq_row_start = init_int_matrix(nirreps, nirreps);
-    for (h = 0; h < nirreps; h++) {
-        for (Gc = 0, offset = 0; Gc < nirreps; Gc++) {
-            Gd = Gc ^ h;
+    for (int h = 0; h < nirreps; h++) {
+        for (int Gc = 0, offset = 0; Gc < nirreps; Gc++) {
+            auto Gd = Gc ^ h;
             T2_pq_row_start[h][Gc] = offset;
             offset += sopi[Gc] * sopi[Gd];
         }
@@ -85,9 +81,9 @@ void CCEnergyWavefunction::BT2_AO() {
         C = moinfo_.Cv;
 
         T2_cd_row_start = init_int_matrix(nirreps, nirreps);
-        for (h = 0; h < nirreps; h++) {
-            for (Gc = 0, offset = 0; Gc < nirreps; Gc++) {
-                Gd = Gc ^ h;
+        for (int h = 0; h < nirreps; h++) {
+            for (int Gc = 0, offset = 0; Gc < nirreps; Gc++) {
+                auto Gd = Gc ^ h;
                 T2_cd_row_start[h][Gc] = offset;
                 offset += virtpi[Gc] * virtpi[Gd];
             }
@@ -99,25 +95,25 @@ void CCEnergyWavefunction::BT2_AO() {
         Cb = moinfo_.Cbv;
 
         T2_CD_row_start = init_int_matrix(nirreps, nirreps);
-        for (h = 0; h < nirreps; h++) {
-            for (Gc = 0, offset = 0; Gc < nirreps; Gc++) {
-                Gd = Gc ^ h;
+        for (int h = 0; h < nirreps; h++) {
+            for (int Gc = 0, offset = 0; Gc < nirreps; Gc++) {
+                auto Gd = Gc ^ h;
                 T2_CD_row_start[h][Gc] = offset;
                 offset += avirtpi[Gc] * avirtpi[Gd];
             }
         }
         T2_cd_row_start = init_int_matrix(nirreps, nirreps);
-        for (h = 0; h < nirreps; h++) {
-            for (Gc = 0, offset = 0; Gc < nirreps; Gc++) {
-                Gd = Gc ^ h;
+        for (int h = 0; h < nirreps; h++) {
+            for (int Gc = 0, offset = 0; Gc < nirreps; Gc++) {
+                auto Gd = Gc ^ h;
                 T2_cd_row_start[h][Gc] = offset;
                 offset += bvirtpi[Gc] * bvirtpi[Gd];
             }
         }
         T2_Cd_row_start = init_int_matrix(nirreps, nirreps);
-        for (h = 0; h < nirreps; h++) {
-            for (Gc = 0, offset = 0; Gc < nirreps; Gc++) {
-                Gd = Gc ^ h;
+        for (int h = 0; h < nirreps; h++) {
+            for (int Gc = 0, offset = 0; Gc < nirreps; Gc++) {
+                auto Gd = Gc ^ h;
                 T2_Cd_row_start[h][Gc] = offset;
                 offset += avirtpi[Gc] * bvirtpi[Gd];
             }
@@ -157,7 +153,7 @@ void CCEnergyWavefunction::BT2_AO() {
                 global_dpd_->contract444_df(&B, &tau1_AO, &tau2_AO, 1.0, 0.0);
                 global_dpd_->buf4_close(&B);
             } else {
-                for (h = 0; h < nirreps; h++) {
+                for (int h = 0; h < nirreps; h++) {
                     global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
                     global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
                     global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -181,7 +177,7 @@ void CCEnergyWavefunction::BT2_AO() {
                 if (params_.print & 2)
                     outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counter);
 
-                for (h = 0; h < nirreps; h++) {
+                for (int h = 0; h < nirreps; h++) {
                     global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
                     global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
                     global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -221,8 +217,6 @@ void CCEnergyWavefunction::BT2_AO() {
             /* close the CC_TAMPS file for cints to use it */
             psio_close(PSIF_CC_TAMPS, 1);
 
-            int statusvalue = system("cints --cc_bt2");
-
             /* re-open CCC_TAMPS for remaining terms */
             psio_open(PSIF_CC_TAMPS, PSIO_OPEN_OLD);
         }
@@ -254,7 +248,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 5, 2, 5, 2, 0, "tauPQIJ (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -277,7 +271,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <AB||CD> --> T2\n", counterAA);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -327,7 +321,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 5, 2, 5, 2, 0, "taupqij (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -350,7 +344,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counterBB);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -400,7 +394,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 5, 0, 5, 0, 0, "tauPqIj (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -423,7 +417,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <Ab|Cd> --> T2\n", counterAB);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -476,7 +470,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 5, 2, 5, 2, 0, "tauPQIJ (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -499,7 +493,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <AB||CD> --> T2\n", counterAA);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -549,7 +543,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 15, 12, 15, 12, 0, "taupqij (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -572,7 +566,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counterBB);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);
@@ -622,7 +616,7 @@ void CCEnergyWavefunction::BT2_AO() {
         global_dpd_->buf4_init(&tau2_AO, PSIF_CC_TMP0, 0, 28, 22, 28, 22, 0, "tauPqIj (2)");
         global_dpd_->buf4_scm(&tau2_AO, 0.0);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_rd(&tau1_AO, h);
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
@@ -645,7 +639,7 @@ void CCEnergyWavefunction::BT2_AO() {
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <Ab|Cd> --> T2\n", counterAB);
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau2_AO, h);
             global_dpd_->buf4_mat_irrep_close(&tau1_AO, h);

--- a/psi4/src/psi4/cc/ccenergy/FT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/FT2.cc
@@ -46,8 +46,8 @@ void CCEnergyWavefunction::FT2() {
     dpdfile2 tIA, tia, t1;
     dpdbuf4 newtIJAB, newtijab, newtIjAb, t2, t2a, t2b;
     dpdbuf4 F_anti, F;
-    dpdbuf4 Z, X;
-    int Gie, Gij, Gab, nrows, ncols, nlinks, Gi, Ge, Gj, i, I;
+    dpdbuf4 X;
+    int Gij, Gab, nrows, ncols, nlinks, Ge, Gj, I;
 
     if (params_.ref == 0) { /** RHF **/
 
@@ -107,13 +107,13 @@ void CCEnergyWavefunction::FT2() {
             global_dpd_->file2_init(&t1, PSIF_CC_OEI, 0, 0, 1, "tIA");
             global_dpd_->file2_mat_init(&t1);
             global_dpd_->file2_mat_rd(&t1);
-            for (Gie = 0; Gie < moinfo_.nirreps; Gie++) {
+            for (int Gie = 0; Gie < moinfo_.nirreps; Gie++) {
                 Gab = Gie; /* F is totally symmetric */
                 Gij = Gab; /* T2 is totally symmetric */
                 global_dpd_->buf4_mat_irrep_init(&X, Gij);
                 ncols = F.params->coltot[Gie];
 
-                for (Gi = 0; Gi < moinfo_.nirreps; Gi++) {
+                for (int Gi = 0; Gi < moinfo_.nirreps; Gi++) {
                     Gj = Ge = Gi ^ Gie; /* T1 is totally symmetric */
 
                     nlinks = moinfo_.virtpi[Ge];
@@ -121,7 +121,7 @@ void CCEnergyWavefunction::FT2() {
 
                     global_dpd_->buf4_mat_irrep_init_block(&F, Gie, nlinks);
 
-                    for (i = 0; i < moinfo_.occpi[Gi]; i++) {
+                    for (int i = 0; i < moinfo_.occpi[Gi]; i++) {
                         I = F.params->poff[Gi] + i;
                         global_dpd_->buf4_mat_irrep_rd_block(&F, Gie, F.row_offset[Gie][I], nlinks);
 

--- a/psi4/src/psi4/cc/ccenergy/Fae.cc
+++ b/psi4/src/psi4/cc/ccenergy/Fae.cc
@@ -43,8 +43,8 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::Fae_build() {
-    int h, a, e, nirreps;
-    int ma, fe, ef, m, f, M, A, Gm, Ga, Ge, Gf, Gma, nrows, ncols;
+    int a, e, nirreps;
+    int ef, m, f, M, A, Gm, Ga, Ge, Gf, nrows, ncols;
     double *X;
     dpdfile2 tIA, tia;
     dpdfile2 FME, Fme;
@@ -85,8 +85,8 @@ void CCEnergyWavefunction::Fae_build() {
         global_dpd_->file2_mat_rd(&FAE);
 
         /*
-          for(h=0; h < moinfo.nirreps; h++) {
-          for(a=0; a < FAE.params->rowtot[h]; a++)
+          for(int h = 0; h < moinfo.nirreps; h++) {
+          for(int a = 0; a < FAE.params->rowtot[h]; a++)
           FAE.matrix[h][a][a] = 0;
           }
         */
@@ -103,12 +103,12 @@ void CCEnergyWavefunction::Fae_build() {
         global_dpd_->file2_mat_init(&Fae);
         global_dpd_->file2_mat_rd(&Fae);
 
-        for (h = 0; h < moinfo_.nirreps; h++) {
-            for (a = 0; a < FAE.params->rowtot[h]; a++)
-                for (e = 0; e < FAE.params->coltot[h]; e++) FAE.matrix[h][a][e] *= (1 - (a == e));
+        for (int h = 0; h < moinfo_.nirreps; h++) {
+            for (int a = 0; a < FAE.params->rowtot[h]; a++)
+                for (int e = 0; e < FAE.params->coltot[h]; e++) FAE.matrix[h][a][e] *= (1 - (a == e));
 
-            for (a = 0; a < Fae.params->rowtot[h]; a++)
-                for (e = 0; e < Fae.params->coltot[h]; e++) Fae.matrix[h][a][e] *= (1 - (a == e));
+            for (int a = 0; a < Fae.params->rowtot[h]; a++)
+                for (int e = 0; e < Fae.params->coltot[h]; e++) Fae.matrix[h][a][e] *= (1 - (a == e));
         }
 
         global_dpd_->file2_mat_wrt(&FAE);
@@ -127,12 +127,12 @@ void CCEnergyWavefunction::Fae_build() {
         global_dpd_->file2_mat_init(&Fae);
         global_dpd_->file2_mat_rd(&Fae);
 
-        for (h = 0; h < moinfo_.nirreps; h++) {
-            for (a = 0; a < FAE.params->rowtot[h]; a++)
-                for (e = 0; e < FAE.params->coltot[h]; e++) FAE.matrix[h][a][e] *= (1 - (a == e));
+        for (int h = 0; h < moinfo_.nirreps; h++) {
+            for (int a = 0; a < FAE.params->rowtot[h]; a++)
+                for (int e = 0; e < FAE.params->coltot[h]; e++) FAE.matrix[h][a][e] *= (1 - (a == e));
 
-            for (a = 0; a < Fae.params->rowtot[h]; a++)
-                for (e = 0; e < Fae.params->coltot[h]; e++) Fae.matrix[h][a][e] *= (1 - (a == e));
+            for (int a = 0; a < Fae.params->rowtot[h]; a++)
+                for (int e = 0; e < Fae.params->coltot[h]; e++) Fae.matrix[h][a][e] *= (1 - (a == e));
         }
 
         global_dpd_->file2_mat_wrt(&FAE);
@@ -175,11 +175,11 @@ void CCEnergyWavefunction::Fae_build() {
         global_dpd_->file2_mat_init(&tIA);
         global_dpd_->file2_mat_rd(&tIA);
         global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
-        for (Gma = 0; Gma < nirreps; Gma++) {
+        for (int Gma = 0; Gma < nirreps; Gma++) {
             global_dpd_->buf4_mat_irrep_row_init(&F, Gma);
             X = init_array(F.params->coltot[Gma]);
 
-            for (ma = 0; ma < F.params->rowtot[Gma]; ma++) {
+            for (int ma = 0; ma < F.params->rowtot[Gma]; ma++) {
                 global_dpd_->buf4_mat_irrep_row_rd(&F, Gma, ma);
                 m = F.params->roworb[Gma][ma][0];
                 a = F.params->roworb[Gma][ma][1];
@@ -192,7 +192,7 @@ void CCEnergyWavefunction::Fae_build() {
                 zero_arr(X, F.params->coltot[Gma]);
 
                 /* build spin-adapted F-integrals for current ma */
-                for (fe = 0; fe < F.params->coltot[Gma]; fe++) {
+                for (int fe = 0; fe < F.params->coltot[Gma]; fe++) {
                     f = F.params->colorb[Gma][fe][0];
                     e = F.params->colorb[Gma][fe][1];
                     ef = F.params->colidx[e][f];

--- a/psi4/src/psi4/cc/ccenergy/Fmi.cc
+++ b/psi4/src/psi4/cc/ccenergy/Fmi.cc
@@ -41,7 +41,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::Fmi_build() {
-    int h, m, i;
     dpdfile2 FMI, Fmi, FMIt, Fmit, fIJ, fij, fIA, fia;
     dpdfile2 tIA, tia, FME, Fme;
     dpdbuf4 E_anti, E, D_anti, D;
@@ -75,8 +74,8 @@ void CCEnergyWavefunction::Fmi_build() {
         global_dpd_->file2_mat_rd(&FMI);
 
         /*
-        for(h=0; h < moinfo.nirreps; h++) {
-          for(m=0; m < FMI.params->rowtot[h]; m++)
+        for(int h = 0; h < moinfo.nirreps; h++) {
+          for(int m = 0; m < FMI.params->rowtot[h]; m++)
             FMI.matrix[h][m][m] = 0;
         }
         */
@@ -93,10 +92,10 @@ void CCEnergyWavefunction::Fmi_build() {
         global_dpd_->file2_mat_init(&Fmi);
         global_dpd_->file2_mat_rd(&Fmi);
 
-        for (h = 0; h < moinfo_.nirreps; h++) {
-            for (m = 0; m < FMI.params->rowtot[h]; m++) FMI.matrix[h][m][m] = 0;
+        for (int h = 0; h < moinfo_.nirreps; h++) {
+            for (int m = 0; m < FMI.params->rowtot[h]; m++) FMI.matrix[h][m][m] = 0;
 
-            for (m = 0; m < Fmi.params->rowtot[h]; m++) Fmi.matrix[h][m][m] = 0;
+            for (int m = 0; m < Fmi.params->rowtot[h]; m++) Fmi.matrix[h][m][m] = 0;
         }
 
         global_dpd_->file2_mat_wrt(&FMI);
@@ -115,10 +114,10 @@ void CCEnergyWavefunction::Fmi_build() {
         global_dpd_->file2_mat_init(&Fmi);
         global_dpd_->file2_mat_rd(&Fmi);
 
-        for (h = 0; h < moinfo_.nirreps; h++) {
-            for (m = 0; m < FMI.params->rowtot[h]; m++) FMI.matrix[h][m][m] = 0;
+        for (int h = 0; h < moinfo_.nirreps; h++) {
+            for (int m = 0; m < FMI.params->rowtot[h]; m++) FMI.matrix[h][m][m] = 0;
 
-            for (m = 0; m < Fmi.params->rowtot[h]; m++) Fmi.matrix[h][m][m] = 0;
+            for (int m = 0; m < Fmi.params->rowtot[h]; m++) Fmi.matrix[h][m][m] = 0;
         }
 
         global_dpd_->file2_mat_wrt(&FMI);

--- a/psi4/src/psi4/cc/ccenergy/Wmbej.cc
+++ b/psi4/src/psi4/cc/ccenergy/Wmbej.cc
@@ -56,9 +56,9 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::Wmbej_build() {
     dpdbuf4 WMBEJ, Wmbej, WMbEj, WmBeJ, WmBEj, WMbeJ, W;
-    dpdbuf4 C, D, E, F, X, tIAjb, tiaJB, t2, Y, Z;
+    dpdbuf4 C, D, E, F, t2, Y;
     dpdfile2 tIA, tia;
-    int Gmb, mb, Gj, Ge, Gf, nrows, ncols, nlinks;
+    int Ge, Gf, nrows, ncols, nlinks;
 
     timer_on("C->Wmbej");
 
@@ -151,15 +151,15 @@ void CCEnergyWavefunction::Wmbej_build() {
         global_dpd_->file2_mat_init(&tIA);
         global_dpd_->file2_mat_rd(&tIA);
 
-        for (Gmb = 0; Gmb < moinfo_.nirreps; Gmb++) {
+        for (int Gmb = 0; Gmb < moinfo_.nirreps; Gmb++) {
             global_dpd_->buf4_mat_irrep_row_init(&W, Gmb);
             global_dpd_->buf4_mat_irrep_row_init(&F, Gmb);
 
-            for (mb = 0; mb < F.params->rowtot[Gmb]; mb++) {
+            for (int mb = 0; mb < F.params->rowtot[Gmb]; mb++) {
                 global_dpd_->buf4_mat_irrep_row_rd(&W, Gmb, mb);
                 global_dpd_->buf4_mat_irrep_row_rd(&F, Gmb, mb);
 
-                for (Gj = 0; Gj < moinfo_.nirreps; Gj++) {
+                for (int Gj = 0; Gj < moinfo_.nirreps; Gj++) {
                     Gf = Gj;       /* T1 is totally symmetric */
                     Ge = Gmb ^ Gf; /* <mb|fe> is totally symmetric */
 

--- a/psi4/src/psi4/cc/ccenergy/WmbejT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/WmbejT2.cc
@@ -118,7 +118,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::WmbejT2() {
-    dpdbuf4 T2new, T2, W, T2B, W1, W2, Z;
+    dpdbuf4 T2new, T2, W, W1, W2, Z;
 
     if (params_.ref == 0) { /** RHF **/
         /*** AB ***/

--- a/psi4/src/psi4/cc/ccenergy/Z.cc
+++ b/psi4/src/psi4/cc/ccenergy/Z.cc
@@ -41,9 +41,8 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::Z_build() {
-    dpdbuf4 ZIJMA, Zijma, ZIjMa, ZIjmA, ZIjAm, ZMaIj, ZmAIj, Z;
+    dpdbuf4 ZIJMA, Zijma, ZIjMa, ZIjmA, ZIjAm, Z;
     dpdbuf4 tauIJAB, tauijab, tauIjAb, tauIjbA, F_anti, F, tau;
-    int Gmb, Gij, mb, nrows, ncols;
 
     timer_on("Z");
 
@@ -54,30 +53,6 @@ void CCEnergyWavefunction::Z_build() {
         global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
         global_dpd_->buf4_init(&tau, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tauIjAb");
         global_dpd_->contract444(&F, &tau, &Z, 0, 0, 1, 0);
-        /*     for(Gmb=0; Gmb < moinfo.nirreps; Gmb++) { */
-        /*       Gij = Gmb;  /\* tau is totally symmetric *\/ */
-        /*       dpd_buf4_mat_irrep_init(&tau, Gij); */
-        /*       dpd_buf4_mat_irrep_rd(&tau, Gij); */
-
-        /*       dpd_buf4_mat_irrep_init(&Z, Gmb); */
-
-        /*       dpd_buf4_mat_irrep_row_init(&F, Gmb); */
-
-        /*       for(mb=0; mb < F.params->rowtot[Gmb]; mb++) { */
-        /* 	dpd_buf4_mat_irrep_row_rd(&F, Gmb, mb); */
-
-        /* 	nrows = tau.params->rowtot[Gij]; */
-        /* 	ncols = tau.params->coltot[Gij]; */
-        /* 	if(nrows && ncols) */
-        /* 	  C_DGEMV('n',nrows,ncols,1.0,tau.matrix[Gij][0],ncols,F.matrix[Gmb][0],1, */
-        /* 		  0.0,Z.matrix[Gmb][mb],1); */
-        /*       } */
-
-        /*       dpd_buf4_mat_irrep_row_close(&F, Gmb); */
-        /*       dpd_buf4_mat_irrep_wrt(&Z, Gmb); */
-        /*       dpd_buf4_mat_irrep_close(&Z, Gmb); */
-        /*       dpd_buf4_mat_irrep_close(&tau, Gij); */
-        /*     } */
         global_dpd_->buf4_close(&tau);
         global_dpd_->buf4_close(&F);
         global_dpd_->buf4_close(&Z);

--- a/psi4/src/psi4/cc/ccenergy/ZT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/ZT2.cc
@@ -41,7 +41,7 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::ZT2() {
     dpdbuf4 ZIJMA, ZIJAM, Zijma, Zijam, ZIjMa, ZIjAm, Z;
-    dpdbuf4 newtIJAB, newtijab, newtIjAb, T2;
+    dpdbuf4 newtIJAB, newtijab, newtIjAb;
     dpdfile2 tIA, tia, T1;
     dpdbuf4 t2, X;
 

--- a/psi4/src/psi4/cc/ccenergy/amp_write.cc
+++ b/psi4/src/psi4/cc/ccenergy/amp_write.cc
@@ -113,17 +113,16 @@ void CCEnergyWavefunction::amp_write() {
 
 void amp_write_T1(dpdfile2 *T1, int length, const char *label, std::string out) {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int m, h, nirreps, Gia;
-    int i, I, a, A, numt1;
+    int I, A;
     int num2print = 0;
     double value;
     struct onestack *t1stack;
 
-    nirreps = T1->params->nirreps;
-    Gia = T1->my_irrep;
+    auto nirreps = T1->params->nirreps;
+    auto Gia = T1->my_irrep;
 
     t1stack = (struct onestack *)malloc(length * sizeof(struct onestack));
-    for (m = 0; m < length; m++) {
+    for (int m = 0; m < length; m++) {
         t1stack[m].value = 0;
         t1stack[m].i = 0;
         t1stack[m].a = 0;
@@ -132,16 +131,16 @@ void amp_write_T1(dpdfile2 *T1, int length, const char *label, std::string out) 
     global_dpd_->file2_mat_init(T1);
     global_dpd_->file2_mat_rd(T1);
 
-    numt1 = 0;
-    for (h = 0; h < nirreps; h++) {
+    auto numt1 = 0;
+    for (int h = 0; h < nirreps; h++) {
         numt1 += T1->params->rowtot[h] * T1->params->coltot[h ^ Gia];
 
-        for (i = 0; i < T1->params->rowtot[h]; i++) {
+        for (int i = 0; i < T1->params->rowtot[h]; i++) {
             I = T1->params->roworb[h][i];
-            for (a = 0; a < T1->params->coltot[h ^ Gia]; a++) {
+            for (int a = 0; a < T1->params->coltot[h ^ Gia]; a++) {
                 A = T1->params->colorb[h][a];
                 value = T1->matrix[h][i][a];
-                for (m = 0; m < length; m++) {
+                for (int m = 0; m < length; m++) {
                     if ((std::fabs(value) - std::fabs(t1stack[m].value)) > 1e-12) {
                         onestack_insert(t1stack, value, I, A, m, length);
                         break;
@@ -153,12 +152,12 @@ void amp_write_T1(dpdfile2 *T1, int length, const char *label, std::string out) 
 
     global_dpd_->file2_mat_close(T1);
 
-    for (m = 0; m < ((numt1 < length) ? numt1 : length); m++)
+    for (int m = 0; m < ((numt1 < length) ? numt1 : length); m++)
         if (std::fabs(t1stack[m].value) > 1e-8) num2print++;
 
     if (num2print) printer->Printf("%s", label);
 
-    for (m = 0; m < ((numt1 < length) ? numt1 : length); m++)
+    for (int m = 0; m < ((numt1 < length) ? numt1 : length); m++)
         if (std::fabs(t1stack[m].value) > 1e-8)
             printer->Printf("            %3d %3d %20.10f\n", t1stack[m].i, t1stack[m].a, t1stack[m].value);
 
@@ -166,7 +165,6 @@ void amp_write_T1(dpdfile2 *T1, int length, const char *label, std::string out) 
 }
 
 void onestack_insert(struct onestack *stack, double value, int i, int a, int level, int stacklen) {
-    int l;
     struct onestack temp;
 
     temp = stack[level];
@@ -179,7 +177,7 @@ void onestack_insert(struct onestack *stack, double value, int i, int a, int lev
     i = temp.i;
     a = temp.a;
 
-    for (l = level; l < stacklen - 1; l++) {
+    for (int l = level; l < stacklen - 1; l++) {
         temp = stack[l + 1];
 
         stack[l + 1].value = value;
@@ -194,17 +192,16 @@ void onestack_insert(struct onestack *stack, double value, int i, int a, int lev
 
 void amp_write_T2(dpdbuf4 *T2, int length, const char *label, std::string out) {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int m, h, nirreps, Gijab, numt2;
-    int ij, ab, i, j, a, b;
+    int i, j, a, b;
     int num2print = 0;
     double value;
     struct twostack *t2stack;
 
-    nirreps = T2->params->nirreps;
-    Gijab = T2->file.my_irrep;
+    auto nirreps = T2->params->nirreps;
+    auto Gijab = T2->file.my_irrep;
 
     t2stack = (struct twostack *)malloc(length * sizeof(struct twostack));
-    for (m = 0; m < length; m++) {
+    for (int m = 0; m < length; m++) {
         t2stack[m].value = 0;
         t2stack[m].i = 0;
         t2stack[m].j = 0;
@@ -212,23 +209,23 @@ void amp_write_T2(dpdbuf4 *T2, int length, const char *label, std::string out) {
         t2stack[m].b = 0;
     }
 
-    numt2 = 0;
-    for (h = 0; h < nirreps; h++) {
+    auto numt2 = 0;
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(T2, h);
         global_dpd_->buf4_mat_irrep_rd(T2, h);
 
         numt2 += T2->params->rowtot[h] * T2->params->coltot[h ^ Gijab];
 
-        for (ij = 0; ij < T2->params->rowtot[h]; ij++) {
+        for (int ij = 0; ij < T2->params->rowtot[h]; ij++) {
             i = T2->params->roworb[h][ij][0];
             j = T2->params->roworb[h][ij][1];
-            for (ab = 0; ab < T2->params->coltot[h ^ Gijab]; ab++) {
+            for (int ab = 0; ab < T2->params->coltot[h ^ Gijab]; ab++) {
                 a = T2->params->colorb[h ^ Gijab][ab][0];
                 b = T2->params->colorb[h ^ Gijab][ab][1];
 
                 value = T2->matrix[h][ij][ab];
 
-                for (m = 0; m < length; m++) {
+                for (int m = 0; m < length; m++) {
                     if ((std::fabs(value) - std::fabs(t2stack[m].value)) > 1e-12) {
                         twostack_insert(t2stack, value, i, j, a, b, m, length);
                         break;
@@ -240,12 +237,12 @@ void amp_write_T2(dpdbuf4 *T2, int length, const char *label, std::string out) {
         global_dpd_->buf4_mat_irrep_close(T2, h);
     }
 
-    for (m = 0; m < ((numt2 < length) ? numt2 : length); m++)
+    for (int m = 0; m < ((numt2 < length) ? numt2 : length); m++)
         if (std::fabs(t2stack[m].value) > 1e-8) num2print++;
 
     if (num2print) printer->Printf("%s", label);
 
-    for (m = 0; m < ((numt2 < length) ? numt2 : length); m++)
+    for (int m = 0; m < ((numt2 < length) ? numt2 : length); m++)
         if (std::fabs(t2stack[m].value) > 1e-8)
             printer->Printf("    %3d %3d %3d %3d %20.10f\n", t2stack[m].i, t2stack[m].j, t2stack[m].a, t2stack[m].b,
                             t2stack[m].value);
@@ -254,7 +251,6 @@ void amp_write_T2(dpdbuf4 *T2, int length, const char *label, std::string out) {
 }
 
 void twostack_insert(struct twostack *stack, double value, int i, int j, int a, int b, int level, int stacklen) {
-    int l;
     struct twostack temp;
 
     temp = stack[level];
@@ -271,7 +267,7 @@ void twostack_insert(struct twostack *stack, double value, int i, int j, int a, 
     a = temp.a;
     b = temp.b;
 
-    for (l = level; l < stacklen - 1; l++) {
+    for (int l = level; l < stacklen - 1; l++) {
         temp = stack[l + 1];
 
         stack[l + 1].value = value;

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wabei.cc
@@ -57,13 +57,12 @@ namespace ccenergy {
 void purge_cc2_Wabei();
 
 void CCEnergyWavefunction::cc2_Wabei_build() {
-    int omit = 0;
-    int e, E;
-    int Gef, Gab, Gei, Ge, Gf, Gi;
+    int e;
+    int Gab, Gei, Gf, Gi;
     int nrows, ncols, nlinks;
     dpdfile2 t1, tIA, tia;
-    dpdbuf4 Z, Z1, Z2, Z3;
-    dpdbuf4 B, C, D, F, W;
+    dpdbuf4 Z, Z1, Z2;
+    dpdbuf4 B, F, W;
 
     timer_on("F->Wabei");
     if (params_.ref == 0) { /** RHF **/
@@ -126,9 +125,9 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
         global_dpd_->buf4_init(&Z1, PSIF_CC_TMP0, 0, 11, 8, 11, 8, 0, "Z1(ei,a>=b)");
         global_dpd_->buf4_scm(&Z1, 0);
 
-        for (Gef = 0; Gef < moinfo_.nirreps; Gef++) {
+        for (int Gef = 0; Gef < moinfo_.nirreps; Gef++) {
             Gei = Gab = Gef; /* W and B are totally symmetric */
-            for (Ge = 0; Ge < moinfo_.nirreps; Ge++) {
+            for (int Ge = 0; Ge < moinfo_.nirreps; Ge++) {
                 Gf = Ge ^ Gef;
                 Gi = Gf; /* t1 is totally symmetric */
                 B.matrix[Gef] = global_dpd_->dpd_block_matrix(moinfo_.virtpi[Gf], B.params->coltot[Gef]);
@@ -137,7 +136,7 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
                 ncols = Z1.params->coltot[Gef];
                 nlinks = moinfo_.virtpi[Gf];
                 if (nrows && ncols && nlinks) {
-                    for (E = 0; E < moinfo_.virtpi[Ge]; E++) {
+                    for (int E = 0; E < moinfo_.virtpi[Ge]; E++) {
                         e = moinfo_.vir_off[Ge] + E;
                         global_dpd_->buf4_mat_irrep_rd_block(&B, Gef, B.row_offset[Gef][e], moinfo_.virtpi[Gf]);
                         C_DGEMM('n', 'n', nrows, ncols, nlinks, 0.5, t1.matrix[Gi][0], nlinks, B.matrix[Gef][0], ncols,
@@ -158,9 +157,9 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
         global_dpd_->buf4_init(&Z2, PSIF_CC_TMP0, 0, 11, 9, 11, 9, 0, "Z2(ei,a>=b)");
         global_dpd_->buf4_scm(&Z2, 0);
 
-        for (Gef = 0; Gef < moinfo_.nirreps; Gef++) {
+        for (int Gef = 0; Gef < moinfo_.nirreps; Gef++) {
             Gei = Gab = Gef; /* W and B are totally symmetric */
-            for (Ge = 0; Ge < moinfo_.nirreps; Ge++) {
+            for (int Ge = 0; Ge < moinfo_.nirreps; Ge++) {
                 Gf = Ge ^ Gef;
                 Gi = Gf; /* t1 is totally symmetric */
                 B.matrix[Gef] = global_dpd_->dpd_block_matrix(moinfo_.virtpi[Gf], B.params->coltot[Gef]);
@@ -169,7 +168,7 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
                 ncols = Z2.params->coltot[Gef];
                 nlinks = moinfo_.virtpi[Gf];
                 if (nrows && ncols && nlinks) {
-                    for (E = 0; E < moinfo_.virtpi[Ge]; E++) {
+                    for (int E = 0; E < moinfo_.virtpi[Ge]; E++) {
                         e = moinfo_.vir_off[Ge] + E;
                         global_dpd_->buf4_mat_irrep_rd_block(&B, Gef, B.row_offset[Gef][e], moinfo_.virtpi[Gf]);
                         C_DGEMM('n', 'n', nrows, ncols, nlinks, 0.5, t1.matrix[Gi][0], nlinks, B.matrix[Gef][0], ncols,
@@ -316,10 +315,9 @@ void CCEnergyWavefunction::cc2_Wabei_build() {
 void CCEnergyWavefunction::purge_cc2_Wabei() {
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int a, b, e, i;
+    int A, B, E, I;
+    int asym, bsym, esym, isym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -335,14 +333,14 @@ void CCEnergyWavefunction::purge_cc2_Wabei() {
 
     /* Purge Wabei matrix elements */
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 7, "CC2 WABEI (EI,A>B)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             e = W.params->roworb[h][ei][0];
             esym = W.params->psym[e];
             E = e - vir_off[esym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 a = W.params->colorb[h][ab][0];
                 b = W.params->colorb[h][ab][1];
                 asym = W.params->rsym[a];
@@ -360,14 +358,14 @@ void CCEnergyWavefunction::purge_cc2_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 7, "CC2 Wabei (ei,a>b)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             i = W.params->roworb[h][ei][1];
             isym = W.params->qsym[i];
             I = i - occ_off[isym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 if (I >= (occpi[isym] - openpi[isym])) W.matrix[h][ei][ab] = 0.0;
             }
         }
@@ -377,17 +375,17 @@ void CCEnergyWavefunction::purge_cc2_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 5, "CC2 WAbEi (Ei,Ab)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             e = W.params->roworb[h][ei][0];
             i = W.params->roworb[h][ei][1];
             esym = W.params->psym[e];
             isym = W.params->qsym[i];
             E = e - vir_off[esym];
             I = i - occ_off[isym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 a = W.params->colorb[h][ab][0];
                 asym = W.params->rsym[a];
                 bsym = W.params->ssym[b];
@@ -403,11 +401,11 @@ void CCEnergyWavefunction::purge_cc2_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 5, "CC2 WaBeI (eI,aB)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 b = W.params->colorb[h][ab][1];
                 bsym = W.params->ssym[b];
                 B = b - vir_off[bsym];

--- a/psi4/src/psi4/cc/ccenergy/cc2_WabeiT2.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_WabeiT2.cc
@@ -42,8 +42,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::cc2_WabeiT2() {
-    int rowx, colx, rowz, colz, ab;
-    int GX, GZ, Ge, Gi, Gj, hxbuf, hzbuf;
     dpdfile2 t1, tia, tIA;
     dpdbuf4 Z, W, X;
     dpdbuf4 t2, t2a, t2b, tIJAB, tijab, tIjAb;

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wmbij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wmbij.cc
@@ -492,10 +492,9 @@ void CCEnergyWavefunction::cc2_Wmbij_build() {
 void CCEnergyWavefunction::purge_cc2_Wmbij() {
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int b, i, j, m;
+    int B, I, J, M;
+    int bsym, isym, jsym, msym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -510,14 +509,14 @@ void CCEnergyWavefunction::purge_cc2_Wmbij() {
     openpi = moinfo_.openpi;
 
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 10, 2, "CC2 WMBIJ (MB,I>J)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             b = W.params->roworb[h][mb][1];
             bsym = W.params->qsym[b];
             B = b - vir_off[bsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 if (B >= (virtpi[bsym] - openpi[bsym])) W.matrix[h][mb][ij] = 0.0;
             }
         }
@@ -527,14 +526,14 @@ void CCEnergyWavefunction::purge_cc2_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 10, 2, "CC2 Wmbij (mb,i>j)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             m = W.params->roworb[h][mb][0];
             msym = W.params->psym[m];
             M = m - occ_off[msym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 j = W.params->colorb[h][ij][1];
                 isym = W.params->rsym[i];
@@ -552,11 +551,11 @@ void CCEnergyWavefunction::purge_cc2_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 10, 0, "CC2 WMbIj");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 j = W.params->colorb[h][ij][1];
                 jsym = W.params->ssym[j];
                 J = j - occ_off[jsym];
@@ -569,17 +568,17 @@ void CCEnergyWavefunction::purge_cc2_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 10, 0, "CC2 WmBiJ (mB,iJ)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             m = W.params->roworb[h][mb][0];
             b = W.params->roworb[h][mb][1];
             msym = W.params->psym[m];
             bsym = W.params->qsym[b];
             M = m - occ_off[msym];
             B = b - vir_off[bsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 isym = W.params->rsym[i];
                 I = i - occ_off[isym];

--- a/psi4/src/psi4/cc/ccenergy/cc2_Wmnij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc2_Wmnij.cc
@@ -47,7 +47,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::cc2_Wmnij_build() {
-    dpdbuf4 A, E, D, Z, W, Z1, X;
+    dpdbuf4 A, E, D, Z, W, Z1;
     dpdfile2 t1, tIA, tia;
 
     timer_on("A->Wmnij");
@@ -321,13 +321,11 @@ void CCEnergyWavefunction::cc2_Wmnij_build() {
 }
 
 void CCEnergyWavefunction::purge_cc2_Wmnij() {
-    dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n, omit;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int i, j, m, n;
+    int I, J, M, N;
+    int isym, jsym, msym, nsym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -343,17 +341,17 @@ void CCEnergyWavefunction::purge_cc2_Wmnij() {
 
     /* Purge Wmnij matrix elements */
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 2, 2, "CC2 Wmnij (m>n,i>j)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             m = W.params->roworb[h][mn][0];
             n = W.params->roworb[h][mn][1];
             msym = W.params->psym[m];
             nsym = W.params->qsym[n];
             M = m - occ_off[msym];
             N = n - occ_off[nsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 j = W.params->colorb[h][ij][1];
                 isym = W.params->rsym[i];
@@ -371,14 +369,14 @@ void CCEnergyWavefunction::purge_cc2_Wmnij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC2_HET1, 0, 0, 0, "CC2 WMnIj");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             n = W.params->roworb[h][mn][1];
             nsym = W.params->qsym[n];
             N = n - occ_off[nsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 j = W.params->colorb[h][ij][1];
                 jsym = W.params->ssym[j];
                 J = j - occ_off[jsym];

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wabei.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wabei.cc
@@ -57,12 +57,11 @@ namespace ccenergy {
 void purge_Wabei();
 
 void CCEnergyWavefunction::cc3_Wabei() {
-    int omit = 0;
     dpdfile2 T1, t1, tIA, tia;
     dpdbuf4 Z, Z1, Z2, Z3;
     dpdbuf4 B, C, D, E, F, W;
-    int Gef, Gei, Gab, Ge, Gf, Gi;
-    int EE, e;
+    int Gei, Gab, Gf, Gi;
+    int e;
     int nrows, ncols, nlinks;
 
     if (params_.ref == 0) { /** RHF **/
@@ -90,9 +89,9 @@ void CCEnergyWavefunction::cc3_Wabei() {
         global_dpd_->file2_mat_rd(&T1);
         global_dpd_->buf4_init(&Z1, PSIF_CC_TMP0, 0, 11, 8, 11, 8, 0, "Z1(ei,a>=b)");
         global_dpd_->buf4_scm(&Z1, 0.0); /* this scm is necessary for cases with empty occpi or virtpi irreps */
-        for (Gef = 0; Gef < moinfo_.nirreps; Gef++) {
+        for (int Gef = 0; Gef < moinfo_.nirreps; Gef++) {
             Gei = Gab = Gef; /* W and B are totally symmetric */
-            for (Ge = 0; Ge < moinfo_.nirreps; Ge++) {
+            for (int Ge = 0; Ge < moinfo_.nirreps; Ge++) {
                 Gf = Ge ^ Gef;
                 Gi = Gf; /* T1 is totally symmetric */
                 B.matrix[Gef] = global_dpd_->dpd_block_matrix(moinfo_.virtpi[Gf], B.params->coltot[Gef]);
@@ -101,7 +100,7 @@ void CCEnergyWavefunction::cc3_Wabei() {
                 ncols = Z1.params->coltot[Gef];
                 nlinks = moinfo_.virtpi[Gf];
                 if (nrows && ncols && nlinks) {
-                    for (EE = 0; EE < moinfo_.virtpi[Ge]; EE++) {
+                    for (int EE = 0; EE < moinfo_.virtpi[Ge]; EE++) {
                         e = moinfo_.vir_off[Ge] + EE;
                         global_dpd_->buf4_mat_irrep_rd_block(&B, Gef, B.row_offset[Gef][e], moinfo_.virtpi[Gf]);
                         C_DGEMM('n', 'n', nrows, ncols, nlinks, 0.5, T1.matrix[Gi][0], nlinks, B.matrix[Gef][0], ncols,
@@ -124,9 +123,9 @@ void CCEnergyWavefunction::cc3_Wabei() {
         global_dpd_->file2_mat_rd(&T1);
         global_dpd_->buf4_init(&Z2, PSIF_CC_TMP0, 0, 11, 9, 11, 9, 0, "Z2(ei,a>=b)");
         global_dpd_->buf4_scm(&Z2, 0.0); /* this scm is necessary for cases with empty occpi or virtpi irreps */
-        for (Gef = 0; Gef < moinfo_.nirreps; Gef++) {
+        for (int Gef = 0; Gef < moinfo_.nirreps; Gef++) {
             Gei = Gab = Gef; /* W and B are totally symmetric */
-            for (Ge = 0; Ge < moinfo_.nirreps; Ge++) {
+            for (int Ge = 0; Ge < moinfo_.nirreps; Ge++) {
                 Gf = Ge ^ Gef;
                 Gi = Gf; /* T1 is totally symmetric */
                 B.matrix[Gef] = global_dpd_->dpd_block_matrix(moinfo_.virtpi[Gf], B.params->coltot[Gef]);
@@ -135,7 +134,7 @@ void CCEnergyWavefunction::cc3_Wabei() {
                 ncols = Z2.params->coltot[Gef];
                 nlinks = moinfo_.virtpi[Gf];
                 if (nrows && ncols && nlinks) {
-                    for (EE = 0; EE < moinfo_.virtpi[Ge]; EE++) {
+                    for (int EE = 0; EE < moinfo_.virtpi[Ge]; EE++) {
                         e = moinfo_.vir_off[Ge] + EE;
                         global_dpd_->buf4_mat_irrep_rd_block(&B, Gef, B.row_offset[Gef][e], moinfo_.virtpi[Gf]);
                         C_DGEMM('n', 'n', nrows, ncols, nlinks, 0.5, T1.matrix[Gi][0], nlinks, B.matrix[Gef][0], ncols,
@@ -1035,10 +1034,9 @@ void CCEnergyWavefunction::cc3_Wabei() {
 void CCEnergyWavefunction::purge_Wabei() {
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int a, b, e, i;
+    int A, B, E, I;
+    int asym, bsym, esym, isym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -1054,14 +1052,14 @@ void CCEnergyWavefunction::purge_Wabei() {
 
     /* Purge Wabei matrix elements */
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 7, "CC3 WABEI (EI,A>B)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             e = W.params->roworb[h][ei][0];
             esym = W.params->psym[e];
             E = e - vir_off[esym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 a = W.params->colorb[h][ab][0];
                 b = W.params->colorb[h][ab][1];
                 asym = W.params->rsym[a];
@@ -1079,14 +1077,14 @@ void CCEnergyWavefunction::purge_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 7, "CC3 Wabei (ei,a>b)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             i = W.params->roworb[h][ei][1];
             isym = W.params->qsym[i];
             I = i - occ_off[isym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 if (I >= (occpi[isym] - openpi[isym])) W.matrix[h][ei][ab] = 0.0;
             }
         }
@@ -1096,17 +1094,17 @@ void CCEnergyWavefunction::purge_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 5, "CC3 WAbEi (Ei,Ab)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
             e = W.params->roworb[h][ei][0];
             i = W.params->roworb[h][ei][1];
             esym = W.params->psym[e];
             isym = W.params->qsym[i];
             E = e - vir_off[esym];
             I = i - occ_off[isym];
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 a = W.params->colorb[h][ab][0];
                 asym = W.params->rsym[a];
                 bsym = W.params->ssym[b];
@@ -1122,11 +1120,11 @@ void CCEnergyWavefunction::purge_Wabei() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC_TMP2, 0, 11, 5, "CC3 WaBeI (eI,aB)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ei = 0; ei < W.params->rowtot[h]; ei++) {
-            for (ab = 0; ab < W.params->coltot[h]; ab++) {
+        for (int ei = 0; ei < W.params->rowtot[h]; ei++) {
+            for (int ab = 0; ab < W.params->coltot[h]; ab++) {
                 b = W.params->colorb[h][ab][1];
                 bsym = W.params->ssym[b];
                 B = b - vir_off[bsym];

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wamef.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wamef.cc
@@ -199,36 +199,28 @@ void CCEnergyWavefunction::cc3_Wamef() {
 }
 
 void CCEnergyWavefunction::purge_Wamef() {
-    dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
-    int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n, omit;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
-    int *occ_off, *vir_off;
-    int *occ_sym, *vir_sym;
-    int *openpi, nirreps;
+    int a, e, f, m;
+    int A, E, F, M;
+    int asym, esym, fsym, msym;
 
-    nirreps = moinfo_.nirreps;
-    occpi = moinfo_.occpi;
-    virtpi = moinfo_.virtpi;
-    occ_off = moinfo_.occ_off;
-    vir_off = moinfo_.vir_off;
-    occ_sym = moinfo_.occ_sym;
-    vir_sym = moinfo_.vir_sym;
-    openpi = moinfo_.openpi;
+    auto nirreps = moinfo_.nirreps;
+    auto occpi = moinfo_.occpi;
+    auto virtpi = moinfo_.virtpi;
+    auto occ_off = moinfo_.occ_off;
+    auto vir_off = moinfo_.vir_off;
+    auto openpi = moinfo_.openpi;
 
     /* Purge Wamef matrix elements */
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 11, 7, "CC3 WAMEF (AM,E>F)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ma = 0; ma < W.params->rowtot[h]; ma++) {
+        for (int ma = 0; ma < W.params->rowtot[h]; ma++) {
             a = W.params->roworb[h][ma][0];
             asym = W.params->psym[a];
             A = a - vir_off[asym];
-            for (ef = 0; ef < W.params->coltot[h]; ef++) {
+            for (int ef = 0; ef < W.params->coltot[h]; ef++) {
                 e = W.params->colorb[h][ef][0];
                 f = W.params->colorb[h][ef][1];
                 esym = W.params->rsym[e];
@@ -246,14 +238,14 @@ void CCEnergyWavefunction::purge_Wamef() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 11, 7, "CC3 Wamef (am,e>f)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ma = 0; ma < W.params->rowtot[h]; ma++) {
+        for (int ma = 0; ma < W.params->rowtot[h]; ma++) {
             m = W.params->roworb[h][ma][1];
             msym = W.params->qsym[m];
             M = m - occ_off[msym];
-            for (ef = 0; ef < W.params->coltot[h]; ef++) {
+            for (int ef = 0; ef < W.params->coltot[h]; ef++) {
                 if (M >= (occpi[msym] - openpi[msym])) W.matrix[h][ma][ef] = 0.0;
             }
         }
@@ -263,17 +255,17 @@ void CCEnergyWavefunction::purge_Wamef() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 11, 5, "CC3 WAmEf (Am,Ef)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ma = 0; ma < W.params->rowtot[h]; ma++) {
+        for (int ma = 0; ma < W.params->rowtot[h]; ma++) {
             a = W.params->roworb[h][ma][0];
             m = W.params->roworb[h][ma][1];
             asym = W.params->psym[a];
             msym = W.params->qsym[m];
             M = m - occ_off[msym];
             A = a - vir_off[asym];
-            for (ef = 0; ef < W.params->coltot[h]; ef++) {
+            for (int ef = 0; ef < W.params->coltot[h]; ef++) {
                 e = W.params->colorb[h][ef][0];
                 esym = W.params->rsym[e];
                 E = e - vir_off[esym];
@@ -288,11 +280,11 @@ void CCEnergyWavefunction::purge_Wamef() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 11, 5, "CC3 WaMeF (aM,eF)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (ma = 0; ma < W.params->rowtot[h]; ma++) {
-            for (ef = 0; ef < W.params->coltot[h]; ef++) {
+        for (int ma = 0; ma < W.params->rowtot[h]; ma++) {
+            for (int ef = 0; ef < W.params->coltot[h]; ef++) {
                 f = W.params->colorb[h][ef][1];
                 fsym = W.params->ssym[f];
                 F = f - vir_off[fsym];
@@ -303,8 +295,6 @@ void CCEnergyWavefunction::purge_Wamef() {
         global_dpd_->file4_mat_irrep_close(&W, h);
     }
     global_dpd_->file4_close(&W);
-
-    return;
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmbij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmbij.cc
@@ -481,33 +481,26 @@ void CCEnergyWavefunction::cc3_Wmbij() {
 
 void CCEnergyWavefunction::purge_Wmbij() {
     dpdfile4 W;
-    int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
-    int *occ_off, *vir_off;
-    int *occ_sym, *vir_sym;
-    int *openpi, nirreps;
+    int b, i, j, m;
+    int B, I, J, M;
+    int bsym, isym, jsym, msym;
 
-    nirreps = moinfo_.nirreps;
-    occpi = moinfo_.occpi;
-    virtpi = moinfo_.virtpi;
-    occ_off = moinfo_.occ_off;
-    vir_off = moinfo_.vir_off;
-    occ_sym = moinfo_.occ_sym;
-    vir_sym = moinfo_.vir_sym;
-    openpi = moinfo_.openpi;
+    auto nirreps = moinfo_.nirreps;
+    auto occpi = moinfo_.occpi;
+    auto virtpi = moinfo_.virtpi;
+    auto occ_off = moinfo_.occ_off;
+    auto vir_off = moinfo_.vir_off;
+    auto openpi = moinfo_.openpi;
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 10, 2, "CC3 WMBIJ (MB,I>J)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             b = W.params->roworb[h][mb][1];
             bsym = W.params->qsym[b];
             B = b - vir_off[bsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 if (B >= (virtpi[bsym] - openpi[bsym])) W.matrix[h][mb][ij] = 0.0;
             }
         }
@@ -517,14 +510,14 @@ void CCEnergyWavefunction::purge_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 10, 2, "CC3 Wmbij (mb,i>j)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             m = W.params->roworb[h][mb][0];
             msym = W.params->psym[m];
             M = m - occ_off[msym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 j = W.params->colorb[h][ij][1];
                 isym = W.params->rsym[i];
@@ -542,11 +535,11 @@ void CCEnergyWavefunction::purge_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 10, 0, "CC3 WMbIj (Mb,Ij)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 j = W.params->colorb[h][ij][1];
                 jsym = W.params->ssym[j];
                 J = j - occ_off[jsym];
@@ -559,17 +552,17 @@ void CCEnergyWavefunction::purge_Wmbij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 10, 0, "CC3 WmBiJ (mB,iJ)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mb = 0; mb < W.params->rowtot[h]; mb++) {
+        for (int mb = 0; mb < W.params->rowtot[h]; mb++) {
             m = W.params->roworb[h][mb][0];
             b = W.params->roworb[h][mb][1];
             msym = W.params->psym[m];
             bsym = W.params->qsym[b];
             M = m - occ_off[msym];
             B = b - vir_off[bsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 isym = W.params->rsym[i];
                 I = i - occ_off[isym];

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmnie.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmnie.cc
@@ -221,10 +221,9 @@ void CCEnergyWavefunction::cc3_Wmnie() {
 void CCEnergyWavefunction::purge_Wmnie() {
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int e, i, m, n;
+    int E, I, M, N;
+    int esym, isym, msym, nsym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -239,14 +238,14 @@ void CCEnergyWavefunction::purge_Wmnie() {
     openpi = moinfo_.openpi;
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 0, 11, "CC3 WMnIe (Mn,eI)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             n = W.params->roworb[h][mn][1];
             nsym = W.params->qsym[n];
             N = n - occ_off[nsym];
-            for (ei = 0; ei < W.params->coltot[h]; ei++) {
+            for (int ei = 0; ei < W.params->coltot[h]; ei++) {
                 if (N >= (occpi[nsym] - openpi[nsym])) W.matrix[h][mn][ei] = 0.0;
             }
         }
@@ -255,11 +254,11 @@ void CCEnergyWavefunction::purge_Wmnie() {
     }
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 2, 11, "CC3 WMNIE (M>N,EI)");
-    for (h = 0; h < W.params->nirreps; h++) {
+    for (int h = 0; h < W.params->nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
-            for (ei = 0; ei < W.params->coltot[h]; ei++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
+            for (int ei = 0; ei < W.params->coltot[h]; ei++) {
                 e = W.params->colorb[h][ei][0];
                 esym = W.params->rsym[e];
                 E = e - vir_off[esym];
@@ -271,17 +270,17 @@ void CCEnergyWavefunction::purge_Wmnie() {
     }
     global_dpd_->file4_close(&W);
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 2, 11, "CC3 Wmnie (m>n,ei)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             m = W.params->roworb[h][mn][0];
             n = W.params->roworb[h][mn][1];
             msym = W.params->psym[m];
             nsym = W.params->qsym[n];
             M = m - occ_off[msym];
             N = n - occ_off[nsym];
-            for (ei = 0; ei < W.params->coltot[h]; ei++) {
+            for (int ei = 0; ei < W.params->coltot[h]; ei++) {
                 i = W.params->colorb[h][ei][1];
                 isym = W.params->ssym[i];
                 I = i - occ_off[isym];
@@ -296,14 +295,14 @@ void CCEnergyWavefunction::purge_Wmnie() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 0, 11, "CC3 WmNiE (mN,Ei)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             m = W.params->roworb[h][mn][0];
             msym = W.params->psym[m];
             M = m - occ_off[msym];
-            for (ei = 0; ei < W.params->coltot[h]; ei++) {
+            for (int ei = 0; ei < W.params->coltot[h]; ei++) {
                 e = W.params->colorb[h][ei][0];
                 i = W.params->colorb[h][ei][1];
                 esym = W.params->rsym[e];
@@ -319,7 +318,6 @@ void CCEnergyWavefunction::purge_Wmnie() {
         global_dpd_->file4_mat_irrep_close(&W, h);
     }
     global_dpd_->file4_close(&W);
-    return;
 }
 
 }  // namespace ccenergy

--- a/psi4/src/psi4/cc/ccenergy/cc3_Wmnij.cc
+++ b/psi4/src/psi4/cc/ccenergy/cc3_Wmnij.cc
@@ -50,7 +50,7 @@ namespace ccenergy {
 void purge_Wmnij();
 
 void CCEnergyWavefunction::cc3_Wmnij() {
-    dpdbuf4 A, E, D, Z, W, Z1, X;
+    dpdbuf4 A, E, D, Z, W, Z1;
     dpdfile2 t1, tIA, tia;
 
     if (params_.ref == 0) { /** RHF **/
@@ -296,13 +296,11 @@ void CCEnergyWavefunction::cc3_Wmnij() {
 }
 
 void CCEnergyWavefunction::purge_Wmnij() {
-    dpdfile2 FAE, Fmi, FME, Fme;
     dpdfile4 W;
     int *occpi, *virtpi;
-    int h, a, b, e, f, i, j, m, n, omit;
-    int A, B, E, F, I, J, M, N;
-    int mn, ei, ma, ef, me, jb, mb, ij, ab;
-    int asym, bsym, esym, fsym, isym, jsym, msym, nsym;
+    int i, j, m, n;
+    int I, J, M, N;
+    int isym, jsym, msym, nsym;
     int *occ_off, *vir_off;
     int *occ_sym, *vir_sym;
     int *openpi, nirreps;
@@ -318,17 +316,17 @@ void CCEnergyWavefunction::purge_Wmnij() {
 
     /* Purge Wmnij matrix elements */
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 2, 2, "CC3 Wmnij (m>n,i>j)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             m = W.params->roworb[h][mn][0];
             n = W.params->roworb[h][mn][1];
             msym = W.params->psym[m];
             nsym = W.params->qsym[n];
             M = m - occ_off[msym];
             N = n - occ_off[nsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 i = W.params->colorb[h][ij][0];
                 j = W.params->colorb[h][ij][1];
                 isym = W.params->rsym[i];
@@ -346,14 +344,14 @@ void CCEnergyWavefunction::purge_Wmnij() {
     global_dpd_->file4_close(&W);
 
     global_dpd_->file4_init(&W, PSIF_CC3_HET1, 0, 0, 0, "CC3 WMnIj (Mn,Ij)");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->file4_mat_irrep_init(&W, h);
         global_dpd_->file4_mat_irrep_rd(&W, h);
-        for (mn = 0; mn < W.params->rowtot[h]; mn++) {
+        for (int mn = 0; mn < W.params->rowtot[h]; mn++) {
             n = W.params->roworb[h][mn][1];
             nsym = W.params->qsym[n];
             N = n - occ_off[nsym];
-            for (ij = 0; ij < W.params->coltot[h]; ij++) {
+            for (int ij = 0; ij < W.params->coltot[h]; ij++) {
                 j = W.params->colorb[h][ij][1];
                 jsym = W.params->ssym[j];
                 J = j - occ_off[jsym];

--- a/psi4/src/psi4/cc/ccenergy/converged.cc
+++ b/psi4/src/psi4/cc/ccenergy/converged.cc
@@ -43,12 +43,11 @@ namespace psi {
 namespace ccenergy {
 
 int CCEnergyWavefunction::converged(double ediff) {
-    int row, col, h, nirreps;
     double rms = 0.0;
     dpdfile2 T1, T1old;
     dpdbuf4 T2, T2old;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     if (params_.ref == 0) { /** RHF **/
 
@@ -58,9 +57,9 @@ int CCEnergyWavefunction::converged(double ediff) {
         global_dpd_->file2_init(&T1old, PSIF_CC_OEI, 0, 0, 1, "tIA");
         global_dpd_->file2_mat_init(&T1old);
         global_dpd_->file2_mat_rd(&T1old);
-        for (h = 0; h < nirreps; h++)
-            for (row = 0; row < T1.params->rowtot[h]; row++)
-                for (col = 0; col < T1.params->coltot[h]; col++)
+        for (int h = 0; h < nirreps; h++)
+            for (int row = 0; row < T1.params->rowtot[h]; row++)
+                for (int col = 0; col < T1.params->coltot[h]; col++)
                     rms += (T1.matrix[h][row][col] - T1old.matrix[h][row][col]) *
                            (T1.matrix[h][row][col] - T1old.matrix[h][row][col]);
 
@@ -71,13 +70,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -95,9 +94,9 @@ int CCEnergyWavefunction::converged(double ediff) {
         global_dpd_->file2_init(&T1old, PSIF_CC_OEI, 0, 0, 1, "tIA");
         global_dpd_->file2_mat_init(&T1old);
         global_dpd_->file2_mat_rd(&T1old);
-        for (h = 0; h < nirreps; h++)
-            for (row = 0; row < T1.params->rowtot[h]; row++)
-                for (col = 0; col < T1.params->coltot[h]; col++)
+        for (int h = 0; h < nirreps; h++)
+            for (int row = 0; row < T1.params->rowtot[h]; row++)
+                for (int col = 0; col < T1.params->coltot[h]; col++)
                     rms += (T1.matrix[h][row][col] - T1old.matrix[h][row][col]) *
                            (T1.matrix[h][row][col] - T1old.matrix[h][row][col]);
 
@@ -112,9 +111,9 @@ int CCEnergyWavefunction::converged(double ediff) {
         global_dpd_->file2_init(&T1old, PSIF_CC_OEI, 0, 0, 1, "tia");
         global_dpd_->file2_mat_init(&T1old);
         global_dpd_->file2_mat_rd(&T1old);
-        for (h = 0; h < nirreps; h++)
-            for (row = 0; row < T1.params->rowtot[h]; row++)
-                for (col = 0; col < T1.params->coltot[h]; col++)
+        for (int h = 0; h < nirreps; h++)
+            for (int row = 0; row < T1.params->rowtot[h]; row++)
+                for (int col = 0; col < T1.params->coltot[h]; col++)
                     rms += (T1.matrix[h][row][col] - T1old.matrix[h][row][col]) *
                            (T1.matrix[h][row][col] - T1old.matrix[h][row][col]);
 
@@ -125,13 +124,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tIJAB");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -142,13 +141,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tijab");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tijab");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -159,13 +158,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -181,9 +180,9 @@ int CCEnergyWavefunction::converged(double ediff) {
         global_dpd_->file2_init(&T1old, PSIF_CC_OEI, 0, 0, 1, "tIA");
         global_dpd_->file2_mat_init(&T1old);
         global_dpd_->file2_mat_rd(&T1old);
-        for (h = 0; h < nirreps; h++)
-            for (row = 0; row < T1.params->rowtot[h]; row++)
-                for (col = 0; col < T1.params->coltot[h]; col++)
+        for (int h = 0; h < nirreps; h++)
+            for (int row = 0; row < T1.params->rowtot[h]; row++)
+                for (int col = 0; col < T1.params->coltot[h]; col++)
                     rms += (T1.matrix[h][row][col] - T1old.matrix[h][row][col]) *
                            (T1.matrix[h][row][col] - T1old.matrix[h][row][col]);
 
@@ -198,9 +197,9 @@ int CCEnergyWavefunction::converged(double ediff) {
         global_dpd_->file2_init(&T1old, PSIF_CC_OEI, 0, 2, 3, "tia");
         global_dpd_->file2_mat_init(&T1old);
         global_dpd_->file2_mat_rd(&T1old);
-        for (h = 0; h < nirreps; h++)
-            for (row = 0; row < T1.params->rowtot[h]; row++)
-                for (col = 0; col < T1.params->coltot[h]; col++)
+        for (int h = 0; h < nirreps; h++)
+            for (int row = 0; row < T1.params->rowtot[h]; row++)
+                for (int col = 0; col < T1.params->coltot[h]; col++)
                     rms += (T1.matrix[h][row][col] - T1old.matrix[h][row][col]) *
                            (T1.matrix[h][row][col] - T1old.matrix[h][row][col]);
 
@@ -211,13 +210,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tIJAB");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -228,13 +227,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "New tijab");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "tijab");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);
@@ -245,13 +244,13 @@ int CCEnergyWavefunction::converged(double ediff) {
 
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "New tIjAb");
         global_dpd_->buf4_init(&T2old, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "tIjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&T2, h);
             global_dpd_->buf4_mat_irrep_rd(&T2, h);
             global_dpd_->buf4_mat_irrep_init(&T2old, h);
             global_dpd_->buf4_mat_irrep_rd(&T2old, h);
-            for (row = 0; row < T2.params->rowtot[h]; row++)
-                for (col = 0; col < T2.params->coltot[h]; col++)
+            for (int row = 0; row < T2.params->rowtot[h]; row++)
+                for (int col = 0; col < T2.params->coltot[h]; col++)
                     rms += (T2.matrix[h][row][col] - T2old.matrix[h][row][col]) *
                            (T2.matrix[h][row][col] - T2old.matrix[h][row][col]);
             global_dpd_->buf4_mat_irrep_close(&T2, h);

--- a/psi4/src/psi4/cc/ccenergy/d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d1diag.cc
@@ -56,18 +56,17 @@ namespace ccenergy {
  * */
 
 double CCEnergyWavefunction::d1diag_t1_rhf() {
-    int h, nirreps, i;
-    double **T, **C, *E, max;
+    double **T, **C, *E;
     dpdfile2 T1;
 
-    nirreps = moinfo_.nirreps;
-    max = 0.0;
+    auto nirreps = moinfo_.nirreps;
+    auto max = 0.0;
 
     global_dpd_->file2_init(&T1, PSIF_CC_OEI, 0, 0, 1, "tIA");
     global_dpd_->file2_mat_init(&T1);
     global_dpd_->file2_mat_rd(&T1);
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         if (T1.params->rowtot[h]) {
             T = block_matrix(T1.params->rowtot[h], T1.params->rowtot[h]);
 
@@ -86,7 +85,7 @@ double CCEnergyWavefunction::d1diag_t1_rhf() {
             sq_rsp(T1.params->rowtot[h], T1.params->rowtot[h], T, E, 0, C, 1e-12);
 
             /* Find maximum eigenvalue of T */
-            for (i = 0; i < T1.params->rowtot[h]; i++)
+            for (int i = 0; i < T1.params->rowtot[h]; i++)
                 if (E[i] > max) max = E[i];
 
             free_block(T);
@@ -104,7 +103,6 @@ double CCEnergyWavefunction::d1diag_t1_rhf() {
 }
 
 static double d1diag_subblock(double **Tave, int row0, int rown, int col0, int coln) {
-    int i, j;
     int nrow = rown - row0;
     int ncol = coln - col0;
     double max = 0.;
@@ -116,8 +114,8 @@ static double d1diag_subblock(double **Tave, int row0, int rown, int col0, int c
         Tsub = block_matrix(nrow, ncol);
         Tsq = block_matrix(nrow, nrow);
 
-        for (i = row0; i < rown; i++) {
-            for (j = col0; j < coln; j++) {
+        for (int i = row0; i < rown; i++) {
+            for (int j = col0; j < coln; j++) {
                 Tsub[i - row0][j - col0] = Tave[i][j];
             }
         }
@@ -130,7 +128,7 @@ static double d1diag_subblock(double **Tave, int row0, int rown, int col0, int c
         sq_rsp(nrow, nrow, Tsq, E, 0, C, 1e-12);
 
         /* Find maximum eigenvalue of T */
-        for (i = 0; i < nrow; i++)
+        for (int i = 0; i < nrow; i++)
             if (E[i] > max) max = E[i];
 
         free_block(C);
@@ -143,12 +141,11 @@ static double d1diag_subblock(double **Tave, int row0, int rown, int col0, int c
 }
 
 double CCEnergyWavefunction::d1diag_t1_rohf() {
-    int h, nirreps, i, j;
     double **Tave, tmp, max;
     double max_ph = 0.0, max_xp = 0.0, max_hx = 0.0;
     dpdfile2 T1_a, T1_b;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     global_dpd_->file2_init(&T1_a, PSIF_CC_OEI, 0, 0, 1, "tia");
     global_dpd_->file2_mat_init(&T1_a);
@@ -158,15 +155,15 @@ double CCEnergyWavefunction::d1diag_t1_rohf() {
     global_dpd_->file2_mat_init(&T1_b);
     global_dpd_->file2_mat_rd(&T1_b);
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         int nrow = T1_a.params->rowtot[h];
         int ncol = T1_a.params->coltot[h];
         int nopen = moinfo_.openpi[h];
         if (nrow && ncol) {
             Tave = block_matrix(nrow, ncol);
 
-            for (i = 0; i < nrow; i++) {
-                for (j = 0; j < ncol; j++) {
+            for (int i = 0; i < nrow; i++) {
+                for (int j = 0; j < ncol; j++) {
                     Tave[i][j] = (T1_a.matrix[h][i][j] + T1_b.matrix[h][i][j]) / 2.;
                 }
             }

--- a/psi4/src/psi4/cc/ccenergy/d2diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d2diag.cc
@@ -50,15 +50,14 @@ namespace ccenergy {
  * */
 
 double CCEnergyWavefunction::d2diag_rhf() {
-    int h, nirreps, i;
-    double **Co, *Eo, max;
+    double **Co, *Eo;
     double **Cv, *Ev;
     dpdbuf4 Tikab, Tjkab;
     dpdbuf4 Tijac, Tijbc;
     dpdfile2 To, Tv;
 
-    nirreps = moinfo_.nirreps;
-    max = 0.0;
+    auto nirreps = moinfo_.nirreps;
+    auto max = 0.0;
 
     global_dpd_->buf4_init(&Tikab, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
     global_dpd_->buf4_init(&Tjkab, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
@@ -86,14 +85,14 @@ double CCEnergyWavefunction::d2diag_rhf() {
     global_dpd_->file2_mat_init(&Tv);
     global_dpd_->file2_mat_rd(&Tv);
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         if (To.params->rowtot[h]) {
             // Diagonalize To //
             Eo = init_array(To.params->rowtot[h]);
             Co = block_matrix(To.params->rowtot[h], To.params->rowtot[h]);
             sq_rsp(To.params->rowtot[h], To.params->rowtot[h], To.matrix[h], Eo, 0, Co, 1e-12);
             // Find maximum To eigenvalue //
-            for (i = 0; i < To.params->rowtot[h]; i++) {
+            for (int i = 0; i < To.params->rowtot[h]; i++) {
                 if (Eo[i] > max) max = Eo[i];
             }
             free_block(Co);
@@ -107,7 +106,7 @@ double CCEnergyWavefunction::d2diag_rhf() {
             sq_rsp(Tv.params->rowtot[h], Tv.params->rowtot[h], Tv.matrix[h], Ev, 0, Cv, 1e-12);
 
             // Find maximum Tv eigenvalue //
-            for (i = 0; i < Tv.params->rowtot[h]; i++) {
+            for (int i = 0; i < Tv.params->rowtot[h]; i++) {
                 if (Ev[i] > max) max = Ev[i];
             }
 
@@ -135,7 +134,7 @@ double CCEnergyWavefunction::d2diag_rhf() {
     dpd_buf4_init(&Tijab, CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
     dpd_buf4_init(&Tjabi, CC_TMP0, 0, 10, 11, 10, 11, 0, "tjAbI");
 
-    for(h=0; h < nirreps; h++) {
+    for(int h = 0; h < nirreps; h++) {
       dpd_buf4_mat_irrep_init(&Tijab, h);
       dpd_buf4_mat_irrep_rd(&Tijab, h);
   //    dpd_buf4_mat_irrep_shift13(&Tijab, h);
@@ -154,7 +153,7 @@ double CCEnergyWavefunction::d2diag_rhf() {
       Co = block_matrix(nrows, nrows);
       sq_rsp(nrows, nrows, To, Eo, 0, Co, 1e-12);
 
-      for(i=0; i < nrows; i++) {
+      for(int i = 0; i < nrows; i++) {
         if(Eo[i] > max) max = Eo[i];
       }
 

--- a/psi4/src/psi4/cc/ccenergy/denom.cc
+++ b/psi4/src/psi4/cc/ccenergy/denom.cc
@@ -46,7 +46,7 @@ void dijabT2();
 /* apply denominators to t1 and t2 */
 
 void CCEnergyWavefunction::denom() {
-    dpdfile2 newtIA, dIA, tIA, newtia, dia, tia;
+    dpdfile2 newtIA, dIA, tIA, newtia, dia;
 
     if (params_.ref == 0) {
         global_dpd_->file2_init(&newtIA, PSIF_CC_OEI, 0, 0, 1, "New tIA");
@@ -99,8 +99,6 @@ void CCEnergyWavefunction::denom() {
     }
 
     dijabT2();
-
-    return;
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/diagnostic.cc
+++ b/psi4/src/psi4/cc/ccenergy/diagnostic.cc
@@ -43,21 +43,15 @@ namespace psi {
 namespace ccenergy {
 
 double CCEnergyWavefunction::diagnostic() {
-    int h, nirreps, Gi, Ga;
-    int i, a, I, A, row, col;
-    int num_elec, num_elec_a, num_elec_b;
-    int *occpi, *virtpi;
-    int *occ_sym, *vir_sym;
-    int *clsdpi, *uoccpi;
-    int *openpi;
-    double t1diag, t1diag_a, t1diag_b;
     dpdfile2 T1A, T1B;
 
-    nirreps = moinfo_.nirreps;
-    clsdpi = moinfo_.clsdpi;
-    uoccpi = moinfo_.uoccpi;
-    openpi = moinfo_.openpi;
+    auto nirreps = moinfo_.nirreps;
+    auto clsdpi = moinfo_.clsdpi;
+    auto uoccpi = moinfo_.uoccpi;
+    auto openpi = moinfo_.openpi;
 
+    int *occpi, *virtpi;
+    int *occ_sym, *vir_sym;
     if (params_.ref != 2) {
         occpi = moinfo_.occpi;
         virtpi = moinfo_.virtpi;
@@ -66,11 +60,15 @@ double CCEnergyWavefunction::diagnostic() {
     }
 
     /* Compute the number of electrons */
-    for (h = 0, num_elec_a = 0, num_elec_b = 0; h < nirreps; h++) {
+    auto num_elec_a = 0;
+    auto num_elec_b = 0;
+    for (int h = 0; h < nirreps; h++) {
         num_elec_a += clsdpi[h] + openpi[h];
         num_elec_b += clsdpi[h];
     }
-    num_elec = num_elec_a + num_elec_b;
+    auto num_elec = num_elec_a + num_elec_b;
+
+    auto t1diag = 0.0;
 
     if (params_.ref == 0) { /** RHF **/
 
@@ -90,25 +88,24 @@ double CCEnergyWavefunction::diagnostic() {
         global_dpd_->file2_mat_init(&T1B);
         global_dpd_->file2_mat_rd(&T1B);
 
-        t1diag = 0.0;
-        for (h = 0; h < nirreps; h++) {
-            for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-                for (a = 0; a < (virtpi[h] - openpi[h]); a++) {
+        for (int h = 0; h < nirreps; h++) {
+            for (int i = 0; i < (occpi[h] - openpi[h]); i++) {
+                for (int a = 0; a < (virtpi[h] - openpi[h]); a++) {
                     t1diag += (T1A.matrix[h][i][a] + T1B.matrix[h][i][a]) * (T1A.matrix[h][i][a] + T1B.matrix[h][i][a]);
                 }
             }
 
-            for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-                for (a = 0; a < openpi[h]; a++) {
-                    A = a + uoccpi[h];
+            for (int i = 0; i < (occpi[h] - openpi[h]); i++) {
+                for (int a = 0; a < openpi[h]; a++) {
+                    auto A = a + uoccpi[h];
 
                     t1diag += 2 * T1B.matrix[h][i][A] * T1B.matrix[h][i][A];
                 }
             }
 
-            for (i = 0; i < openpi[h]; i++) {
-                I = i + clsdpi[h];
-                for (a = 0; a < (virtpi[h] - openpi[h]); a++) {
+            for (int i = 0; i < openpi[h]; i++) {
+                auto I = i + clsdpi[h];
+                for (int a = 0; a < (virtpi[h] - openpi[h]); a++) {
                     t1diag += 2 * T1A.matrix[h][I][a] * T1A.matrix[h][I][a];
                 }
             }
@@ -132,15 +129,15 @@ double CCEnergyWavefunction::diagnostic() {
         global_dpd_->file2_mat_init(&T1B);
         global_dpd_->file2_mat_rd(&T1B);
 
-        t1diag_a = 0.0;
-        t1diag_b = 0.0;
-        for (h = 0; h < nirreps; h++) {
-            for (row = 0; row < T1A.params->rowtot[h]; row++)
-                for (col = 0; col < T1A.params->coltot[h]; col++)
+        auto t1diag_a = 0.0;
+        auto t1diag_b = 0.0;
+        for (int h = 0; h < nirreps; h++) {
+            for (int row = 0; row < T1A.params->rowtot[h]; row++)
+                for (int col = 0; col < T1A.params->coltot[h]; col++)
                     t1diag_a += (T1A.matrix[h][row][col] * T1A.matrix[h][row][col]);
 
-            for (row = 0; row < T1B.params->rowtot[h]; row++)
-                for (col = 0; col < T1B.params->coltot[h]; col++)
+            for (int row = 0; row < T1B.params->rowtot[h]; row++)
+                for (int col = 0; col < T1B.params->coltot[h]; col++)
                     t1diag_b += (T1B.matrix[h][row][col] * T1B.matrix[h][row][col]);
         }
 

--- a/psi4/src/psi4/cc/ccenergy/diis.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis.cc
@@ -70,8 +70,6 @@ void CCEnergyWavefunction::diis(int iter) {
         diis_ROHF(iter);
     else if (params_.ref == 2)
         diis_UHF(iter);
-
-    return;
 }
 
 void CCEnergyWavefunction::diis_invert_B(double** B, double* C, int dimension, double tolerance) {

--- a/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
@@ -61,25 +61,19 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::diis_RHF(int iter) {
     int nvector = 8; /* Number of error vectors to keep */
-    int h, nirreps;
-    int row, col;
-    size_t p, q, diis_cycle;
-    size_t vector_length = 0;
-    size_t t1_word, word;
-    int errcod, *ipiv;
     dpdfile2 T1, T1a, T1b;
-    dpdbuf4 T2, T2a, T2b, T2c;
-    psio_address start, end, next;
-    double **error;
+    dpdbuf4 T2, T2a, T2b;
+    psio_address start, end;
     double **B, *C, **vector;
-    double product, determinant, maximum;
+    double product, maximum;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     /* Compute the length of a single error vector */
     global_dpd_->file2_init(&T1, PSIF_CC_TAMPS, 0, 0, 1, "tIA");
     global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    auto vector_length = 0;
+    for (int h = 0; h < nirreps; h++) {
         vector_length += T1.params->rowtot[h] * T1.params->coltot[h];
         vector_length += T2.params->rowtot[h] * T2.params->coltot[h];
     }
@@ -87,45 +81,45 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     global_dpd_->buf4_close(&T2);
 
     /* Set the diis cycle value */
-    diis_cycle = (iter - 1) % nvector;
+    auto diis_cycle = (iter - 1) % nvector;
 
     /* Build the current error vector and dump it to disk */
-    error = global_dpd_->dpd_block_matrix(1, vector_length);
+    auto error = global_dpd_->dpd_block_matrix(1, vector_length);
 
-    word = 0;
+    auto word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
     global_dpd_->file2_init(&T1b, PSIF_CC_OEI, 0, 0, 1, "tIA");
     global_dpd_->file2_mat_init(&T1b);
     global_dpd_->file2_mat_rd(&T1b);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++)
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++)
                 error[0][word++] = T1a.matrix[h][row][col] - T1b.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
     global_dpd_->file2_mat_close(&T1b);
     global_dpd_->file2_close(&T1b);
 
-    t1_word = word;
+    auto t1_word = word;
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     word = t1_word;
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2b.params->rowtot[h]; row++)
-            for (col = 0; col < T2b.params->coltot[h]; col++) error[0][word++] -= T2b.matrix[h][row][col];
+        for (int row = 0; row < T2b.params->rowtot[h]; row++)
+            for (int col = 0; col < T2b.params->coltot[h]; col++) error[0][word++] -= T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
     }
     global_dpd_->buf4_close(&T2b);
@@ -139,18 +133,18 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
@@ -172,7 +166,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     /* Build B matrix of error vector products */
     vector = global_dpd_->dpd_block_matrix(2, vector_length);
     B = block_matrix(nvector + 1, nvector + 1);
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
@@ -183,7 +177,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
 
         B[p][p] = product;
 
-        for (q = 0; q < p; q++) {
+        for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, q * vector_length * sizeof(double));
 
             psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
@@ -197,7 +191,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     }
     global_dpd_->free_dpd_block(vector, 2, vector_length);
 
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         B[p][nvector] = -1;
         B[nvector][p] = -1;
     }
@@ -206,12 +200,12 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
 
     /* Find the maximum value in B and scale all its elements */
     maximum = std::fabs(B[0][0]);
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++)
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++)
             if (std::fabs(B[p][q]) > maximum) maximum = std::fabs(B[p][q]);
 
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++) B[p][q] /= maximum;
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++) B[p][q] /= maximum;
 
     /* Build the constant vector */
     C = init_array(nvector + 1);
@@ -222,14 +216,14 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
 
     /* Build a new amplitude vector from the old ones */
     vector = global_dpd_->dpd_block_matrix(1, vector_length);
-    for (p = 0; p < vector_length; p++) error[0][p] = 0.0;
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < vector_length; p++) error[0][p] = 0.0;
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
                   &end);
 
-        for (q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
+        for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
     }
     global_dpd_->free_dpd_block(vector, 1, vector_length);
 
@@ -237,18 +231,18 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
     global_dpd_->file2_mat_wrt(&T1a);
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
@@ -259,8 +253,6 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     free_block(B);
     free(C);
     global_dpd_->free_dpd_block(error, 1, vector_length);
-
-    return;
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
@@ -61,26 +61,20 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::diis_ROHF(int iter) {
     int nvector = 8; /* Number of error vectors to keep */
-    int h, nirreps;
-    int row, col;
-    size_t p, q, diis_cycle;
-    size_t vector_length = 0;
-    size_t word;
-    int errcod, *ipiv;
     dpdfile2 T1, T1a, T1b;
-    dpdbuf4 T2, T2a, T2b, T2c;
-    psio_address start, end, next;
-    double **error;
+    dpdbuf4 T2a, T2b;
+    psio_address start, end;
     double **B, *C, **vector;
-    double product, determinant, maximum;
+    double product, maximum;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     /* Compute the length of a single error vector */
     global_dpd_->file2_init(&T1, PSIF_CC_TMP0, 0, 0, 1, "tIA");
     global_dpd_->buf4_init(&T2a, PSIF_CC_TMP0, 0, 2, 7, 2, 7, 0, "tIJAB");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TMP0, 0, 0, 5, 0, 5, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    auto vector_length = 0;
+    for (int h = 0; h < nirreps; h++) {
         vector_length += 2 * T1.params->rowtot[h] * T1.params->coltot[h];
         vector_length += 2 * T2a.params->rowtot[h] * T2a.params->coltot[h];
         vector_length += T2b.params->rowtot[h] * T2b.params->coltot[h];
@@ -90,20 +84,20 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     global_dpd_->buf4_close(&T2b);
 
     /* Set the diis cycle value */
-    diis_cycle = (iter - 1) % nvector;
+    auto diis_cycle = (iter - 1) % nvector;
 
     /* Build the current error vector and dump it to disk */
-    error = global_dpd_->dpd_block_matrix(1, vector_length);
-    word = 0;
+    auto error = global_dpd_->dpd_block_matrix(1, vector_length);
+    auto word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
     global_dpd_->file2_init(&T1b, PSIF_CC_OEI, 0, 0, 1, "tIA");
     global_dpd_->file2_mat_init(&T1b);
     global_dpd_->file2_mat_rd(&T1b);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++)
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++)
                 error[0][word++] = T1a.matrix[h][row][col] - T1b.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
@@ -116,9 +110,9 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     global_dpd_->file2_init(&T1b, PSIF_CC_OEI, 0, 0, 1, "tia");
     global_dpd_->file2_mat_init(&T1b);
     global_dpd_->file2_mat_rd(&T1b);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++)
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++)
                 error[0][word++] = T1a.matrix[h][row][col] - T1b.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
@@ -127,13 +121,13 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -143,13 +137,13 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tijab");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -159,13 +153,13 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -181,47 +175,47 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tia");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
@@ -243,7 +237,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     /* Build B matrix of error vector products */
     vector = global_dpd_->dpd_block_matrix(2, vector_length);
     B = block_matrix(nvector + 1, nvector + 1);
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
@@ -254,7 +248,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
         B[p][p] = product;
 
-        for (q = 0; q < p; q++) {
+        for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, q * vector_length * sizeof(double));
 
             psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
@@ -268,7 +262,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     }
     global_dpd_->free_dpd_block(vector, 2, vector_length);
 
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         B[p][nvector] = -1;
         B[nvector][p] = -1;
     }
@@ -277,12 +271,12 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
     /* Find the maximum value in B and scale all its elements */
     maximum = std::fabs(B[0][0]);
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++)
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++)
             if (std::fabs(B[p][q]) > maximum) maximum = std::fabs(B[p][q]);
 
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++) B[p][q] /= maximum;
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++) B[p][q] /= maximum;
 
     /* Build the constant vector */
     C = init_array(nvector + 1);
@@ -293,14 +287,14 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
 
     /* Build the new amplitude vector from the old ones */
     vector = global_dpd_->dpd_block_matrix(1, vector_length);
-    for (p = 0; p < vector_length; p++) error[0][p] = 0.0;
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < vector_length; p++) error[0][p] = 0.0;
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
                   &end);
 
-        for (q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
+        for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
     }
     global_dpd_->free_dpd_block(vector, 1, vector_length);
 
@@ -308,47 +302,47 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
     global_dpd_->file2_mat_wrt(&T1a);
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tia");
     global_dpd_->file2_mat_init(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
     global_dpd_->file2_mat_wrt(&T1a);
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
@@ -358,8 +352,6 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     free_block(B);
     free(C);
     global_dpd_->free_dpd_block(error, 1, vector_length);
-
-    return;
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
@@ -61,20 +61,13 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::diis_UHF(int iter) {
     int nvector = 8; /* Number of error vectors to keep */
-    int h, nirreps;
-    int row, col;
-    size_t p, q, diis_cycle;
-    size_t vector_length = 0;
-    size_t word;
-    int errcod, *ipiv;
-    dpdfile2 T1, T1a, T1b;
-    dpdbuf4 T2, T2a, T2b, T2c;
-    psio_address start, end, next;
-    double **error;
+    dpdfile2 T1a, T1b;
+    dpdbuf4 T2a, T2b, T2c;
+    psio_address start, end;
     double **B, *C, **vector;
-    double product, determinant, maximum;
+    double product, maximum;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     /* Compute the length of a single error vector */
     global_dpd_->file2_init(&T1a, PSIF_CC_TMP0, 0, 0, 1, "tIA");
@@ -82,7 +75,8 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->buf4_init(&T2a, PSIF_CC_TMP0, 0, 2, 7, 2, 7, 0, "tIJAB");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TMP0, 0, 12, 17, 12, 17, 0, "tIJAB");
     global_dpd_->buf4_init(&T2c, PSIF_CC_TMP0, 0, 22, 28, 22, 28, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    auto vector_length = 0;
+    for (int h = 0; h < nirreps; h++) {
         vector_length += T1a.params->rowtot[h] * T1a.params->coltot[h];
         vector_length += T1b.params->rowtot[h] * T1b.params->coltot[h];
         vector_length += T2a.params->rowtot[h] * T2a.params->coltot[h];
@@ -96,21 +90,21 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->buf4_close(&T2c);
 
     /* Set the diis cycle value */
-    diis_cycle = (iter - 1) % nvector;
+    auto diis_cycle = (iter - 1) % nvector;
 
     /* Build the current error vector and dump it to disk */
-    error = global_dpd_->dpd_block_matrix(1, vector_length);
+    auto error = global_dpd_->dpd_block_matrix(1, vector_length);
 
-    word = 0;
+    auto word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
     global_dpd_->file2_init(&T1b, PSIF_CC_OEI, 0, 0, 1, "tIA");
     global_dpd_->file2_mat_init(&T1b);
     global_dpd_->file2_mat_rd(&T1b);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++)
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++)
                 error[0][word++] = T1a.matrix[h][row][col] - T1b.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
@@ -123,9 +117,9 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->file2_init(&T1b, PSIF_CC_OEI, 0, 2, 3, "tia");
     global_dpd_->file2_mat_init(&T1b);
     global_dpd_->file2_mat_rd(&T1b);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++)
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++)
                 error[0][word++] = T1a.matrix[h][row][col] - T1b.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
@@ -134,13 +128,13 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -150,13 +144,13 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "New tijab");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -166,13 +160,13 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "New tIjAb");
     global_dpd_->buf4_init(&T2b, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
         global_dpd_->buf4_mat_irrep_init(&T2b, h);
         global_dpd_->buf4_mat_irrep_rd(&T2b, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++)
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++)
                 error[0][word++] = T2a.matrix[h][row][col] - T2b.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2b, h);
@@ -189,47 +183,47 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 2, 3, "New tia");
     global_dpd_->file2_mat_init(&T1a);
     global_dpd_->file2_mat_rd(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) error[0][word++] = T1a.matrix[h][row][col];
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "New tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
         global_dpd_->buf4_mat_irrep_rd(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) error[0][word++] = T2a.matrix[h][row][col];
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
@@ -251,7 +245,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     /* Now grab the full set of error[0] vectors from the file */
     vector = global_dpd_->dpd_block_matrix(2, vector_length);
     B = block_matrix(nvector + 1, nvector + 1);
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
@@ -262,7 +256,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
         B[p][p] = product;
 
-        for (q = 0; q < p; q++) {
+        for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, q * vector_length * sizeof(double));
 
             psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
@@ -276,7 +270,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     }
     global_dpd_->free_dpd_block(vector, 2, vector_length);
 
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < nvector; p++) {
         B[p][nvector] = -1;
         B[nvector][p] = -1;
     }
@@ -285,12 +279,12 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
     /* Find the maximum value in B and scale all its elements */
     maximum = std::fabs(B[0][0]);
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++)
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++)
             if (std::fabs(B[p][q]) > maximum) maximum = std::fabs(B[p][q]);
 
-    for (p = 0; p < nvector; p++)
-        for (q = 0; q < nvector; q++) B[p][q] /= maximum;
+    for (int p = 0; p < nvector; p++)
+        for (int q = 0; q < nvector; q++) B[p][q] /= maximum;
 
     /* Build the constant vector */
     C = init_array(nvector + 1);
@@ -301,14 +295,14 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
 
     /* Build the new amplitude vector from the old ones */
     vector = global_dpd_->dpd_block_matrix(1, vector_length);
-    for (p = 0; p < vector_length; p++) error[0][p] = 0.0;
-    for (p = 0; p < nvector; p++) {
+    for (int p = 0; p < vector_length; p++) error[0][p] = 0.0;
+    for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, p * vector_length * sizeof(double));
 
         psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
                   &end);
 
-        for (q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
+        for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
     }
     global_dpd_->free_dpd_block(vector, 1, vector_length);
 
@@ -316,47 +310,47 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     word = 0;
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 0, 1, "New tIA");
     global_dpd_->file2_mat_init(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
     global_dpd_->file2_mat_wrt(&T1a);
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->file2_init(&T1a, PSIF_CC_OEI, 0, 2, 3, "New tia");
     global_dpd_->file2_mat_init(&T1a);
-    for (h = 0; h < nirreps; h++)
-        for (row = 0; row < T1a.params->rowtot[h]; row++)
-            for (col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
+    for (int h = 0; h < nirreps; h++)
+        for (int row = 0; row < T1a.params->rowtot[h]; row++)
+            for (int col = 0; col < T1a.params->coltot[h]; col++) T1a.matrix[h][row][col] = error[0][word++];
     global_dpd_->file2_mat_wrt(&T1a);
     global_dpd_->file2_mat_close(&T1a);
     global_dpd_->file2_close(&T1a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "New tIJAB");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "New tijab");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
     global_dpd_->buf4_close(&T2a);
 
     global_dpd_->buf4_init(&T2a, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "New tIjAb");
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(&T2a, h);
-        for (row = 0; row < T2a.params->rowtot[h]; row++)
-            for (col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
+        for (int row = 0; row < T2a.params->rowtot[h]; row++)
+            for (int col = 0; col < T2a.params->coltot[h]; col++) T2a.matrix[h][row][col] = error[0][word++];
         global_dpd_->buf4_mat_irrep_wrt(&T2a, h);
         global_dpd_->buf4_mat_irrep_close(&T2a, h);
     }
@@ -366,8 +360,6 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     free_block(B);
     free(C);
     global_dpd_->free_dpd_block(error, 1, vector_length);
-
-    return;
 }
 }  // namespace ccenergy
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/energy.cc
+++ b/psi4/src/psi4/cc/ccenergy/energy.cc
@@ -56,13 +56,12 @@ double CCEnergyWavefunction::energy() {
 double CCEnergyWavefunction::rhf_energy() {
     double tauIjAb_energy, tIA_energy;
     dpdfile2 fIA, tIA;
-    dpdbuf4 tauIjAb, D, E;
+    dpdbuf4 tauIjAb, D;
     dpdbuf4 S;
-    double os_energy, ss_energy, Energy;
+    double os_energy, ss_energy;
 
     global_dpd_->file2_init(&fIA, PSIF_CC_OEI, 0, 0, 1, "fIA");
     global_dpd_->file2_init(&tIA, PSIF_CC_OEI, 0, 0, 1, "tIA");
-    /*   dpd_file2_print(&tIA, outfile); */
     tIA_energy = 2.0 * global_dpd_->file2_dot(&fIA, &tIA);
     global_dpd_->file2_close(&fIA);
     global_dpd_->file2_close(&tIA);
@@ -81,10 +80,6 @@ double CCEnergyWavefunction::rhf_energy() {
     global_dpd_->buf4_close(&S);
     global_dpd_->buf4_close(&tauIjAb);
     global_dpd_->buf4_close(&D);
-
-    /*
-      outfile->Printf( "Two AB Energy = %20.14f\n", tauIjAb_energy);
-    */
 
     return (tauIjAb_energy + tIA_energy);
 }

--- a/psi4/src/psi4/cc/ccenergy/fock_build.cc
+++ b/psi4/src/psi4/cc/ccenergy/fock_build.cc
@@ -50,21 +50,18 @@ namespace ccenergy {
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
 
 void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
-    int i, j;
-    int nso, ntri;
-    int lastbuf, idx, p, q, r, s, pq, rs;
+    int lastbuf, p, q, r, s, pq, rs;
     double value;
     Value *valptr;
     Label *lblptr;
     struct iwlbuf InBuf;
 
-    nso = moinfo_.nso;
-    ntri = nso * (nso + 1) / 2;
+    auto nso = moinfo_.nso;
 
-    double **H = H_->to_block_matrix();
+    auto H = H_->to_block_matrix();
 
-    for (i = 0; i < nso; i++) {
-        for (j = 0; j <= i; j++) {
+    for (int i = 0; i < nso; i++) {
+        for (int j = 0; j <= i; j++) {
             fock[i][j] = fock[j][i] = H[i][j];
         }
     }
@@ -76,7 +73,7 @@ void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
         lblptr = InBuf.labels;
         valptr = InBuf.values;
 
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
+        for (int idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
             p = std::abs((int)lblptr[idx++]);
             q = (int)lblptr[idx++];
             r = (int)lblptr[idx++];
@@ -175,30 +172,24 @@ void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
 }
 
 void CCEnergyWavefunction::uhf_fock_build(double **fock_a, double **fock_b, double **D_a, double **D_b) {
-    int i, j, ij;
-    int nso, ntri, ntei, stat;
-    double *scratch;
-    int lastbuf, idx, p, q, r, s, pq, rs;
+    int lastbuf, p, q, r, s, pq, rs;
     double value;
     Value *valptr;
     Label *lblptr;
     struct iwlbuf InBuf;
-    double **Dt;
 
-    nso = moinfo_.nso;
-    ntri = nso * (nso + 1) / 2;
-    ntei = ntri * (ntri + 1) / 2;
+    auto nso = moinfo_.nso;
 
-    Dt = block_matrix(nso, nso);
-    for (p = 0; p < nso; p++)
-        for (q = 0; q < nso; q++) Dt[p][q] = D_a[p][q] + D_b[p][q];
+    auto Dt = block_matrix(nso, nso);
+    for (int p = 0; p < nso; p++)
+        for (int q = 0; q < nso; q++) Dt[p][q] = D_a[p][q] + D_b[p][q];
 
     /* one-electron contributions */
 
-    double **H = H_->to_block_matrix();
+    auto H = H_->to_block_matrix();
 
-    for (i = 0; i < nso; i++) {
-        for (j = 0; j <= i; j++) {
+    for (int i = 0; i < nso; i++) {
+        for (int j = 0; j <= i; j++) {
             fock_a[i][j] = fock_a[j][i] = H[i][j];
             fock_b[i][j] = fock_b[j][i] = H[i][j];
         }
@@ -210,7 +201,7 @@ void CCEnergyWavefunction::uhf_fock_build(double **fock_a, double **fock_b, doub
         lblptr = InBuf.labels;
         valptr = InBuf.values;
 
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
+        for (int idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
             p = std::abs((int)lblptr[idx++]);
             q = (int)lblptr[idx++];
             r = (int)lblptr[idx++];

--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -49,8 +49,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *cachefiles,
-                                        dpd_file4_cache_entry *priority) {
+void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *cachefiles) {
     /*
      * Set up the DF tensor machinery
      */

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -61,7 +61,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::get_moinfo() {
-    int i, j, h, p, q, errcod, nactive, nirreps;
+    int j, nactive;
     double ***Co, ***Cv, ***Ca, ***Cb;
     psio_address next;
 
@@ -83,7 +83,7 @@ void CCEnergyWavefunction::get_moinfo() {
     // TODO: figure out why I can't just directly assign doccpi_ here, the same as soccpi_.
     for (int h = 0; h < moinfo_.nirreps; ++h) moinfo_.clsdpi[h] = doccpi_[h];
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params_.ref), sizeof(int));
 
@@ -184,15 +184,15 @@ void CCEnergyWavefunction::get_moinfo() {
 
     /* Build sosym array (for AO-basis BT2) */
     moinfo_.sosym = init_int_array(moinfo_.nso);
-    for (h = 0, q = 0; h < nirreps; h++)
-        for (p = 0; p < moinfo_.sopi[h]; p++) moinfo_.sosym[q++] = h;
+    for (int h = 0, q = 0; h < nirreps; h++)
+        for (int p = 0; p < moinfo_.sopi[h]; p++) moinfo_.sosym[q++] = h;
 
     /* Get the active virtual orbitals */
     if (params_.ref == 0 || params_.ref == 1) { /** RHF/ROHF **/
 
         Co = (double ***)malloc(nirreps * sizeof(double **));
         next = PSIO_ZERO;
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             if (moinfo_.sopi[h] && moinfo_.occpi[h]) {
                 Co[h] = block_matrix(moinfo_.sopi[h], moinfo_.occpi[h]);
                 psio_read(PSIF_CC_INFO, "RHF/ROHF Active Occupied Orbitals", (char *)Co[h][0],
@@ -203,7 +203,7 @@ void CCEnergyWavefunction::get_moinfo() {
 
         Cv = (double ***)malloc(nirreps * sizeof(double **));
         next = PSIO_ZERO;
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             if (moinfo_.sopi[h] && moinfo_.virtpi[h]) {
                 Cv[h] = block_matrix(moinfo_.sopi[h], moinfo_.virtpi[h]);
                 psio_read(PSIF_CC_INFO, "RHF/ROHF Active Virtual Orbitals", (char *)Cv[h][0],
@@ -215,7 +215,7 @@ void CCEnergyWavefunction::get_moinfo() {
 
         Ca = (double ***)malloc(nirreps * sizeof(double **));
         next = PSIO_ZERO;
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             if (moinfo_.sopi[h] && moinfo_.avirtpi[h]) {
                 Ca[h] = block_matrix(moinfo_.sopi[h], moinfo_.avirtpi[h]);
                 psio_read(PSIF_CC_INFO, "UHF Active Alpha Virtual Orbs", (char *)Ca[h][0],
@@ -226,7 +226,7 @@ void CCEnergyWavefunction::get_moinfo() {
 
         Cb = (double ***)malloc(nirreps * sizeof(double **));
         next = PSIO_ZERO;
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             if (moinfo_.sopi[h] && moinfo_.bvirtpi[h]) {
                 Cb[h] = block_matrix(moinfo_.sopi[h], moinfo_.bvirtpi[h]);
                 psio_read(PSIF_CC_INFO, "UHF Active Beta Virtual Orbs", (char *)Cb[h][0],
@@ -242,7 +242,7 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.qt2pitzer = init_int_array(moinfo_.nmo);
         reorder_qt(moinfo_.clsdpi, moinfo_.openpi, moinfo_.frdocc, moinfo_.fruocc, moinfo_.pitzer2qt, moinfo_.orbspi,
                    moinfo_.nirreps);
-        for (i = 0; i < moinfo_.nmo; i++) {
+        for (int i = 0; i < moinfo_.nmo; i++) {
             j = moinfo_.pitzer2qt[i];
             moinfo_.qt2pitzer[j] = i;
         }
@@ -253,7 +253,7 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.qt2pitzer_b = init_int_array(moinfo_.nmo);
         reorder_qt_uhf(moinfo_.clsdpi, moinfo_.openpi, moinfo_.frdocc, moinfo_.fruocc, moinfo_.pitzer2qt_a,
                        moinfo_.pitzer2qt_b, moinfo_.orbspi, moinfo_.nirreps);
-        for (i = 0; i < moinfo_.nmo; i++) {
+        for (int i = 0; i < moinfo_.nmo; i++) {
             j = moinfo_.pitzer2qt_a[i];
             moinfo_.qt2pitzer_a[j] = i;
             j = moinfo_.pitzer2qt_b[i];
@@ -262,16 +262,16 @@ void CCEnergyWavefunction::get_moinfo() {
     }
 
     /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < nirreps; i++) moinfo_.clsdpi[i] -= moinfo_.frdocc[i];
+    for (int i = 0; i < nirreps; i++) moinfo_.clsdpi[i] -= moinfo_.frdocc[i];
 
     moinfo_.uoccpi = init_int_array(moinfo_.nirreps);
-    for (i = 0; i < nirreps; i++)
+    for (int i = 0; i < nirreps; i++)
         moinfo_.uoccpi[i] =
             moinfo_.orbspi[i] - moinfo_.clsdpi[i] - moinfo_.openpi[i] - moinfo_.fruocc[i] - moinfo_.frdocc[i];
 
     if (params_.ref == 0) {
         moinfo_.nvirt = 0;
-        for (h = 0; h < nirreps; h++) moinfo_.nvirt += moinfo_.virtpi[h];
+        for (int h = 0; h < nirreps; h++) moinfo_.nvirt += moinfo_.virtpi[h];
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Energy", (char *)&(moinfo_.eref), sizeof(double));
@@ -283,9 +283,6 @@ void CCEnergyWavefunction::get_moinfo() {
 
 /* Frees memory allocated in get_moinfo() and dumps out the energy. */
 void CCEnergyWavefunction::cleanup() {
-    int i, h;
-    char *keyw = nullptr;
-
     if (params_.wfn == "CC2" || params_.wfn == "EOM_CC2")
         psio_write_entry(PSIF_CC_INFO, "CC2 Energy", (char *)&(moinfo_.ecc), sizeof(double));
     else if (params_.wfn == "CC3" || params_.wfn == "EOM_CC3")
@@ -294,17 +291,17 @@ void CCEnergyWavefunction::cleanup() {
         psio_write_entry(PSIF_CC_INFO, "CCSD Energy", (char *)&(moinfo_.ecc), sizeof(double));
 
     if (params_.ref == 0 || params_.ref == 1) {
-        for (h = 0; h < moinfo_.nirreps; h++) {
+        for (int h = 0; h < moinfo_.nirreps; h++) {
             if (moinfo_.sopi[h] && moinfo_.occpi[h]) free_block(moinfo_.Co[h]);
             if (moinfo_.sopi[h] && moinfo_.virtpi[h]) free_block(moinfo_.Cv[h]);
         }
         free(moinfo_.Cv);
         free(moinfo_.Co);
     } else if (params_.ref == 2) {
-        for (h = 0; h < moinfo_.nirreps; h++)
+        for (int h = 0; h < moinfo_.nirreps; h++)
             if (moinfo_.sopi[h] && moinfo_.avirtpi[h]) free_block(moinfo_.Cav[h]);
         free(moinfo_.Cav);
-        for (h = 0; h < moinfo_.nirreps; h++)
+        for (int h = 0; h < moinfo_.nirreps; h++)
             if (moinfo_.sopi[h] && moinfo_.bvirtpi[h]) free_block(moinfo_.Cbv[h]);
         free(moinfo_.Cbv);
     }

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -52,7 +52,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::get_params(Options &options) {
-    int errcod, iconv, forceit;
     std::string cachetype = "";
     std::string junk;
 

--- a/psi4/src/psi4/cc/ccenergy/halftrans.cc
+++ b/psi4/src/psi4/cc/ccenergy/halftrans.cc
@@ -63,10 +63,10 @@ namespace ccenergy {
 void CCEnergyWavefunction::halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, int dpdnum2, double ***C1, double ***C2,
                                      int nirreps, int **mo_row, int **so_row, int *mospi_left, int *mospi_right,
                                      int *sospi, int type, double alpha, double beta) {
-    int h, Gc, Gd, cd, pq, ij;
+    int Gd, cd, pq;
     double **X;
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         dpd_set_default(dpdnum1);
         global_dpd_->buf4_mat_irrep_init(Buf1, h);
 
@@ -94,7 +94,7 @@ void CCEnergyWavefunction::halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, 
             }
         }
 
-        for (Gc = 0; Gc < nirreps; Gc++) {
+        for (int Gc = 0; Gc < nirreps; Gc++) {
             Gd = h ^ Gc;
 
             cd = mo_row[h][Gc];
@@ -104,7 +104,7 @@ void CCEnergyWavefunction::halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, 
                 if (type == 0) {
                     X = block_matrix(mospi_left[Gc], sospi[Gd]);
 
-                    for (ij = 0; ij < Buf1->params->rowtot[h]; ij++) {
+                    for (int ij = 0; ij < Buf1->params->rowtot[h]; ij++) {
                         C_DGEMM('n', 't', mospi_left[Gc], sospi[Gd], mospi_right[Gd], 1.0, &(Buf1->matrix[h][ij][cd]),
                                 mospi_right[Gd], &(C2[Gd][0][0]), mospi_right[Gd], 0.0, &(X[0][0]), sospi[Gd]);
 
@@ -114,7 +114,7 @@ void CCEnergyWavefunction::halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, 
                 } else {
                     X = block_matrix(sospi[Gc], mospi_right[Gd]);
 
-                    for (ij = 0; ij < Buf1->params->rowtot[h]; ij++) {
+                    for (int ij = 0; ij < Buf1->params->rowtot[h]; ij++) {
                         C_DGEMM('n', 'n', sospi[Gc], mospi_right[Gd], sospi[Gd], 1.0, &(Buf2->matrix[h][ij][pq]),
                                 sospi[Gd], &(C2[Gd][0][0]), mospi_right[Gd], 0.0, &(X[0][0]), mospi_right[Gd]);
 

--- a/psi4/src/psi4/cc/ccenergy/local.cc
+++ b/psi4/src/psi4/cc/ccenergy/local.cc
@@ -67,12 +67,10 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::local_init() {
-    int i, k, ij, nocc;
-
     local_.nso = moinfo_.nso;
     local_.nocc = moinfo_.occpi[0];  /* active doubly occupied orbitals */
     local_.nvir = moinfo_.virtpi[0]; /* active virtual orbitals */
-    nocc = local_.nocc;
+    auto nocc = local_.nocc;
 
     local_.weak_pair_energy = 0.0;
 
@@ -86,13 +84,12 @@ void CCEnergyWavefunction::local_init() {
 void CCEnergyWavefunction::local_done() { outfile->Printf("    Local parameters free.\n"); }
 
 void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
-    int i, a, ij, ii;
-    int nocc, nvir;
+    int ii;
     double *T1tilde, *T1bar;
     psio_address next;
 
-    nocc = local_.nocc;
-    nvir = local_.nvir;
+    auto nocc = local_.nocc;
+    auto nvir = local_.nvir;
 
     /*   local.weak_pairs = init_int_array(nocc*nocc); */
     local_.pairdom_len = init_int_array(nocc * nocc);
@@ -109,19 +106,19 @@ void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
     local_.V = (double ***)malloc(nocc * nocc * sizeof(double **));
     local_.eps_vir = (double **)malloc(nocc * nocc * sizeof(double *));
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.eps_vir[ij] = init_array(local_.pairdom_nrlen[ij]);
         psio_read(PSIF_CC_INFO, "Local Virtual Orbital Energies", (char *)local_.eps_vir[ij],
                   local_.pairdom_nrlen[ij] * sizeof(double), next, &next);
     }
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.V[ij] = block_matrix(nvir, local_.pairdom_len[ij]);
         psio_read(PSIF_CC_INFO, "Local Residual Vector (V)", (char *)local_.V[ij][0],
                   nvir * local_.pairdom_len[ij] * sizeof(double), next, &next);
     }
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.W[ij] = block_matrix(local_.pairdom_len[ij], local_.pairdom_nrlen[ij]);
         psio_read(PSIF_CC_INFO, "Local Transformation Matrix (W)", (char *)local_.W[ij][0],
                   local_.pairdom_len[ij] * local_.pairdom_nrlen[ij] * sizeof(double), next, &next);
@@ -130,7 +127,7 @@ void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
     global_dpd_->file2_mat_init(T1);
     global_dpd_->file2_mat_rd(T1);
 
-    for (i = 0; i < nocc; i++) {
+    for (int i = 0; i < nocc; i++) {
         ii = i * nocc + i; /* diagonal element of pair matrices */
 
         if (!local_.pairdom_len[ii]) {
@@ -150,7 +147,7 @@ void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
                 local_.pairdom_nrlen[ii], &(T1tilde[0]), 1, 0.0, &(T1bar[0]), 1);
 
         /* Apply the denominators */
-        for (a = 0; a < local_.pairdom_nrlen[ii]; a++) T1bar[a] /= (local_.eps_occ[i] - local_.eps_vir[ii][a]);
+        for (int a = 0; a < local_.pairdom_nrlen[ii]; a++) T1bar[a] /= (local_.eps_occ[i] - local_.eps_vir[ii][a]);
 
         /* Transform the new T1's to the redundant projected virtual basis */
         C_DGEMV('n', local_.pairdom_len[ii], local_.pairdom_nrlen[ii], 1.0, &(local_.W[ii][0][0]),
@@ -167,7 +164,7 @@ void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
     global_dpd_->file2_mat_wrt(T1);
     global_dpd_->file2_mat_close(T1);
 
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         free_block(local_.W[ij]);
         free_block(local_.V[ij]);
         free(local_.eps_vir[ij]);
@@ -183,14 +180,11 @@ void CCEnergyWavefunction::local_filter_T1(dpdfile2 *T1) {
 }
 
 void CCEnergyWavefunction::local_filter_T2(dpdbuf4 *T2) {
-    int ij, i, j, a, b;
-    int nso, nocc, nvir;
-    double **X1, **X2, **T2tilde, **T2bar;
     psio_address next;
 
-    nso = local_.nso;
-    nocc = local_.nocc;
-    nvir = local_.nvir;
+    auto nso = local_.nso;
+    auto nocc = local_.nocc;
+    auto nvir = local_.nvir;
 
     /*   local.weak_pairs = init_int_array(nocc*nocc); */
     local_.pairdom_len = init_int_array(nocc * nocc);
@@ -207,19 +201,19 @@ void CCEnergyWavefunction::local_filter_T2(dpdbuf4 *T2) {
     local_.V = (double ***)malloc(nocc * nocc * sizeof(double **));
     local_.eps_vir = (double **)malloc(nocc * nocc * sizeof(double *));
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.eps_vir[ij] = init_array(local_.pairdom_nrlen[ij]);
         psio_read(PSIF_CC_INFO, "Local Virtual Orbital Energies", (char *)local_.eps_vir[ij],
                   local_.pairdom_nrlen[ij] * sizeof(double), next, &next);
     }
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.V[ij] = block_matrix(nvir, local_.pairdom_len[ij]);
         psio_read(PSIF_CC_INFO, "Local Residual Vector (V)", (char *)local_.V[ij][0],
                   nvir * local_.pairdom_len[ij] * sizeof(double), next, &next);
     }
     next = PSIO_ZERO;
-    for (ij = 0; ij < nocc * nocc; ij++) {
+    for (int ij = 0; ij < nocc * nocc; ij++) {
         local_.W[ij] = block_matrix(local_.pairdom_len[ij], local_.pairdom_nrlen[ij]);
         psio_read(PSIF_CC_INFO, "Local Transformation Matrix (W)", (char *)local_.W[ij][0],
                   local_.pairdom_len[ij] * local_.pairdom_nrlen[ij] * sizeof(double), next, &next);
@@ -229,13 +223,13 @@ void CCEnergyWavefunction::local_filter_T2(dpdbuf4 *T2) {
     global_dpd_->buf4_mat_irrep_init(T2, 0);
     global_dpd_->buf4_mat_irrep_rd(T2, 0);
 
-    X1 = block_matrix(nso, nvir);
-    X2 = block_matrix(nvir, nso);
-    T2tilde = block_matrix(nso, nso);
-    T2bar = block_matrix(nvir, nvir);
+    auto X1 = block_matrix(nso, nvir);
+    auto X2 = block_matrix(nvir, nso);
+    auto T2tilde = block_matrix(nso, nso);
+    auto T2bar = block_matrix(nvir, nvir);
 
-    for (i = 0, ij = 0; i < nocc; i++) {
-        for (j = 0; j < nocc; j++, ij++) {
+    for (int i = 0, ij = 0; i < nocc; i++) {
+        for (int j = 0; j < nocc; j++, ij++) {
             if (!local_.weak_pairs[ij]) {
                 /* Transform the virtuals to the redundant projected virtual basis */
                 C_DGEMM('t', 'n', local_.pairdom_len[ij], nvir, nvir, 1.0, &(local_.V[ij][0][0]),
@@ -250,8 +244,8 @@ void CCEnergyWavefunction::local_filter_T2(dpdbuf4 *T2) {
                         &(X2[0][0]), nso, &(local_.W[ij][0][0]), local_.pairdom_nrlen[ij], 0.0, &(T2bar[0][0]), nvir);
 
                 /* Divide the new amplitudes by the denominators */
-                for (a = 0; a < local_.pairdom_nrlen[ij]; a++)
-                    for (b = 0; b < local_.pairdom_nrlen[ij]; b++)
+                for (int a = 0; a < local_.pairdom_nrlen[ij]; a++)
+                    for (int b = 0; b < local_.pairdom_nrlen[ij]; b++)
                         T2bar[a][b] /=
                             (local_.eps_occ[i] + local_.eps_occ[j] - local_.eps_vir[ij][a] - local_.eps_vir[ij][b]);
 
@@ -280,7 +274,7 @@ void CCEnergyWavefunction::local_filter_T2(dpdbuf4 *T2) {
     global_dpd_->buf4_mat_irrep_wrt(T2, 0);
     global_dpd_->buf4_mat_irrep_close(T2, 0);
 
-    for (i = 0; i < nocc * nocc; i++) {
+    for (int i = 0; i < nocc * nocc; i++) {
         free_block(local_.W[i]);
         free_block(local_.V[i]);
         free(local_.eps_vir[i]);

--- a/psi4/src/psi4/cc/ccenergy/mp2_energy.cc
+++ b/psi4/src/psi4/cc/ccenergy/mp2_energy.cc
@@ -58,7 +58,7 @@ double CCEnergyWavefunction::rhf_mp2_energy() {
     dpdfile2 F, T1, D1;
     dpdbuf4 T2, D;
     dpdbuf4 S;
-    double os_energy, ss_energy, scs_energy;
+    double os_energy, ss_energy;
 
     /* Initialize MP2 T1 Amps (zero for true HF references) */
     global_dpd_->file2_init(&F, PSIF_CC_OEI, 0, 0, 1, "fIA");

--- a/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
@@ -48,14 +48,13 @@ namespace ccenergy {
  * */
 
 double CCEnergyWavefunction::new_d1diag_t1_rohf() {
-    int h, nirreps, i, j;
     int nclsd, nuocc, nopen;
     double **T1_hp, **T1_hx, **T1_xp, **T1_sq;
     double *E, **C;
     double max_hp = 0.0, max_xp = 0.0, max_hx = 0.0, max;
     dpdfile2 T1_a, T1_b;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     global_dpd_->file2_init(&T1_a, PSIF_CC_OEI, 0, 0, 1, "tIA");
     global_dpd_->file2_mat_init(&T1_a);
@@ -65,15 +64,15 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
     global_dpd_->file2_mat_init(&T1_b);
     global_dpd_->file2_mat_rd(&T1_b);
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         nclsd = moinfo_.clsdpi[h];
         nuocc = moinfo_.uoccpi[h];
         nopen = moinfo_.openpi[h];
 
         if (nclsd && nuocc) {
             T1_hp = block_matrix(nclsd, nuocc);
-            for (i = 0; i < nclsd; i++)
-                for (j = 0; j < nuocc; j++) T1_hp[i][j] = (T1_a.matrix[h][i][j] + T1_b.matrix[h][i][j]) / 2.;
+            for (int i = 0; i < nclsd; i++)
+                for (int j = 0; j < nuocc; j++) T1_hp[i][j] = (T1_a.matrix[h][i][j] + T1_b.matrix[h][i][j]) / 2.;
 
             T1_sq = block_matrix(nclsd, nclsd);
             C_DGEMM('n', 't', nclsd, nclsd, nuocc, 1.0, &(T1_hp[0][0]), nuocc, &(T1_hp[0][0]), nuocc, 0.0,
@@ -82,7 +81,7 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
             E = init_array(nclsd);
             C = block_matrix(nclsd, nclsd);
             sq_rsp(nclsd, nclsd, T1_sq, E, 0, C, 1e-12);
-            for (i = 0; i < nclsd; i++)
+            for (int i = 0; i < nclsd; i++)
                 if (E[i] > max_hp) max_hp = E[i];
             free(E);
             free_block(C);
@@ -92,8 +91,8 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
 
         if (nclsd && nopen) {
             T1_hx = block_matrix(nclsd, nopen);
-            for (i = 0; i < nclsd; i++)
-                for (j = 0; j < nopen; j++) T1_hx[i][j] = T1_b.matrix[h][i][nuocc + j] / sqrt(2.);
+            for (int i = 0; i < nclsd; i++)
+                for (int j = 0; j < nopen; j++) T1_hx[i][j] = T1_b.matrix[h][i][nuocc + j] / sqrt(2.);
 
             T1_sq = block_matrix(nclsd, nclsd);
             C_DGEMM('n', 't', nclsd, nclsd, nopen, 1.0, &(T1_hx[0][0]), nopen, &(T1_hx[0][0]), nopen, 0.0,
@@ -102,7 +101,7 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
             E = init_array(nclsd);
             C = block_matrix(nclsd, nclsd);
             sq_rsp(nclsd, nclsd, T1_sq, E, 0, C, 1e-12);
-            for (i = 0; i < nclsd; i++)
+            for (int i = 0; i < nclsd; i++)
                 if (E[i] > max_hx) max_hx = E[i];
             free(E);
             free_block(C);
@@ -112,8 +111,8 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
 
         if (nopen && nuocc) {
             T1_xp = block_matrix(nopen, nuocc);
-            for (i = 0; i < nopen; i++)
-                for (j = 0; j < nuocc; j++) T1_xp[i][j] = T1_a.matrix[h][nclsd + i][j] / sqrt(2.);
+            for (int i = 0; i < nopen; i++)
+                for (int j = 0; j < nuocc; j++) T1_xp[i][j] = T1_a.matrix[h][nclsd + i][j] / sqrt(2.);
 
             T1_sq = block_matrix(nopen, nopen);
             C_DGEMM('n', 't', nopen, nopen, nuocc, 1.0, &(T1_xp[0][0]), nuocc, &(T1_xp[0][0]), nuocc, 0.0,
@@ -122,7 +121,7 @@ double CCEnergyWavefunction::new_d1diag_t1_rohf() {
             E = init_array(nopen);
             C = block_matrix(nopen, nopen);
             sq_rsp(nopen, nopen, T1_sq, E, 0, C, 1e-12);
-            for (i = 0; i < nopen; i++)
+            for (int i = 0; i < nopen; i++)
                 if (E[i] > max_xp) max_xp = E[i];
             free(E);
             free_block(C);

--- a/psi4/src/psi4/cc/ccenergy/pair_energies.cc
+++ b/psi4/src/psi4/cc/ccenergy/pair_energies.cc
@@ -56,13 +56,10 @@ void CCEnergyWavefunction::pair_energies(double** epair_aa, double** epair_ab) {
 
     if (params_.ref == 0) { /** RHF **/
 
-        int i, j, ij;
-        int irrep;
-        int nocc_act = 0;
-        int naa, nab;
-        for (irrep = 0; irrep < moinfo_.nirreps; irrep++) nocc_act += moinfo_.clsdpi[irrep];
-        naa = nocc_act * (nocc_act - 1) / 2;
-        nab = nocc_act * nocc_act;
+        auto nocc_act = 0;
+        for (int irrep = 0; irrep < moinfo_.nirreps; irrep++) nocc_act += moinfo_.clsdpi[irrep];
+        auto naa = nocc_act * (nocc_act - 1) / 2;
+        auto nab = nocc_act * nocc_act;
 
         /* Compute alpha-alpha pair energies */
         if (naa) {
@@ -76,23 +73,18 @@ void CCEnergyWavefunction::pair_energies(double** epair_aa, double** epair_ab) {
             // dpd_buf4_print(&E, outfile, 1);
 
             /* Extract diagonal elements (i.e. pair energies) and print them out nicely */
-            for (irrep = 0; irrep < moinfo_.nirreps; irrep++) {
-                double** block;
+            for (int irrep = 0; irrep < moinfo_.nirreps; irrep++) {
                 dpdparams4* Params = E.params;
-                int p;
-                int np = Params->rowtot[irrep];
 
                 global_dpd_->buf4_mat_irrep_init(&E, irrep);
                 global_dpd_->buf4_mat_irrep_rd(&E, irrep);
-                block = E.matrix[irrep];
+                auto block = E.matrix[irrep];
 
-                for (p = 0; p < np; p++) {
-                    int i, j, ij;
+                for (int p = 0; p < Params->rowtot[irrep]; p++) {
+                    auto i = Params->roworb[irrep][p][0];
+                    auto j = Params->roworb[irrep][p][1];
 
-                    i = Params->roworb[irrep][p][0];
-                    j = Params->roworb[irrep][p][1];
-
-                    ij = (i > j) ? i * (i - 1) / 2 + j : j * (j - 1) / 2 + i;
+                    auto ij = (i > j) ? i * (i - 1) / 2 + j : j * (j - 1) / 2 + i;
                     eaa[ij] = block[p][p];
                 }
                 global_dpd_->buf4_mat_irrep_close(&E, irrep);
@@ -107,7 +99,7 @@ void CCEnergyWavefunction::pair_energies(double** epair_aa, double** epair_ab) {
 
         /* Compute alpha-beta pair energies */
         if (nab) {
-            double* eab = init_array(nab);
+            auto eab = init_array(nab);
 
             global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");
             global_dpd_->buf4_init(&tau, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tauIjAb");
@@ -117,23 +109,18 @@ void CCEnergyWavefunction::pair_energies(double** epair_aa, double** epair_ab) {
             // dpd_buf4_print(&E, outfile, 1);
 
             /* Extract diagonal elements (i.e. pair energies) and print them out nicely */
-            for (irrep = 0; irrep < moinfo_.nirreps; irrep++) {
-                double** block;
+            for (int irrep = 0; irrep < moinfo_.nirreps; irrep++) {
                 dpdparams4* Params = E.params;
-                int p;
-                int np = Params->rowtot[irrep];
 
                 global_dpd_->buf4_mat_irrep_init(&E, irrep);
                 global_dpd_->buf4_mat_irrep_rd(&E, irrep);
-                block = E.matrix[irrep];
+                auto block = E.matrix[irrep];
 
-                for (p = 0; p < np; p++) {
-                    int i, j, ij;
+                for (int p = 0; p < Params->rowtot[irrep]; p++) {
+                    auto i = Params->roworb[irrep][p][0];
+                    auto j = Params->roworb[irrep][p][1];
 
-                    i = Params->roworb[irrep][p][0];
-                    j = Params->roworb[irrep][p][1];
-
-                    ij = i * nocc_act + j;
+                    auto ij = i * nocc_act + j;
                     eab[ij] = block[p][p];
                 }
                 global_dpd_->buf4_mat_irrep_close(&E, irrep);
@@ -151,13 +138,10 @@ void CCEnergyWavefunction::pair_energies(double** epair_aa, double** epair_ab) {
 void CCEnergyWavefunction::print_pair_energies(double* emp2_aa, double* emp2_ab, double* ecc_aa, double* ecc_ab) {
     if (params_.ref == 0) { /** RHF **/
 
-        int i, j, ij;
-        int irrep;
-        int nocc_act = 0;
-        int naa, nab;
-        for (irrep = 0; irrep < moinfo_.nirreps; irrep++) nocc_act += moinfo_.clsdpi[irrep];
-        naa = nocc_act * (nocc_act - 1) / 2;
-        nab = nocc_act * nocc_act;
+        auto nocc_act = 0;
+        for (int irrep = 0; irrep < moinfo_.nirreps; irrep++) nocc_act += moinfo_.clsdpi[irrep];
+        auto naa = nocc_act * (nocc_act - 1) / 2;
+        auto nab = nocc_act * nocc_act;
 
         if (!params_.spinadapt_energies) {
             double emp2_aa_tot = 0.0;
@@ -169,9 +153,9 @@ void CCEnergyWavefunction::print_pair_energies(double* emp2_aa, double* emp2_ab,
             outfile->Printf("        i       j         MP2             %s\n", params_.wfn.c_str());
             outfile->Printf("      -----   -----   ------------   ------------\n");
             if (naa) {
-                ij = 0;
-                for (i = 0; i < nocc_act; i++)
-                    for (j = 0; j < i; j++, ij++) {
+                auto ij = 0;
+                for (int i = 0; i < nocc_act; i++)
+                    for (int j = 0; j < i; j++, ij++) {
                         outfile->Printf("      %3d     %3d     %12.9lf   %12.9lf\n", i + 1, j + 1, emp2_aa[ij],
                                         ecc_aa[ij]);
                         emp2_aa_tot += emp2_aa[ij];
@@ -185,9 +169,9 @@ void CCEnergyWavefunction::print_pair_energies(double* emp2_aa, double* emp2_ab,
             outfile->Printf("        i       j         MP2             %s\n", params_.wfn.c_str());
             outfile->Printf("      -----   -----   ------------   ------------\n");
             if (nab) {
-                ij = 0;
-                for (i = 0; i < nocc_act; i++)
-                    for (j = 0; j < nocc_act; j++, ij++) {
+                auto ij = 0;
+                for (int i = 0; i < nocc_act; i++)
+                    for (int j = 0; j < nocc_act; j++, ij++) {
                         outfile->Printf("      %3d     %3d     %12.9lf   %12.9lf\n", i + 1, j + 1, emp2_ab[ij],
                                         ecc_ab[ij]);
                         emp2_ab_tot += emp2_ab[ij];
@@ -207,9 +191,9 @@ void CCEnergyWavefunction::print_pair_energies(double* emp2_aa, double* emp2_ab,
             outfile->Printf("    Singlet pair energies\n");
             outfile->Printf("        i       j         MP2             %s\n", params_.wfn.c_str());
             outfile->Printf("      -----   -----   ------------   ------------\n");
-            ij = 0;
-            for (i = 0; i < nocc_act; i++)
-                for (j = 0; j <= i; j++, ij++) {
+            auto ij = 0;
+            for (int i = 0; i < nocc_act; i++)
+                for (int j = 0; j <= i; j++, ij++) {
                     double emp2_s, ecc_s;
                     int ij_ab = i * nocc_act + j;
                     int ij_aa = i * (i - 1) / 2 + j;
@@ -242,9 +226,9 @@ void CCEnergyWavefunction::print_pair_energies(double* emp2_aa, double* emp2_ab,
             outfile->Printf("        i       j         MP2             %s\n", params_.wfn.c_str());
             outfile->Printf("      -----   -----   ------------   ------------\n");
             if (naa) {
-                ij = 0;
-                for (i = 0; i < nocc_act; i++)
-                    for (j = 0; j < i; j++, ij++) {
+                auto ij = 0;
+                for (int i = 0; i < nocc_act; i++)
+                    for (int j = 0; j < i; j++, ij++) {
                         outfile->Printf("      %3d     %3d     %12.9lf   %12.9lf\n", i + 1, j + 1, 1.5 * emp2_aa[ij],
                                         1.5 * ecc_aa[ij]);
                         emp2_t_tot += 1.5 * emp2_aa[ij];

--- a/psi4/src/psi4/cc/ccenergy/priority.cc
+++ b/psi4/src/psi4/cc/ccenergy/priority.cc
@@ -41,9 +41,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::init_priority_list() {
-    if (!cache_priority_list_)
-        throw PSIEXCEPTION(
-            "Cache priority list must be allocated before calling *CCEnergyWavefunction::init_priority_list().");
     strcpy(cache_priority_list_[0].label, "D <ij||ab> (i>j,a>b)");
     cache_priority_list_[0].filenum = 105;
     cache_priority_list_[0].irrep = 0;

--- a/psi4/src/psi4/cc/ccenergy/spinad_amps.cc
+++ b/psi4/src/psi4/cc/ccenergy/spinad_amps.cc
@@ -62,7 +62,7 @@ namespace ccenergy {
 
 void CCEnergyWavefunction::spinad_amps() {
     dpdfile2 T1, F;
-    dpdbuf4 T2AB1, T2AB2, T2, W, W1, W2;
+    dpdbuf4 T2AB1, T2AB2, W, W1, W2;
 
     if (params_.ref == 0) { /** RHF **/
 

--- a/psi4/src/psi4/cc/ccenergy/t1.cc
+++ b/psi4/src/psi4/cc/ccenergy/t1.cc
@@ -44,10 +44,9 @@ namespace ccenergy {
 void CCEnergyWavefunction::t1_build() {
     dpdfile2 newtIA, newtia, tIA, tia, fIA, fia;
     dpdfile2 FAE, Fae, FMI, Fmi, FME, Fme;
-    dpdfile2 dIA, dia;
     dpdbuf4 tIJAB, tijab, tIjAb, tiJaB, T2;
-    dpdbuf4 C, C_anti, D, F_anti, F, E_anti, E, Z;
-    int Gma, Gmi, Gm, Gi, Ga, ma, m, a, A, nrows, ncols;
+    dpdbuf4 C, C_anti, D, F_anti, F, E_anti, E;
+    int Gmi, Gm, Gi, Ga, m, a, A, nrows, ncols;
 
     if (params_.ref == 0) { /** RHF **/
         global_dpd_->file2_init(&fIA, PSIF_CC_OEI, 0, 0, 1, "fIA");
@@ -106,14 +105,14 @@ void CCEnergyWavefunction::t1_build() {
         global_dpd_->file2_mat_rd(&newtIA);
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "2 tIjAb - tIjBa");
         global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
-        for (Gma = 0; Gma < moinfo_.nirreps; Gma++) {
+        for (int Gma = 0; Gma < moinfo_.nirreps; Gma++) {
             Gmi = Gma; /* T1 is totally symmetric */
 
             global_dpd_->buf4_mat_irrep_row_init(&F, Gma);
             global_dpd_->buf4_mat_irrep_init(&T2, Gmi);
             global_dpd_->buf4_mat_irrep_rd(&T2, Gmi);
 
-            for (ma = 0; ma < F.params->rowtot[Gma]; ma++) {
+            for (int ma = 0; ma < F.params->rowtot[Gma]; ma++) {
                 global_dpd_->buf4_mat_irrep_row_rd(&F, Gma, ma);
 
                 m = F.params->roworb[Gma][ma][0];

--- a/psi4/src/psi4/cc/ccenergy/t1_ijab.cc
+++ b/psi4/src/psi4/cc/ccenergy/t1_ijab.cc
@@ -41,13 +41,12 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::t1_ijab() {
-    int h, ij, ab, i, j, a, b, I, J, A, B;
+    int i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
-    int nirreps;
     dpdbuf4 t1_IJAB, t1_ijab, t1_IjAb, t1_IjbA;
     dpdfile2 tIA, tia;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     if (params_.ref == 0) { /** RHF **/
 
@@ -57,17 +56,17 @@ void CCEnergyWavefunction::t1_ijab() {
 
         global_dpd_->buf4_init(&t1_IjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "t1_IjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_IjAb, h);
 
-            for (ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
                 i = t1_IjAb.params->roworb[h][ij][0];
                 j = t1_IjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
                     a = t1_IjAb.params->colorb[h][ab][0];
                     b = t1_IjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -99,17 +98,17 @@ void CCEnergyWavefunction::t1_ijab() {
 
         global_dpd_->buf4_init(&t1_IJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "t1_IJAB");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_IJAB, h);
 
-            for (ij = 0; ij < t1_IJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_IJAB.params->rowtot[h]; ij++) {
                 i = t1_IJAB.params->roworb[h][ij][0];
                 j = t1_IJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < t1_IJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_IJAB.params->coltot[h]; ab++) {
                     a = t1_IJAB.params->colorb[h][ab][0];
                     b = t1_IJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -132,17 +131,17 @@ void CCEnergyWavefunction::t1_ijab() {
 
         global_dpd_->buf4_init(&t1_ijab, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "t1_ijab");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_ijab, h);
 
-            for (ij = 0; ij < t1_ijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_ijab.params->rowtot[h]; ij++) {
                 i = t1_ijab.params->roworb[h][ij][0];
                 j = t1_ijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < t1_ijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_ijab.params->coltot[h]; ab++) {
                     a = t1_ijab.params->colorb[h][ab][0];
                     b = t1_ijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -165,17 +164,17 @@ void CCEnergyWavefunction::t1_ijab() {
 
         global_dpd_->buf4_init(&t1_IjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "t1_IjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_IjAb, h);
 
-            for (ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
                 i = t1_IjAb.params->roworb[h][ij][0];
                 j = t1_IjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
                     a = t1_IjAb.params->colorb[h][ab][0];
                     b = t1_IjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -213,16 +212,16 @@ void CCEnergyWavefunction::t1_ijab() {
         global_dpd_->file2_mat_rd(&tia);
 
         global_dpd_->buf4_init(&t1_IJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "t1_IJAB");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_IJAB, h);
-            for (ij = 0; ij < t1_IJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_IJAB.params->rowtot[h]; ij++) {
                 i = t1_IJAB.params->roworb[h][ij][0];
                 j = t1_IJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < t1_IJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_IJAB.params->coltot[h]; ab++) {
                     a = t1_IJAB.params->colorb[h][ab][0];
                     b = t1_IJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -241,16 +240,16 @@ void CCEnergyWavefunction::t1_ijab() {
         global_dpd_->buf4_close(&t1_IJAB);
 
         global_dpd_->buf4_init(&t1_ijab, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "t1_ijab");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_ijab, h);
-            for (ij = 0; ij < t1_ijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_ijab.params->rowtot[h]; ij++) {
                 i = t1_ijab.params->roworb[h][ij][0];
                 j = t1_ijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < t1_ijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_ijab.params->coltot[h]; ab++) {
                     a = t1_ijab.params->colorb[h][ab][0];
                     b = t1_ijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -269,16 +268,16 @@ void CCEnergyWavefunction::t1_ijab() {
         global_dpd_->buf4_close(&t1_ijab);
 
         global_dpd_->buf4_init(&t1_IjAb, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "t1_IjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&t1_IjAb, h);
-            for (ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < t1_IjAb.params->rowtot[h]; ij++) {
                 i = t1_IjAb.params->roworb[h][ij][0];
                 j = t1_IjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < t1_IjAb.params->coltot[h]; ab++) {
                     a = t1_IjAb.params->colorb[h][ab][0];
                     b = t1_IjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];

--- a/psi4/src/psi4/cc/ccenergy/t2.cc
+++ b/psi4/src/psi4/cc/ccenergy/t2.cc
@@ -43,9 +43,6 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::t2_build() {
-    dpdbuf4 tIjAb;
-    double dotval;
-
     DT2();
     if (params_.print & 2) status("<ij||ab> -> T2", "outfile");
 

--- a/psi4/src/psi4/cc/ccenergy/tau.cc
+++ b/psi4/src/psi4/cc/ccenergy/tau.cc
@@ -41,14 +41,13 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::tau_build() {
-    int h, ij, ab, i, j, a, b, I, J, A, B;
+    int i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
-    int nirreps;
-    dpdbuf4 tauIJAB, tauijab, tauIjAb, tauiJaB, tauIjbA;
+    dpdbuf4 tauIJAB, tauijab, tauIjAb, tauIjbA;
     dpdbuf4 tIJAB, tijab, tIjAb;
     dpdfile2 tIA, tia;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     if (params_.ref == 0) { /** RHF **/
 
@@ -62,18 +61,18 @@ void CCEnergyWavefunction::tau_build() {
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tauIjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
 
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -119,18 +118,18 @@ void CCEnergyWavefunction::tau_build() {
 
         global_dpd_->buf4_init(&tauIJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tauIJAB");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIJAB, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIJAB, h);
 
-            for (ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
                 i = tauIJAB.params->roworb[h][ij][0];
                 j = tauIJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
                     a = tauIJAB.params->colorb[h][ab][0];
                     b = tauIJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -153,18 +152,18 @@ void CCEnergyWavefunction::tau_build() {
 
         global_dpd_->buf4_init(&tauijab, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tauijab");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauijab, h);
             global_dpd_->buf4_mat_irrep_rd(&tauijab, h);
 
-            for (ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
                 i = tauijab.params->roworb[h][ij][0];
                 j = tauijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauijab.params->coltot[h]; ab++) {
                     a = tauijab.params->colorb[h][ab][0];
                     b = tauijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -187,18 +186,18 @@ void CCEnergyWavefunction::tau_build() {
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tauIjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
 
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -249,17 +248,17 @@ void CCEnergyWavefunction::tau_build() {
         global_dpd_->file2_mat_rd(&tia);
 
         global_dpd_->buf4_init(&tauIJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tauIJAB");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIJAB, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIJAB, h);
-            for (ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
                 i = tauIJAB.params->roworb[h][ij][0];
                 j = tauIJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
                     a = tauIJAB.params->colorb[h][ab][0];
                     b = tauIJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -278,17 +277,17 @@ void CCEnergyWavefunction::tau_build() {
         global_dpd_->buf4_close(&tauIJAB);
 
         global_dpd_->buf4_init(&tauijab, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "tauijab");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauijab, h);
             global_dpd_->buf4_mat_irrep_rd(&tauijab, h);
-            for (ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
                 i = tauijab.params->roworb[h][ij][0];
                 j = tauijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauijab.params->coltot[h]; ab++) {
                     a = tauijab.params->colorb[h][ab][0];
                     b = tauijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -307,17 +306,17 @@ void CCEnergyWavefunction::tau_build() {
         global_dpd_->buf4_close(&tauijab);
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "tauIjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];

--- a/psi4/src/psi4/cc/ccenergy/taut.cc
+++ b/psi4/src/psi4/cc/ccenergy/taut.cc
@@ -41,14 +41,13 @@ namespace psi {
 namespace ccenergy {
 
 void CCEnergyWavefunction::taut_build() {
-    int h, ij, ab, i, j, a, b, I, J, A, B;
+    int i, j, a, b, I, J, A, B;
     int Isym, Jsym, Asym, Bsym;
-    int nirreps;
-    dpdbuf4 tauIJAB, tauijab, tauIjAb, tauiJaB, tauIjbA;
+    dpdbuf4 tauIJAB, tauijab, tauIjAb;
     dpdbuf4 tIJAB, tijab, tIjAb;
     dpdfile2 tIA, tia;
 
-    nirreps = moinfo_.nirreps;
+    auto nirreps = moinfo_.nirreps;
 
     if (params_.ref == 0) { /*** RHF ***/
 
@@ -62,18 +61,18 @@ void CCEnergyWavefunction::taut_build() {
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tautIjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
 
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -118,18 +117,18 @@ void CCEnergyWavefunction::taut_build() {
 
         global_dpd_->buf4_init(&tauIJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tautIJAB");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIJAB, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIJAB, h);
 
-            for (ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
                 i = tauIJAB.params->roworb[h][ij][0];
                 j = tauIJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
                     a = tauIJAB.params->colorb[h][ab][0];
                     b = tauIJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -152,18 +151,18 @@ void CCEnergyWavefunction::taut_build() {
 
         global_dpd_->buf4_init(&tauijab, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tautijab");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauijab, h);
             global_dpd_->buf4_mat_irrep_rd(&tauijab, h);
 
-            for (ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
                 i = tauijab.params->roworb[h][ij][0];
                 j = tauijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauijab.params->coltot[h]; ab++) {
                     a = tauijab.params->colorb[h][ab][0];
                     b = tauijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -186,18 +185,18 @@ void CCEnergyWavefunction::taut_build() {
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "tautIjAb");
 
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
 
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -243,17 +242,17 @@ void CCEnergyWavefunction::taut_build() {
         global_dpd_->file2_mat_rd(&tia);
 
         global_dpd_->buf4_init(&tauIJAB, PSIF_CC_TAMPS, 0, 2, 7, 2, 7, 0, "tautIJAB");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIJAB, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIJAB, h);
-            for (ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIJAB.params->rowtot[h]; ij++) {
                 i = tauIJAB.params->roworb[h][ij][0];
                 j = tauIJAB.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tIA.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tIA.params->psym[j];
-                for (ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIJAB.params->coltot[h]; ab++) {
                     a = tauIJAB.params->colorb[h][ab][0];
                     b = tauIJAB.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];
@@ -272,17 +271,17 @@ void CCEnergyWavefunction::taut_build() {
         global_dpd_->buf4_close(&tauIJAB);
 
         global_dpd_->buf4_init(&tauijab, PSIF_CC_TAMPS, 0, 12, 17, 12, 17, 0, "tautijab");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauijab, h);
             global_dpd_->buf4_mat_irrep_rd(&tauijab, h);
-            for (ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauijab.params->rowtot[h]; ij++) {
                 i = tauijab.params->roworb[h][ij][0];
                 j = tauijab.params->roworb[h][ij][1];
                 I = tia.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tia.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauijab.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauijab.params->coltot[h]; ab++) {
                     a = tauijab.params->colorb[h][ab][0];
                     b = tauijab.params->colorb[h][ab][1];
                     A = tia.params->colidx[a];
@@ -301,17 +300,17 @@ void CCEnergyWavefunction::taut_build() {
         global_dpd_->buf4_close(&tauijab);
 
         global_dpd_->buf4_init(&tauIjAb, PSIF_CC_TAMPS, 0, 22, 28, 22, 28, 0, "tautIjAb");
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             global_dpd_->buf4_mat_irrep_init(&tauIjAb, h);
             global_dpd_->buf4_mat_irrep_rd(&tauIjAb, h);
-            for (ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
+            for (int ij = 0; ij < tauIjAb.params->rowtot[h]; ij++) {
                 i = tauIjAb.params->roworb[h][ij][0];
                 j = tauIjAb.params->roworb[h][ij][1];
                 I = tIA.params->rowidx[i];
                 J = tia.params->rowidx[j];
                 Isym = tIA.params->psym[i];
                 Jsym = tia.params->psym[j];
-                for (ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
+                for (int ab = 0; ab < tauIjAb.params->coltot[h]; ab++) {
                     a = tauIjAb.params->colorb[h][ab][0];
                     b = tauIjAb.params->colorb[h][ab][1];
                     A = tIA.params->colidx[a];

--- a/psi4/src/psi4/cc/cclambda/cache.cc
+++ b/psi4/src/psi4/cc/cclambda/cache.cc
@@ -38,7 +38,6 @@
 #include "cclambda.h"
 
 namespace psi {
-extern FILE *outfile;
 namespace cclambda {
 
 void cache_abcd_rhf(int **cachelist);

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -29,7 +29,10 @@
 #ifndef CCWAVE_H
 #define CCWAVE_H
 
+#include <array>
+
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/libdpd/dpd.h"
 
 #include "ccenergy/MOInfo.h"
 #include "ccenergy/Params.h"
@@ -37,7 +40,6 @@
 
 namespace psi {
 class Options;
-struct dpd_file4_cache_entry;
 struct dpdfile2;
 struct dpdbuf4;
 struct iwlbuf;
@@ -57,7 +59,6 @@ class CCEnergyWavefunction : public Wavefunction {
     /* setup, info and teardown */
     void init();
     void init_io();
-    void init_ioff();
     void exit_io();
     void cleanup();
     void status(const char *, std::string);
@@ -151,7 +152,7 @@ class CCEnergyWavefunction : public Wavefunction {
     void pair_energies(double **epair_aa, double **epair_ab);
     void print_pair_energies(double *emp2_aa, double *emp2_ab, double *ecc_aa, double *ecc_ab);
 
-    void form_df_ints(Options &options, int **cachelist, int *cachefiles, dpd_file4_cache_entry *priority);
+    void form_df_ints(Options &options, int **cachelist, int *cachefiles);
 
     /* diagnostics */
     void analyze();
@@ -192,11 +193,10 @@ class CCEnergyWavefunction : public Wavefunction {
     void diis_invert_B(double **B, double *C, int dimension, double tolerance);
 
     /* member variables */
-    int *ioff_;
     MOInfo moinfo_;
     Params params_;
     Local local_;
-    dpd_file4_cache_entry *cache_priority_list_;
+    std::array<dpd_file4_cache_entry, 113> cache_priority_list_;
 };
 
 }  // namespace ccenergy


### PR DESCRIPTION
## Description
Some C++ style fixes for files in the `ccenergy` folder. 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Remove `return;` where useless
- [x] Remove unused `ioff_` array
- [x] Localize loop variables, use `auto`
- [x] Switch to `std::` data structures

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
