### PR TITLE
Replace only the last match when generating outfile name from infile. 

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -111,7 +111,8 @@ if args["inplace"]:
     import sysconfig
     core_location = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + "core" + sysconfig.get_config_var("SO")
     if not os.path.isfile(core_location):
-        raise ImportError("A compiled Psi4 core{} needs to be symlinked to the {} folder".format(sysconfig.get_config_var("SO"), os.path.dirname(__file__)))
+        raise ImportError("A compiled Psi4 core{} needs to be symlinked to the {} folder".format(
+            sysconfig.get_config_var("SO"), os.path.dirname(__file__)))
 
     lib_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if ("PSIDATADIR" not in os.environ.keys()) and (not args["psidatadir"]):
@@ -134,9 +135,9 @@ if args["output"] is None:
     if args["input"] == "input.dat":
         args["output"] = "output.dat"
     elif args["input"].endswith(".in"):
-        args["output"] = args["input"].replace(".in", ".out")
+        args["output"] = args["input"][:-2] + "out"
     elif args["input"].endswith(".dat"):
-        args["output"] = args["input"].replace(".dat", ".out")
+        args["output"] = args["input"][:-3] + "out"
     else:
         args["output"] = args["input"] + ".dat"
 


### PR DESCRIPTION
## Description
There is no `rreplace` function which would be handy, so split on the first match from the end, and join on the replacement. does the job. 

fixes #1286 

## Status
- [x] Ready for review
- [x] Ready for merge
