### PR TITLE
Fix #1298, full_hess_every taking hessians at the starting geometry.

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1151,7 +1151,7 @@ def optimize(name, **kwargs):
             G = core.get_gradient()  # TODO
             core.IOManager.shared_object().set_specific_retention(1, True)
             core.IOManager.shared_object().set_specific_path(1, './')
-            frequencies(hessian_with_method, **kwargs)
+            frequencies(hessian_with_method, molecule=moleculeclone, **kwargs)
             steps_since_last_hessian = 0
             core.set_gradient(G)
             core.set_global_option('CART_HESS_READ', True)

--- a/tests/opt-full-hess-every/CMakeLists.txt
+++ b/tests/opt-full-hess-every/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(opt1 "psi;quicktests;opt")

--- a/tests/opt-full-hess-every/input.dat
+++ b/tests/opt-full-hess-every/input.dat
@@ -1,0 +1,20 @@
+# SCF/sto-3g optimization with a hessian every step
+
+molecule h2o {
+     O
+     H 1 1.0
+     H 1 1.0 2 104.5
+}
+
+set {
+  basis sto-3g
+  e_convergence 10
+  d_convergence 10
+  geom_maxiter 5
+  full_hess_every 1
+  g_convergence gau_verytight
+}
+
+opt_energy = optimize('scf')
+
+compare_values(opt_energy, -74.965990122534, 6, "SCF Optimized energy") #TEST


### PR DESCRIPTION
## Description
Fixes and closes #1298. `full_hess_every` now takes hessians at the latest geometry rather than the reference geometry.

Because this bug was not caught by the test suite, I've added a test to catch this bug, and it clocks in at just over 6 seconds on my Mac.

## Checklist
- [x] Tests added for newly working features

## Status
- [x] Ready for review
- [x] Ready for merge
