### PR TITLE
Findif Metadata

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,8 +77,11 @@ test_script:
   # Failling tests:
   #     ci-property
   #
+  # Tests requiring AM > 5:
+  #     opt-full-hess-every
+  #
   - ctest --build-config %CONFIGURATION%
-          --exclude-regex "^(cbs-delta-energy|cbs-xtpl-gradient|dfmp2-ecp|fnocc2|mp2-module|scf5|psimrcc-sp1|pywrap-all|pywrap-cbs1|ci-property)$"
+          --exclude-regex "^(cbs-delta-energy|cbs-xtpl-gradient|dfmp2-ecp|fnocc2|mp2-module|scf5|psimrcc-sp1|pywrap-all|pywrap-cbs1|ci-property|opt-full-hess-every)$"
           --label-regex quick
           --output-on-failure
           --parallel %NUMBER_OF_PROCESSORS%

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
         GIT_REPOSITORY https://github.com/MolSSI/QCElemental
-        GIT_TAG v0.1.0a
+        GIT_TAG master
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental) # ATLEAST 1.0.0 QUIET)
+    find_python_module(qcelemental ATLEAST 0.1.1 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -20,7 +20,7 @@ else()
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
         GIT_REPOSITORY https://github.com/MolSSI/QCElemental
-        GIT_TAG master
+        GIT_TAG v0.1.1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -151,7 +151,7 @@ def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, *
 
        Returns
        -------
-       wfn: psi4.core.wfn
+       wfn: :py:class:`~psi4.core.Wavefunction`
            The wavefunction computed.
     """
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -131,7 +131,29 @@ def _energy_is_invariant(gradient, stationary_criterion=1.e-2):
 
 def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, **kwargs):
     """A helper function to perform all processing for an individual finite
-       difference computation."""
+       difference computation.
+
+       Parameters
+       ----------
+       derivfunc : func
+           The function computing the target derivative.
+       method : str
+          A string specifying the method to be used for the computation.
+       molecule: psi4.core.molecule or qcdb.molecule
+          The molecule for the computation. Geometry setting is handled internally.
+       displacement : dict
+          A dictionary containing the necessary information for the displacement.
+          See driver_findif/_geom_generator.py docstring for details.
+       n : int
+          The number of the displacement being computed, for print purposes.
+       ndisp : int
+           The total number of geometries, for print purposes.
+
+       Returns
+       -------
+       wfn: psi4.core.wfn
+           The wavefunction computed.
+    """
 
     # print progress to file and screen
     core.print_out('\n')

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1033,7 +1033,7 @@ def optimize(name, **kwargs):
             old_thisenergy = core.get_variable('CURRENT ENERGY')
 
         # Compute the gradient - preserve opt data despite core.clean calls in gradient
-        #core.IOManager.shared_object().set_specific_retention(1, True)
+        core.IOManager.shared_object().set_specific_retention(1, True)
         G, wfn = gradient(lowername, return_wfn=True, molecule=moleculeclone, **kwargs)
         thisenergy = core.get_variable('CURRENT ENERGY')
 
@@ -1099,6 +1099,8 @@ def optimize(name, **kwargs):
             print('Optimizer: Optimization complete!')
             core.print_out('\n    Final optimized geometry and variables:\n')
             moleculeclone.print_in_input_format()
+            # Mark the optimization data as disposable now that the optimization is done.
+            core.IOManager.shared_object().set_specific_retention(1, False)
             # Check if user wants to see the intcos; if so, don't delete them.
             if core.get_option('OPTKING', 'INTCOS_GENERATE_EXIT') == False:
                 if core.get_option('OPTKING', 'KEEP_INTCOS') == False:
@@ -1115,10 +1117,6 @@ def optimize(name, **kwargs):
                     fmaster.write(
                         '# This is a psi4 input file auto-generated from the gradient() wrapper.\n\n'.encode('utf-8'))
                     fmaster.write('# Optimization complete!\n\n'.encode('utf-8'))
-
-            # Cleanup binary file 1
-            if custom_gradient or ('/' in lowername):
-                core.IOManager.shared_object().set_specific_retention(1, False)
 
             optstash.restore()
 
@@ -1140,6 +1138,8 @@ def optimize(name, **kwargs):
 
         elif optking_rval == core.PsiReturnType.Failure:
             print('Optimizer: Optimization failed!')
+            # Mark the optimization data as disposable now that the optimization is done.
+            core.IOManager.shared_object().set_specific_retention(1, False)
             if (core.get_option('OPTKING', 'KEEP_INTCOS') == False):
                 core.opt_clean()
             molecule.set_geometry(moleculeclone.geometry())

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -152,7 +152,7 @@ def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, *
         displacement["gradient"] = wfn.gradient().np.ravel().tolist()
 
     # clean may be necessary when changing irreps of displacements
-    #core.clean()
+    core.clean()
 
     return wfn
 
@@ -674,7 +674,8 @@ def gradient(name, **kwargs):
         print(""" %d displacements needed ...""" % (ndisp), end='')
 
         for n, displacement in enumerate(findif_meta_dict["displacements"].values(), start=1):
-            _process_displacement(energy, lowername, moleculeclone, displacement, n, ndisp, **kwargs)
+            _process_displacement(
+                energy, lowername, moleculeclone, displacement, n, ndisp, write_orbitals=False, **kwargs)
 
         wfn = _process_displacement(energy, lowername, moleculeclone, findif_meta_dict["reference"], ndisp, ndisp,
                                     **kwargs)
@@ -1301,8 +1302,8 @@ def hessian(name, **kwargs):
         print(""" %d displacements needed.""" % ndisp)
 
         for n, displacement in enumerate(findif_meta_dict["displacements"].values(), start=1):
-            _process_displacement(gradient, lowername, moleculeclone, displacement, n, ndisp, **kwargs)
-            core.clean()
+            _process_displacement(
+                gradient, lowername, moleculeclone, displacement, n, ndisp, write_orbitals=False, **kwargs)
 
         wfn = _process_displacement(gradient, lowername, moleculeclone, findif_meta_dict["reference"], ndisp, ndisp,
                                     **kwargs)
@@ -1344,8 +1345,8 @@ def hessian(name, **kwargs):
         print(' %d displacements needed.' % ndisp)
 
         for n, displacement in enumerate(findif_meta_dict["displacements"].values(), start=1):
-            _process_displacement(energy, lowername, moleculeclone, displacement, n, ndisp, **kwargs)
-            core.clean()
+            _process_displacement(
+                energy, lowername, moleculeclone, displacement, n, ndisp, write_orbitals=False, **kwargs)
 
         wfn = _process_displacement(energy, lowername, moleculeclone, findif_meta_dict["reference"], ndisp, ndisp,
                                     **kwargs)

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -261,7 +261,7 @@ def _geom_generator(mol, freq_irrep_only, mode):
         A descriptor for the finite difference step.
         In future, this can be overriden by step fields for individual displacements.
 
-        units : string
+        units : {'bohr', 'angstrom'}
             The units for the displacement. The code currently assumes "bohr".
         size : float
             The step size for the displacement.
@@ -270,7 +270,7 @@ def _geom_generator(mol, freq_irrep_only, mode):
         Number of points to evaluate at for each displacement basis vector. The count
         includes the reference. Psi currently supports 3 and 5.
 
-    displacement_space : string
+    displacement_space : {'CdSalc'}
         A string specifying the vector space in which displacements are performed.
         Currently, only CdSalc is supported.
 
@@ -286,9 +286,9 @@ def _geom_generator(mol, freq_irrep_only, mode):
 
     displacements : dict
         A dictionary mapping labels specifying the displacement to data about
-        the geometry. Labels are of the form "A: B, C: D" where A and B index the
-        basis vector in displacement space and are ordered, and C and D index the
-        step magnitude. For instance, "0: 1, 1: -1" specifies displacing +1 in
+        the geometry. Labels are of the form "A: a, B: b" where A and B index the
+        basis vector in displacement space and A < B, and a and b index the step
+        magnitude. For instance, "0: 1, 1: -1" specifies displacing +1 in
         displacement vector 0 and -1 in displacement vector 1. "1: -1, 0: 1" is
         forbidden for breaking ordering. Generalizes to arbitrary numbers of
         simultaneous displacements in the obvious way.

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -332,6 +332,11 @@ def _geom_generator(mol, freq_irrep_only, mode):
                 "    Generating geometries for use with {:d}-point formula.\n"
                 "    Displacement size will be {:6.2e}.\n".format(print_msg, data["num_pts"], data["disp_size"]))
 
