### PR TITLE
Fix proposal for issue 1284 (SCF printing)

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -507,7 +507,7 @@ void py_psi_clean_options() {
     Process::environment.options.set_read_globals(false);
 }
 
-void py_psi_print_out(std::string s) { (*outfile->stream()) << s; }
+void py_psi_print_out(std::string s) { (*outfile->stream()) << s << std::flush; }
 
 /**
  * @return whether key describes a convergence threshold or not


### PR DESCRIPTION
## Description
fixes #1284 by forcing flush in `core.print_out`. Similar to what is done in `PsiOutStream.cc` is already.
Perhaps @PeterKraus can test it, as he was the only one confirming the issue.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
