### PR TITLE
Serialize Wavefunction 

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -208,7 +208,7 @@ def pywrite_wavefunction(wfn, filename=None):
             'Fa'       : wfn.Fa().to_array()       if wfn.Fa()       else None,
             'Fb'       : wfn.Fb().to_array()       if wfn.Fb()       else None,
             'H'        : wfn.H().to_array()        if wfn.H()        else None,
-            'S'        : wfn.S().to_array()        if wfn.Ca()       else None,
+            'S'        : wfn.S().to_array()        if wfn.S()       else None,
             'X'        : wfn.X().to_array()        if wfn.X()        else None,
             'aotoso'   : wfn.aotoso().to_array()   if wfn.aotoso()   else None,
             'gradient' : wfn.gradient().to_array() if wfn.gradient() else None,

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -155,8 +155,6 @@ def pyread_wavefunction(filename):
     # change some variables to psi4 specific data types (Matrix, Vector, Dimension)
     for label in wfn_matrix:
         array = wfn_matrix[label]
-        #core.print_out(label + '\n')
-        #core.print_out(str(type(array))+'\n')
         wfn_matrix[label] = core.Matrix.from_array(array,name=label) if array is not None else None
     
     for label in wfn_vector:
@@ -245,7 +243,10 @@ def pywrite_wavefunction(wfn, filename):
             },
         'float' : {
             'energy' : wfn.energy(),
-            'efzc' : wfn.efzc()
+            'efzc' : wfn.efzc(),
+            'dipole_field_x' : wfn.get_dipole_field_strength()[0],
+            'dipole_field_y' : wfn.get_dipole_field_strength()[1],
+            'dipole_field_z' : wfn.get_dipole_field_strength()[2]
             },
         'floatvar' : wfn.variables(),
         'matrixarr' : {k: v.to_array() for k, v in wfn.arrays().items()}

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -421,7 +421,7 @@ def compare_wavefunctions(expected, computed, label):
     compare_integers(expected.nmo(), computed.nmo(), 'compare nmo') 
     compare_integers(expected.nso(), computed.nso(), 'compare nso') 
     compare_strings(expected.name(), computed.name(), 'compare name') 
-    compare_values(expected.energy(), computed.energy(), 5, 'compare energy') 
+    compare_values(expected.energy(), computed.energy(), 9, 'compare energy') 
     compare_values(expected.efzc(), computed.efzc(), 9, 'compare frozen core energy') 
     compare_values(expected.get_dipole_field_strength()[0], computed.get_dipole_field_strength()[0], 9, 'compare dipole field strength x') 
     compare_values(expected.get_dipole_field_strength()[1], computed.get_dipole_field_strength()[1], 9, 'compare dipole field strength y') 

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -392,6 +392,52 @@ def compare_cubes(expected, computed, label):
     success(label)
     return True
 