+    # Genuine support for qcdb molecules would be nice. But that requires qcdb CdSalc tech.
+    # Until then, silently swap the qcdb molecule out for a psi4.core.molecule.
+    if isinstance(mol, molecule.Molecule):
+        mol = core.Molecule.from_dict(mol.to_dict())
+
     data = _initialize_findif(mol, freq_irrep_only, mode, init_string, 1)
 
     # We can finally start generating displacements.

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -352,12 +352,7 @@ def _geom_generator(mol, freq_irrep_only, mode):
         "displacement_space": "CdSALC",
         "project_translations": data["project_translations"],
         "project_rotations": data["project_rotations"],
-        # TODO: Hand-coding schema information is bad. Fix this post-QCElemental.
-        "molecule": {
-            "schema_name": "qc_schema_input",
-            "schema_version": 1,
-            "molecule": mol.to_schema(dtype=1, units='Bohr')
-        },
+        "molecule": mol.to_schema(dtype=1, units='Bohr'),
         "displacements": {},
         "reference": {}
     }

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -45,11 +45,11 @@ def _displace_cart(mol, geom, salc_list, i_m, step_size):
 
     Parameters
     ----------
-    mol : qcdb.molecule or psi4.core.Molecule
+    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to displace
     geom : ndarray
         The geometry of the molecule.
-    salc_list : psi4.core.CdSalcList
+    salc_list : :py:class:`~psi4.core.CdSalcList`
         A list of Cartesian displacement SALCs
     i_m : iterator of tuples
         An iterator containing tuples. Each tuple has the index of a salc in
@@ -81,7 +81,7 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
 
     Parameters
     ----------
-    mol : qcdb.molecule or psi4.core.Molecule
+    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to displace
     freq_irrep_only : int
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
@@ -234,7 +234,7 @@ def _geom_generator(mol, freq_irrep_only, mode):
 
     Parameters
     ----------
-    mol : qcdb.molecule or psi4.core.Molecule
+    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to perform finite difference calculations on.
     freq_irrep_only : int
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
@@ -261,7 +261,7 @@ def _geom_generator(mol, freq_irrep_only, mode):
         A descriptor for the finite difference step.
         In future, this can be overriden by step fields for individual displacements.
 
-        units : {'bohr', 'angstrom'}
+        units : {'Bohr', 'Angstrom'}
             The units for the displacement. The code currently assumes "bohr".
         size : float
             The step size for the displacement.
@@ -855,7 +855,7 @@ def gradient_from_energy_geometries(molecule):
     
     Parameters
     ----------
-    molecule : qcdb.molecule or psi4.core.Molecule
+    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to compute the gradient of.
 
     Returns
@@ -877,7 +877,7 @@ def hessian_from_gradient_geometries(molecule, irrep):
     
     Parameters
     ----------
-    molecule : qcdb.molecule or psi4.core.Molecule
+    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to compute the frequencies of.
     irrep : int
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
@@ -897,7 +897,7 @@ def hessian_from_energy_geometries(molecule, irrep):
     
     Parameters
     ----------
-    molecule : qcdb.molecule or psi4.core.Molecule
+    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
         The molecule to compute the frequencies of.
     irrep : int
         The Cotton ordered irrep to get frequencies for. Choose -1 for all

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -277,12 +277,12 @@ class EmpiricalDispersion(object):
         # Record undisplaced symmetry for projection of diplaced point groups
         core.set_parent_symmetry(molecule.schoenflies_symbol())
 
-        gradients = []
-        for geom in driver_findif.hessian_from_gradient_geometries(molecule, -1):
-            molclone.set_geometry(geom)
+        findif_meta_dict = driver_findif.hessian_from_gradient_geometries(molclone, -1)
+        for displacement in findif_meta_dict["displacements"].values():
+            molclone.set_geometry(core.Matrix.from_array(displacement["geometry"]))
             molclone.update_geometry()
-            gradients.append(self.compute_gradient(molclone))
+            displacement["gradient"] = self.compute_gradient(molclone).to_array()
 
-        H = driver_findif.compute_hessian_from_gradient(molecule, gradients, -1)
+        H = driver_findif.compute_hessian_from_gradient(molecule, findif_meta_dict, -1)
         optstash.restore()
         return core.Matrix.from_array(H)

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -279,10 +279,11 @@ class EmpiricalDispersion(object):
 
         findif_meta_dict = driver_findif.hessian_from_gradient_geometries(molclone, -1)
         for displacement in findif_meta_dict["displacements"].values():
-            molclone.set_geometry(core.Matrix.from_array(displacement["geometry"]))
+            geom_array = np.reshape(displacement["geometry"], (-1, 3))
+            molclone.set_geometry(core.Matrix.from_array(geom_array))
             molclone.update_geometry()
-            displacement["gradient"] = self.compute_gradient(molclone).to_array()
+            displacement["gradient"] = self.compute_gradient(molclone).np.ravel().tolist()
 
-        H = driver_findif.compute_hessian_from_gradient(molecule, findif_meta_dict, -1)
+        H = driver_findif.compute_hessian_from_gradient(findif_meta_dict, -1)
         optstash.restore()
         return core.Matrix.from_array(H)

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1405,29 +1405,30 @@ def scf_helper(name, post_scf=True, **kwargs):
                  scf_wfn.epsilon_b(), scf_wfn.occupation_a(),
                  scf_wfn.occupation_b(), dovirt)
 
-    # Write out orbitals and basis
-    fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
-    write_filename = os.path.join(psi_scratch, fname + ".180.npz")
-    data = {}
-    data.update(scf_wfn.Ca().np_write(None, prefix="Ca"))
-    data.update(scf_wfn.Cb().np_write(None, prefix="Cb"))
+    # Write out orbitals and basis; Can be disabled, e.g., for findif displacements
+    if kwargs.get('write_orbitals', True):
+        fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
+        write_filename = os.path.join(psi_scratch, fname + ".180.npz")
+        data = {}
+        data.update(scf_wfn.Ca().np_write(None, prefix="Ca"))
+        data.update(scf_wfn.Cb().np_write(None, prefix="Cb"))
 
-    Ca_occ = scf_wfn.Ca_subset("SO", "OCC")
-    data.update(Ca_occ.np_write(None, prefix="Ca_occ"))
+        Ca_occ = scf_wfn.Ca_subset("SO", "OCC")
+        data.update(Ca_occ.np_write(None, prefix="Ca_occ"))
 
-    Cb_occ = scf_wfn.Cb_subset("SO", "OCC")
-    data.update(Cb_occ.np_write(None, prefix="Cb_occ"))
+        Cb_occ = scf_wfn.Cb_subset("SO", "OCC")
+        data.update(Cb_occ.np_write(None, prefix="Cb_occ"))
 
-    data["reference"] = core.get_option('SCF', 'REFERENCE')
-    data["nsoccpi"] = scf_wfn.soccpi().to_tuple()
-    data["ndoccpi"] = scf_wfn.doccpi().to_tuple()
-    data["nalphapi"] = scf_wfn.nalphapi().to_tuple()
-    data["nbetapi"] = scf_wfn.nbetapi().to_tuple()
-    data["symmetry"] = scf_molecule.schoenflies_symbol()
-    data["BasisSet"] = scf_wfn.basisset().name()
-    data["BasisSet PUREAM"] = scf_wfn.basisset().has_puream()
-    np.savez(write_filename, **data)
-    extras.register_numpy_file(write_filename)
+        data["reference"] = core.get_option('SCF', 'REFERENCE')
+        data["nsoccpi"] = scf_wfn.soccpi().to_tuple()
+        data["ndoccpi"] = scf_wfn.doccpi().to_tuple()
+        data["nalphapi"] = scf_wfn.nalphapi().to_tuple()
+        data["nbetapi"] = scf_wfn.nbetapi().to_tuple()
+        data["symmetry"] = scf_molecule.schoenflies_symbol()
+        data["BasisSet"] = scf_wfn.basisset().name()
+        data["BasisSet PUREAM"] = scf_wfn.basisset().has_puream()
+        np.savez(write_filename, **data)
+        extras.register_numpy_file(write_filename)
 
     if do_timer:
         core.tstop()

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1335,12 +1335,12 @@ class Molecule(LibmintsMolecule):
         else:
             return Molecule.from_dict(molrec)
 
-    def to_schema(self, dtype, units='Angstrom', return_type='json'):
-        """Serializes instance into JSON or YAML according to schema `dtype`."""
+    def to_schema(self, dtype, units='Bohr'):
+        """Serializes instance into dictionary according to schema `dtype`."""
 
         molrec = self.to_dict(np_out=True)
-        jymol = qcel.molparse.to_schema(molrec, dtype=dtype, units=units, return_type=return_type)
-        return jymol
+        schmol = qcel.molparse.to_schema(molrec, dtype=dtype, units=units)
+        return schmol
 
     def to_dict(self, force_c1=False, force_units=False, np_out=True):
         """Serializes instance into Molecule dictionary."""

