### PR TITLE
Replace calls to deprecated LAPACK subroutines

### DIFF
--- a/psi4/include/psi4/pragma.h
+++ b/psi4/include/psi4/pragma.h
@@ -155,4 +155,24 @@
 #define PSI_API PSI_HELPER_SO_EXPORT
 #define PSI_LOCAL PSI_HELPER_SO_LOCAL
 
+// Use in the header file as follows:
+// PSI_DEPRECATED("extremely unsafe, use 'combust' instead!!!") void explode(void);
+// will produce this kind output when compiling:
+//    warning: 'explode' is deprecated: extremely unsafe, use 'combust' instead!!!
+// The macro can similarly be used to deprecate variables.
+// The implementation uses the standard attribute if C++14 available, falling back
+// to compiler extensions if C++11 is used.
+#if __cplusplus >= 201402L
+#define PSI_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#if defined(__GNUC__) || defined(__clang__)
+#define PSI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define PSI_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#pragma message("WARNING: You need to implement PSI_DEPRECATED for this compiler")
+#define PSI_DEPRECATED
+#endif
+#endif
+
 #endif

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -24,13 +24,18 @@ set(sources_list lapack_intfc.cc
 )
 add_definitions("-DFC_SYMBOL=${FC_SYMBOL}")
 
-include(CheckFortranFunctionExists)
-set(CMAKE_REQUIRED_LIBRARIES tgt::lapack)
-# Check whether DGGSVD3 is available
-check_fortran_function_exists(DGGSVD3 _has_dggsvd3)
-# Check whether DGGSVP3 is available
-check_fortran_function_exists(DGGSVP3 _has_dggsvp3)
-unset(CMAKE_REQUIRED_LIBRARIES)
+if(WIN32)
+  set(_has_dggsvd3 TRUE)
+  set(_has_dggsvp3 TRUE)
+else()
+  include(CheckFortranFunctionExists)
+  set(CMAKE_REQUIRED_LIBRARIES tgt::lapack)
+  # Check whether DGGSVD3 is available
+  check_fortran_function_exists(DGGSVD3 _has_dggsvd3)
+  # Check whether DGGSVP3 is available
+  check_fortran_function_exists(DGGSVP3 _has_dggsvp3)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
 
 psi4_add_module(lib qt sources_list psio ciomr mints)
 target_compile_definitions(qt

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -23,4 +23,20 @@ set(sources_list lapack_intfc.cc
                  david.cc
 )
 add_definitions("-DFC_SYMBOL=${FC_SYMBOL}")
+
+include(CheckFortranFunctionExists)
+set(CMAKE_REQUIRED_LIBRARIES tgt::lapack)
+# Check whether DGGSVD3 is available
+check_fortran_function_exists(DGGSVD3 _has_dggsvd3)
+# Check whether DGGSVP3 is available
+check_fortran_function_exists(DGGSVP3 _has_dggsvp3)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
 psi4_add_module(lib qt sources_list psio ciomr mints)
+target_compile_definitions(qt
+  PRIVATE
+    $<$<BOOL:${_has_dggsvd3}>:LAPACK_HAS_DGGSVD3>
+    $<$<BOOL:${_has_dggsvp3}>:LAPACK_HAS_DGGSVP3>
+  )
+unset(_has_dggsvd3)
+unset(_has_dggsvp3)

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -35,6 +35,8 @@
 **
 */
 
+#include <algorithm>
+
 #include "qt.h"
 #include "lapack_intfc_mangle.h"
 
@@ -6467,8 +6469,10 @@ int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* 
              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
              double* work, int* iwork) {
     int info;
-    ::F_DGGSVD(&jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb, alpha, beta, u, &ldu, v, &ldv, q, &ldq, work,
-               iwork, &info);
+    // Infer dimension of work array: max(3*N,M,P)+N
+    int lwork = std::max(std::max(3*n, m), p) + n;
+    ::F_DGGSVD3(&jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb, alpha, beta, u, &ldu, v, &ldv, q, &ldq, work,
+               iwork, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -2834,7 +2834,7 @@ int C_DGEGS(char jobvsl, char jobvsr, int n, double* a, int lda, double* b, int 
 int C_DGEGV(char jobvl, char jobvr, int n, double* a, int lda, double* b, int ldb, double* alphar, double* alphai,
             double* beta, double* vl, int ldvl, double* vr, int ldvr, double* work, int lwork) {
     int info;
-    ::F_DGEGV(&jobvl, &jobvr, &n, a, &lda, b, &ldb, alphar, alphai, beta, vl, &ldvl, vr, &ldvr, work, &lwork, &info);
+    ::F_DGGEV(&jobvl, &jobvr, &n, a, &lda, b, &ldb, alphar, alphai, beta, vl, &ldvl, vr, &ldvr, work, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -2616,8 +2616,11 @@ int C_DGEEVX(char balanc, char jobvl, char jobvr, char sense, int n, double* a, 
 int C_DGEGS(char jobvsl, char jobvsr, int n, double* a, int lda, double* b, int ldb, double* alphar, double* alphai,
             double* beta, double* vsl, int ldvsl, double* vsr, int ldvsr, double* work, int lwork) {
     int info;
-    ::F_DGEGS(&jobvsl, &jobvsr, &n, a, &lda, b, &ldb, alphar, alphai, beta, vsl, &ldvsl, vsr, &ldvsr, work, &lwork,
-              &info);
+    char sort = 'n';
+    int sdim;
+    ::F_DGGES(&jobvsl, &jobvsr, &sort, &n, a, &lda, b, &ldb, &sdim, alphar, alphai, beta, vsl, &ldvsl, vsr, &ldvsr,
+              work, &lwork, &info);
+
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -20212,7 +20212,19 @@ int C_DTRTRS(char uplo, char trans, char diag, int n, int nrhs, double* a, int l
  **/
 int C_DTZRQF(int m, int n, double* a, int lda, double* tau) {
     int info;
-    ::F_DTZRQF(&m, &n, a, &lda, tau, &info);
+    // First invoke F_DTZRZF querying for the optimal size of the work array.
+    auto tmp = new double[5];
+    int lwork = -1;
+    ::F_DTZRZF(&m, &n, a, &lda, tau, tmp, &lwork, &info);
+    if (info == 0) {
+        lwork = tmp[0];
+    }
+    delete[] tmp;
+    // Now allocate the work array of the correct size and call F_DTZRZF
+    // to do the real work.
+    auto work = new double[lwork];
+    ::F_DTZRZF(&m, &n, a, &lda, tau, work, &lwork, &info);
+    if (info == 0) delete[] work;
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -6931,8 +6931,10 @@ int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, in
              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
              double* tau, double* work) {
     int info;
-    ::F_DGGSVP(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
-               tau, work, &info);
+    // Infer dimension of work array: max(3*N,M,P)
+    int lwork = std::max(std::max(3*n, m), p);
+    ::F_DGGSVP3(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
+               tau, work, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -110,8 +110,12 @@ extern int F_DGGQRF(int*, int*, int*, double*, int*, double*, double*, int*, dou
 extern int F_DGGRQF(int*, int*, int*, double*, int*, double*, double*, int*, double*, double*, int*, int*);
 extern int F_DGGSVD(char*, char*, char*, int*, int*, int*, int*, int*, double*, int*, double*, int*, double*, double*,
                     double*, int*, double*, int*, double*, int*, double*, int*, int*);
+extern int F_DGGSVD3(char*, char*, char*, int*, int*, int*, int*, int*, double*, int*, double*, int*, double*, double*,
+                     double*, int*, double*, int*, double*, int*, double*, int*, int*, int*);
 extern int F_DGGSVP(char*, char*, char*, int*, int*, int*, double*, int*, double*, int*, double*, double*, int*, int*,
                     double*, int*, double*, int*, double*, int*, int*, double*, double*, int*);
+extern int F_DGGSVP3(char*, char*, char*, int*, int*, int*, double*, int*, double*, int*, double*, double*, int*, int*,
+                     double*, int*, double*, int*, double*, int*, int*, double*, double*, int*, int*);
 extern int F_DGTCON(char*, int*, double*, double*, double*, double*, int*, double*, double*, double*, int*, int*);
 extern int F_DGTRFS(char*, int*, int*, double*, double*, double*, double*, double*, double*, double*, int*, double*,
                     int*, double*, int*, double*, double*, double*, int*, int*);
@@ -6468,6 +6472,15 @@ int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* 
     return info;
 }
 
+int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
+              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
+              double* work, int lwork, int* iwork) {
+    int info;
+    ::F_DGGSVD3(&jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb, alpha, beta, u, &ldu, v, &ldv, q, &ldq, work,
+                &lwork, iwork, &info);
+    return info;
+}
+
 /**
  *  Purpose
  *  =======
@@ -6605,6 +6618,15 @@ int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, in
     int info;
     ::F_DGGSVP(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
                tau, work, &info);
+    return info;
+}
+
+int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
+              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
+              double* tau, double* work, int lwork) {
+    int info;
+    ::F_DGGSVP3(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
+                tau, work, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -3450,7 +3450,10 @@ int C_DGELSS(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, dou
 int C_DGELSX(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, int* jpvt, double rcond, int* rank,
              double* work) {
     int info;
-    ::F_DGELSX(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, rank, work, &info);
+    // Infer dimension of work array
+    // max( min(M,N)+3*N, 2*min(M,N)+NRHS )
+    int lwork = std::max(std::min(m, n) + 3 * n, 2 * std::min(m, n) + nrhs);
+    ::F_DGELSY(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, rank, work, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -6469,10 +6469,15 @@ int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* 
              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
              double* work, int* iwork) {
     int info;
+#ifdef LAPACK_HAS_DGGSVD3
     // Infer dimension of work array: max(3*N,M,P)+N
-    int lwork = std::max(std::max(3*n, m), p) + n;
+    int lwork = std::max(std::max(3 * n, m), p) + n;
     ::F_DGGSVD3(&jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb, alpha, beta, u, &ldu, v, &ldv, q, &ldq, work,
-               iwork, &lwork, &info);
+                iwork, &lwork, &info);
+#else
+    ::F_DGGSVD(&jobu, &jobv, &jobq, &m, &n, &p, k, l, a, &lda, b, &ldb, alpha, beta, u, &ldu, v, &ldv, q, &ldq, work,
+               iwork, &info);
+#endif
     return info;
 }
 
@@ -6787,6 +6792,7 @@ int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* 
  *
  *  DGGSVD3 replaces the deprecated subroutine DGGSVD.
  **/
+#ifdef LAPACK_HAS_DGGSVD3
 int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
               int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
               double* work, int lwork, int* iwork) {
@@ -6795,6 +6801,7 @@ int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int*
                 &lwork, iwork, &info);
     return info;
 }
+#endif
 
 /**
  *  Purpose
@@ -6931,10 +6938,15 @@ int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, in
              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
              double* tau, double* work) {
     int info;
+#ifdef LAPACK_HAS_DGGSVP3
     // Infer dimension of work array: max(3*N,M,P)
-    int lwork = std::max(std::max(3*n, m), p);
+    int lwork = std::max(std::max(3 * n, m), p);
     ::F_DGGSVP3(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
-               tau, work, &lwork, &info);
+                tau, work, &lwork, &info);
+#else
+    ::F_DGGSVP(&jobu, &jobv, &jobq, &m, &p, &n, a, &lda, b, &ldb, &tola, &tolb, k, l, u, &ldu, v, &ldv, q, &ldq, iwork,
+               tau, work, &info);
+#endif
     return info;
 }
 
@@ -7170,6 +7182,7 @@ int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, in
  *
  * DGGSVP3 replaces the deprecated subroutine DGGSVP.
  **/
+#ifdef LAPACK_HAS_DGGSVP3
 int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
               double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
               double* tau, double* work, int lwork) {
@@ -7178,6 +7191,7 @@ int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, i
                 tau, work, &lwork, &info);
     return info;
 }
+#endif
 
 /**
  *  Purpose

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -3819,7 +3819,8 @@ int C_DGEQP3(int m, int n, double* a, int lda, int* jpvt, double* tau, double* w
  **/
 int C_DGEQPF(int m, int n, double* a, int lda, int* jpvt, double* tau, double* work) {
     int info;
-    ::F_DGEQPF(&m, &n, a, &lda, jpvt, tau, work, &info);
+    int lwork = 3 * n;
+    ::F_DGEQP3(&m, &n, a, &lda, jpvt, tau, work, &lwork, &info);
     return info;
 }
 

--- a/psi4/src/psi4/libqt/lapack_intfc_mangle.h
+++ b/psi4/src/psi4/libqt/lapack_intfc_mangle.h
@@ -104,7 +104,9 @@
 #define F_DGGQRF FC_GLOBAL(dggqrf, DGGQRF)
 #define F_DGGRQF FC_GLOBAL(dggrqf, DGGRQF)
 #define F_DGGSVD FC_GLOBAL(dggsvd, DGGSVD)
+#define F_DGGSVD3 FC_GLOBAL(dggsvd3, DGGSVD3)
 #define F_DGGSVP FC_GLOBAL(dggsvp, DGGSVP)
+#define F_DGGSVP3 FC_GLOBAL(dggsvp3, DGGSVP3)
 #define F_DGTCON FC_GLOBAL(dgtcon, DGTCON)
 #define F_DGTRFS FC_GLOBAL(dgtrfs, DGTRFS)
 #define F_DGTSV FC_GLOBAL(dgtsv, DGTSV)
@@ -301,7 +303,9 @@
 #define F_DGGQRF dggqrf_
 #define F_DGGRQF dggrqf_
 #define F_DGGSVD dggsvd_
+#define F_DGGSVD3 dggsvd3_
 #define F_DGGSVP dggsvp_
+#define F_DGGSVP3 dggsvp3_
 #define F_DGTCON dgtcon_
 #define F_DGTRFS dgtrfs_
 #define F_DGTSV dgtsv_
@@ -497,7 +501,9 @@
 #define F_DGGQRF dggqrf
 #define F_DGGRQF dggrqf
 #define F_DGGSVD dggsvd
+#define F_DGGSVD3 dggsvd3
 #define F_DGGSVP dggsvp
+#define F_DGGSVP3 dggsvp3
 #define F_DGTCON dgtcon
 #define F_DGTRFS dgtrfs
 #define F_DGTSV dgtsv
@@ -693,7 +699,9 @@
 #define F_DGGQRF DGGQRF
 #define F_DGGRQF DGGRQF
 #define F_DGGSVD DGGSVD
+#define F_DGGSVD3 DGGSVD3
 #define F_DGGSVP DGGSVP
+#define F_DGGSVP3 DGGSVP3
 #define F_DGTCON DGTCON
 #define F_DGTRFS DGTRFS
 #define F_DGTSV DGTSV
@@ -889,7 +897,9 @@
 #define F_DGGQRF DGGQRF_
 #define F_DGGRQF DGGRQF_
 #define F_DGGSVD DGGSVD_
+#define F_DGGSVD3 DGGSVD3_
 #define F_DGGSVP DGGSVP_
+#define F_DGGSVP3 DGGSVP3_
 #define F_DGTCON DGTCON_
 #define F_DGTRFS DGTRFS_
 #define F_DGTSV DGTSV_

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -242,9 +242,15 @@ int C_DGGRQF(int m, int p, int n, double* a, int lda, double* taua, double* b, i
 int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
              double* work, int* iwork);
+int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
+              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
+              double* work, int lwork, int* iwork);
 int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
              double* tau, double* work);
+int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
+              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
+              double* tau, double* work, int lwork);
 int C_DGTCON(char norm, int n, double* dl, double* d, double* du, double* du2, int* ipiv, double anorm, double* rcond,
              double* work, int* iwork);
 int C_DGTRFS(char trans, int n, int nrhs, double* dl, double* d, double* du, double* dlf, double* df, double* duf,

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -246,16 +246,20 @@ PSI_DEPRECATED("DGGSVD will soon be removed from LAPACK. Please use DGVSVD3")
 int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
              double* work, int* iwork);
+#ifdef LAPACK_HAS_DGGSVD3
 int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
               int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
               double* work, int lwork, int* iwork);
+#endif
 PSI_DEPRECATED("DGGSVP will soon be removed from LAPACK. Please use DGVSVP3")
 int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
              double* tau, double* work);