+
+def compare_wavefunctions(expected, computed, label):
+    """Function to compare two wavefunctions. Prints :py:func:`util.success`
+    when value *computed* matches value *expected*.
+    Performs a system exit on failure. Used in input files in the test suite.
+
+    """
+    if expected.Ca():       compare_matrices(expected.Ca(), computed.Ca(), 9, 'compare Ca') 
+    if expected.Cb():       compare_matrices(expected.Cb(), computed.Cb(), 9, 'compare Cb') 
+    if expected.Da():       compare_matrices(expected.Da(), computed.Da(), 9, 'compare Da') 
+    if expected.Db():       compare_matrices(expected.Db(), computed.Db(), 9, 'compare Db') 
+    if expected.Fa():       compare_matrices(expected.Fa(), computed.Fa(), 9, 'compare Fa') 
+    if expected.Fb():       compare_matrices(expected.Fb(), computed.Fb(), 9, 'compare Fb') 
+    if expected.H():        compare_matrices(expected.H(), computed.H(), 9, 'compare H') 
+    if expected.S():        compare_matrices(expected.S(), computed.S(), 9, 'compare S') 
+    if expected.X():        compare_matrices(expected.X(), computed.X(), 9, 'compare X') 
+    if expected.aotoso():   compare_matrices(expected.aotoso(), computed.aotoso(), 9, 'compare aotoso')
+    if expected.gradient(): compare_matrices(expected.gradient(), computed.gradient(), 9, 'compare gradient')
+    if expected.hessian():  compare_matrices(expected.hessian(), computed.hessian(), 9, 'compare hessian')
+    if expected.epsilon_a():   compare_vectors(expected.epsilon_a(), computed.epsilon_a(), 5, 'compare epsilon_a')
+    if expected.epsilon_b():   compare_vectors(expected.epsilon_b(), computed.epsilon_b(), 5, 'compare epsilon_b')
+    if expected.frequencies(): compare_vectors(expected.frequencies(), computed.frequencies(), 5, 'compare frequencies')
+    compare_integers(expected.nalpha(), computed.nalpha(), 'compare nalpha') 
+    compare_integers(expected.nbeta(), computed.nbeta(), 'compare nbeta') 
+    compare_integers(expected.nfrzc(), computed.nfrzc(), 'compare nfrzc') 
+    compare_integers(expected.nirrep(), computed.nirrep(), 'compare nirrep') 
+    compare_integers(expected.nmo(), computed.nmo(), 'compare nmo') 
+    compare_integers(expected.nso(), computed.nso(), 'compare nso') 
+    compare_strings(expected.name(), computed.name(), 'compare name') 
+    compare_values(expected.energy(), computed.energy(), 5, 'compare energy') 
+    compare_values(expected.efzc(), computed.efzc(), 9, 'compare frozen core energy') 
+    compare_values(expected.get_dipole_field_strength()[0], computed.get_dipole_field_strength()[0], 9, 'compare dipole field strength x') 
+    compare_values(expected.get_dipole_field_strength()[1], computed.get_dipole_field_strength()[1], 9, 'compare dipole field strength y') 
+    compare_values(expected.get_dipole_field_strength()[2], computed.get_dipole_field_strength()[2], 9, 'compare dipole field strength z') 
+    
+    compare_strings(expected.basisset().name(), computed.basisset().name(), 'compare basis set name') 
+    compare_integers(expected.basisset().nbf(), computed.basisset().nbf(), 'compare number of basis functions in set') 
+    compare_integers(expected.basisset().nprimitive(), computed.basisset().nprimitive(), 'compare total number of primitives in basis set') 
+    
+    compare_strings(expected.molecule().name(), computed.molecule().name(), 'compare molecule name')
+    compare_strings(expected.molecule().get_full_point_group(), computed.molecule().get_full_point_group(), 'compare molecule point group')
+    compare_matrices(expected.molecule().geometry(), computed.molecule().geometry(), 9, 'compare molecule geometry')
+
+    success(label)
+    return True
+
 # Uncomment and use if compare_arrays above is inadequate
 #def compare_lists(expected, computed, digits, label):
 #    """Function to compare two Python lists. Prints :py:func:`util.success`

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -95,6 +95,7 @@ void export_wavefunction(py::module& m) {
         .def("nso", &Wavefunction::nso, "Number of symmetry orbitals.")
         .def("nmo", &Wavefunction::nmo, "Number of molecule orbitals.")
         .def("nirrep", &Wavefunction::nirrep, "Number of irreps in the system.")
+        .def("efzc", &Wavefunction::efzc, "Returns the frozen-core energy")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership,
@@ -147,6 +148,7 @@ void export_wavefunction(py::module& m) {
         .def("molecule", &Wavefunction::molecule, "Returns the Wavefunction's molecule.")
         .def("doccpi", &Wavefunction::doccpi, py::return_value_policy::copy,
              "Returns the number of doubly occupied orbitals per irrep.")
+        .def("density_fitted", &Wavefunction::density_fitted, "Returns whether this wavefunction was obtained using density fitting or not.")
         .def("force_doccpi", &Wavefunction::force_doccpi, "Specialized expert use only. Sets the number of doubly occupied oribtals per irrep. Note that this results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy,
              "Returns the number of singly occupied orbitals per irrep.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -31,6 +31,7 @@
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/matrix.h"
+#include "psi4/libmints/dimension.h"
 #include "psi4/libmints/oeprop.h"
 #include "psi4/libmints/orbitalspace.h"
 #include "psi4/libmints/extern.h"
@@ -73,6 +74,10 @@ void export_wavefunction(py::module& m) {
     py::class_<Wavefunction, std::shared_ptr<Wavefunction>>(m, "Wavefunction", "docstring", py::dynamic_attr())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, Options&>())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>>())
+        .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, std::map<std::string, std::shared_ptr<Matrix>>,
+                      std::map<std::string, std::shared_ptr<Vector>>, std::map<std::string, Dimension>,
+                      std::map<std::string, int>, std::map<std::string, std::string>, std::map<std::string, bool>,
+                      std::map<std::string, float>>())
         .def("reference_wavefunction", &Wavefunction::reference_wavefunction, "Returns the reference wavefunction.")
         .def("set_reference_wavefunction", &Wavefunction::set_reference_wavefunction, "docstring")
         .def("shallow_copy", take_sharedwfn(&Wavefunction::shallow_copy), "Copies the pointers to the internal data.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -77,7 +77,7 @@ void export_wavefunction(py::module& m) {
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, std::map<std::string, std::shared_ptr<Matrix>>,
                       std::map<std::string, std::shared_ptr<Vector>>, std::map<std::string, Dimension>,
                       std::map<std::string, int>, std::map<std::string, std::string>, std::map<std::string, bool>,
-                      std::map<std::string, float>>())
+                      std::map<std::string, double>>())
         .def("reference_wavefunction", &Wavefunction::reference_wavefunction, "Returns the reference wavefunction.")
         .def("set_reference_wavefunction", &Wavefunction::set_reference_wavefunction, "docstring")
         .def("shallow_copy", take_sharedwfn(&Wavefunction::shallow_copy), "Copies the pointers to the internal data.")

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -158,15 +158,14 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     PCM_enabled_ = booleans["PCM_enabled"];
     same_a_b_dens_ = booleans["same_a_b_dens"];
     same_a_b_orbs_ = booleans["same_a_b_orbs"];
-    density_fitted_ = booleans["density fitted"];
+    density_fitted_ = booleans["density_fitted"];
 
     // set floats
     energy_ = floats["energy"];
     efzc_ = floats["efzc"];
-    
-    // set PCM??
-    // dipole field strength??
-
+    dipole_field_strength_[0] = floats["dipole_field_x"];
+    dipole_field_strength_[1] = floats["dipole_field_y"];
+    dipole_field_strength_[2] = floats["dipole_field_z"];
 }
 
 Wavefunction::Wavefunction(Options &options)

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -92,6 +92,72 @@ Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &o
     set_reference_wavefunction(reference_wavefunction);
 }
 
+Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, 
+                           std::map<std::string, std::shared_ptr<Matrix>> matrices,
+                           std::map<std::string, std::shared_ptr<Vector>> vectors,
+                           std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints, 
+                           std::map<std::string, std::string> strings, std::map<std::string, bool> booleans, 
+                           std::map<std::string, float> floats)
+    : options_(Process::environment.options),
+      molecule_(molecule) {
+
+    //TODO: get basis set working
+    //basisset_ = basisset;
+    
+    // set matrices
+    Ca_ = matrices["Ca"];
+    Cb_ = matrices["Cb"];
+    Da_ = matrices["Da"];
+    Db_ = matrices["Db"];
+    Fa_ = matrices["Fa"];
+    Fb_ = matrices["Fb"];
+    H_ = matrices["H"];
+    S_ = matrices["S"];
+    Lagrangian_ = matrices["X"];
+    AO2SO_ = matrices["aotoso"];
+    gradient_ = matrices["gradient"];
+    hessian_ = matrices["hessian"];
+
+    // set vectors
+    epsilon_a_ = vectors["epsilon_a"];
+    epsilon_b_ = vectors["epsilon_b"];
+    frequencies_ = vectors["frequencies"];
+
+    // set dimensions
+    doccpi_ = dimensions["doccpi"];
+    soccpi_ = dimensions["soccpi"];
+    frzcpi_ = dimensions["frzcpi"];
+    frzvpi_ = dimensions["frzvpi"];
+    nalphapi_ = dimensions["nalphapi"];
+    nbetapi_ = dimensions["nbetapi"];
+    nmopi_ = dimensions["nmopi"];
+    nsopi_ = dimensions["nsopi"];
+     
+    // set integers
+    nalpha_ = ints["nalpha"];
+    nbeta_ = ints["nbeta"];
+    nfrzc_ = ints["nfrzc"];
+    nirrep_ = ints["nirrep"];
+    nmo_ = ints["nmo"];
+    nso_ = ints["nso"];
+    
+    // set strings
+    name_ = strings["name"];
+
+    // set booleans
+    PCM_enabled_ = booleans["PCM_enabled"];
+    same_a_b_dens_ = booleans["same_a_b_dens"];
+    same_a_b_orbs_ = booleans["same_a_b_orbs"];
+    //density fitted??
+
+    // set floats
+    energy_ = floats["energy"];
+    efzc_ = floats["efzc"];
+    
+    // set PCM??
+
+}
+
 Wavefunction::Wavefunction(Options &options)
     : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {}
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -99,11 +99,9 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
                            std::map<std::string, std::string> strings, std::map<std::string, bool> booleans, 
                            std::map<std::string, float> floats)
     : options_(Process::environment.options),
+      basisset_(basisset),
       molecule_(molecule) {
 
-    //TODO: get basis set working
-    //basisset_ = basisset;
-    
     // set matrices
     Ca_ = matrices["Ca"];
     Cb_ = matrices["Cb"];
@@ -155,6 +153,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     efzc_ = floats["efzc"];
     
     // set PCM??
+    // dipole field strength??
 
 }
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -93,12 +93,12 @@ Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &o
 }
 
 // TODO: pass Options object to constructor instead of relying on globals
-Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, 
+Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basisset, 
                            std::map<std::string, std::shared_ptr<Matrix>> matrices,
                            std::map<std::string, std::shared_ptr<Vector>> vectors,
                            std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints, 
                            std::map<std::string, std::string> strings, std::map<std::string, bool> booleans, 
-                           std::map<std::string, float> floats)
+                           std::map<std::string, double> floats)
     : options_(Process::environment.options),
       basisset_(basisset),
       molecule_(molecule) {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -92,6 +92,7 @@ Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &o
     set_reference_wavefunction(reference_wavefunction);
 }
 
+// TODO: pass Options object to constructor instead of relying on globals
 Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, 
                            std::map<std::string, std::shared_ptr<Matrix>> matrices,
                            std::map<std::string, std::shared_ptr<Vector>> vectors,
@@ -101,6 +102,16 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     : options_(Process::environment.options),
       basisset_(basisset),
       molecule_(molecule) {
+
+
+    // Check the point group of the molecule. If it is not set, set it.
+    if (!molecule_->point_group()) {
+        molecule_->set_point_group(molecule_->find_point_group());
+    }
+
+    // Create an SO basis...we need the point group for this part.
+    integral_ = std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
+    sobasisset_ = std::make_shared<SOBasisSet>(basisset_, integral_);
 
     // set matrices
     Ca_ = matrices["Ca"];
@@ -138,6 +149,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     nirrep_ = ints["nirrep"];
     nmo_ = ints["nmo"];
     nso_ = ints["nso"];
+    print_ = ints["print"];
     
     // set strings
     name_ = strings["name"];
@@ -146,7 +158,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     PCM_enabled_ = booleans["PCM_enabled"];
     same_a_b_dens_ = booleans["same_a_b_dens"];
     same_a_b_orbs_ = booleans["same_a_b_orbs"];
-    //density fitted??
+    density_fitted_ = booleans["density fitted"];
 
     // set floats
     energy_ = floats["energy"];

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -256,12 +256,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis);
 
     /// Constructor for a wavefunction deserialized from a file and initialized in the form of maps to all member variables
-    Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basisset, 
+    Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basisset, 
                                std::map<std::string, std::shared_ptr<Matrix>> matrices,
                                std::map<std::string, std::shared_ptr<Vector>> vectors,
                                std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints, 
                                std::map<std::string, std::string> strings, std::map<std::string, bool> booleans, 
-                               std::map<std::string, float> floats);
+                               std::map<std::string, double> floats);
 
     /// Blank constructor for derived classes
     Wavefunction(SharedWavefunction reference_wavefunction, Options& options);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -255,6 +255,14 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Constructor for an entirely new wavefunction with an existing basis and global options
     Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis);
 
