### PR TITLE
clang-tidy apply modernize-redundant-void-arg fixes

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -90,7 +90,7 @@ extern std::map<std::string, plugin_info> plugins;
 
 namespace opt {
 psi::PsiReturnType optking(psi::Options&);
-void opt_clean(void);
+void opt_clean();
 }
 // Forward declare /src/bin/ methods
 namespace psi {

--- a/psi4/src/psi4/cctransort/a_spinad.cc
+++ b/psi4/src/psi4/cctransort/a_spinad.cc
@@ -31,7 +31,7 @@
 namespace psi {
 namespace cctransort {
 
-void a_spinad(void) {
+void a_spinad() {
     dpdbuf4 A;
 
     global_dpd_->buf4_init(&A, PSIF_CC_AINTS, 0, 0, 0, 0, 0, 0, "A <ij|kl>");

--- a/psi4/src/psi4/cctransort/e_spinad.cc
+++ b/psi4/src/psi4/cctransort/e_spinad.cc
@@ -31,7 +31,7 @@
 namespace psi {
 namespace cctransort {
 
-void e_spinad(void) {
+void e_spinad() {
     dpdbuf4 E;
 
     global_dpd_->buf4_init(&E, PSIF_CC_EINTS, 0, 11, 0, 11, 0, 0, "E <ai|jk>");

--- a/psi4/src/psi4/detci/civect.cc
+++ b/psi4/src/psi4/detci/civect.cc
@@ -121,7 +121,7 @@ CIvect::CIvect(int incor, int maxvect, int nunits, int funit, struct ci_blks *CI
     }
 }
 
-void CIvect::common_init(void) {
+void CIvect::common_init() {
     vectlen_ = 0;
     num_blocks_ = 0;
     icore_ = 1;
@@ -458,7 +458,7 @@ CIvect::~CIvect() {
 ** Returns:
 **    pointer to memory buffer (double *)
 */
-double *CIvect::buf_malloc(void) {
+double *CIvect::buf_malloc() {
     double *tmp;
 
     tmp = init_array(buffer_size_);
@@ -1597,7 +1597,7 @@ void CIvect::buf_lock(double *a) {
 ** Parameters: none
 ** Returns: none
 */
-void CIvect::buf_unlock(void) {
+void CIvect::buf_unlock() {
     buf_locked_ = 0;
     blocks_[0][0] = nullptr;
     buffer_ = nullptr;
@@ -2058,7 +2058,7 @@ int CIvect::schmidt_add2(CIvect &c, int first_vec, int last_vec, int source_vec,
 ** Parameters: none
 ** Returns: none
 **/
-void CIvect::zero(void) { zero_arr(buffer_, (int)buffer_size_); }
+void CIvect::zero() { zero_arr(buffer_, (int)buffer_size_); }
 
 /*
 ** CIvect::sigma_renorm()
@@ -2689,7 +2689,7 @@ void CIvect::transp_block(int iblock, double **tmparr) {
 ** Return the maximum RAS subblock size as a long size_teger
 **
 */
-size_t CIvect::get_max_blk_size(void) {
+size_t CIvect::get_max_blk_size() {
     int i;
     size_t blksize, maxblksize = 0;
 
@@ -2706,7 +2706,7 @@ size_t CIvect::get_max_blk_size(void) {
 **
 ** Check the norm of a CI vector
 */
-double CIvect::checknorm(void) {
+double CIvect::checknorm() {
     double tval, dotprod = 0.0;
 
     for (int buf = 0; buf < buf_per_vect_; buf++) {
@@ -2853,7 +2853,7 @@ void CIvect::print_fptrs() {
 ** Initialize H0block stuff pertaining to buffers
 **
 */
-void CIvect::h0block_buf_init(void) {
+void CIvect::h0block_buf_init() {
     int i, cnt, irrep, buf, blk;
     int *tmparr;
 
@@ -3167,7 +3167,7 @@ void CIvect::set_zero_block(int blocknum, int value) {
     zero_blocks_[blocknum] = value;
 }
 
-void CIvect::set_zero_blocks_all(void) {
+void CIvect::set_zero_blocks_all() {
     int i;
 
     for (i = 0; i < num_blocks_; i++) zero_blocks_[i] = 1;
@@ -3182,7 +3182,7 @@ void CIvect::copy_zero_blocks(CIvect &src) {
     }
 }
 
-void CIvect::print_zero_blocks(void) {
+void CIvect::print_zero_blocks() {
     int i;
 
     for (i = 0; i < num_blocks_; i++) {
@@ -3302,7 +3302,7 @@ double CIvect::dcalc_evangelisti(int rootnum, int num_vecs, double lambda, CIvec
 ** changed so that it is a little easier to deal with two logical CIvectors
 ** which point to the same physical CIvector (as happens if nodfile).
 */
-void CIvect::write_new_first_buf(void) {
+void CIvect::write_new_first_buf() {
     int unit;
 
     unit = first_unit_;
@@ -3317,7 +3317,7 @@ void CIvect::write_new_first_buf(void) {
 ** which point to the same physical CIvector (as happens if nodfile).
 ** Return -1 if "New First Buffer" is not stored in the file yet.
 */
-int CIvect::read_new_first_buf(void) {
+int CIvect::read_new_first_buf() {
     int unit;
     int nfb;
 
@@ -3340,7 +3340,7 @@ void CIvect::set_new_first_buf(int nfb) { new_first_buf_ = nfb; }
 ** Read the number of valid vectors in this object.  That will be stored
 ** in the first unit.
 */
-int CIvect::read_num_vecs(void) {
+int CIvect::read_num_vecs() {
     int unit;
     int nv;
 
@@ -3369,7 +3369,7 @@ void CIvect::write_num_vecs(int nv) {
 ** done filling it up, it will be wiped out by the next write but written
 ** again at the new end of file next time we call this function.
 */
-void CIvect::write_toc(void) {
+void CIvect::write_toc() {
     int i, unit;
 
     for (i = 0; i < nunits_; i++) {
@@ -3380,7 +3380,7 @@ void CIvect::write_toc(void) {
 /*
 ** Print libpsio debug info
 */
-void CIvect::civect_psio_debug(void) {
+void CIvect::civect_psio_debug() {
     int i, unit;
 
     /* psio_tocprint not available right now in PSI4; re-enable it if you

--- a/psi4/src/psi4/detci/civect.h
+++ b/psi4/src/psi4/detci/civect.h
@@ -146,7 +146,7 @@ class CIvect {
     void shift(double a, int tvec);
     void copy(SharedCIVector src, int tvec, int ovec);
     void divide(SharedCIVector denom, double min_val, int tvec, int ovec);
-    void zero(void);
+    void zero();
     double vdot(SharedCIVector b, int tvec, int ovec);
     double norm(int tvec);
 
@@ -163,8 +163,8 @@ class CIvect {
     int read(int tvec, int ibuf);
     int write(int tvec, int ibuf);
     void buf_lock(double *a);
-    void buf_unlock(void);
-    double *buf_malloc(void);
+    void buf_unlock();
+    double *buf_malloc();
     void set_nvect(int i);
 
     // Questionable functions and/or should be private
@@ -215,34 +215,34 @@ class CIvect {
     void civ_xeay(double a, CIvect &Y, int xvect, int yvect);
     void civ_xpeay(double a, CIvect &Y, int xvect, int yvect);
     void transp_block(int iblock, double **tmparr);
-    size_t get_max_blk_size(void);
-    double checknorm(void);
+    size_t get_max_blk_size();
+    double checknorm();
     void copy(CIvect &Src, int targetvec, int srcvec);
     void restart_gather(int ivec, int nvec, int nroot, double **alpha, double *buffer1, double *buffer2);
     void gather(int ivec, int nvec, int nroot, double **alpha, CIvect &C);
     void restart_reord_fp(int L);
-    void print_fptrs(void);
+    void print_fptrs();
     double calc_ssq(double *buffer1, double *buffer2, struct stringwr **alplist, struct stringwr **betlist,
                     int vec_num);
-    void h0block_buf_init(void);
+    void h0block_buf_init();
     void h0block_buf_ols(double *norm, double *ovrlap, double *c1norm, double E_est);
     void h0block_buf_precon(double *norm, int root);
     void h0block_gather_vec(int vecode);
     void h0block_gather_multivec(double *vec);
     int check_zero_block(int blocknum);
     void set_zero_block(int blocknum, int value);
-    void set_zero_blocks_all(void);
+    void set_zero_blocks_all();
     void copy_zero_blocks(CIvect &src);
-    void print_zero_blocks(void);
+    void print_zero_blocks();
     void scale_sigma(CIvect &Hd, CIvect &C, struct stringwr **alplist, struct stringwr **betlist, int i, double *buf1,
                      double *buf2);
-    int read_new_first_buf(void);
-    void write_new_first_buf(void);
+    int read_new_first_buf();
+    void write_new_first_buf();
     void set_new_first_buf(int nfb);
-    int read_num_vecs(void);
+    int read_num_vecs();
     void write_num_vecs(int nv);
-    void write_toc(void);
-    void civect_psio_debug(void);
+    void write_toc();
+    void civect_psio_debug();
     void pt_correction(struct stringwr **alplist, struct stringwr **betlist);
     double compute_follow_overlap(int troot, int ncoef, double *coef, int *Iac, int *Iaridx, int *Ibc, int *Ibridx);
 

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -442,7 +442,7 @@ SharedMatrix CIWavefunction::get_tpdm(const std::string& spin, bool symmetrize) 
 /*
 ** cleanup(): Free any allocated memory that wasn't already freed elsewhere
 */
-void CIWavefunction::cleanup_ci(void) {
+void CIWavefunction::cleanup_ci() {
     // Make sure we dont double clean
     if (!cleaned_up_ci_) {
         // Free Bendazzoli OV arrays
@@ -475,7 +475,7 @@ void CIWavefunction::cleanup_ci(void) {
         cleaned_up_ci_ = true;
     }
 }
-void CIWavefunction::cleanup_dpd(void) {
+void CIWavefunction::cleanup_dpd() {
     if (ints_init_) {
         ints_.reset();
         ints_init_ = false;

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -107,7 +107,7 @@ class CIWavefunction : public Wavefunction {
     /**!
      * Transform the one and two electron integrals for a CI computation.
      */
-    void transform_ci_integrals(void);
+    void transform_ci_integrals();
 
     /**!
      * Transform the one and two electron integrals for a MCSCF computation.
@@ -378,16 +378,16 @@ class CIWavefunction : public Wavefunction {
 
     /// => H0block functions <= //
     void H0block_init(size_t size);
-    void H0block_free(void);
-    void H0block_print(void);
+    void H0block_free();
+    void H0block_print();
     int H0block_calc(double E);
     void H0block_gather(double **mat, int al, int bl, int cscode, int mscode, int phase);
     void H0block_xy(double *x, double *y, double E);
     void H0block_setup(int num_blocks, int *Ia_code, int *Ib_code);
     void H0block_pairup(int guess);
-    void H0block_spin_cpl_chk(void);
-    void H0block_filter_setup(void);
-    void H0block_fill(void);
+    void H0block_spin_cpl_chk();
+    void H0block_filter_setup();
+    void H0block_fill();
     void H0block_coupling_calc(double E);
     std::string print_config(int nbf, int num_alp_el, int num_bet_el, struct stringwr *stralp, struct stringwr *strbet,
                              int num_drc_orbs);
@@ -422,7 +422,7 @@ class CIWavefunction : public Wavefunction {
     /// => Sigma Calculations <= //
     struct sigma_data *SigmaData_;
     void sigma_init(CIvect &C, CIvect &S);
-    void sigma_free(void);
+    void sigma_free();
     void sigma(CIvect &C, CIvect &S, double *oei, double *tei, int ivec);
 
     void sigma_a(struct stringwr **alplist, struct stringwr **betlist, CIvect &C, CIvect &S, double *oei, double *tei,

--- a/psi4/src/psi4/detci/compute_cc.cc
+++ b/psi4/src/psi4/detci/compute_cc.cc
@@ -58,7 +58,7 @@ namespace detci {
 ** computation
 **
 */
-void CIWavefunction::compute_cc(void) { outfile->Printf("compute_cc: Not yet available\n"); }
+void CIWavefunction::compute_cc() { outfile->Printf("compute_cc: Not yet available\n"); }
 
 }  // namespace detci
 }  // namespace psi

--- a/psi4/src/psi4/detci/h0block.cc
+++ b/psi4/src/psi4/detci/h0block.cc
@@ -106,7 +106,7 @@ void CIWavefunction::H0block_init(size_t size) {
     }
 }
 
-void CIWavefunction::H0block_free(void) {
+void CIWavefunction::H0block_free() {
     if (H0block_->osize) {
         free_matrix(H0block_->H0b, H0block_->osize);
         if (Parameters_->precon == PRECON_GEN_DAVIDSON) {
@@ -145,7 +145,7 @@ void CIWavefunction::H0block_free(void) {
     }
 }
 
-void CIWavefunction::H0block_print(void) {
+void CIWavefunction::H0block_print() {
     int i;
 
     outfile->Printf("\nMembers of H0 block:\n\n");
@@ -484,7 +484,7 @@ void CIWavefunction::H0block_pairup(int guess) {
 ** Substantial modifications by David Sherrill, October 1998
 **
 */
-void CIWavefunction::H0block_spin_cpl_chk(void) {
+void CIWavefunction::H0block_spin_cpl_chk() {
     int i, newsize;
     double zero = 1E-13;
     double diff = 0.0, spin_cpl_vals2;
@@ -592,7 +592,7 @@ void CIWavefunction::H0block_spin_cpl_chk(void) {
 **
 ** C. David Sherrill, July 2003
 */
-void CIWavefunction::H0block_filter_setup(void) {
+void CIWavefunction::H0block_filter_setup() {
     int Iac, Ibc, Iaridx, Ibridx;
     int Jac, Jbc, Jaridx, Jbridx;
     int i, found1, found2, replace;

--- a/psi4/src/psi4/detci/olsengraph.cc
+++ b/psi4/src/psi4/detci/olsengraph.cc
@@ -77,7 +77,7 @@ void og_print(struct olsen_graph *Graph);
 **    graph for every irrep * (num el in RAS I) * (num el in RAS III)
 **
 */
-void CIWavefunction::form_strings(void) {
+void CIWavefunction::form_strings() {
     int i, nlists, nirreps, ncodes;
     int irrep, code, listnum;
     int *occs;

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -57,7 +57,7 @@ namespace detci {
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
 #define TOL 1E-14
 
-void CIWavefunction::form_opdm(void) {
+void CIWavefunction::form_opdm() {
     // if we're trying to follow a root, figure out which one here
     // CDS help: Why is this here and where can we move it?
     if (Parameters_->follow_vec_num > 0) {

--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -677,7 +677,7 @@ void CIWavefunction::get_parameters(Options &options) {
 ** print_parameters(): Function prints the program's running parameters
 **   found in the Parameters structure.
 */
-void CIWavefunction::print_parameters(void) {
+void CIWavefunction::print_parameters() {
     int i;
 
     outfile->Printf("\n");
@@ -896,7 +896,7 @@ void CIWavefunction::print_parameters(void) {
 **   (i.e. fermi level, etc).
 **
 */
-void CIWavefunction::set_ras_parameters(void) {
+void CIWavefunction::set_ras_parameters() {
     int i, j, cnt;
     int errcod;
     int tot_expl_el, nras2alp, nras2bet, betsocc;
@@ -1291,7 +1291,7 @@ std::string _concat_dim(std::string label, size_t spacer1, Dimension dim, size_t
 **   (i.e. fermi level, etc).
 **
 */
-void CIWavefunction::print_ras_parameters(void) {
+void CIWavefunction::print_ras_parameters() {
     outfile->Printf("   ==> CI Orbital and Space information <==\n\n");
 
     // Print out any specific space info

--- a/psi4/src/psi4/detci/slaterd.h
+++ b/psi4/src/psi4/detci/slaterd.h
@@ -86,8 +86,8 @@ class SlaterDeterminant {
         if (Occs_[1] != nullptr) free(Occs_[1]);
     }
     void set(size_t nalp, unsigned char* alpoccs, size_t nbet, unsigned char* betoccs);
-    void print(void);
-    void print_config(void);
+    void print();
+    void print_config();
     SlaterDeterminant& operator=(const SlaterDeterminant& s);
     friend int operator==(SlaterDeterminant& s1, SlaterDeterminant& s2);
     friend double matrix_element(SlaterDeterminant* I, SlaterDeterminant* J);

--- a/psi4/src/psi4/detci/tpdm.cc
+++ b/psi4/src/psi4/detci/tpdm.cc
@@ -52,7 +52,7 @@ namespace detci {
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
 
 // DGAS this is still awkward, I think the TPDM code can be less general than the OPDM one for now.
-void CIWavefunction::form_tpdm(void) {
+void CIWavefunction::form_tpdm() {
     SharedCIVector Ivec = new_civector(Parameters_->num_roots, Parameters_->d_filenum);
     Ivec->init_io_files(true);
     SharedCIVector Jvec = new_civector(Parameters_->num_roots, Parameters_->d_filenum);

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -429,29 +429,29 @@ class PSI_API DPD {
 
     int mat4_irrep_print(double **matrix, dpdparams4 *Params, int irrep, int my_irrep, std::string out_fname);
 
-    void file2_cache_init(void);
-    void file2_cache_close(void);
+    void file2_cache_init();
+    void file2_cache_close();
     void file2_cache_print(std::string out_fname);
     dpd_file2_cache_entry *file2_cache_scan(int filenum, int irrep, int pnum, int qnum, const char *label, int dpdnum);
-    dpd_file2_cache_entry *dpd_file2_cache_last(void);
+    dpd_file2_cache_entry *dpd_file2_cache_last();
     int file2_cache_add(dpdfile2 *File);
     int file2_cache_del(dpdfile2 *File);
-    int file4_cache_del_low(void);
+    int file4_cache_del_low();
     void file2_cache_dirty(dpdfile2 *File);
 
-    void file4_cache_init(void);
-    void file4_cache_close(void);
+    void file4_cache_init();
+    void file4_cache_close();
     void file4_cache_print(std::string out_fname);
-    void file4_cache_print_screen(void);
+    void file4_cache_print_screen();
     int file4_cache_get_priority(dpdfile4 *File);
 
     dpd_file4_cache_entry *file4_cache_scan(int filenum, int irrep, int pqnum, int rsnum, const char *label,
                                             int dpdnum);
-    dpd_file4_cache_entry *file4_cache_last(void);
+    dpd_file4_cache_entry *file4_cache_last();
     int file4_cache_add(dpdfile4 *File, size_t priority);
     int file4_cache_del(dpdfile4 *File);
-    dpd_file4_cache_entry *file4_cache_find_lru(void);
-    int file4_cache_del_lru(void);
+    dpd_file4_cache_entry *file4_cache_find_lru();
+    int file4_cache_del_lru();
     void file4_cache_dirty(dpdfile4 *File);
     void file4_cache_lock(dpdfile4 *File);
     void file4_cache_unlock(dpdfile4 *File);
@@ -523,7 +523,7 @@ extern PSI_API int dpd_set_default(int dpd_num);
 extern int dpd_init(int dpd_num, int nirreps, long int memory, int cachetype, int *cachefiles, int **cachelist,
                     dpd_file4_cache_entry *priority, int num_subspaces, std::vector<int *> &spaceArrays);
 extern int dpd_close(int dpd_num);
-extern long int PSI_API dpd_memfree(void);
+extern long int PSI_API dpd_memfree();
 extern void dpd_memset(long int memory);
 
 }  // Namespace psi

--- a/psi4/src/psi4/libdpd/file2_cache.cc
+++ b/psi4/src/psi4/libdpd/file2_cache.cc
@@ -37,9 +37,9 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {
 
-void DPD::file2_cache_init(void) { dpd_main.file2_cache = nullptr; }
+void DPD::file2_cache_init() { dpd_main.file2_cache = nullptr; }
 
-void DPD::file2_cache_close(void) {
+void DPD::file2_cache_close() {
     int dpdnum;
     dpd_file2_cache_entry *this_entry, *next_entry;
     dpdfile2 Outfile;
@@ -83,7 +83,7 @@ dpd_file2_cache_entry *DPD::file2_cache_scan(int filenum, int irrep, int pnum, i
     return (this_entry);
 }
 
-dpd_file2_cache_entry *DPD::dpd_file2_cache_last(void) {
+dpd_file2_cache_entry *DPD::dpd_file2_cache_last() {
     dpd_file2_cache_entry *this_entry;
 
     this_entry = dpd_main.file2_cache;

--- a/psi4/src/psi4/libdpd/file4_cache.cc
+++ b/psi4/src/psi4/libdpd/file4_cache.cc
@@ -38,7 +38,7 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {
 
-void DPD::file4_cache_init(void) {
+void DPD::file4_cache_init() {
     dpd_main.file4_cache = nullptr;
     dpd_main.file4_cache_most_recent = 0;
     dpd_main.file4_cache_least_recent = 1;
@@ -46,7 +46,7 @@ void DPD::file4_cache_init(void) {
     dpd_main.file4_cache_low_del = 0;
 }
 
-void DPD::file4_cache_close(void) {
+void DPD::file4_cache_close() {
     int dpdnum;
     dpd_file4_cache_entry *this_entry, *next_entry;
     dpdfile4 Outfile;
@@ -110,7 +110,7 @@ dpd_file4_cache_entry *DPD::file4_cache_scan(int filenum, int irrep, int pqnum, 
     return (this_entry);
 }
 
-dpd_file4_cache_entry *DPD::file4_cache_last(void) {
+dpd_file4_cache_entry *DPD::file4_cache_last() {
     dpd_file4_cache_entry *this_entry;
 
     this_entry = dpd_main.file4_cache;
@@ -247,7 +247,7 @@ int DPD::file4_cache_del(dpdfile4 *File) {
     return 0;
 }
 
-void DPD::file4_cache_print_screen(void) {
+void DPD::file4_cache_print_screen() {
     int total_size = 0;
     dpd_file4_cache_entry *this_entry;
 
@@ -310,7 +310,7 @@ void DPD::file4_cache_print(std::string out) {
     printer->Printf("Least recent entry = %d\n", dpd_main.file4_cache_least_recent);
 }
 
-dpd_file4_cache_entry *DPD::file4_cache_find_lru(void) {
+dpd_file4_cache_entry *DPD::file4_cache_find_lru() {
     dpd_file4_cache_entry *this_entry;
 
     this_entry = dpd_main.file4_cache;
@@ -342,7 +342,7 @@ dpd_file4_cache_entry *DPD::file4_cache_find_lru(void) {
     return (nullptr);
 }
 
-int DPD::file4_cache_del_lru(void) {
+int DPD::file4_cache_del_lru() {
     int dpdnum;
     dpdfile4 File;
     dpd_file4_cache_entry *this_entry;
@@ -420,7 +420,7 @@ int DPD::file4_cache_get_priority(dpdfile4 *File) {
     return (0);
 }
 
-dpd_file4_cache_entry *dpd_file4_cache_find_low(void) {
+dpd_file4_cache_entry *dpd_file4_cache_find_low() {
     dpd_file4_cache_entry *this_entry, *low_entry;
 
     this_entry = dpd_main.file4_cache;
@@ -445,7 +445,7 @@ dpd_file4_cache_entry *dpd_file4_cache_find_low(void) {
     return low_entry;
 }
 
-int DPD::file4_cache_del_low(void) {
+int DPD::file4_cache_del_low() {
     int dpdnum;
     dpdfile4 File;
     dpd_file4_cache_entry *this_entry;

--- a/psi4/src/psi4/libdpd/init.cc
+++ b/psi4/src/psi4/libdpd/init.cc
@@ -81,7 +81,7 @@ extern int dpd_close(int dpd_num) {
     return 0;
 }
 
-extern long int dpd_memfree(void) {
+extern long int dpd_memfree() {
     return dpd_main.memory - (dpd_main.memused - dpd_main.memcache + dpd_main.memlocked);
 }
 

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -144,7 +144,7 @@ private:
     struct GridData {
         int order;
         int npoints;
-        MassPoint const *(*mkGridFn)(void);
+        MassPoint const *(*mkGridFn)();
         MassPoint const *grid;
     };
     static GridData grids_[];

--- a/psi4/src/psi4/libfock/points.h
+++ b/psi4/src/psi4/libfock/points.h
@@ -204,7 +204,7 @@ public:
     void compute_orbitals(std::shared_ptr<BlockOPoints> block, bool force_compute = true);
     void set_Cs(SharedMatrix Cocc);
     void set_Cs(SharedMatrix Caocc, SharedMatrix Cbocc);
-    size_t block_index(void) { return block_index_; }
+    size_t block_index() { return block_index_; }
 };
 
 class UKSFunctions : public PointFunctions {
@@ -262,7 +262,7 @@ public:
     void compute_orbitals(std::shared_ptr<BlockOPoints> block, bool force_compute = true);
     void set_Cs(SharedMatrix Cocc);
     void set_Cs(SharedMatrix Caocc, SharedMatrix Cbocc);
-    size_t block_index(void) { return block_index_; }
+    size_t block_index() { return block_index_; }
 };
 
 

--- a/psi4/src/psi4/libfock/soscf.h
+++ b/psi4/src/psi4/libfock/soscf.h
@@ -71,7 +71,7 @@ public:
      */
      SOMCSCF(std::shared_ptr<JK> jk, SharedMatrix AOTOSO, SharedMatrix H);
 
-    virtual ~SOMCSCF(void);
+    virtual ~SOMCSCF();
 
     /**
      * Sets the amount of memory (in doubles) available to the program

--- a/psi4/src/psi4/libfock/v.h
+++ b/psi4/src/psi4/libfock/v.h
@@ -129,7 +129,7 @@ public:
 
     // Creates a collocation cache map based on stride
     void build_collocation_cache(size_t memory);
-    void clear_collocation_cache(void) { cache_map_.clear(); }
+    void clear_collocation_cache() { cache_map_.clear(); }
 
     // Set the D matrix, get it back if needed
     void set_D(std::vector<SharedMatrix> Dvec);

--- a/psi4/src/psi4/libmints/cdsalclist.h
+++ b/psi4/src/psi4/libmints/cdsalclist.h
@@ -162,7 +162,7 @@ class CdSalcList {
     std::string salc_name(int index) const;
 
     char needed_irreps() const { return needed_irreps_; }
-    int nirrep(void) const { return nirrep_; }
+    int nirrep() const { return nirrep_; }
     int cdsalcpi(int h) const { return cdsalcpi_[h]; }
     bool project_out_translations() const { return project_out_translations_; }
     bool project_out_rotations() const { return project_out_rotations_; }

--- a/psi4/src/psi4/libmints/element_to_Z.h
+++ b/psi4/src/psi4/libmints/element_to_Z.h
@@ -55,7 +55,7 @@ class Element_to_Z {
         return element_to_Z[elem_sym];
     }
 
-    void load_values(void) {
+    void load_values() {
         loaded = true;
         element_to_Z["G"] = element_to_Z["GHOST"] = 0.0;
         element_to_Z["H"] = element_to_Z["HYDROGEN"] = 1.0;

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -187,7 +187,7 @@ class PSI_API Molecule {
     Molecule(const Molecule& other);
     virtual ~Molecule();
 
-    Molecule clone(void) {
+    Molecule clone() {
         Molecule new_obj(*this);
         return new_obj;
     }
@@ -383,7 +383,7 @@ class PSI_API Molecule {
     Vector rotational_constants(double tol = FULL_PG_TOL) const;
 
     /// Print the rotational constants
-    void print_rotational_constants(void) const;
+    void print_rotational_constants() const;
     /// Return the rotor type
     RotorType rotor_type(double tol = FULL_PG_TOL) const;
 

--- a/psi4/src/psi4/libmints/twobody.cc
+++ b/psi4/src/psi4/libmints/twobody.cc
@@ -90,12 +90,12 @@ TwoBodyAOInt *TwoBodyAOInt::clone() const {
     throw FeatureNotImplemented("libmints", "TwoBodyInt::clone()", __FILE__, __LINE__);
 }
 
-std::vector<ShellPairBlock> TwoBodyAOInt::get_blocks12(void) const { return blocks12_; }
+std::vector<ShellPairBlock> TwoBodyAOInt::get_blocks12() const { return blocks12_; }
 
-std::vector<ShellPairBlock> TwoBodyAOInt::get_blocks34(void) const { return blocks34_; }
+std::vector<ShellPairBlock> TwoBodyAOInt::get_blocks34() const { return blocks34_; }
 
 // Expected to be overridden by derived classes
-void TwoBodyAOInt::create_blocks(void) {
+void TwoBodyAOInt::create_blocks() {
     // Default implementation : do no blocking.
     // Each ShellPairBlock will only contain one shell pair
     blocks12_.clear();

--- a/psi4/src/psi4/libmints/twobody.h
+++ b/psi4/src/psi4/libmints/twobody.h
@@ -102,7 +102,7 @@ class PSI_API TwoBodyAOInt {
      *
      * Default implementation
      */
-    void create_blocks(void);
+    void create_blocks();
 
     void permute_target(double *s, double *t, int sh1, int sh2, int sh3, int sh4, bool p12, bool p34, bool p13p24);
     void permute_1234_to_1243(double *s, double *t, int nbf1, int nbf2, int nbf3, int nbf4);
@@ -156,10 +156,10 @@ class PSI_API TwoBodyAOInt {
     virtual size_t compute_shell(int, int, int, int) = 0;
 
     //! Get optimal blocks of shell pairs for centers 1 & 2
-    std::vector<ShellPairBlock> get_blocks12(void) const;
+    std::vector<ShellPairBlock> get_blocks12() const;
 
     //! Get optimal blocks of shell pairs for centers 3 & 4
-    std::vector<ShellPairBlock> get_blocks34(void) const;
+    std::vector<ShellPairBlock> get_blocks34() const;
 
     /*! Compute integrals for two blocks
      *

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -642,12 +642,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Get and set variables dictionary
     double get_variable(const std::string key);
     void set_variable(const std::string key, double value) { variables_[key] = value; }
-    std::map<std::string, double> variables(void) { return variables_; }
+    std::map<std::string, double> variables() { return variables_; }
 
     /// Get and set arrays dictionary
     SharedMatrix get_array(const std::string key);
     void set_array(const std::string key, SharedMatrix value) { arrays_[key] = value; }
-    std::map<std::string, SharedMatrix> arrays(void) { return arrays_; }
+    std::map<std::string, SharedMatrix> arrays() { return arrays_; }
 
     /// Set PCM object
     void set_PCM(const std::shared_ptr<PCM>& pcm);

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -684,7 +684,7 @@ DataType* Options::set_local_array_array(const std::string& module, const std::s
     return set_local_array_entry(module, key, new ArrayType(), entry);
 }
 
-void Options::clear(void) {
+void Options::clear() {
     globals_.clear();
     locals_.clear();
 }

--- a/psi4/src/psi4/liboptions/liboptions.h
+++ b/psi4/src/psi4/liboptions/liboptions.h
@@ -418,7 +418,7 @@ class PSI_API Options {
     void set_local_array_int(const std::string& module, const std::string& key, int val, DataType* entry);
     DataType* set_local_array_array(const std::string& module, const std::string& key, DataType* entry);
 
-    void clear(void);
+    void clear();
 
     bool exists_in_active(std::string key);
 

--- a/psi4/src/psi4/libpsio/done.cc
+++ b/psi4/src/psi4/libpsio/done.cc
@@ -79,7 +79,7 @@ PSIO::~PSIO() {
     files_keywords_.clear();
 }
 
-int psio_done(void) {
+int psio_done() {
     if (_default_psio_lib_) {
         // The old pointer implementation of this used to set the pointer to zero for
         // the test used in psio_init.  This is not necessary with smart pointers

--- a/psi4/src/psi4/libpsio/get_numvols.cc
+++ b/psi4/src/psi4/libpsio/get_numvols.cc
@@ -58,7 +58,7 @@ size_t PSIO::get_numvols(size_t unit) {
     abort();
 }
 
-size_t psio_get_numvols_default(void) {
+size_t psio_get_numvols_default() {
     std::string charnum;
 
     charnum = _default_psio_lib_->filecfg_kwd("PSI", "NVOLUME", -1);

--- a/psi4/src/psi4/libpsio/getpid.cc
+++ b/psi4/src/psi4/libpsio/getpid.cc
@@ -49,7 +49,7 @@
 
 namespace psi {
 
-std::string PSIO::getpid(void) {
+std::string PSIO::getpid() {
     std::stringstream ss;
 
     if (psi::restart_id.empty()) {
@@ -60,7 +60,7 @@ std::string PSIO::getpid(void) {
     return ss.str();
 }
 
-std::string psio_getpid(void) {
+std::string psio_getpid() {
     std::stringstream ss;
 
     if (psi::restart_id.empty()) {

--- a/psi4/src/psi4/libpsio/init.cc
+++ b/psi4/src/psi4/libpsio/init.cc
@@ -114,7 +114,7 @@ PSIO::PSIO() {
 
 std::shared_ptr<PSIO> PSIO::shared_object() { return _default_psio_lib_; }
 
-int psio_init(void) {
+int psio_init() {
     if (_default_psio_lib_.get() == 0) {
         auto temp = std::make_shared<PSIO>();
         _default_psio_lib_ = temp;

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -35,16 +35,16 @@
 
 namespace psi {
 
-int psio_init(void);
-int psio_ipv1_config(void);
-int psio_state(void);
-int psio_done(void);
+int psio_init();
+int psio_ipv1_config();
+int psio_state();
+int psio_done();
 void psio_error(size_t unit, size_t errval);
 int psio_open(size_t unit, int status);
 int psio_close(size_t unit, int keep);
-std::string psio_getpid(void);
+std::string psio_getpid();
 
-size_t psio_get_numvols_default(void);
+size_t psio_get_numvols_default();
 int psio_get_volpath_default(size_t volume, char **path);
 int psio_get_filename_default(char **name);
 PSI_API psio_address psio_get_address(psio_address start, size_t shift);

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -229,7 +229,7 @@ public:
     /// close unit. if keep == 0, will remove the file, else keep it
     void close(size_t unit, int keep);
     /// lookup process id
-    std::string getpid(void);
+    std::string getpid();
     /// sync up the object to the file on disk by closing and opening the file, if necessary
     void rehash(size_t unit);
     /// return 1 if unit is open

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -80,8 +80,8 @@ void dirprd_block(double** A, double** B, int rows, int cols);
 int pople(double** A, double* x, int dimen, int num_vecs, double tolerance, std::string out_fname, int print_lvl);
 void mat_print(double** A, int rows, int cols, std::string out_fname);
 
-void timer_init(void);
-void timer_done(void);
+void timer_init();
+void timer_done();
 void timer_on(const std::string& key);
 void timer_off(const std::string& key);
 void parallel_timer_on(const std::string& key, int thread_rank);

--- a/psi4/src/psi4/libqt/timer.cc
+++ b/psi4/src/psi4/libqt/timer.cc
@@ -980,7 +980,7 @@ bool empty_parallel() {
 **
 ** \ingroup QT
 */
-void timer_init(void) {
+void timer_init() {
     omp_init_lock(&lock_timer);
     omp_set_lock(&lock_timer);
     extern time_t timer_start;
@@ -999,7 +999,7 @@ void timer_init(void) {
 **
 ** \ingroup QT
 */
-void timer_done(void) {
+void timer_done() {
     extern time_t timer_start, timer_end;
     omp_set_lock(&lock_timer);
     extern Timer_Structure root_timer;

--- a/psi4/src/psi4/optking/IRC_data.h
+++ b/psi4/src/psi4/optking/IRC_data.h
@@ -79,18 +79,18 @@ class IRC_POINT {
 
     ~IRC_POINT() {free_array(q_pivot); free_array(x_pivot); free_array(q); free_array(x); free_array(f_q); free_array(f_x);}
 
-    int g_coord_step(void) const { return coord_step; }
-    double *g_q_pivot(void) const { return q_pivot; }
-    double *g_x_pivot(void) const { return x_pivot; }
-    double *g_q(void) const { return q; }
+    int g_coord_step() const { return coord_step; }
+    double *g_q_pivot() const { return q_pivot; }
+    double *g_x_pivot() const { return x_pivot; }
+    double *g_q() const { return q; }
     double g_q(int i) const { return q[i]; }
-    double *g_x(void) const { return x; }
-    double *g_f_q(void) const { return f_q; }
-    double *g_f_x(void) const { return f_x; }
-    double g_energy(void) const { return energy; }
-    double g_step_dist(void) const { return step_dist; }
-    double g_arc_dist(void) const { return arc_dist; }
-    double g_line_dist(void) const { return line_dist; }
+    double *g_x() const { return x; }
+    double *g_f_q() const { return f_q; }
+    double *g_f_x() const { return f_x; }
+    double g_energy() const { return energy; }
+    double g_step_dist() const { return step_dist; }
+    double g_arc_dist() const { return arc_dist; }
+    double g_line_dist() const { return line_dist; }
 };
 
 // IRC reaction path data
@@ -128,33 +128,33 @@ class IRC_DATA {
       steps.clear();
     }
 
-    int size(void) { return steps.size(); }
+    int size() { return steps.size(); }
 
-    int g_next_coord_step(void) {
+    int g_next_coord_step() {
       if(size() == 0)
         return 0;
       else
         return steps.back()->g_coord_step() + 1;
     }
 
-    int g_coord_step(void)  { return coord_step;  }
-    int g_sphere_step(void) { return sphere_step; }
-    double g_arc_dist(void) { return arc_dist;    }
+    int g_coord_step()  { return coord_step;  }
+    int g_sphere_step() { return sphere_step; }
+    double g_arc_dist() { return arc_dist;    }
 
-    double g_energy(void)    const { return steps.back()->g_energy()   ; }
-    double g_step_dist(void) const { return steps.back()->g_step_dist(); }
-    double g_arc_dist(void)  const { return steps.back()->g_arc_dist() ; }
-    double g_line_dist(void) const { return steps.back()->g_line_dist(); }
+    double g_energy()    const { return steps.back()->g_energy()   ; }
+    double g_step_dist() const { return steps.back()->g_step_dist(); }
+    double g_arc_dist()  const { return steps.back()->g_arc_dist() ; }
+    double g_line_dist() const { return steps.back()->g_line_dist(); }
 
-    double *g_q_pivot(void) const
+    double *g_q_pivot() const
     {
       return steps[steps.size()-1]->g_q_pivot();
     }
-    double *g_x_pivot(void) const
+    double *g_x_pivot() const
     {
       return steps[steps.size()-1]->g_x_pivot();
     }
-    double *g_q(void) const
+    double *g_q() const
     {
       return steps[steps.size()-1]->g_q();
     }
@@ -162,15 +162,15 @@ class IRC_DATA {
     //{
       //return g_q(i);
     //}
-    double *g_x(void) const
+    double *g_x() const
     {
       return steps[steps.size()-1]->g_x();
     }
-    double *g_f_q(void) const
+    double *g_f_q() const
     {
       return steps[steps.size()-1]->g_f_q();
     }
-    double *g_f_x(void) const
+    double *g_f_x() const
     {
       return steps[steps.size()-1]->g_f_x();
     }
@@ -201,7 +201,7 @@ class IRC_DATA {
       steps.push_back(onepoint);
     }
 
-    friend void MOLECULE::irc_step(void);
+    friend void MOLECULE::irc_step();
 
     void point_converged(opt::MOLECULE &mol);
     void progress_report(opt::MOLECULE &mol);

--- a/psi4/src/psi4/optking/bend.h
+++ b/psi4/src/psi4/optking/bend.h
@@ -70,17 +70,17 @@ class BEND : public SIMPLE_COORDINATE {
     bool operator==(const SIMPLE_COORDINATE & s2) const;
     std::string get_definition_string(int atom_offset=0) const;
 
-    void make_lb_normal(void)     { _bend_type = 1; }
-    void make_lb_complement(void) { _bend_type = 2; }
+    void make_lb_normal()     { _bend_type = 1; }
+    void make_lb_complement() { _bend_type = 2; }
 
-    bool is_linear_bend(void) const { return ((_bend_type == 1) || (_bend_type == 2)); }
-    bool is_lb_normal(void) const     { return (_bend_type == 1); }
-    bool is_lb_complement(void) const { return (_bend_type == 2); }
+    bool is_linear_bend() const { return ((_bend_type == 1) || (_bend_type == 2)); }
+    bool is_lb_normal() const     { return (_bend_type == 1); }
+    bool is_lb_complement() const { return (_bend_type == 2); }
 
-    int  g_bend_type(void) const { return _bend_type; }
+    int  g_bend_type() const { return _bend_type; }
     void compute_axes(GeomType geom) const;
-    void fix_axes(void)   { axes_fixed = true; }
-    void unfix_axes(void) { axes_fixed = false; }
+    void fix_axes()   { axes_fixed = true; }
+    void unfix_axes() { axes_fixed = false; }
 
 };
 

--- a/psi4/src/psi4/optking/cart.h
+++ b/psi4/src/psi4/optking/cart.h
@@ -54,7 +54,7 @@ class CART : public SIMPLE_COORDINATE {
     // returned matrix is [atom][x,y,z]
     double **DqDx(GeomType geom) const;
 
-    int g_xyz(void) const { return xyz; }
+    int g_xyz() const { return xyz; }
 
     // compute and return array of second derivative (B' matrix elements)
     // returned matrix is order 3N cart by 3N cart

--- a/psi4/src/psi4/optking/combo_coordinates.cc
+++ b/psi4/src/psi4/optking/combo_coordinates.cc
@@ -115,7 +115,7 @@ bool COMBO_COORDINATES::Dq2Dx2(GeomType geom, int lookup, double **dq2dx2, int a
 }
 
 // Clear current combinations.  Leaves simples in place
-void COMBO_COORDINATES::clear_combos(void) {
+void COMBO_COORDINATES::clear_combos() {
   for (std::size_t i=0; i<index.size(); ++i)
     index[i].clear();
   for (std::size_t i=0; i<coeff.size(); ++i)

--- a/psi4/src/psi4/optking/combo_coordinates.h
+++ b/psi4/src/psi4/optking/combo_coordinates.h
@@ -76,7 +76,7 @@ class COMBO_COORDINATES {
   string get_coord_definition(int lookup, int frag_atom_offset) const;
 
   // Clear current combination coordinates. Leave simples in place.
-  void clear_combos(void);
+  void clear_combos();
 
   // Remove a particular combination coordinate by index.
   void erase_combo(int cc);
@@ -97,7 +97,7 @@ class COMBO_COORDINATES {
   // Transform vector from simples to combination via linear combination
   double ** transform_simples_to_combo(double **mat_simples) const;
 
-  int Nsimples(void) const { return simples.size(); }
+  int Nsimples() const { return simples.size(); }
 
 };
 

--- a/psi4/src/psi4/optking/fb_frag.cc
+++ b/psi4/src/psi4/optking/fb_frag.cc
@@ -76,7 +76,7 @@ void FB_FRAG::print_intcos(std::string psi_fp, FILE *qc_fp) {
   oprintf(psi_fp, qc_fp, "\n");
 }
 
-double **FB_FRAG::H_guess(void) {
+double **FB_FRAG::H_guess() {
   double **H = init_matrix(Ncoord(), Ncoord());
 
   for (int i=0; i<Ncoord(); ++i)

--- a/psi4/src/psi4/optking/fb_frag.h
+++ b/psi4/src/psi4/optking/fb_frag.h
@@ -75,8 +75,8 @@ class FB_FRAG : public FRAG {
   void set_values(double * values_in);
   void set_forces(double * forces_in);
 
-  double * get_values_pointer(void) const { return values; }
-  double * get_forces_pointer(void) const { return forces; }
+  double * get_values_pointer() const { return values; }
+  double * get_forces_pointer() const { return forces; }
 
   // we don't have a valid B matrix for these
   // add 6 bogus stretches
@@ -91,7 +91,7 @@ class FB_FRAG : public FRAG {
   std::string get_coord_definition(int coord_index, int atom_offset_A=0, int atom_offset_B=0);
 */
 
-  double **H_guess(void);
+  double **H_guess();
 
   // Tell QChem to update rotation matrix and com for FB fragment
   void displace (int fb_frag_index, double *dq);

--- a/psi4/src/psi4/optking/frag.cc
+++ b/psi4/src/psi4/optking/frag.cc
@@ -94,7 +94,7 @@ FRAG::~FRAG() {
 }
 
 // for now just set default masses - fix later
-void FRAG::set_masses(void) {
+void FRAG::set_masses() {
   int i;
   for (i=0; i<natom; ++i)
     mass[i] = Z_to_mass[(int) Z[i]];
@@ -103,7 +103,7 @@ void FRAG::set_masses(void) {
 
 // automatically determine bond connectivity by comparison of interatomic distance
 //with scale_connectivity * sum of covalent radii
-void FRAG::update_connectivity_by_distances(void) {
+void FRAG::update_connectivity_by_distances() {
   int i, j, *Zint;
   double Rij;
   double scale = Opt_params.scale_connectivity;
@@ -130,7 +130,7 @@ void FRAG::update_connectivity_by_distances(void) {
 }
 
 //build connectivity matrix from the current set of bonds
-void FRAG::update_connectivity_by_bonds(void) {
+void FRAG::update_connectivity_by_bonds() {
   for (int i=0; i<natom; ++i)
     for (int j=0; j<natom; ++j)
       connectivity[i][j] = false;
@@ -146,7 +146,7 @@ void FRAG::update_connectivity_by_bonds(void) {
 
 // automatically add bond stretch coodinates based on connectivity matrix
 // return number of added coordinates
-int FRAG::add_stre_by_connectivity(void) {
+int FRAG::add_stre_by_connectivity() {
   int nadded = 0;
   int i,j;
   for (i=0; i<natom; ++i) {
@@ -168,7 +168,7 @@ int FRAG::add_stre_by_connectivity(void) {
 // Add missing hydrogen bond stretches - return number added
 // defined as [O,N,F,Cl]-H ... [O,N,F,Cl] with distance < 2.3 Angstroms
 // and angle greater than 90 degrees
-int FRAG::add_hbonds(void) {
+int FRAG::add_hbonds() {
   int nadded = 0;
   double dist, ang;
   const double pi = acos(-1);
@@ -223,7 +223,7 @@ int FRAG::add_hbonds(void) {
 }
 
 // Add auxiliary bonds; distance is < 2.5 times sum of covalent radii
-int FRAG::add_auxiliary_bonds(void) {
+int FRAG::add_auxiliary_bonds() {
   int nadded = 0;
 
   int *Zint = new int [natom];
@@ -277,7 +277,7 @@ int FRAG::add_auxiliary_bonds(void) {
 }
 
 // angles for all bonds present; return number added
-int FRAG::add_bend_by_connectivity(void) {
+int FRAG::add_bend_by_connectivity() {
   int nadded = 0;
   double phi;
 
@@ -357,7 +357,7 @@ int FRAG::add_bend_by_connectivity(void) {
 }
 
 // torsions for all bonds present; return number added
-int FRAG::add_tors_by_connectivity(void) {
+int FRAG::add_tors_by_connectivity() {
   int nadded = 0;
   int i,j,k,l;
   double phi;

--- a/psi4/src/psi4/optking/frag.h
+++ b/psi4/src/psi4/optking/frag.h
@@ -82,9 +82,9 @@ class FRAG {
   /** Description
     \returns number of atoms.
     */
-  int g_natom(void) const { return natom; };
+  int g_natom() const { return natom; };
 
-  void set_masses(void);
+  void set_masses();
 
   void print_geom(std::string psi_fp, FILE *qc_fp, const int id, bool print_mass = false);
   void print_geom_grad(std::string psi_fp, FILE *qc_fp, const int id, bool print_mass = false);
@@ -98,23 +98,23 @@ class FRAG {
 
   INTCO_TYPE get_simple_type(int simple_index);
 
-  void update_connectivity_by_distances(void);
-  void update_connectivity_by_bonds(void);
+  void update_connectivity_by_distances();
+  void update_connectivity_by_bonds();
 
   void print_connectivity(std::string psi_fp, FILE *qc_fp, const int id, const int offset = 0) const ;
 
   // add simple internals based on connectivity; return number added
-  int add_stre_by_connectivity(void);
-  int add_bend_by_connectivity(void);
-  int add_tors_by_connectivity(void);
-  int add_cartesians(void);
+  int add_stre_by_connectivity();
+  int add_bend_by_connectivity();
+  int add_tors_by_connectivity();
+  int add_cartesians();
 
-  int form_trivial_coord_combinations(void);
+  int form_trivial_coord_combinations();
   void add_trivial_coord_combination(int simple_id);
-  int form_delocalized_coord_combinations(void);
-  int form_natural_coord_combinations(void);
+  int form_delocalized_coord_combinations();
+  int form_natural_coord_combinations();
 
-  int add_simples_by_connectivity(void) {
+  int add_simples_by_connectivity() {
     int n;
     n  = add_stre_by_connectivity();
     n += add_bend_by_connectivity();
@@ -122,7 +122,7 @@ class FRAG {
     return n;
   }
 
-  int add_auxiliary_bonds(void);
+  int add_auxiliary_bonds();
 
   // add connectivity between two atoms; atom numbers are for fragment
   void connect(int i, int j) {
@@ -130,7 +130,7 @@ class FRAG {
   }
 
   // Compute B matrix for only this fragment
-  double ** compute_B(void) const ;
+  double ** compute_B() const ;
 
   // Compute B matrix. Use prevously allocated memory.  Offsets are ideal for molecule.
   void compute_B(double **B_in, int coord_offset, int atom_offset) const ;
@@ -153,20 +153,20 @@ class FRAG {
   void print_B(std::string psi_fp, FILE *qc_fp) const ;
 
   // check nearness to 180 and save value
-  void fix_tors_near_180(void);
+  void fix_tors_near_180();
 
   // check nearness to 180 and save value
-  void fix_oofp_near_180(void);
+  void fix_oofp_near_180();
 
   // Fix bend axes for consistency during displacments
-  void fix_bend_axes(void);
-  void unfix_bend_axes(void);
+  void fix_bend_axes();
+  void unfix_bend_axes();
 
   // check if interior angles of torsion are near 0 or linear
   //bool check_tors_for_bad_angles(void) const;
 
   // return number of intrafragment coordinates
-  int Ncoord(void) const { return coords.index.size(); };
+  int Ncoord() const { return coords.index.size(); };
 
   // The following 2 functions are only used by the B matrix testing routines.
   // return natom in definition of coord # coord_index
@@ -180,8 +180,8 @@ class FRAG {
   }
 
   // return array of atomic numbers
-  double *g_Z(void) const;
-  double *g_Z_pointer(void) { return Z; }
+  double *g_Z() const;
+  double *g_Z_pointer() { return Z; }
 
   //print s vectors to output file
   void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const {
@@ -190,7 +190,7 @@ class FRAG {
   }
 
   // Get all values.
-  double *coord_values(void) const;
+  double *coord_values() const;
   double *coord_values(GeomType geom) const;
 
   // Get one value.
@@ -210,15 +210,15 @@ class FRAG {
   // utility used by displace
   bool displace_util(double *dq, bool focus_on_constraints);
 
-  double ** g_geom_pointer(void) { return geom; };           // returns pointer
-  double ** g_geom(void) const;                              // returns a copy
-  GeomType g_geom_const_pointer(void) const { return geom;}; // returns const pointer
+  double ** g_geom_pointer() { return geom; };           // returns pointer
+  double ** g_geom() const;                              // returns a copy
+  GeomType g_geom_const_pointer() const { return geom;}; // returns const pointer
 
-  double ** g_grad(void);
-  double ** g_grad_pointer(void) {return grad;};
+  double ** g_grad();
+  double ** g_grad_pointer() {return grad;};
 
-  double * g_geom_array(void);
-  double * g_grad_array(void);
+  double * g_geom_array();
+  double * g_grad_array();
   void set_geom_array(double * geom_array_in);
   void set_geom(double ** geom_in);
   void set_grad(double **grad_in);
@@ -226,22 +226,22 @@ class FRAG {
   void print_geom(std::string psi_fp, FILE *qc_fp); // write cartesian geometry out for next step
   void print_geom_irc(std::string psi_fp, FILE *qc_fp); // write cartesian geometry out for next step
 
-  double ** H_guess(void);
+  double ** H_guess();
   // function to help with Lindh guess hessian
   double Lindh_rho(int A, int B, double RAB) const;
   // function to help with Lindh guess hessian - original constants
-  double **Lindh_guess(void);
-  bool **g_connectivity(void) const;
-  const bool * const * g_connectivity_pointer(void) const;
+  double **Lindh_guess();
+  bool **g_connectivity() const;
+  const bool * const * g_connectivity_pointer() const;
 
   bool read_coord(std::vector<std::string> & tokens, int first_atom_offset);
 
   // return matrix of constraints on coordinates
-  double ** compute_constraints(void) const;
+  double ** compute_constraints() const;
 
   // add any missing hydrogen bonds within the fragment
   // return number added
-  int add_hbonds(void);
+  int add_hbonds();
 
   void simple_add(SIMPLE_COORDINATE * i) {
     coords.simples.push_back(i);
@@ -250,12 +250,12 @@ class FRAG {
   double g_mass(int i) { return mass[i]; }
 
   // relating to frozen fragments
-  bool is_frozen(void) const { return frozen; }
-  void freeze(void)   { frozen = true; }
-  void unfreeze(void) { frozen = false; }
+  bool is_frozen() const { return frozen; }
+  void freeze()   { frozen = true; }
+  void unfreeze() { frozen = false; }
 
   // freeze coords within fragments
-  void freeze_coords(void);
+  void freeze_coords();
 
   /**
    * Compute center of mass of given geometry
@@ -264,7 +264,7 @@ class FRAG {
   /**
    * Compute center of mass of fragment geometry
    */
-  double *com(void) { return (com(geom)); }
+  double *com() { return (com(geom)); }
   /**
    * Compute intertia tensor of given geometry
    */
@@ -272,7 +272,7 @@ class FRAG {
   /**
    * Compute intertia tensor of fragment geometry
    */
-  double **inertia_tensor(void) { return (inertia_tensor(geom)); }
+  double **inertia_tensor() { return (inertia_tensor(geom)); }
   /**
    * Compute principal axes of given geometry
    */
@@ -319,7 +319,7 @@ class FRAG {
   void erase_combo_coord(int index) { coords.erase_combo(index); } ;
 
   /* Are any coordinates present that are not cartesians? */
-  bool is_noncart_present(void) const;
+  bool is_noncart_present() const;
 
 };
 

--- a/psi4/src/psi4/optking/frag_H_guess.cc
+++ b/psi4/src/psi4/optking/frag_H_guess.cc
@@ -116,7 +116,7 @@ static inline double Rcov(double ZA, double ZB) {
 }
 
 // This function generates various diagonal Hessian guesses.
-double ** FRAG::H_guess(void) {
+double ** FRAG::H_guess() {
 
   double **R = init_matrix(natom, natom);
   for (int i=0; i<natom; ++i)

--- a/psi4/src/psi4/optking/frag_natural.cc
+++ b/psi4/src/psi4/optking/frag_natural.cc
@@ -60,7 +60,7 @@ bool int_compare(int i, int j) {return i<j;}
 using namespace v3d;
 
 // Determine Pulay simple coordinate combinations.
-int FRAG::form_natural_coord_combinations(void) {
+int FRAG::form_natural_coord_combinations() {
   coords.clear_combos();
 
   int Ns = coords.Nsimples();

--- a/psi4/src/psi4/optking/geom_gradients_io.cc
+++ b/psi4/src/psi4/optking/geom_gradients_io.cc
@@ -67,7 +67,7 @@ bool is_integer(const char *check) {
 }
 
 // read the number of atoms
-int read_natoms(void) {
+int read_natoms() {
   int natom=0;
 
 #if defined(OPTKING_PACKAGE_PSI)
@@ -93,7 +93,7 @@ int read_natoms(void) {
 // Read geometry and gradient into a molecule object.
 // The fragments must already exist with the number of atoms in each set
 // and with allocated memory.
-void MOLECULE::read_geom_grad(void) {
+void MOLECULE::read_geom_grad() {
   int nfrag = fragments.size();
   //int nallatom = g_natom();
 
@@ -337,7 +337,7 @@ void MOLECULE::symmetrize_geom(bool flexible) {
 #endif
 }
 
-void MOLECULE::write_geom(void) {
+void MOLECULE::write_geom() {
 
 #if defined(OPTKING_PACKAGE_PSI)
 
@@ -360,7 +360,7 @@ void MOLECULE::write_geom(void) {
 #endif
 }
 
-double ** OPT_DATA::read_cartesian_H(void) const {
+double ** OPT_DATA::read_cartesian_H() const {
 
   double **H_cart = init_matrix(Ncart, Ncart);
 

--- a/psi4/src/psi4/optking/globals.h
+++ b/psi4/src/psi4/optking/globals.h
@@ -54,7 +54,7 @@ namespace opt {
   EXTERN std::string psi_outfile;
   EXTERN FILE *qc_outfile;
 
-  int read_natoms(void);
+  int read_natoms();
 }
 
 

--- a/psi4/src/psi4/optking/interfrag.cc
+++ b/psi4/src/psi4/optking/interfrag.cc
@@ -74,7 +74,7 @@ INTERFRAG::INTERFRAG(FRAG *A_in, FRAG *B_in, int A_index_in, int B_index_in,
 
 // adds the coordinates connecting A2-A1-A0-B0-B1-B2
 // sets D_on to indicate which ones (of the 6) are unusued
-void INTERFRAG::add_coordinates_of_reference_pts(void) {
+void INTERFRAG::add_coordinates_of_reference_pts() {
   STRE *one_stre = nullptr;  // RAB
   BEND *one_bend = nullptr;  // theta_A
   BEND *one_bend2 = nullptr; // theta_B
@@ -281,7 +281,7 @@ void INTERFRAG::update_reference_points(GeomType new_geom_A, GeomType new_geom_B
   }
 }
 
-int INTERFRAG::Ncoord(void) const {
+int INTERFRAG::Ncoord() const {
   int dim = 0;
   for (int i=0; i<6; ++i)
     if (D_on[i]) ++dim;
@@ -311,7 +311,7 @@ void INTERFRAG::freeze(int index_to_freeze) {
   inter_frag->coords.simples[index_to_freeze]->freeze();
 }
 
-void INTERFRAG::freeze(void) {
+void INTERFRAG::freeze() {
   inter_frag->freeze();
 }
 
@@ -323,7 +323,7 @@ bool INTERFRAG::is_frozen(int J) {
 }
 
 // are all interfragment modes frozen?
-bool INTERFRAG::is_frozen(void) {
+bool INTERFRAG::is_frozen() {
   return inter_frag->is_frozen();
 }
 
@@ -733,7 +733,7 @@ std::string INTERFRAG::get_coord_definition(int coord_index, int off_A, int off_
 }
 
 // Make the initial Hessian guess for interfragment coordinates
-double ** INTERFRAG::H_guess(void) {
+double ** INTERFRAG::H_guess() {
   double **H;
 
   // use formulas from Fischer et al - not designed for interfragment modes
@@ -784,7 +784,7 @@ double ** INTERFRAG::H_guess(void) {
 }
 
 // return matrix with 1's on diagonal for frozen coordinates
-double ** INTERFRAG::compute_constraints(void) const {
+double ** INTERFRAG::compute_constraints() const {
   double **C = init_matrix(Ncoord(), Ncoord());
   int cnt = 0;
   for (int i=0; i<6; ++i) {
@@ -796,7 +796,7 @@ double ** INTERFRAG::compute_constraints(void) const {
   return C;
 }
 
-int INTERFRAG::form_trivial_coord_combinations(void) {
+int INTERFRAG::form_trivial_coord_combinations() {
   inter_frag->coords.clear_combos();
   for (std::size_t s=0; s<inter_frag->coords.simples.size(); ++s) {
     std::vector<int> i1;

--- a/psi4/src/psi4/optking/interfrag.h
+++ b/psi4/src/psi4/optking/interfrag.h
@@ -101,24 +101,24 @@ class INTERFRAG {
   ~INTERFRAG() { delete inter_frag; }
 
   // update location of reference points using fragment member geometries
-  void update_reference_points(void) {
+  void update_reference_points() {
     update_reference_points(A->geom, B->geom);
   }
 
   // update location of reference points using given geometries
   void update_reference_points(GeomType new_geom_A, GeomType new_geom_B);
 
-  int Ncoord(void) const;
+  int Ncoord() const;
 
   // return vector index of fragments in molecule vector
-  int g_A_index(void) const { return A_index; }
-  int g_B_index(void) const { return B_index; }
+  int g_A_index() const { return A_index; }
+  int g_B_index() const { return B_index; }
 
-  int g_ndA(void) const { return ndA; }
-  int g_ndB(void) const { return ndB; }
+  int g_ndA() const { return ndA; }
+  int g_ndB() const { return ndB; }
 
   // compute and return coordinate values - using fragment member geometries
-  double *coord_values(void) {
+  double *coord_values() {
     double *q = coord_values(A->geom, B->geom);
     return q;
   }
@@ -130,33 +130,33 @@ class INTERFRAG {
   void freeze(int J);
 
   // freeze all interfragment coordinates in this set
-  void freeze(void);
+  void freeze();
 
   // is coordinate J frozen?  J runs over only active coordinates.
   bool is_frozen(int J);
 
   // are all of these interfragment coordinates frozen?
-  bool is_frozen(void);
+  bool is_frozen();
 
   // compute and return coordinate values - using given fragment geometries
   double *coord_values(GeomType new_geom_A, GeomType new_geom_B);
 
   // check nearness to 180 and save value
-  void fix_tors_near_180(void) {
+  void fix_tors_near_180() {
     update_reference_points();
     inter_frag->fix_tors_near_180();
   }
 
-  void fix_oofp_near_180(void) {
+  void fix_oofp_near_180() {
     update_reference_points();
     inter_frag->fix_oofp_near_180();
   }
 
-  void fix_bend_axes(void) {
+  void fix_bend_axes() {
     update_reference_points();
     inter_frag->fix_bend_axes();
   }
-  void unfix_bend_axes(void) {
+  void unfix_bend_axes() {
     update_reference_points();
     inter_frag->unfix_bend_axes();
   }
@@ -172,7 +172,7 @@ class INTERFRAG {
   }
 
   // allocate and return B matrix only for this interfragment.
-  double **compute_B(void) {
+  double **compute_B() {
     double **Bout = init_matrix(Ncoord(), 3*g_natom());
     compute_B(A->geom, B->geom, Bout, 0, 0, 0);
     return Bout;
@@ -201,22 +201,22 @@ class INTERFRAG {
   std::string get_coord_definition(int coord_index, int atom_offset_A=0, int atom_offset_B=0) const;
 
   // get number of atoms in the two fragments
-  int g_natom(void) const { return (A->g_natom() + B->g_natom()); }
-  int g_natom_A(void) const { return (A->g_natom()); }
-  int g_natom_B(void) const { return (B->g_natom()); }
+  int g_natom() const { return (A->g_natom() + B->g_natom()); }
+  int g_natom_A() const { return (A->g_natom()); }
+  int g_natom_B() const { return (B->g_natom()); }
 
   bool coordinate_on(int i) const { return D_on[i]; }
 
-  double ** H_guess(void); // guess Hessian
+  double ** H_guess(); // guess Hessian
 
   // orient fragments and displace by dq; forces are just for printing
   bool orient_fragment(double *dq, double *f_q=nullptr);
 
-  double ** compute_constraints(void) const;
+  double ** compute_constraints() const;
 
-  void add_coordinates_of_reference_pts(void);
+  void add_coordinates_of_reference_pts();
 
-  int form_trivial_coord_combinations(void);
+  int form_trivial_coord_combinations();
 
 }; // class INTERFRAG
 

--- a/psi4/src/psi4/optking/io.h
+++ b/psi4/src/psi4/optking/io.h
@@ -42,14 +42,14 @@ namespace opt {
 
 enum OPT_IO_FILE_STATUS {OPT_IO_OPEN_NEW, OPT_IO_OPEN_OLD} ;
 
-bool opt_io_is_present(void);
+bool opt_io_is_present();
 void opt_io_remove(bool force=false);
 void opt_io_open(OPT_IO_FILE_STATUS status);
 void opt_io_close(int keep);
 void opt_io_read_entry(const char *key, char *buffer, size_t size);
 void opt_io_write_entry(const char *key, char *buffer, size_t size);
-void opt_intco_dat_remove(void);
-void opt_clean(void);
+void opt_intco_dat_remove();
+void opt_clean();
 
 }
 

--- a/psi4/src/psi4/optking/lindh_guess.cc
+++ b/psi4/src/psi4/optking/lindh_guess.cc
@@ -75,7 +75,7 @@ inline double alpha_table(int perA, int perB);
 using namespace v3d;
 
 // Returns cartesian Lindh guess Hessian for whole system
-double **MOLECULE::Lindh_guess(void) const {
+double **MOLECULE::Lindh_guess() const {
 
   // Build one oprint_matrix_out( fragment that contains ALL the atoms.
   int natom = g_natom();
@@ -96,7 +96,7 @@ double **MOLECULE::Lindh_guess(void) const {
 
 
 // Build cartesian hessian according to model in  Lindh paper.
-double ** FRAG::Lindh_guess(void) {
+double ** FRAG::Lindh_guess() {
 
   // Build distance matrix
   double **R = init_matrix(natom, natom);

--- a/psi4/src/psi4/optking/molecule.cc
+++ b/psi4/src/psi4/optking/molecule.cc
@@ -70,7 +70,7 @@ MOLECULE::MOLECULE(int num_atoms) {
 }
 
 // return vector of reciprocal masses of dimension = num of cartesians
-double * MOLECULE::g_u_vector(void) const {
+double * MOLECULE::g_u_vector() const {
   double *m = g_masses();
   int Natom = g_natom();
 
@@ -86,7 +86,7 @@ double * MOLECULE::g_u_vector(void) const {
 // compute forces in internal coordinates in au
 // forces in internal coordinates, f_q = G_inv B u f_x
 // if u is unit matrix, f_q = (BB^T)^(-1) * B f_x
-void MOLECULE::forces(void) {
+void MOLECULE::forces() {
   double *f_x, *temp_arr, **B, **G, **G_inv;
   int Ncart = 3*g_natom();
   int Nintco = Ncoord();
@@ -154,7 +154,7 @@ void MOLECULE::forces(void) {
 }
 
 // Tell whether there are any fixed equilibrium values
-bool MOLECULE::has_fixed_eq_vals(void) {
+bool MOLECULE::has_fixed_eq_vals() {
   for (std::size_t f=0; f<fragments.size(); ++f)
     for (int i=0; i<fragments[f]->Ncoord(); ++i)
       if (fragments[f]->coord_has_fixed_eq_val(i))
@@ -164,7 +164,7 @@ bool MOLECULE::has_fixed_eq_vals(void) {
 }
 
 // Is any coordinate present that is not a cartesian.
-bool MOLECULE::is_noncart_present(void) const {
+bool MOLECULE::is_noncart_present() const {
 
   if (interfragments.size()) return true;
 
@@ -177,7 +177,7 @@ bool MOLECULE::is_noncart_present(void) const {
 
 // Apply extra forces for internal coordinates with user-defined
 // equilibrium values.
-void MOLECULE::apply_constraint_forces(void) {
+void MOLECULE::apply_constraint_forces() {
   double * f_q = p_Opt_data->g_forces_pointer();
   double **H = p_Opt_data->g_H_pointer();
   int N = Ncoord();
@@ -215,7 +215,7 @@ void MOLECULE::apply_constraint_forces(void) {
 
 // project redundancies (and constraints) out of forces and Hessian matrix
 // add constraints here later
-void MOLECULE::project_f_and_H(void) {
+void MOLECULE::project_f_and_H() {
   int Nintco = Ncoord();
 
   // compute G = B B^t
@@ -412,7 +412,7 @@ std::vector<int> MOLECULE::validate_angles(double const * const dq) {
   return lin_angle;
 }
 
-void MOLECULE::H_guess(void) const {
+void MOLECULE::H_guess() const {
   double **H = p_Opt_data->g_H_pointer();
 
   if (Opt_params.intrafragment_H == OPT_PARAMS::SCHLEGEL)
@@ -567,7 +567,7 @@ bool MOLECULE::cartesian_H_to_internals(double **H_cart) const {
   return success;
 }
 
-double *MOLECULE::g_masses(void) const {
+double *MOLECULE::g_masses() const {
   double *u = init_array(g_natom());
   int cnt = 0;
   for (std::size_t f=0; f<fragments.size(); ++f)
@@ -576,7 +576,7 @@ double *MOLECULE::g_masses(void) const {
   return u;
 }
 
-double *MOLECULE::g_Z(void) const {
+double *MOLECULE::g_Z() const {
   double *Zs = init_array(g_natom());
   int cnt = 0;
   for (std::size_t f=0; f<fragments.size(); ++f) {
@@ -588,7 +588,7 @@ double *MOLECULE::g_Z(void) const {
 }
 
 // compute B matrix - leave rows for FB coordinates empty
-double ** MOLECULE::compute_B(void) const {
+double ** MOLECULE::compute_B() const {
   double **B = init_matrix(Ncoord(), 3*g_natom());
 
   for (std::size_t f=0; f<fragments.size(); ++f)
@@ -736,7 +736,7 @@ double ** MOLECULE::compute_G(bool use_masses) const {
 }
 
 // Apply strings of atoms for frozen and fixed coordinates;
-bool MOLECULE::apply_input_constraints(void) {
+bool MOLECULE::apply_input_constraints() {
   bool frozen_present = false;
   bool fixed_present = false;
 
@@ -761,7 +761,7 @@ bool MOLECULE::apply_input_constraints(void) {
 }
 
 // Add cartesian coordinates
-int MOLECULE::add_cartesians(void) {
+int MOLECULE::add_cartesians() {
   int nadded = 0;
   for (std::size_t f=0; f<fragments.size(); ++f)
     nadded += fragments[f]->add_cartesians();
@@ -769,21 +769,21 @@ int MOLECULE::add_cartesians(void) {
 }
 
 // freeze all fragments in molecule
-void MOLECULE::freeze_intrafragments(void) {
+void MOLECULE::freeze_intrafragments() {
   oprintf_out("\tSetting all fragments to frozen.\n");
   for (std::size_t f=0; f<fragments.size(); ++f)
     fragments[f]->freeze();
 }
 
 // Freeze all coordinates within fragments
-void MOLECULE::freeze_intrafragment_coords(void) {
+void MOLECULE::freeze_intrafragment_coords() {
   oprintf_out("\tSetting all coordinates within each fragment to frozen.\n");
   for (std::size_t f=0; f<fragments.size(); ++f)
     fragments[f]->freeze_coords();
 }
 
 // Determine trivial coordinate combinations, i.e., don't combine..
-int MOLECULE::form_trivial_coord_combinations(void) {
+int MOLECULE::form_trivial_coord_combinations() {
   int nadded = 0;
   for (std::size_t f=0; f<fragments.size(); ++f)
     nadded += fragments[f]->form_trivial_coord_combinations();
@@ -793,7 +793,7 @@ int MOLECULE::form_trivial_coord_combinations(void) {
 }
 
 // Determine initial delocalized coordinate coefficients.
-int MOLECULE::form_delocalized_coord_combinations(void) {
+int MOLECULE::form_delocalized_coord_combinations() {
   int nadded = 0;
   for (std::size_t f=0; f<fragments.size(); ++f)
     nadded += fragments[f]->form_delocalized_coord_combinations();
@@ -852,7 +852,7 @@ int MOLECULE::form_delocalized_coord_combinations(void) {
 
 
 // Determine Pulay natural coordinate combinations.
-int MOLECULE::form_natural_coord_combinations(void) {
+int MOLECULE::form_natural_coord_combinations() {
   int nadded = 0;
   for (std::size_t f=0; f<fragments.size(); ++f)
     nadded += fragments[f]->form_natural_coord_combinations();
@@ -863,7 +863,7 @@ int MOLECULE::form_natural_coord_combinations(void) {
 // since the beginning of the optimization.  These values are determined
 
 // Compute constraint matrix.
-double ** MOLECULE::compute_constraints(void) {
+double ** MOLECULE::compute_constraints() {
   double **C, **C_frag, **C_inter;
   int i, j;
 
@@ -945,7 +945,7 @@ bool MOLECULE::is_coord_fixed(int coord_index) {
 
 // Add dummy FB fragment which contains no atoms.  Read in the energy
 // and the forces from QChem.  This will only work (maybe:) for QChem
-void MOLECULE::add_fb_fragments(void) {
+void MOLECULE::add_fb_fragments() {
 
 #if defined(OPTKING_PACKAGE_QCHEM)
   // get number of FB fragments
@@ -982,7 +982,7 @@ void MOLECULE::add_fb_fragments(void) {
 }
 
 // from the data in opt_data after that data is read.
-void MOLECULE::update_fb_values(void) {
+void MOLECULE::update_fb_values() {
 
   for (std::size_t i=0; i<fb_fragments.size(); ++i) {
     double *vals = init_array(6);

--- a/psi4/src/psi4/optking/molecule.h
+++ b/psi4/src/psi4/optking/molecule.h
@@ -70,33 +70,33 @@ class MOLECULE {
 
   // if you have one fragment - make sure all atoms are bonded
   // if not, break up into multiple fragments
-  void fragmentize(void);
+  void fragmentize();
 
-  void add_interfragment(void);
+  void add_interfragment();
 
   // Determine trivial, simple coordinate combinations.
-  int form_trivial_coord_combinations(void);
+  int form_trivial_coord_combinations();
 
   // Determine initial delocalized coordinate coefficients.
-  int form_delocalized_coord_combinations(void);
+  int form_delocalized_coord_combinations();
 
   // Determine Pulay natural coordinate combinations.
-  int form_natural_coord_combinations(void);
+  int form_natural_coord_combinations();
 
-  int add_cartesians(void);
+  int add_cartesians();
 
-  int g_nfragment(void) const { return fragments.size(); };
+  int g_nfragment() const { return fragments.size(); };
 
-  int g_nfb_fragment(void) const { return fb_fragments.size(); };
+  int g_nfb_fragment() const { return fb_fragments.size(); };
 
-  int g_natom(void) const { // excludes atoms in fb fragments
+  int g_natom() const { // excludes atoms in fb fragments
     int n = 0;
     for (std::size_t f=0; f<fragments.size(); ++f)
       n += fragments[f]->g_natom();
     return n;
   }
 
-  int Ncoord(void) const {
+  int Ncoord() const {
     int n=0;
     for (std::size_t f=0; f<fragments.size(); ++f)
       n += fragments[f]->Ncoord();
@@ -107,21 +107,21 @@ class MOLECULE {
     return n;
   }
 
-  int Ncoord_intrafragment(void) const {
+  int Ncoord_intrafragment() const {
     int n=0;
     for (std::size_t f=0; f<fragments.size(); ++f)
       n += fragments[f]->Ncoord();
     return n;
   }
 
-  int Ncoord_interfragment(void) const {
+  int Ncoord_interfragment() const {
     int n=0;
     for (std::size_t f=0; f<interfragments.size(); ++f)
       n += interfragments[f]->Ncoord();
     return n;
   }
 
-  int Ncoord_fb_fragment(void) const {
+  int Ncoord_fb_fragment() const {
     int n=0;
     for (std::size_t f=0; f<fb_fragments.size(); ++f)
       n += fb_fragments[f]->Ncoord();
@@ -163,14 +163,14 @@ class MOLECULE {
     return n;
   }
 
-  double g_energy(void) const { return energy; }
+  double g_energy() const { return energy; }
 
-  void update_connectivity_by_distances(void) {
+  void update_connectivity_by_distances() {
     for (std::size_t i=0; i<fragments.size(); ++i)
       fragments[i]->update_connectivity_by_distances();
   }
 
-  void update_connectivity_by_bonds(void) {
+  void update_connectivity_by_bonds() {
     for (std::size_t i=0; i<fragments.size(); ++i)
       fragments[i]->update_connectivity_by_bonds();
   }
@@ -199,25 +199,25 @@ class MOLECULE {
   // print definition of an internal coordinate from global index
   std::string get_coord_definition_from_global_index(int coord_index) const;
 
-  void update_fb_values(void);
+  void update_fb_values();
 
   void print_intco_dat(std::string psi_fp_coord, FILE *qc_fp);
 
-  int add_intrafragment_simples_by_connectivity(void) {
+  int add_intrafragment_simples_by_connectivity() {
     int n=0;
     for (std::size_t i=0; i<fragments.size(); ++i)
       n += fragments[i]->add_simples_by_connectivity();
     return n;
   }
 
-  int add_intrafragment_hbonds(void) {
+  int add_intrafragment_hbonds() {
     int n=0;
     for (std::size_t i=0; i<fragments.size(); ++i)
       n += fragments[i]->add_hbonds();
     return n;
   }
 
-  int add_intrafragment_auxiliary_bonds(void) {
+  int add_intrafragment_auxiliary_bonds() {
     int n=0;
     for (std::size_t i=0; i<fragments.size(); ++i)
       n += fragments[i]->add_auxiliary_bonds();
@@ -225,7 +225,7 @@ class MOLECULE {
   }
 
   // compute coord values from frag member geometries
-  double * coord_values(void) const {
+  double * coord_values() const {
     GeomType x = g_geom_2D();
     double *q = coord_values(x);
     return q;
@@ -261,17 +261,17 @@ class MOLECULE {
     return q;
   }
 
-  void write_geom(void);
+  void write_geom();
   void symmetrize_geom(bool flexible=false);
-  void print_geom_out(void);
-  void print_geom_out_irc(void);
+  void print_geom_out();
+  void print_geom_out_irc();
 
-  double ** compute_B(void) const;
+  double ** compute_B() const;
   double ** compute_derivative_B(int coord_index) const ;
 
   double ** compute_G(bool use_masses=false) const;
 
-  double * g_grad_array(void) const {
+  double * g_grad_array() const {
     double *g, *g_frag;
 
     g = init_array(3*g_natom());
@@ -284,11 +284,11 @@ class MOLECULE {
     return g;
   }
 
-  double * g_masses(void) const;
-  double * g_Z(void) const;
-  double * g_u_vector(void) const; // reciprocal masses in vector
+  double * g_masses() const;
+  double * g_Z() const;
+  double * g_u_vector() const; // reciprocal masses in vector
 
-  double * g_geom_array(void) {
+  double * g_geom_array() {
     double *g, *g_frag;
 
     g = init_array(3*g_natom());
@@ -301,7 +301,7 @@ class MOLECULE {
     return g;
   }
 
-  double ** g_geom_2D(void) const {
+  double ** g_geom_2D() const {
     double **g_frag;
     double **g = init_matrix(g_natom(),3);
 
@@ -315,7 +315,7 @@ class MOLECULE {
     return g;
   }
 
-  double ** g_grad_2D(void) const {
+  double ** g_grad_2D() const {
     double **g, *g_frag;
 
     g = init_matrix(g_natom(),3);
@@ -330,22 +330,22 @@ class MOLECULE {
     return g;
   }
 
-  void H_guess(void) const;
-  double **Lindh_guess(void) const;
+  void H_guess() const;
+  double **Lindh_guess() const;
 
-  void forces(void);
-  void apply_constraint_forces(void);
-  bool has_fixed_eq_vals(void);
-  void project_f_and_H(void);
+  void forces();
+  void apply_constraint_forces();
+  bool has_fixed_eq_vals();
+  void project_f_and_H();
   void project_dq(double *);
-  void irc_step(void);
-  void nr_step(void);
-  void rfo_step(void);
-  void prfo_step(void);
-  void backstep(void);
-  void sd_step(void);
+  void irc_step();
+  void nr_step();
+  void rfo_step();
+  void prfo_step();
+  void backstep();
+  void sd_step();
   //void sd_step_cartesians(void); now obsolete
-  void linesearch_step(void);
+  void linesearch_step();
 
   void apply_intrafragment_step_limit(double * & dq);
   std::vector<int> validate_angles(double const * const dq);
@@ -355,27 +355,27 @@ class MOLECULE {
       fragments[f]->set_geom_array( &(array_in[3*g_atom_offset(f)]) );
   }
 
-  void fix_tors_near_180(void) {
+  void fix_tors_near_180() {
     for (std::size_t f=0; f<fragments.size(); ++f)
       fragments[f]->fix_tors_near_180();
     for (std::size_t I=0; I<interfragments.size(); ++I)
       interfragments[I]->fix_tors_near_180();
   }
 
-  void fix_bend_axes(void) {
+  void fix_bend_axes() {
     for (std::size_t f=0; f<fragments.size(); ++f)
       fragments[f]->fix_bend_axes();
     for (std::size_t I=0; I<interfragments.size(); ++I)
       interfragments[I]->fix_bend_axes();
   }
-  void unfix_bend_axes(void) {
+  void unfix_bend_axes() {
     for (std::size_t f=0; f<fragments.size(); ++f)
       fragments[f]->unfix_bend_axes();
     for (std::size_t I=0; I<interfragments.size(); ++I)
       interfragments[I]->unfix_bend_axes();
   }
 
-  void fix_oofp_near_180(void) {
+  void fix_oofp_near_180() {
     for (std::size_t f=0; f<fragments.size(); ++f)
       fragments[f]->fix_oofp_near_180();
     for (std::size_t I=0; I<interfragments.size(); ++I)
@@ -391,33 +391,33 @@ class MOLECULE {
   }
 */
 
-  void test_B(void);
-  void test_derivative_B(void);
+  void test_B();
+  void test_derivative_B();
 
   bool cartesian_H_to_internals(double **H_cart) const;
 
-  void set_masses(void) {
+  void set_masses() {
     for (std::size_t f=0; f<fragments.size(); ++f)
       fragments[f]->set_masses();
   }
 
   bool read_coords(std::ifstream & fin);
   // function to obtain geometry and gradient
-  void read_geom_grad(void);
+  void read_geom_grad();
 
   // Compute constraint matrix
-  double ** compute_constraints(void);
+  double ** compute_constraints();
 
-  void add_fb_fragments(void);
+  void add_fb_fragments();
 
   // freeze interfragment modes that break symmetry
-  void freeze_interfragment_asymm(void);
+  void freeze_interfragment_asymm();
 
   // freeze all fragments in molecule
-  void freeze_intrafragments(void);
+  void freeze_intrafragments();
 
   // Freeze all coordinates within fragments
-  void freeze_intrafragment_coords(void);
+  void freeze_intrafragment_coords();
 
   // determine whether a linear combination of coords breaks symmetry
   bool coord_combo_is_symmetric(double *coord_combo, int dim);

--- a/psi4/src/psi4/optking/molecule_backstep.cc
+++ b/psi4/src/psi4/optking/molecule_backstep.cc
@@ -87,7 +87,7 @@ inline double DE_rfo_energy(double rfo_t, double rfo_g, double rfo_h) {
   return (rfo_t * rfo_g + 0.5 * rfo_t * rfo_t * rfo_h)/(1 + rfo_t*rfo_t);
 }
 
-void MOLECULE::backstep(void) {
+void MOLECULE::backstep() {
 
   oprintf_out("\tRe-doing last optimization step - smaller this time.\n");
   oprintf_out("\tConsecutive backstep number %d.\n", p_Opt_data->g_consecutive_backsteps()+1);

--- a/psi4/src/psi4/optking/molecule_fragments.cc
+++ b/psi4/src/psi4/optking/molecule_fragments.cc
@@ -67,7 +67,7 @@ using namespace v3d;
 //
 // If fragment_mode == MULTI, then this function splits one fragment into more
 // than one, according to the connectivity previously established for the fragment.
-void MOLECULE::fragmentize(void) {
+void MOLECULE::fragmentize() {
   int i, j, xyz;
 
   if (fragments.size() != 1) return;
@@ -289,7 +289,7 @@ void MOLECULE::fragmentize(void) {
 
 // add interfragment coordinates
 // for now, coordinates for fragments in order 1-2-3-
-void MOLECULE::add_interfragment(void) {
+void MOLECULE::add_interfragment() {
   int nA, nB;               // fragment natom
   const double * const * A; // fragment geometries
   const double * const * B;
@@ -531,7 +531,7 @@ void MOLECULE::add_interfragment(void) {
 // Check to see if displacement along any of the interfragment modes breaks
 // the symmetry of the molecule.  If so, freeze it.  This is a hack for now.
 // Will it work?  RAK 3-2012
-void MOLECULE::freeze_interfragment_asymm(void) {
+void MOLECULE::freeze_interfragment_asymm() {
   double **coord_orig = g_geom_2D();
   double disp_size = 0.1;
 

--- a/psi4/src/psi4/optking/molecule_irc_step.cc
+++ b/psi4/src/psi4/optking/molecule_irc_step.cc
@@ -178,7 +178,7 @@ void IRC_DATA::progress_report(opt::MOLECULE &mol)
 
 
 // See Gonzalez and Schlegel JCP 2154 (1989).
-void MOLECULE::irc_step(void)
+void MOLECULE::irc_step()
 {
   // Are we at the TS?  at_TS
   bool at_TS = !(p_irc_data->size());

--- a/psi4/src/psi4/optking/molecule_linesearch_step.cc
+++ b/psi4/src/psi4/optking/molecule_linesearch_step.cc
@@ -62,7 +62,7 @@
 
 namespace opt {
 
-void MOLECULE::linesearch_step(void) {
+void MOLECULE::linesearch_step() {
   int dim = Ncoord();
   double *fq = p_Opt_data->g_forces_pointer();
   double *dq = p_Opt_data->g_dq_pointer();

--- a/psi4/src/psi4/optking/molecule_nr_step.cc
+++ b/psi4/src/psi4/optking/molecule_nr_step.cc
@@ -57,7 +57,7 @@ inline double DE_nr_energy(double step, double grad, double hess) {
   return (step * grad + 0.5 * step * step * hess);
 }
 
-void MOLECULE::nr_step(void) {
+void MOLECULE::nr_step() {
   int Nintco = Ncoord();
   double **H_inv;
 

--- a/psi4/src/psi4/optking/molecule_prfo_step.cc
+++ b/psi4/src/psi4/optking/molecule_prfo_step.cc
@@ -53,7 +53,7 @@ inline double DE_rfo_energy(double rfo_t, double rfo_g, double rfo_h) {
   return (rfo_t * rfo_g + 0.5 * rfo_t * rfo_t * rfo_h)/(1 + rfo_t*rfo_t);
 }
 
-void MOLECULE::prfo_step(void) {
+void MOLECULE::prfo_step() {
   double **Horig = p_Opt_data->g_H_pointer();
   double *fq = p_Opt_data->g_forces_pointer();
   double *dq = p_Opt_data->g_dq_pointer();

--- a/psi4/src/psi4/optking/molecule_print.cc
+++ b/psi4/src/psi4/optking/molecule_print.cc
@@ -54,7 +54,7 @@
 
 namespace opt {
 
-void MOLECULE::print_geom_out(void) {
+void MOLECULE::print_geom_out() {
 #if defined(OPTKING_PACKAGE_QCHEM)
   oprintf_out("\tCartesian Geometry (au)\n");
 #elif defined(OPTKING_PACKAGE_PSI)
@@ -65,7 +65,7 @@ void MOLECULE::print_geom_out(void) {
     fragments[i]->print_geom(psi_outfile, qc_outfile);
 }
 
-void MOLECULE::print_geom_out_irc(void) {
+void MOLECULE::print_geom_out_irc() {
 #if defined(OPTKING_PACKAGE_QCHEM)
   oprintf_out("@IRC    Cartesian Geometry (au)\n");
 #elif defined(OPTKING_PACKAGE_PSI)

--- a/psi4/src/psi4/optking/molecule_rfo_step.cc
+++ b/psi4/src/psi4/optking/molecule_rfo_step.cc
@@ -58,7 +58,7 @@ inline double DE_rfo_energy(double rfo_t, double rfo_g, double rfo_h) {
 }
 
 // Take Rational Function Optimization step
-void MOLECULE::rfo_step(void) {
+void MOLECULE::rfo_step() {
   int i, j;
   int dim = Ncoord();
   double tval, tval2;

--- a/psi4/src/psi4/optking/molecule_sd_step.cc
+++ b/psi4/src/psi4/optking/molecule_sd_step.cc
@@ -57,7 +57,7 @@ inline double DE_quadratic_energy(double step, double grad, double hess) {
   return (step * grad + 0.5 * step * step * hess);
 }
 
-void MOLECULE::sd_step(void) {
+void MOLECULE::sd_step() {
   int dim = Ncoord();
   double *fq = p_Opt_data->g_forces_pointer();
   double *dq = p_Opt_data->g_dq_pointer();

--- a/psi4/src/psi4/optking/molecule_tests.cc
+++ b/psi4/src/psi4/optking/molecule_tests.cc
@@ -54,7 +54,7 @@ namespace opt {
 
 // test the analytic B matrix (and displacement code) by comparing
 // analytic DqDx to finite-difference DqDx
-void MOLECULE::test_B(void) {
+void MOLECULE::test_B() {
   int Natom = g_natom();
   int Nintco = Ncoord();
   const double disp_size = 0.01;
@@ -147,7 +147,7 @@ void MOLECULE::test_B(void) {
   return;
 }
 
-void MOLECULE::test_derivative_B(void) {
+void MOLECULE::test_derivative_B() {
   int Natom = g_natom();
   int Nintco = Ncoord();
   const double disp_size = 0.01;

--- a/psi4/src/psi4/optking/opt_data.cc
+++ b/psi4/src/psi4/optking/opt_data.cc
@@ -278,7 +278,7 @@ bool OPT_DATA::conv_check(opt::MOLECULE &mol) const {
 #endif
 }
 
-void OPT_DATA::summary(void) const {
+void OPT_DATA::summary() const {
   double DE, *f, *dq, max_force, max_disp, rms_force, rms_disp;
 
   oprintf_out( "\n  ==> Optimization Summary <==\n\n");
@@ -647,7 +647,7 @@ OPT_DATA::OPT_DATA(int Nintco_in, int Ncart_in) {
 }
 
 // write data to binary file
-void OPT_DATA::write(void) {
+void OPT_DATA::write() {
   opt_io_open(opt::OPT_IO_OPEN_OLD);
 
   oprintf_out("\tWriting optimization data to binary file.\n");
@@ -669,7 +669,7 @@ void OPT_DATA::write(void) {
 
 // Report on performance of last step
 // Eventually might have this function return false to reject a step
-bool OPT_DATA::previous_step_report(void) const {
+bool OPT_DATA::previous_step_report() const {
   oprintf_out(  "\tCurrent energy   : %20.10lf\n\n", p_Opt_data->g_energy());
 
   if (steps.size() == 1) {
@@ -723,7 +723,7 @@ bool OPT_DATA::previous_step_report(void) const {
 
 // These functions are a bit out of place, given that the trust radius is not
 // stored inside opt_data.
-void OPT_DATA::increase_trust_radius(void) const {
+void OPT_DATA::increase_trust_radius() const {
   std::string module = "OPTKING";
   std::string key = "INTRAFRAG_STEP_LIMIT";
   double max = Opt_params.intrafragment_step_limit_max;
@@ -745,7 +745,7 @@ void OPT_DATA::increase_trust_radius(void) const {
   return;
 }
 
-void OPT_DATA::decrease_trust_radius(void) const {
+void OPT_DATA::decrease_trust_radius() const {
   std::string module = "OPTKING";
   std::string key = "INTRAFRAG_STEP_LIMIT";
   double min = Opt_params.intrafragment_step_limit_min;
@@ -764,7 +764,7 @@ void OPT_DATA::decrease_trust_radius(void) const {
   return;
 }
 
-void OPT_DATA::reset_trust_radius(void) const {
+void OPT_DATA::reset_trust_radius() const {
   std::string module = "OPTKING";
   std::string key = "INTRAFRAG_STEP_LIMIT";
 

--- a/psi4/src/psi4/optking/opt_data.h
+++ b/psi4/src/psi4/optking/opt_data.h
@@ -80,14 +80,14 @@ class STEP_DATA {
     void read(int istep, int Nintco, int Ncart);
 
     // functions to retrieve data
-    double *g_forces_pointer(void) const { return f_q; }
-    double *g_geom_const_pointer(void) const { return geom; }
-    double *g_dq_pointer(void) const { return dq; }
-    double g_energy(void) const { return energy; }
-    double g_DE_predicted(void) const { return DE_predicted; }
-    double g_dq_norm(void) const { return dq_norm; }
-    double g_dq_gradient(void) const { return dq_gradient; }
-    double g_dq_hessian(void) const { return dq_hessian; }
+    double *g_forces_pointer() const { return f_q; }
+    double *g_geom_const_pointer() const { return geom; }
+    double *g_dq_pointer() const { return dq; }
+    double g_energy() const { return energy; }
+    double g_DE_predicted() const { return DE_predicted; }
+    double g_dq_norm() const { return dq_norm; }
+    double g_dq_gradient() const { return dq_gradient; }
+    double g_dq_hessian() const { return dq_hessian; }
 };
 
 // data for an optimization
@@ -112,7 +112,7 @@ class OPT_DATA {
     ~OPT_DATA();
 
     // write data to binary file
-    void write(void);
+    void write();
 
     // save geometry and energy to current (last) step
     void save_geom_energy(double *geom_in, double energy_in) {
@@ -127,12 +127,12 @@ class OPT_DATA {
     }
 
     // return (pointers) to current-step data
-    int g_iteration(void) const { return iteration; }
-    double **g_H_pointer(void) { return H; }
-    double g_energy(void) const { return steps[steps.size()-1]->g_energy(); }
-    double *g_rfo_eigenvector_pointer(void) const { return rfo_eigenvector; }
+    int g_iteration() const { return iteration; }
+    double **g_H_pointer() { return H; }
+    double g_energy() const { return steps[steps.size()-1]->g_energy(); }
+    double *g_rfo_eigenvector_pointer() const { return rfo_eigenvector; }
     // return dimension of Hessian matrix
-    int Ncoord(void) const { return Nintco; }
+    int Ncoord() const { return Nintco; }
 
     void set_rfo_eigenvector(double *evect_in) {
       for (int i=0; i<Nintco; ++i)
@@ -140,21 +140,21 @@ class OPT_DATA {
     }
 
     // step data
-    double *g_forces_pointer(void) const {
+    double *g_forces_pointer() const {
       return steps[steps.size()-1]->g_forces_pointer();
     }
-    double *g_dq_pointer(void) const {
+    double *g_dq_pointer() const {
       return steps[steps.size()-1]->g_dq_pointer();
     }
     // return energy from the previous step (last entry - 1)
-    double g_last_energy(void) const {
+    double g_last_energy() const {
       if (steps.size() > 1)
         return steps[steps.size()-2]->g_energy();
       else return 0.0;
     }
 
     // return predicted energy change at the previous step (last entry - 1)
-    double g_last_DE_predicted(void) const {
+    double g_last_DE_predicted() const {
       if (steps.size() > 1)
         return steps[steps.size()-2]->g_DE_predicted();
       else return 0.0;
@@ -167,7 +167,7 @@ class OPT_DATA {
     double *g_forces_pointer(int i) const {
       return steps.at(i)->g_forces_pointer();
     }
-    double *g_last_forces_pointer(void) const {
+    double *g_last_forces_pointer() const {
       if (steps.size() > 1)
         return steps.at(steps.size()-2)->g_forces_pointer();
       else return nullptr;
@@ -181,7 +181,7 @@ class OPT_DATA {
     double g_dq_norm(int i) const {
       return steps.at(i)->g_dq_norm();
     }
-    double g_last_dq_norm(void) const {
+    double g_last_dq_norm() const {
       if (steps.size() > 1)
         return steps[steps.size()-2]->g_dq_norm();
       else return 0.0;
@@ -189,7 +189,7 @@ class OPT_DATA {
     double g_dq_gradient(int i) const {
       return steps.at(i)->g_dq_gradient();
     }
-    double g_last_dq_gradient(void) const {
+    double g_last_dq_gradient() const {
       if (steps.size() > 1)
         return steps[steps.size()-2]->g_dq_gradient();
       else return 0.0;
@@ -204,34 +204,34 @@ class OPT_DATA {
     bool conv_check(opt::MOLECULE &) const;
 
     // summarize optimization up til now
-    void summary(void) const;
+    void summary() const;
 
     // perform Hessian update
     void H_update(opt::MOLECULE & mol);
 
     // read in cartesian Hessian
-    double ** read_cartesian_H(void) const;
+    double ** read_cartesian_H() const;
 
     // return number of steps present
-    int nsteps(void) const { return steps.size(); }
+    int nsteps() const { return steps.size(); }
 
-    void decrement_iteration(void) { --iteration; }
+    void decrement_iteration() { --iteration; }
 
-    void increment_consecutive_backsteps(void) { ++consecutive_backsteps; }
-    void reset_consecutive_backsteps(void) {
+    void increment_consecutive_backsteps() { ++consecutive_backsteps; }
+    void reset_consecutive_backsteps() {
       previous_consecutive_backsteps = consecutive_backsteps; // only used in current memory; not saved
       consecutive_backsteps = 0;
     }
-    void restore_previous_consecutive_backsteps(void) {
+    void restore_previous_consecutive_backsteps() {
       consecutive_backsteps = previous_consecutive_backsteps; // for last second aborts after reset has been done
     }
-    int g_consecutive_backsteps(void) { return consecutive_backsteps; }
+    int g_consecutive_backsteps() { return consecutive_backsteps; }
 
-    int g_steps_since_last_H(void) const { return steps_since_last_H; }
-    void reset_steps_since_last_H(void) { steps_since_last_H = 0; }
-    void increment_steps_since_last_H(void) { ++steps_since_last_H; }
+    int g_steps_since_last_H() const { return steps_since_last_H; }
+    void reset_steps_since_last_H() { steps_since_last_H = 0; }
+    void increment_steps_since_last_H() { ++steps_since_last_H; }
 
-    void erase_last_step(void) { // free last step
+    void erase_last_step() { // free last step
       delete steps.back();
       steps.erase(steps.end()-1);
     }
@@ -239,12 +239,12 @@ class OPT_DATA {
       delete steps[i];
       steps.erase(steps.begin() + i);
     }
-    void reset_iteration_to_size(void) {
+    void reset_iteration_to_size() {
       iteration = steps.size() + 1;
     }
-    void increase_trust_radius(void) const;
-    void decrease_trust_radius(void) const;
-    void reset_trust_radius(void) const;
+    void increase_trust_radius() const;
+    void decrease_trust_radius() const;
+    void reset_trust_radius() const;
 
 };
 

--- a/psi4/src/psi4/optking/opt_data_io.cc
+++ b/psi4/src/psi4/optking/opt_data_io.cc
@@ -60,7 +60,7 @@ namespace opt_io {
 namespace opt {
 
 // returns true if the binary file exists and is not empty
-bool opt_io_is_present(void) {
+bool opt_io_is_present() {
   bool file_present = false;
 
 #if defined(OPTKING_PACKAGE_PSI)
@@ -102,11 +102,11 @@ void opt_io_remove(bool force) {
 #endif
 }
 
-void opt_intco_dat_remove(void) {
+void opt_intco_dat_remove() {
   std::remove(FILENAME_INTCO_DAT); // rm intco definitions
 }
 
-void opt_clean(void) {
+void opt_clean() {
   opt_io_remove();        // remove file1
   if (!Opt_params.keep_intcos)
     opt_intco_dat_remove(); // remove intco.dat

--- a/psi4/src/psi4/optking/opt_except.h
+++ b/psi4/src/psi4/optking/opt_except.h
@@ -69,7 +69,7 @@ class INTCO_EXCEPT {
       //try_other_intcos = t;
     }
 
-    void increment_dynamic_level(void) {
+    void increment_dynamic_level() {
       if (dynamic_level == 0) // turning 'on' dynamic
         dynamic_level = 1;
 
@@ -79,8 +79,8 @@ class INTCO_EXCEPT {
     ~INTCO_EXCEPT() {};
 
     //bool try_again() { return try_other_intcos; }
-    const char *g_message(void) { return message; }
-    bool g_really_quit(void) { return really_quit; }
+    const char *g_message() { return message; }
+    bool g_really_quit() { return really_quit; }
 };
 
 class BAD_STEP_EXCEPT {
@@ -92,7 +92,7 @@ class BAD_STEP_EXCEPT {
 
     ~BAD_STEP_EXCEPT() {};
 
-    const char *g_message(void) { return message; }
+    const char *g_message() { return message; }
 };
 
 class BROKEN_SYMMETRY_EXCEPT {
@@ -104,7 +104,7 @@ class BROKEN_SYMMETRY_EXCEPT {
 
     ~BROKEN_SYMMETRY_EXCEPT() {};
 
-    const char *g_message(void) { return message; }
+    const char *g_message() { return message; }
 };
 
 }

--- a/psi4/src/psi4/optking/optking.cc
+++ b/psi4/src/psi4/optking/optking.cc
@@ -58,7 +58,7 @@
 #endif
 
 #if defined(OPTKING_PACKAGE_PSI)
-namespace psi { void psiclean(void); }
+namespace psi { void psiclean(); }
 #endif
 
 #if defined(OPTKING_PACKAGE_QCHEM)
@@ -70,11 +70,11 @@ namespace psi { void psiclean(void); }
 #endif
 
 namespace opt {
-  void open_output_dat(void); // open/link outfile to text output
-  void close_output_dat(void);// close above
-  void print_title_out(void); // print header
-  void print_end_out(void);   // print footer
-  void init_ioff(void);
+  void open_output_dat(); // open/link outfile to text output
+  void close_output_dat();// close above
+  void print_title_out(); // print header
+  void print_end_out();   // print footer
+  void init_ioff();
   int INTCO_EXCEPT::dynamic_level = 0;          // initialized only once
   std::vector<int> INTCO_EXCEPT::linear_angles; // static class members must be defined
   //bool INTCO_EXCEPT::already_tried_other_intcos = false;
@@ -585,7 +585,7 @@ OptReturnType optking(void) {
 
 // Standard text output file string (psi) or file pointer (qchem)
 // Interpreted by functions in print.cc
-void open_output_dat(void) {
+void open_output_dat() {
 #if defined (OPTKING_PACKAGE_PSI)
   psi_outfile = "outfile";
 #elif defined (OPTKING_PACKAGE_QCHEM)
@@ -593,13 +593,13 @@ void open_output_dat(void) {
 #endif
 }
 
-void close_output_dat(void) {
+void close_output_dat() {
 #if defined(OPTKING_PACKAGE_QCHEM)
 
 #endif
 }
 
-void print_title_out(void) {
+void print_title_out() {
   oprintf_out( "\n\t\t\t-----------------------------------------\n");
   oprintf_out(   "\t\t\t OPTKING 2.0: for geometry optimizations \n");
   oprintf_out(   "\t\t\t  - R.A. King,  Bethel University        \n");
@@ -607,7 +607,7 @@ void print_title_out(void) {
 
 }
 
-void print_end_out(void) {
+void print_end_out() {
 #if defined (OPTKING_PACKAGE_PSI)
   oprintf_out( "\t\t\t--------------------------\n");
   oprintf_out( "\t\t\t OPTKING Finished Execution \n");
@@ -615,7 +615,7 @@ void print_end_out(void) {
 #endif
 }
 
-void init_ioff(void)
+void init_ioff()
 {
   int i;
   ioff = init_int_array(IOFF_MAX);

--- a/psi4/src/psi4/optking/print.cc
+++ b/psi4/src/psi4/optking/print.cc
@@ -59,7 +59,7 @@ void oprintf(const std::string psi_fp, const FILE *qc_fp, const char* format,...
 #endif
 }
 
-void offlush_out(void) {
+void offlush_out() {
 #if defined(OPTKING_PACKAGE_PSI)
   std::shared_ptr<psi::PsiOutStream> printer(psi::outfile);
 #elif defined(OPTKING_PACKAGE_QCHEM)

--- a/psi4/src/psi4/optking/print.h
+++ b/psi4/src/psi4/optking/print.h
@@ -59,7 +59,7 @@ void oprint_array_out(double *A, const int x);
 
 void oprint_array_out_precise(double *A, const int x);
 
-void offlush_out(void);
+void offlush_out();
 
 }
 

--- a/psi4/src/psi4/optking/set_params.cc
+++ b/psi4/src/psi4/optking/set_params.cc
@@ -48,7 +48,7 @@
 
 namespace opt {
 
-void print_params_out(void);
+void print_params_out();
 
 #if defined(OPTKING_PACKAGE_PSI)
 void set_params(psi::Options & options)
@@ -904,7 +904,7 @@ void set_params(void)
 
 }
 
-void print_params_out(void) {
+void print_params_out() {
 
   oprintf_out( "dynamic level          = %18d\n", Opt_params.dynamic);
   oprintf_out( "conv_max_force         = %18.2e\n", Opt_params.conv_max_force);

--- a/psi4/src/psi4/optking/simple_base.h
+++ b/psi4/src/psi4/optking/simple_base.h
@@ -72,13 +72,13 @@ class SIMPLE_COORDINATE {
       free_int_array(s_atom);
     }
 
-    INTCO_TYPE g_type(void) const { return s_type; }
-    int g_natom(void) const { return s_natom; }
+    INTCO_TYPE g_type() const { return s_type; }
+    int g_natom() const { return s_natom; }
     int g_atom(int a) const { return s_atom[a]; }
 
-    bool is_frozen(void) { return s_frozen; }
-    void freeze(void)    { s_frozen = true; }
-    void unfreeze(void)  { s_frozen = false; }
+    bool is_frozen() { return s_frozen; }
+    void freeze()    { s_frozen = true; }
+    void unfreeze()  { s_frozen = false; }
 
     // do-nothing function overridden only by torsion class
     virtual void fix_tors_near_180(GeomType) { return; }
@@ -87,19 +87,19 @@ class SIMPLE_COORDINATE {
     virtual void fix_oofp_near_180(GeomType) { return; }
 
     // do-nothing function overridden by stretch class 
-    virtual bool is_hbond(void) const { return false; }
+    virtual bool is_hbond() const { return false; }
 
     // do-nothing function overridden by stretch class 
     virtual void set_hbond(bool) { printf("base_hbond"); return; }
 
     // do-nothing function overridden by stretch class 
-    virtual bool is_inverse_stre(void) const { return false; }
+    virtual bool is_inverse_stre() const { return false; }
 
     // do-nothing function overridden by bend class
-    virtual int g_bend_type(void) const { return -1; }
+    virtual int g_bend_type() const { return -1; }
 
     // do-nothing function overridden by cartesian class
-    virtual int g_xyz(void) const { return 0; }
+    virtual int g_xyz() const { return 0; }
 
     // each internal coordinate type must provide the following virtual functions:
 
@@ -139,10 +139,10 @@ class SIMPLE_COORDINATE {
       s_fixed_eq_val = val;
       s_has_fixed_eq_val = true;
     }
-    double fixed_eq_val(void) {
+    double fixed_eq_val() {
       return s_fixed_eq_val;
     }
-    bool has_fixed_eq_val(void) { return s_has_fixed_eq_val; }
+    bool has_fixed_eq_val() { return s_has_fixed_eq_val; }
 
 };
 

--- a/psi4/src/psi4/optking/stre.h
+++ b/psi4/src/psi4/optking/stre.h
@@ -68,9 +68,9 @@ class STRE : public SIMPLE_COORDINATE {
     std::string get_definition_string(int atom_offset=0) const;
 
     void set_hbond(bool val) { hbond = val; }
-    bool is_hbond(void) const { return hbond; }
-    void make_inverse_stre(void) { inverse_stre = true; }
-    bool is_inverse_stre(void) const { return inverse_stre; }
+    bool is_hbond() const { return hbond; }
+    void make_inverse_stre() { inverse_stre = true; }
+    bool is_inverse_stre() const { return inverse_stre; }
 
 };
 


### PR DESCRIPTION
## Description
Uses `clang-tidy` to find and fix uses of redundant `void` argument in functions. Fixes applied with:
```
cd <build-dir>/psi4-core-prefix/src/psi4-core-build
run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-redundant-void-arg' -fix
```
Based on #1312 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `clang-tidy` find and fix with `modernize-redundant-void-arg`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge

