### PR TITLE
Use Python 3.6 for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
                  numpy
                  pybind11
                  pytest
+                 python=3.6
   - conda clean --all
   - activate %CONDA_ENV%
   - conda list


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

*Appveyor* is switching to Python 3.7 by default, but some package are not yet ready. So stay with Python 3.6 for a while.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Use Python 3.6 for Windows builds

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge