### PR TITLE
Update timer.cc

### DIFF
--- a/psi4/src/psi4/libqt/timer.cc
+++ b/psi4/src/psi4/libqt/timer.cc
@@ -1021,17 +1021,21 @@ void timer_done(void) {
     printer->Printf("Timers Off: %s", ctime(&timer_end));
     printer->Printf("\nWall Time:  %10.2f seconds\n\n",
                     std::chrono::duration_cast<std::chrono::duration<double>>(root_timer.get_total_wtime()).count());
+    printer->Printf("                                                       Time (seconds)\n");
+    printer->Printf("Module                               %12s%12s%12s%13s\n",
+                    "User", "System", "Wall", "Calls");
+
 
     const std::list<Timer_Structure> timer_list = root_timer.summarize();
     for (auto timer_iter = timer_list.begin(), end_iter = timer_list.end(); timer_iter != end_iter; ++timer_iter) {
         print_timer(*timer_iter, printer, 36);
     }
 
-    printer->Printf("\n-----------------------------------------------------------\n");
+    printer->Printf("\n--------------------------------------------------------------------------------------\n");
 
     print_nested_timer(root_timer, printer, "");
 
-    printer->Printf("\n***********************************************************\n");
+    printer->Printf("\n**************************************************************************************\n");
 
     omp_unset_lock(&lock_timer);
     omp_destroy_lock(&lock_timer);


### PR DESCRIPTION
Addresses http://forum.psicode.org/t/timer-dat-output-detailed/1104

Header looks like:
```
Host: ds1.sherrill.chemistry.gatech.edu

Timers On : Tue Oct 16 11:14:57 2018
Timers Off: Tue Oct 16 11:15:00 2018

Wall Time:        3.04 seconds

                                                       Time (seconds)
Module                                       User      System        Wall        Calls
Total PK formation time             :      0.850u      0.033s      0.526w      1 calls
```