+    /// Constructor for a wavefunction deserialized from a file and initialized in the form of maps to all member variables
+    Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, 
+                               std::map<std::string, std::shared_ptr<Matrix>> matrices,
+                               std::map<std::string, std::shared_ptr<Vector>> vectors,
+                               std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints, 
+                               std::map<std::string, std::string> strings, std::map<std::string, bool> booleans, 
+                               std::map<std::string, float> floats);
+
     /// Blank constructor for derived classes
     Wavefunction(SharedWavefunction reference_wavefunction, Options& options);
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -256,7 +256,7 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis);
 
     /// Constructor for a wavefunction deserialized from a file and initialized in the form of maps to all member variables
-    Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, 
+    Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basisset, 
                                std::map<std::string, std::shared_ptr<Matrix>> matrices,
                                std::map<std::string, std::shared_ptr<Vector>> vectors,
                                std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints, 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,7 +88,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-molecule pywrap-opt-sowreap rasci-c2-active rasci-h2o
                   rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
                   sapt7 sapt8 scf-bz2 scf-ecp scf-guess-read1 scf-upcast-custom-basis scf-guess-read2 scf-bs scf1 scf-occ
-                  scf2 scf3 scf4 scf5 scf6 scf7 scf-property soscf-large soscf-ref
+                  scf2 scf3 scf4 scf5 scf6 scf7 scf-property serial-wfn soscf-large soscf-ref
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare sapt-sf1 dft-custom dft-reference
                   stability2 tu1-h2o-energy tu2-ch2-energy tu3-h2o-opt scf-response1
                   tu4-h2o-freq tu5-sapt tu6-cp-ne2 x2c1 x2c2 x2c3 zaptn-nh2

--- a/tests/serial-wfn/CMakeLists.txt
+++ b/tests/serial-wfn/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(serial-wfn "psi;quicktests;scf")

--- a/tests/serial-wfn/input.dat
+++ b/tests/serial-wfn/input.dat
@@ -15,7 +15,7 @@ set {
 }
 
 # get wavefunction
-e, wfn_old = energy('mp2', return_wfn=True)
+e, wfn_old = energy('hf', return_wfn=True)
 
 # write to wavefunction to ile
 Wavefunction.to_file(wfn_old, 'my_wfn')
@@ -23,25 +23,7 @@ Wavefunction.to_file(wfn_old, 'my_wfn')
 # read wavefunction from file
 wfn_new = Wavefunction.from_file('my_wfn')
 
-if wfn_old.Ca():     compare_matrices(wfn_old.Ca(), wfn_new.Ca(), 9, 'compare Ca') #TEST
-if wfn_old.Cb():     compare_matrices(wfn_old.Cb(), wfn_new.Cb(), 9, 'compare Cb') #TEST
-if wfn_old.Da():     compare_matrices(wfn_old.Da(), wfn_new.Da(), 9, 'compare Da') #TEST
-if wfn_old.Db():     compare_matrices(wfn_old.Db(), wfn_new.Db(), 9, 'compare Db') #TEST
-if wfn_old.Fa():     compare_matrices(wfn_old.Fa(), wfn_new.Fa(), 9, 'compare Fa') #TEST
-if wfn_old.Fb():     compare_matrices(wfn_old.Fb(), wfn_new.Fb(), 9, 'compare Fb') #TEST
-if wfn_old.H():      compare_matrices(wfn_old.H(), wfn_new.H(), 9, 'compare H') #TEST
-if wfn_old.S():      compare_matrices(wfn_old.S(), wfn_new.S(), 9, 'compare S') #TEST
-if wfn_old.X():      compare_matrices(wfn_old.X(), wfn_new.X(), 9, 'compare X') #TEST
-if wfn_old.aotoso(): compare_matrices(wfn_old.aotoso(), wfn_new.aotoso(), 5, 'compare aotoso') #TEST
-if wfn_old.epsilon_a():   compare_vectors(wfn_old.epsilon_a(), wfn_new.epsilon_a(), 5, 'compare epsilon_a') #TEST
-if wfn_old.epsilon_b():   compare_vectors(wfn_old.epsilon_b(), wfn_new.epsilon_b(), 5, 'compare epsilon_b') #TEST
-if wfn_old.frequencies(): compare_vectors(wfn_old.frequencies(), wfn_new.frequencies(), 5, 'compare frequencies') #TEST
-compare_integers(wfn_old.nalpha(), wfn_new.nalpha(), 'compare nalpha') #TEST
-compare_integers(wfn_old.nbeta(), wfn_new.nbeta(), 'compare nbeta') #TEST
-compare_integers(wfn_old.nfrzc(), wfn_new.nfrzc(), 'compare nfrzc') #TEST
-compare_integers(wfn_old.nirrep(), wfn_new.nirrep(), 'compare nirrep') #TEST
-compare_integers(wfn_old.nmo(), wfn_new.nmo(), 'compare nirrep') #TEST
-compare_integers(wfn_old.nso(), wfn_new.nso(), 'compare nso') #TEST
-compare_strings(wfn_old.name(), wfn_new.name(), 'compare name') #TEST
-compare_values(wfn_old.energy(), wfn_new.energy(), 5, 'compare energy') #TEST
+compare_wavefunctions(wfn_old, wfn_new, 'Serialization Check')
+
+
 