--- a/psi4/driver/qcdb/psiutil.py
+++ b/psi4/driver/qcdb/psiutil.py
@@ -255,6 +255,12 @@ def compare_molrecs(expected, computed, tol, label, forgive=None, verbose=1, rel
         ageom = mill.align_coordinates(cgeom)
         cptd['geom'] = ageom.reshape((-1))
 
+    # TEMP TODO just in case working from qcel head, not 0.1
+    if forgive is None:
+        forgive = ['provenance']
+    if 'provenance' not in forgive:
+        forgive.append('provenance')
+
     compare_dicts(xptd, cptd, tol, label, forgive=forgive, verbose=verbose)
 
 

--- a/psi4/src/export_psio.cc
+++ b/psi4/src/export_psio.cc
@@ -36,6 +36,7 @@ void export_psio(py::module &m) {
     py::class_<PSIO, std::shared_ptr<PSIO> >(m, "IO", "docstring")
         .def("state", &PSIO::state, "Return 1 if PSIO library is activated")
         .def("open", &PSIO::open, "Open unit. Status can be PSIO_OPEN_OLD (if existing file is to be opened) or PSIO_OPEN_NEW if new file should be open", py::arg("unit"), py::arg("status"))
+        .def("exists", &PSIO::exists, "Check if the unit exists.", py::arg("unit"))
         .def("close", &PSIO::close, "Close unit. If keep == 0, will remove the file, else keep it", py::arg("unit"), py::arg("keep"))
         .def("rehash", &PSIO::rehash, "Sync up the object to the file on disk by closing and opening the file, if necessary", py::arg("unit"))
         .def("open_check", &PSIO::open_check, "Return 1 if unit is open", py::arg("unit"))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   fci-dipole fci-h2o fci-h2o-2 fci-h2o-fzcv fci-tdm fci-tdm-2
                   fci-coverage
                   fcidump
-                  fd-qcdb fd-freq-energy fd-freq-energy-large fd-freq-gradient
+                  fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
                   fnocc3 fnocc4 frac frac-ip-fitting frac-traverse ghosts gibbs matrix1
                   mcscf1 mcscf2 mcscf3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   fci-dipole fci-h2o fci-h2o-2 fci-h2o-fzcv fci-tdm fci-tdm-2
                   fci-coverage
                   fcidump
-                  fd-freq-energy fd-freq-energy-large fd-freq-gradient
+                  fd-qcdb fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
                   fnocc3 fnocc4 frac frac-ip-fitting frac-traverse ghosts gibbs matrix1
                   mcscf1 mcscf2 mcscf3
@@ -75,6 +75,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   omp3-3 omp3-4 omp3-5 omp3-grad1 omp3-grad2 opt-lindep-change
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9
                   opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-irc-3 opt-freeze-coords
+                  opt-full-hess-every
                   props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1
                   psimrcc-fd-freq2 psimrcc-pt2 psimrcc-sp1 psithon1 psithon2

--- a/tests/cookbook/manual-fd-hess-energy/input.dat
+++ b/tests/cookbook/manual-fd-hess-energy/input.dat
@@ -21,28 +21,44 @@ h2o.update_geometry()
 h2o.reinterpret_coordentry(False)
 h2o.fix_orientation(True)
 
+method = "scf" # Change this line to change the method you compute with.
+
 # Displace the h2o molecule to get all displacements for hessian by energies.
 # Set -1 to 1 to get A1 frequencies, to 4 for B2...
-displacements = psi4.driver_findif.hessian_from_energy_geometries(h2o, -1)
+findif_meta_dict = psi4.driver_findif.hessian_from_energy_geometries(h2o, -1)
 
-ndisp = len(displacements)
+ndisp = len(findif_meta_dict["displacements"]) + 1
 
 print(" %d displacements needed." % ndisp)
-energies = []
 
-for n, displacement in enumerate(displacements):
-  banner("Loading displacement %d of %d" % (n+1, ndisp))
-  print("    displacement %d" % (n+1))
+def process_displacement(method, molecule, displacement, n, ndisp, **kwargs):
+    # print progress to file and screen
+    core.print_out('\n')
+    p4util.banner('Loading displacement %d of %d' % (n, ndisp))
+    print(""" %d""" % (n), end=('\n' if (n == ndisp) else ''))
+    sys.stdout.flush()
 
-  get_active_molecule().set_geometry(displacement)
+    # Load in displacement (flat list) into the active molecule
+    geom_array = np.reshape(displacement["geometry"], (-1, 3))
+    molecule.set_geometry(core.Matrix.from_array(geom_array))
 
-  E = energy('scf')
-  energies.append(E)
+    # Perform the energy calculation
+    derivative, wfn = energy(method, return_wfn=True, molecule=molecule, **kwargs)
+    displacement["energy"] = core.get_variable('CURRENT ENERGY')
+
+    # clean may be necessary when changing irreps of displacements
+    core.clean()
+
+    return wfn
+
+for n, displacement in enumerate(findif_meta_dict["displacements"].values(), start=1):
+    process_displacement(method, h2o, displacement, n, ndisp, write_orbitals=False)
+
+wfn = process_displacement(method, h2o, findif_meta_dict["reference"], ndisp, ndisp)
 
 # Compute the hessian of the h2o molecule from the energies, for all symmetry blocks
-H = driver_findif.compute_hessian_from_energy(h2o, energies, -1)
+H = driver_findif.compute_hessian_from_energy(findif_meta_dict, -1)
 
-wfn = core.Wavefunction.build(h2o, core.get_global_option('BASIS'))
 wfn.set_hessian(core.Matrix.from_array(H))
 # Only project out translations and rotations if you know you're not at a stationary point!
 # Have irrep to None if you computed all frequencies, and set it to anything else otherwise 

--- a/tests/cookbook/manual-fd-hess-grad/input.dat
+++ b/tests/cookbook/manual-fd-hess-grad/input.dat
@@ -21,26 +21,45 @@ h2o.update_geometry()
 h2o.reinterpret_coordentry(False)
 h2o.fix_orientation(True)
 
+method = "scf" # Change this line to change the method you compute with.
+
 # Displace the h2o molecule to get all displacements for hessian by gradients.
 # Set -1 to 1 to get A1 frequencies, to 4 for B2...
-displacements = driver_findif.hessian_from_gradient_geometries(h2o, -1)
+findif_meta_dict = driver_findif.hessian_from_gradient_geometries(h2o, -1)
 
-ndisp = len(displacements)
+ndisp = len(findif_meta_dict["displacements"]) + 1
 
 print(" %d displacements needed." % ndisp)
-gradients = []
 
-for n, displacement in enumerate(displacements):
-  banner("Loading displacement %d of %d" % (n+1, ndisp))
-  print("    displacement %d" % (n+1))
+def process_displacement(method, molecule, displacement, n, ndisp, **kwargs):
+    # print progress to file and screen
+    core.print_out('\n')
+    p4util.banner('Loading displacement %d of %d' % (n, ndisp))
+    print(""" %d""" % (n), end=('\n' if (n == ndisp) else ''))
+    sys.stdout.flush()
 
-  get_active_molecule().set_geometry(displacement)
+    # Load in displacement (flat list) into the active molecule
+    geom_array = np.reshape(displacement["geometry"], (-1, 3))
+    molecule.set_geometry(core.Matrix.from_array(geom_array))
 
-  G = gradient('scf')
-  gradients.append(G)
+    # Perform the energy calculation
+    derivative, wfn = gradient(method, return_wfn=True, molecule=molecule, **kwargs)
+    displacement["energy"] = core.get_variable('CURRENT ENERGY')
+    displacement["gradient"] = wfn.gradient().np.ravel().tolist()
+
+    # clean may be necessary when changing irreps of displacements
+    core.clean()
+
+    return wfn
+
+for n, displacement in enumerate(findif_meta_dict["displacements"].values(), start=1):
+    process_displacement(method, h2o, displacement, n, ndisp, write_orbitals=False)
+
+wfn = process_displacement(method, h2o, findif_meta_dict["reference"], ndisp, ndisp)
+
 
 # Compute the hessian of the h2o molecule from the gradients, for all symmetry blocks
-H = driver_findif.compute_hessian_from_gradient(h2o, gradients, -1)
+H = driver_findif.compute_hessian_from_gradient(findif_meta_dict, -1)
 
 wfn = core.Wavefunction.build(h2o, core.get_global_option('BASIS'))
 wfn.set_hessian(core.Matrix.from_array(H))

--- a/tests/cookbook/manual-sow-reap/input.dat
+++ b/tests/cookbook/manual-sow-reap/input.dat
@@ -38,20 +38,23 @@ molecule = psi4.get_active_molecule()
 molecule.update_geometry()
 natom = molecule.natom()
 
-displacements = driver_findif.hessian_from_energy_geometries(molecule, -1)
-
 if sow:
-  ndisp = len(displacements)
+  findif_meta_dict = driver_findif.hessian_from_energy_geometries(molecule, irrep)
+
+  with open("manual_findif.json", "w") as f:
+      import json
+      json.dump(findif_meta_dict, f)
+
+  ndisp = len(findif_meta_dict["displacements"]) + 1
   print(" %d displacements needed." % ndisp)
 
   dispdir = "displacements"
   if not os.path.exists(dispdir):
     os.makedirs(dispdir)
 
-  # Loop over displacements
-  for n, disp in enumerate(displacements):
-
-    nm = str(n) + "-disp.in"
+  def write_disp(label, displacement):
+    geom = displacement["geometry"][:]
+    nm = label + ".in"
     disp_input_file = open(nm, "w")
 
     with open("E-input.dat","r") as E_input_file:
@@ -66,29 +69,36 @@ if sow:
           disp_input_file.write("unit au\n")
           for atom in range(natom):
             sym = molecule.symbol(atom)
-            xval = disp.get(atom,0)
-            yval = disp.get(atom,1)
-            zval = disp.get(atom,2)
+            xval = geom.pop(0)
+            yval = geom.pop(0)
+            zval = geom.pop(0)
       
             l = "{:10s}{:20.15f}{:20.15f}{:20.15f}\n".format(sym, xval, yval, zval)
             disp_input_file.write(l)
         else:                           # copy line as is
-          disp_input_file.write(line);
+          disp_input_file.write(line)
       else:
         disp_input_file.write("\n")     # empty line
-  
+
     # Close the input file and move into the displacements directory..
-    E_input_file.close()
     disp_input_file.close()
     shutil.move(nm, dispdir)
+    return
+
+  # Loop over displacements
+  for label, displacement in findif_meta_dict["displacements"].items():
+      write_disp(label, displacement)
+
+  write_disp("reference", findif_meta_dict["reference"])
+
 
 else: # sow=0, means that we are ready to compute the frequencies, run after energy points
 
-  energies = []
+  with open("manual_findif.json") as f:
+      findif_meta_dict = json.load(f)
 
-  for n, disp in enumerate(displacements):
-
-    disp_output_file = str(n) + "-disp.out"
+  def read_disp(label, displacement):
+    disp_output_file = label + ".out"
 
     with open("displacements/" + disp_output_file, "r") as dispOutput:
       dispOutputLines = dispOutput.readlines()
@@ -98,9 +108,14 @@ else: # sow=0, means that we are ready to compute the frequencies, run after ene
       words = line.split();
       if (len(words) >= 4):  # check for empty lines
         if (words[0] == "FD") and (words[1] == "ENERGY") and (words[2] == "="):
-          energies.append(float(words[3]))
-    
-  H = driver_findif.compute_hessian_from_energy(molecule, energies, -1)
+          displacement["energy"] = float(words[3])
+
+  for label, displacement in findif_meta_dict["displacements"].items():
+      read_disp(label, displacement)
+
+  read_disp("reference", findif_meta_dict["reference"])
+
+  H = driver_findif.compute_hessian_from_energy(findif_meta_dict, irrep)
   wfn = core.Wavefunction.build(molecule, core.get_global_option('BASIS'))
   wfn.set_hessian(core.Matrix.from_array(H))
   vibinfo = vibanal_wfn(wfn, irrep=None, project_trans=project_trans, project_rot=project_rot)

--- a/tests/cookbook/manual-sow-reap/run-psi4-disps.csh
+++ b/tests/cookbook/manual-sow-reap/run-psi4-disps.csh
@@ -1,11 +1,8 @@
 #!/bin/csh
 
-set n = 0
-
 cd displacements
 
-while ($n < 19)
-  psi4 -i $n-disp.in -o $n-disp.out
-  @ n++
+foreach n (*.in)
+   psi4 -i "$n"
 end
 

--- a/tests/cubeprop-esp/input.dat
+++ b/tests/cubeprop-esp/input.dat
@@ -14,8 +14,8 @@ h2o.R = 0.52917721067 / 0.52917720859
 
 set basis cc-pvqz
 set cubeprop_tasks ['esp']
-set e_convergence 9
-set d_convergence 8
+set e_convergence 12
+set d_convergence 12
 
 e, wfn = energy('scf', return_wfn=True)
 cubeprop(wfn)

--- a/tests/cubeprop-frontier/input.dat
+++ b/tests/cubeprop-frontier/input.dat
@@ -23,8 +23,9 @@ set df_scf_guess  false
 set scf_type pk
 set cubeprop_tasks ['frontier_orbitals']
 set cubic_grid_overage [1.0,1.0,1.0]
-set e_convergence 9
-set d_convergence 8
+set e_convergence 12
+set d_convergence 12
+set DOCC [3, 0, 0, 1]
 
 set reference rhf
 scf_e, scf_wfn = energy('scf', return_wfn=True, molecule=ch2s)
@@ -34,6 +35,8 @@ compare_cubes("CH2s_HOMO.cube.ref","Psi_a_4_3-A1_HOMO.cube", "Comparing singlet 
 compare_cubes("CH2s_LUMO.cube.ref","Psi_a_5_1-B1_LUMO.cube", "Comparing singlet LUMO") #TEST
 
 set reference rohf
+set DOCC [2, 0, 0, 1]
+set SOCC [1, 0, 1, 0]
 scf_e, scf_wfn = energy('scf', return_wfn=True, molecule=ch2t)
 cubeprop(scf_wfn)
 

--- a/tests/cubeprop/input.dat
+++ b/tests/cubeprop/input.dat
@@ -13,8 +13,8 @@ set scf_type pk
 set cubeprop_tasks ['orbitals','density','frontier_orbitals','dual_descriptor']
 set cubeprop_orbitals [1,2,3,4,5,6]
 set cubic_grid_overage [1.0,1.0,1.0]
-set e_convergence 9
-set d_convergence 8
+set e_convergence 12
+set d_convergence 12
 
 scf_e, scf_wfn = energy('scf', return_wfn=True)
 cubeprop(scf_wfn)

--- a/tests/fd-freq-energy-large/input.dat
+++ b/tests/fd-freq-energy-large/input.dat
@@ -14,52 +14,29 @@ molecule c4nh4 {
     H         1.274488047821    -0.899961499592    -1.835960153318
 }
 
-#These are the old reference values
-## Test against analytic second derivatives from PSI3 (for now).
-#anal_freqs.set(0, 0,  -184.0613)
-#anal_freqs.set(0, 1,   236.5665)
-#anal_freqs.set(0, 2,   601.8179)
-#anal_freqs.set(0, 3,   663.5969)
-#anal_freqs.set(0, 4,   667.0854)
-#anal_freqs.set(0, 5,   895.5586)
-#anal_freqs.set(0, 6,  1008.6894)
-#anal_freqs.set(0, 7,  1008.9522)
-#anal_freqs.set(0, 8,  1046.9718)
-#anal_freqs.set(0, 9,  1160.1266)
-#anal_freqs.set(0,10,  1161.1594)
-#anal_freqs.set(0,11,  1215.7027)
-#anal_freqs.set(0,12,  1225.2493)
-#anal_freqs.set(0,13,  1600.6695)
-#anal_freqs.set(0,14,  1622.1779)
-#anal_freqs.set(0,15,  1673.4861)
-#anal_freqs.set(0,16,  2239.4185)
-#anal_freqs.set(0,17,  3171.5147)
-#anal_freqs.set(0,18,  3182.4027)
-#anal_freqs.set(0,20,  3244.2997)
-
-#These are the new reference values, they are the finite difference results
+# From analytic hessian, 10/13/18
 list_freqs = [
- -185.3806810,
-  236.6736194,
-  600.8861278,
-  663.7373907,
-  667.1277034,
-  895.6058773,
- 1009.3357983,
-  1008.9476251,
-  1047.0252516,
- 1160.0942687,
-  1161.2390978,
-  1215.7764819,
- 1225.2606141,
-  1600.7766133,
-  1622.1707093,
-  1673.4406189,
-  2239.3784603,
-  3171.4980225,
-  3182.3588200,
- 3224.6209621,
- 3244.2534858]
+-184.0607,
+236.5670,
+601.8184,
+663.5974,
+667.0856,
+895.5593,
+1008.6902,
+1008.9525,
+1046.9721,
+1160.1273,
+1161.1602,
+1215.7034,
+1225.2500,
+1600.6701,
+1622.1788,
+1673.4867,
+2239.4190,
+3171.5156,
+3182.4036,
+3224.7643,
+3244.3007]
 
 ref_freqs = psi4.Vector.from_list(list_freqs)
 a1_freqs = psi4.Vector.from_list([list_freqs[i] for i in [4, 7, 10, 13, 15, 16, 18]])
@@ -72,137 +49,46 @@ set {
   basis dz
   d_convergence 11
   points 3
+  scf_type pk
 }
 
 set findif {print 3}
 
-scf_e, scf_wfn = frequencies('scf',dertype=0,irrep=2, return_wfn=True)
+scf_e, scf_wfn = frequencies('scf', irrep=1, dertype=0,  return_wfn=True)
 fd_freqs = scf_wfn.frequencies()
 clean()
 
-compare_vectors(a2_freqs, fd_freqs, 0, "Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
+compare_vectors(a1_freqs, fd_freqs, 0, "A1 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
 del fd_freqs
 
-# *** Test frequencies by 5-pt formula for A1 irrep only.
-molecule c4nh4 {
-  units angstrom
-  -1 1
-    C         0.000000000000     0.000000000000     1.119905811674
-    N         0.000000000000     0.000000000000     2.310087277449
-    C         0.000000000000     0.000000000000    -0.231085072523
-    C        -0.781617287494     0.000000000000    -1.483869398827
-    C         0.781617287494     0.000000000000    -1.483869398827
-    H        -1.274488047821    -0.899961499592    -1.835960153318
-    H        -1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821    -0.899961499592    -1.835960153318
-}
-
-set {
- basis dz
- points 5
- d_convergence 11    # necessary for guaranteeing accuracy down to 0.001 cm^-1
- disp_size 0.010
-}
-
-scf_e, scf_wfn = frequencies('scf', irrep=1, return_wfn=True)
+scf_e, scf_wfn = frequencies('scf', irrep=2, dertype=0,  return_wfn=True)
 fd_freqs = scf_wfn.frequencies()
 clean()
 
-compare_vectors(a1_freqs, fd_freqs, 0, "A1 finite-diffence frequencies with 5-pt. formula to 1 cm^-1")  #TEST
+compare_vectors(a2_freqs, fd_freqs, 0, "A2 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
 del fd_freqs
 
-# *** Test frequencies by 3-pt formula for A2 irrep only.
-molecule c4nh4 {
-  units angstrom
-  -1 1
-    C         0.000000000000     0.000000000000     1.119905811674
-    N         0.000000000000     0.000000000000     2.310087277449
-    C         0.000000000000     0.000000000000    -0.231085072523
-    C        -0.781617287494     0.000000000000    -1.483869398827
-    C         0.781617287494     0.000000000000    -1.483869398827
-    H        -1.274488047821    -0.899961499592    -1.835960153318
-    H        -1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821    -0.899961499592    -1.835960153318
-}
-
-set {
- basis dz
- points 5
- d_convergence 11    # necessary for guaranteeing accuracy down to 0.001 cm^-1
- disp_size 0.010
-}
-
-scf_e, scf_wfn = frequencies('scf', irrep=2, return_wfn=True)
+scf_e, scf_wfn = frequencies('scf', irrep=3, dertype=0,  return_wfn=True)
 fd_freqs = scf_wfn.frequencies()
 clean()
 
-compare_vectors(a2_freqs, fd_freqs, 0, "A2 finite-diffence frequencies with 5-pt. formula to 1 cm^-1")  #TEST
+compare_vectors(b1_freqs, fd_freqs, 0, "B1 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
 del fd_freqs
 
 
-# *** Test frequencies by 3-pt formula for B1 irrep only.
-molecule c4nh4 {
-  units angstrom
-  -1 1
-    C         0.000000000000     0.000000000000     1.119905811674
-    N         0.000000000000     0.000000000000     2.310087277449
-    C         0.000000000000     0.000000000000    -0.231085072523
-    C        -0.781617287494     0.000000000000    -1.483869398827
-    C         0.781617287494     0.000000000000    -1.483869398827
-    H        -1.274488047821    -0.899961499592    -1.835960153318
-    H        -1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821    -0.899961499592    -1.835960153318
-}
-
-set {
- basis dz
- points 5
- d_convergence 11    # necessary for guaranteeing accuracy down to 0.001 cm^-1
- disp_size 0.010
-}
-
-scf_e, scf_wfn = frequencies('scf', irrep=3, return_wfn=True)
+scf_e, scf_wfn = frequencies('scf', irrep=4, dertype=0,  return_wfn=True)
 fd_freqs = scf_wfn.frequencies()
 clean()
 
-compare_vectors(b1_freqs, fd_freqs, 0, "B1 finite-diffence frequencies with 5-pt. formula to 1 cm^-1")  #TEST
+compare_vectors(b2_freqs, fd_freqs, 0, "B2 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
 del fd_freqs
 
+set findif {points 5}
 
-# *** Test frequencies by 3-pt formula for B2 irrep only.
-molecule c4nh4 {
-  units angstrom
-  -1 1
-    C         0.000000000000     0.000000000000     1.119905811674
-    N         0.000000000000     0.000000000000     2.310087277449
-    C         0.000000000000     0.000000000000    -0.231085072523
-    C        -0.781617287494     0.000000000000    -1.483869398827
-    C         0.781617287494     0.000000000000    -1.483869398827
-    H        -1.274488047821    -0.899961499592    -1.835960153318
-    H        -1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821     0.899961499592    -1.835960153318
-    H         1.274488047821    -0.899961499592    -1.835960153318
-}
-
-set {
- basis dz
- points 5
- d_convergence 11    # necessary for guaranteeing accuracy down to 0.001 cm^-1
- disp_size 0.010
-}
-
-scf_e, scf_wfn = frequencies('scf', irrep=4, return_wfn=True)
+scf_e, scf_wfn = frequencies('scf', irrep=1, dertype=0, return_wfn=True)
 fd_freqs = scf_wfn.frequencies()
+clean()
 
-compare_vectors(b2_freqs, fd_freqs, 0, "B2 finite-diffence frequencies with 5-pt. formula to 1 cm^-1")  #TEST
+compare_vectors(a1_freqs, fd_freqs, 0, "A1 Finite-difference frequencies with 5-pt. formula to 1 cm^-1")  #TEST
 del fd_freqs
-
-del a1_freqs
-del a2_freqs
-del b1_freqs
-del b2_freqs
-del ref_freqs
 

--- a/tests/fd-freq-gradient-large/input.dat
+++ b/tests/fd-freq-gradient-large/input.dat
@@ -1,4 +1,4 @@
-#! SCF DZ finite difference frequencies by energies for C4NH4
+#! SCF DZ finite difference frequencies by gradients for C4NH4
 
 molecule c4nh4 {
   units angstrom
@@ -14,67 +14,82 @@ molecule c4nh4 {
     H         1.274488047821    -0.899961499592    -1.835960153318
 }
 
+# From analytic hessian, 10/13/18
 list_freqs = [
--184.0613, #TEST
- 236.5665, #TEST
- 601.8179, #TEST
- 663.5969, #TEST
- 667.0854, #TEST
- 895.5586, #TEST
-1008.6894, #TEST
-1008.9522, #TEST
-1046.9718, #TEST
-1160.1266, #TEST
-1161.1594, #TEST
-1215.7027, #TEST
-1225.2493, #TEST
-1600.6695, #TEST
-1622.1779, #TEST
-1673.4861, #TEST
-2239.4185, #TEST
-3171.5147, #TEST
-3182.4027, #TEST
-3224.7634, #TEST
-3244.2997] #TEST
+-184.0607,
+236.5670,
+601.8184,
+663.5974,
+667.0856,
+895.5593,
+1008.6902,
+1008.9525,
+1046.9721,
+1160.1273,
+1161.1602,
+1215.7034,
+1225.2500,
+1600.6701,
+1622.1788,
+1673.4867,
+2239.4190,
+3171.5156,
+3182.4036,
+3224.7643,
+3244.3007]
 
-anal_freqs = psi4.Vector.from_list(list_freqs)
+ref_freqs = psi4.Vector.from_list(list_freqs)
 a1_freqs = psi4.Vector.from_list([list_freqs[i] for i in [4, 7, 10, 13, 15, 16, 18]])
 a2_freqs = psi4.Vector.from_list([list_freqs[i] for i in [6, 12, 19]])
 b1_freqs = psi4.Vector.from_list([list_freqs[i] for i in [1, 3, 8, 11, 14, 17]])
 b2_freqs = psi4.Vector.from_list([list_freqs[i] for i in [0, 2, 5, 9, 20]])
 
-
-# Compute all frequencies by 3-pt formula.
+# *** Test all frequencies by 3-pt formula.
 set {
   basis dz
   d_convergence 11
+  points 3
   scf_type pk
 }
 
-scf_e, scf_wfn = frequencies('scf', dertype=1, return_wfn=True)
-fd_freqs = scf_wfn.frequencies() #TEST
+set findif {print 3}
 
-compare_vectors(anal_freqs, fd_freqs, 1, "C4NH4 frequencies by gradients (3-pt.) to 0.1 cm^-1") #TEST
-del fd_freqs #TEST
-
-# Compute A2 frequencies by 5-pt formula.
-set findif {
- points 5
- disp_size 0.01
-}
-
-scf_e, scf_wfn = frequencies('scf', dertype=1, irrep=2, return_wfn=True)
-fd_freqs = scf_wfn.frequencies() #TEST
-
-compare_vectors(a2_freqs, fd_freqs, 3, "C4NH4 frequencies (A2) by gradients (5-pt.) to 0.001 cm^-1") #TEST
-del fd_freqs #TEST
-
-# Compute B2 frequencies by 5-pt formula.
-
-scf_e, scf_wfn = frequencies('scf', dertype=1, irrep=4, return_wfn=True)
-fd_freqs = scf_wfn.frequencies() #TEST
-
-compare_vectors(b2_freqs, fd_freqs, 3, "C4NH4 frequencies (B2) by gradients (5-pt.) to 0.001 cm^-1") #TEST
-del fd_freqs #TEST
-
+scf_e, scf_wfn = frequencies('scf', irrep=1, dertype=1,  return_wfn=True)
+fd_freqs = scf_wfn.frequencies()
 clean()
+
+compare_vectors(a1_freqs, fd_freqs, 0, "A1 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
+del fd_freqs
+
+scf_e, scf_wfn = frequencies('scf', irrep=2, dertype=1,  return_wfn=True)
+fd_freqs = scf_wfn.frequencies()
+clean()
+
+compare_vectors(a2_freqs, fd_freqs, 0, "A2 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
+del fd_freqs
+
+scf_e, scf_wfn = frequencies('scf', irrep=3, dertype=1,  return_wfn=True)
+fd_freqs = scf_wfn.frequencies()
+clean()
+
+compare_vectors(b1_freqs, fd_freqs, 0, "B1 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
+del fd_freqs
+
+
+scf_e, scf_wfn = frequencies('scf', irrep=4, dertype=1,  return_wfn=True)
+fd_freqs = scf_wfn.frequencies()
+clean()
+
+compare_vectors(b2_freqs, fd_freqs, 0, "B2 Finite-difference frequencies with 3-pt. formula to 1 cm^-1")  #TEST
+del fd_freqs
+
+set findif {points 5}
+
+scf_e, scf_wfn = frequencies('scf', irrep=1, dertype=1, return_wfn=True)
+fd_freqs = scf_wfn.frequencies()
+clean()
+
+compare_vectors(a1_freqs, fd_freqs, 0, "A1 Finite-difference frequencies with 5-pt. formula to 1 cm^-1")  #TEST
+del fd_freqs
+
+

--- a/tests/json/schema-1-properties/input.py
+++ b/tests/json/schema-1-properties/input.py
@@ -43,7 +43,8 @@ json_data = {
     ]
   },
   "keywords": {"scf_type": "df",
-               "mp2_type": "df"}
+               "mp2_type": "df",
+               "e_convergence": 9}
 }
 
 # Write expected output

--- a/tests/opt-full-hess-every/CMakeLists.txt
+++ b/tests/opt-full-hess-every/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(opt1 "psi;quicktests;opt")
+add_regression_test(opt-full-hess-every "psi;quicktests;opt")

--- a/tests/x2c1/input.dat
+++ b/tests/x2c1/input.dat
@@ -76,8 +76,8 @@ set basis_relativistic adecon  # shouldn't need to specify
 ccsd_rel_energy = energy('ccsd')
 scf_rel_energy = psi4.get_variable("HF TOTAL ENERGY")
 
-compare_values(ref_nuc_energy, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
-compare_values(scf_ref_nr_energy, scf_nr_energy, 9, "Non-relativistic SCF energy")            #TEST
-compare_values(ccsd_ref_nr_energy, ccsd_nr_energy, 9, "Non-relativistic CCSD energy")         #TEST
-compare_values(scf_ref_rel_energy, scf_rel_energy, 9, "X2C relativistic SCF energy")          #TEST
-compare_values(ccsd_ref_rel_energy, ccsd_rel_energy, 9, "X2C relativistic CCSD energy")       #TEST
+compare_values(ref_nuc_energy, h2o.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy") #TEST
+compare_values(scf_ref_nr_energy, scf_nr_energy, 8, "Non-relativistic SCF energy")            #TEST
+compare_values(ccsd_ref_nr_energy, ccsd_nr_energy, 8, "Non-relativistic CCSD energy")         #TEST
+compare_values(scf_ref_rel_energy, scf_rel_energy, 8, "X2C relativistic SCF energy")          #TEST
+compare_values(ccsd_ref_rel_energy, ccsd_rel_energy, 8, "X2C relativistic CCSD energy")       #TEST


### PR DESCRIPTION
## Description
Change of FINDIF to be metadata based per #1148, task one, and qcdb molecule compatibility per #1148, task two.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change finite difference code to use metadata.
- [x] Fixes bugs #1296 and #1306.
- [x] Reap/Sow code removed.

## Questions
- [x] How should I document that a functions takes as an argument or returns the metadata dictionary? That needs to be specified somewhere.
- [x] Are we all agreed on the metadata style? The things I've left undone are going to depend heavily on any additional metadata changes.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
- [x] Implement the changes to all four finite difference functions: empirical dispersion, hessian by gradients, hessian by energies, gradient by energies.
- [x] Polish the resulting code. In particular, there are a few variables taken from the initialization `data` that should probably be taken from `metadict` instead. For the compute functions, it should only need the barest skeleton of the current initialization call. Depending on other revisions, I may want to create a separate initialization function for the compute functions.
- [x] Modify the reap/sow cookbooks to work.
- [x] Make this compatible with QCDB molecules. To do this _correctly_, we need CdSalc tech reproduced in QCDB. Better to just coerce the QCDB molecule for now.
- [x] Remove the optimization side reap/sow code.

## Status
- [x] Ready for review
- [x] Ready for merge.