### PR TITLE
Fixes #1309, clears DCT files correctly.

### DIFF
--- a/psi4/src/psi4/dcft/dcft_memory.cc
+++ b/psi4/src/psi4/dcft/dcft_memory.cc
@@ -202,7 +202,7 @@ void DCFTSolver::init() {
  * Frees up the memory sequestered by the init_moinfo() and read_checkpoint() routines.
  */
 void DCFTSolver::finalize() {
-    psio_->close(PSIF_DCFT_DPD, 1);
+    psio_->close(PSIF_DCFT_DPD, 0);
     delete _ints;
 
     aocc_c_.reset();


### PR DESCRIPTION
## Description
DCT files were not correctly being cleared upon completion. Among other things, the tau matrix was not properly cleared, which led to energy denominator computations for the MP2 guess incorporating the tau matrix when a DC-12 variant was selected. The MP2 guess was not correct.

Requesting the attention of @andysim on this.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Clears DCT files correctly

## Checklist
- [x] [All 'dcft' tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