--- a/tests/serial-wfn/input.dat
+++ b/tests/serial-wfn/input.dat
@@ -1,0 +1,47 @@
+#! A simple mp2/cc-pvdz water calculation. The resulting wavefunction is written to a file, and then a new wavefunction is generated from that file. The  member variables of both wavefunctions should be identical in value
+
+memory 40 gb
+
+molecule mol {
+0 1
+O 0.0 0.0 0.0
+H 1.0 0.0 0.0
+H -.7 0.7 0.0
+}
+
+set {
+    basis cc-pvdz
+    guess sad
+}
+
+# get wavefunction
+e, wfn_old = energy('mp2', return_wfn=True)
+
+# write to wavefunction to ile
+Wavefunction.to_file(wfn_old, 'my_wfn')
+
+# read wavefunction from file
+wfn_new = Wavefunction.from_file('my_wfn')
+
+if wfn_old.Ca():     compare_matrices(wfn_old.Ca(), wfn_new.Ca(), 9, 'compare Ca') #TEST
+if wfn_old.Cb():     compare_matrices(wfn_old.Cb(), wfn_new.Cb(), 9, 'compare Cb') #TEST
+if wfn_old.Da():     compare_matrices(wfn_old.Da(), wfn_new.Da(), 9, 'compare Da') #TEST
+if wfn_old.Db():     compare_matrices(wfn_old.Db(), wfn_new.Db(), 9, 'compare Db') #TEST
+if wfn_old.Fa():     compare_matrices(wfn_old.Fa(), wfn_new.Fa(), 9, 'compare Fa') #TEST
+if wfn_old.Fb():     compare_matrices(wfn_old.Fb(), wfn_new.Fb(), 9, 'compare Fb') #TEST
+if wfn_old.H():      compare_matrices(wfn_old.H(), wfn_new.H(), 9, 'compare H') #TEST
+if wfn_old.S():      compare_matrices(wfn_old.S(), wfn_new.S(), 9, 'compare S') #TEST
+if wfn_old.X():      compare_matrices(wfn_old.X(), wfn_new.X(), 9, 'compare X') #TEST
+if wfn_old.aotoso(): compare_matrices(wfn_old.aotoso(), wfn_new.aotoso(), 5, 'compare aotoso') #TEST
+if wfn_old.epsilon_a():   compare_vectors(wfn_old.epsilon_a(), wfn_new.epsilon_a(), 5, 'compare epsilon_a') #TEST
+if wfn_old.epsilon_b():   compare_vectors(wfn_old.epsilon_b(), wfn_new.epsilon_b(), 5, 'compare epsilon_b') #TEST
+if wfn_old.frequencies(): compare_vectors(wfn_old.frequencies(), wfn_new.frequencies(), 5, 'compare frequencies') #TEST
+compare_integers(wfn_old.nalpha(), wfn_new.nalpha(), 'compare nalpha') #TEST
+compare_integers(wfn_old.nbeta(), wfn_new.nbeta(), 'compare nbeta') #TEST
+compare_integers(wfn_old.nfrzc(), wfn_new.nfrzc(), 'compare nfrzc') #TEST
+compare_integers(wfn_old.nirrep(), wfn_new.nirrep(), 'compare nirrep') #TEST
+compare_integers(wfn_old.nmo(), wfn_new.nmo(), 'compare nirrep') #TEST
+compare_integers(wfn_old.nso(), wfn_new.nso(), 'compare nso') #TEST
+compare_strings(wfn_old.name(), wfn_new.name(), 'compare name') #TEST
+compare_values(wfn_old.energy(), wfn_new.energy(), 5, 'compare energy') #TEST
+