+#ifdef LAPACK_HAS_DGGSVP3
 int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
               double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
               double* tau, double* work, int lwork);
+#endif
 int C_DGTCON(char norm, int n, double* dl, double* d, double* du, double* du2, int* ipiv, double anorm, double* rcond,
              double* work, int* iwork);
 int C_DGTRFS(char trans, int n, int nrhs, double* dl, double* d, double* du, double* dlf, double* df, double* duf,

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -36,8 +36,7 @@
 ** Modifications by Daniel Crawford 1996, 1997
 */
 
-#ifndef _psi_src_lib_libqt_qt_h_
-#define _psi_src_lib_libqt_qt_h_
+#pragma once
 
 #include <cstdio>
 #include <string>
@@ -183,8 +182,10 @@ int C_DGEEV(char jobvl, char jobvr, int n, double* a, int lda, double* wr, doubl
 int C_DGEEVX(char balanc, char jobvl, char jobvr, char sense, int n, double* a, int lda, double* wr, double* wi,
              double* vl, int ldvl, double* vr, int ldvr, int* ilo, int* ihi, double* scale, double* abnrm,
              double* rconde, double* rcondv, double* work, int lwork, int* iwork);
+PSI_DEPRECATED("DGEGS will soon be removed from LAPACK. Please use DGGES")
 int C_DGEGS(char jobvsl, char jobvsr, int n, double* a, int lda, double* b, int ldb, double* alphar, double* alphai,
             double* beta, double* vsl, int ldvsl, double* vsr, int ldvsr, double* work, int lwork);
+PSI_DEPRECATED("DGEGV will soon be removed from LAPACK. Please use DGGEV")
 int C_DGEGV(char jobvl, char jobvr, int n, double* a, int lda, double* b, int ldb, double* alphar, double* alphai,
             double* beta, double* vl, int ldvl, double* vr, int ldvr, double* work, int lwork);
 int C_DGEHRD(int n, int ilo, int ihi, double* a, int lda, double* tau, double* work, int lwork);
@@ -194,12 +195,14 @@ int C_DGELSD(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, dou
              double* work, int lwork, int* iwork);
 int C_DGELSS(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, double* s, double rcond, int* rank,
              double* work, int lwork);
+PSI_DEPRECATED("DGELSX will soon be removed from LAPACK. Please use DGELSY")
 int C_DGELSX(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, int* jpvt, double rcond, int* rank,
              double* work);
 int C_DGELSY(int m, int n, int nrhs, double* a, int lda, double* b, int ldb, int* jpvt, double rcond, int* rank,
              double* work, int lwork);
 int C_DGEQLF(int m, int n, double* a, int lda, double* tau, double* work, int lwork);
 int C_DGEQP3(int m, int n, double* a, int lda, int* jpvt, double* tau, double* work, int lwork);
+PSI_DEPRECATED("DGEQPF will soon be removed from LAPACK. Please use DGEQPF3")
 int C_DGEQPF(int m, int n, double* a, int lda, int* jpvt, double* tau, double* work);
 int C_DGEQRF(int m, int n, double* a, int lda, double* tau, double* work, int lwork);
 int C_DGERFS(char trans, int n, int nrhs, double* a, int lda, double* af, int ldaf, int* ipiv, double* b, int ldb,
@@ -239,12 +242,14 @@ int C_DGGQRF(int n, int m, int p, double* a, int lda, double* taua, double* b, i
              int lwork);
 int C_DGGRQF(int m, int p, int n, double* a, int lda, double* taua, double* b, int ldb, double* taub, double* work,
              int lwork);
+PSI_DEPRECATED("DGGSVD will soon be removed from LAPACK. Please use DGVSVD3")
 int C_DGGSVD(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
              int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
              double* work, int* iwork);
 int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
               int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
               double* work, int lwork, int* iwork);
+PSI_DEPRECATED("DGGSVP will soon be removed from LAPACK. Please use DGVSVP3")
 int C_DGGSVP(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
              double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
              double* tau, double* work);
@@ -460,9 +465,8 @@ int C_DTRSYL(char trana, char tranb, int isgn, int m, int n, double* a, int lda,
              double* scale);
 int C_DTRTRI(char uplo, char diag, int n, double* a, int lda);
 int C_DTRTRS(char uplo, char trans, char diag, int n, int nrhs, double* a, int lda, double* b, int ldb);
+PSI_DEPRECATED("DTZRQF will soon be removed from LAPACK. Please use DTZRZF")
 int C_DTZRQF(int m, int n, double* a, int lda, double* tau);
 int C_DTZRZF(int m, int n, double* a, int lda, double* tau, double* work, int lwork);
 
 }  // namespace psi
-
-#endif /* _psi_src_lib_libqt_qt_h */


### PR DESCRIPTION
## Description
Fixes #1290 by wrapping calls to deprecated (and removed in Netlib's LAPACK 3.8.0) with appropriate replacements.

**UPDATE**
I have added a `PSI_DEPRECATED` macro in `pragma.h` to be used to deprecate functions, classes, variables. It will emit a warning at compile-time.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Added a `PSI_DEPRECATED` macro
- [x] Wrap call to `DGEGS` with `DGGES`. Deprecate `C_DGEGS`.
- [x] Wrap call to `DTZRQF` with `DTZRZF`. Deprecate `C_DTZRQF`.
- [x] Wrap call to `DGEGV` with `DGGEV`. Deprecate `C_DGEGV`
- [x] Wrap call to `DGELSX` with `DGELSY`. Deprecate `C_DGELSX`
- [x] Wrap call to `DGEQPF` with `DGEQP3`. Deprecate `C_DGEQPF`
- [x] Check whether `DGGSVD3` and `DGGSVP3` are available in `tgt::lapack`. Fence off their use accordingly based on the `LAPACK_HAS_DGGSVD3` and `LAPACK_HAS_DGGSVP3` preprocessor variables, respectively. 
- [x] Wrap call to `DGGSVD` with `DGGSVD3`, if the latter is available. Deprecate `C_DGGSVD`.
- [x] Wrap call to `DGGSVP` with `DGGSVP3`, if the latter is available. Deprecate `C_DGGSVP`

## Checklist
None of these subroutines were used in Psi4, so I only ran smoketests locally.
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge **SQUASH**
