### PR TITLE
Wavefunction constructor from reference

### DIFF
--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -51,19 +51,13 @@ PRAGMA_WARNING_POP
 namespace psi {
 namespace detci {
 
-CIWavefunction::CIWavefunction(std::shared_ptr<Wavefunction> ref_wfn) : Wavefunction(Process::environment.options) {
-    // Copy the wavefuntion then update
-    shallow_copy(ref_wfn);
-    set_reference_wavefunction(ref_wfn);
+CIWavefunction::CIWavefunction(std::shared_ptr<Wavefunction> ref_wfn, Options& options)
+    : Wavefunction{ref_wfn, options} {
     common_init();
 }
 
-CIWavefunction::CIWavefunction(std::shared_ptr<Wavefunction> ref_wfn, Options& options) : Wavefunction(options) {
-    // Copy the wavefuntion then update
-    shallow_copy(ref_wfn);
-    set_reference_wavefunction(ref_wfn);
-    common_init();
-}
+CIWavefunction::CIWavefunction(std::shared_ptr<Wavefunction> ref_wfn)
+    : CIWavefunction{ref_wfn, Process::environment.options} {}
 
 CIWavefunction::~CIWavefunction() {
     cleanup_ci();

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -72,8 +72,8 @@ namespace detci {
 
 class CIWavefunction : public Wavefunction {
    public:
-    CIWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction);
     CIWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
+    explicit CIWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction);
     virtual ~CIWavefunction();
 
     double compute_energy();

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -85,6 +85,13 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     common_init();
 }
 
+Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &options)
+    : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {
+    // Copy the wavefuntion then update
+    shallow_copy(reference_wavefunction);
+    set_reference_wavefunction(reference_wavefunction);
+}
+
 Wavefunction::Wavefunction(Options &options)
     : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {}
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -256,6 +256,9 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis);
 
     /// Blank constructor for derived classes
+    Wavefunction(SharedWavefunction reference_wavefunction, Options& options);
+
+    /// Blank constructor for derived classes
     Wavefunction(Options& options);
 
     /**


### PR DESCRIPTION
## Description
Adds a constructor to `Wavefunction` taking a reference wavefunction as argument. The body of the CTOR performs:
```
shallow_copy(reference_wavefunction);
set_reference_wavefunction(reference_wavefunction);
```
which seemed to be otherwise copy-pasted in correlated wavefunction CTORs.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Add CTOR from `SharedWavefunction` in `Wavefunction` class 
- [x] Rework CTOR in `CIWavefunction` to use the new CTOR in the base class.
- [x] Mark one-parameter CTOR for `CIWavefunction` as `explicit`
- [x] Use delegating CTOR for one-parameter CTOR of `CIWavefunction`.

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