--- a/tests/serial-wfn/input.dat
+++ b/tests/serial-wfn/input.dat
@@ -1,6 +1,5 @@
 #! A simple hf/cc-pvdz water calculation. The resulting wavefunction is written to a file, and then a new wavefunction is generated from that file. The  member variables of both wavefunctions should be identical in value
 
-memory 40 gb
 
 molecule mol {
 0 1

--- a/tests/serial-wfn/input.dat
+++ b/tests/serial-wfn/input.dat
@@ -1,4 +1,4 @@
-#! A simple mp2/cc-pvdz water calculation. The resulting wavefunction is written to a file, and then a new wavefunction is generated from that file. The  member variables of both wavefunctions should be identical in value
+#! A simple hf/cc-pvdz water calculation. The resulting wavefunction is written to a file, and then a new wavefunction is generated from that file. The  member variables of both wavefunctions should be identical in value
 
 memory 40 gb
 
@@ -14,16 +14,24 @@ set {
     guess sad
 }
 
-# get wavefunction
+# make a wavefunction
 e, wfn_old = energy('hf', return_wfn=True)
 
-# write to wavefunction to ile
+# write the wavefunction to file
 Wavefunction.to_file(wfn_old, 'my_wfn')
 
 # read wavefunction from file
 wfn_new = Wavefunction.from_file('my_wfn')
 
-compare_wavefunctions(wfn_old, wfn_new, 'Serialization Check')
+compare_wavefunctions(wfn_old, wfn_new, 'Serialization Check 1') #TEST
+
+# alternatively store the dict representation of the wavefunction in memory
+wfn_dict = Wavefunction.to_file(wfn_old)
+
+# make a wavefunction from the dict
+wfn_new2 = Wavefunction.from_file(wfn_dict)
+
+compare_wavefunctions(wfn_old, wfn_new2, 'Serialization Check 2') #TEST
 
 
 


### PR DESCRIPTION
## Description
This is a first pass at implementing serialization of the Wavefunction object as suggested by @dgasmith in #887 . This functionality allows a wavefunction to be read to or written from a file:

closes #887 

```
# get a wavefunction from some calculation
e, wfn_old = energy('mp2', return_wfn=True)

# write the wavefunction to file
Wavefunction.to_file(wfn_old, filename)

# ...
# other calculations may occur
# ...

# read the wavefunction from file
wfn_new = Wavefunction.from_file(filename)
```

The wavefunction can also be stored directly in memory as a python dictionary:
```
# write the wavefunction to file
wfn_dict = Wavefunction.to_file(wfn_old)

# ...
# other calculations may occur
# ...

# read the wavefunction from file
wfn_new = Wavefunction.from_file(wfn_dict)
```


In this code snippet, `wfn_new` and `wfn_old` should be identical (by value, not reference). A test case was added that corresponds to this example.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Read/Write Wavefunction object to file
- [x] Serialize a few more variables (PCM related stuff, etc.)
- [x] ~~Deal with Wavefunction inheritance~~ (future PR)

## Questions
- [x] Does anyone have thoughts on the file naming scheme? Currently, the user specifies the filename in the call and a `.npy` file is generated in the working directory. This allows the user to have an arbitrary number of saved wavefunctions that persist between jobs. Alternatively, using a reserved filename (similar the `scf guess` procedure) might be better because users wouldn't have to work with filenames at all, but they would be limited to a single wavefunction.
- [x] ~~How should classes that are derived from Wavefunction (like CIWavefunction) be dealt with?~~
- [ ] Is everything implemented in a reasonable location? 
- [ ] Any inconsistencies in format/style?

## Checklist
- [x] Added Test `serial-wfn`
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
