### PR TITLE
clang-tidy apply modernize-deprecated-headers fixes

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
@@ -30,7 +30,7 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
@@ -30,7 +30,7 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
@@ -30,11 +30,11 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdlib.h>
+#include <cstdlib>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libciomr/libciomr.h"
-#include <math.h>
+#include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
@@ -40,7 +40,7 @@
 #define EXTERN
 #include "globals.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace psi {
 namespace ccdensity {

--- a/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
@@ -30,7 +30,7 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"

--- a/psi4/src/psi4/cc/ccdensity/energy_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_RHF.cc
@@ -31,7 +31,7 @@
     \brief Calculates the one- and two-electron CC energies using the
     coresponding one- and two-particle density matrices.
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/energy_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_ROHF.cc
@@ -31,7 +31,7 @@
     \brief  Calculates the one- and two-electron CC energies using the
     coresponding one- and two-particle density matrices.
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/energy_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_UHF.cc
@@ -31,7 +31,7 @@
     \brief Calculates the one- and two-electron CC energies using the
     coresponding one- and two-particle density matrices.
 */
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
@@ -30,7 +30,7 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
@@ -30,9 +30,9 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
-#include <math.h>
+#include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
@@ -30,9 +30,9 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include <stdio.h>
+#include <cstdio>
 #include "psi4/libdpd/dpd.h"
-#include <math.h>
+#include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libiwl/iwl.h"

--- a/psi4/src/psi4/cc/ccdensity/x_xi2.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
-#include "math.h"
+#include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
-#include "math.h"
+#include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libdpd/dpd.h"
-#include "math.h"
+#include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/cchbar/Wamef.cc
+++ b/psi4/src/psi4/cc/cchbar/Wamef.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <math.h>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/cchbar/Wmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbej.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <math.h>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/cchbar/Wmbij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbij.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <math.h>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/cchbar/Wmnie.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmnie.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include <math.h>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/cclambda/L1.cc
+++ b/psi4/src/psi4/cc/cclambda/L1.cc
@@ -30,8 +30,8 @@
     \ingroup CCLAMBDA
     \brief Enter brief description of file here
 */
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <cstring>
 #include "psi4/libdpd/dpd.h"

--- a/psi4/src/psi4/cc/cctriples/T3_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_UHF_AAA.cc
@@ -103,10 +103,10 @@
 ** Modified to return disconnected triples, TDC, Feburary 2008
 */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <math.h>
+#include <cmath>
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/cctriples/T3_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_UHF_AAB.cc
@@ -101,10 +101,10 @@
 ** TDC, July 2004
 */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <math.h>
+#include <cmath>
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/cctriples/T3_UHF_ABC.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_UHF_ABC.cc
@@ -26,10 +26,10 @@
  * @END LICENSE
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <math.h>
+#include <cmath>
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
@@ -31,9 +31,9 @@
     \brief Computes T3-dependent terms needed in cclambda and
     ccdensity for (T) contributions to the CCSD(T) energy gradient.
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
@@ -30,9 +30,9 @@
     \ingroup CCTRIPLES
     \brief Enter brief description of file here
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
@@ -30,9 +30,9 @@
     \ingroup CCTRIPLES
     \brief Enter brief description of file here
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
@@ -30,9 +30,9 @@
     \ingroup CCTRIPLES
     \brief Enter brief description of file here
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
@@ -30,9 +30,9 @@
     \ingroup CCTRIPLES
     \brief Enter brief description of file here
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/dcft/main.cc
+++ b/psi4/src/psi4/dcft/main.cc
@@ -35,8 +35,8 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/liboptions/liboptions.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 using namespace psi;
 

--- a/psi4/src/psi4/detci/slaterd.h
+++ b/psi4/src/psi4/detci/slaterd.h
@@ -58,7 +58,7 @@
 #ifndef _psi_src_bin_detci_slaterd_h
 #define _psi_src_bin_detci_slaterd_h
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 namespace psi {

--- a/psi4/src/psi4/dfocc/ekt.cc
+++ b/psi4/src/psi4/dfocc/ekt.cc
@@ -27,7 +27,7 @@
  */
 
 // Latest revision on April 38, 2013.
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 #include <cmath>
 #include "ekt.h"

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -27,7 +27,7 @@
  */
 
 // Latest revision on April 38, 2013.
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 #include <cmath>
 #include "psi4/libqt/qt.h"

--- a/psi4/src/psi4/fnocc/blas.cc
+++ b/psi4/src/psi4/fnocc/blas.cc
@@ -27,7 +27,7 @@
  */
 
 #include "blas.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "psi4/pragma.h"
 

--- a/psi4/src/psi4/lib3index/cholesky.cc
+++ b/psi4/src/psi4/lib3index/cholesky.cc
@@ -32,7 +32,7 @@ PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
 PRAGMA_WARNING_POP
 #include "psi4/libqt/qt.h"
-#include <math.h>
+#include <cmath>
 #include <limits>
 #include <vector>
 #include "cholesky.h"

--- a/psi4/src/psi4/lib3index/dftensor.cc
+++ b/psi4/src/psi4/lib3index/dftensor.cc
@@ -37,7 +37,7 @@
 #include <fstream>
 #include <algorithm>
 #include <utility>
-#include <ctype.h>
+#include <cctype>
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/basisset.h"

--- a/psi4/src/psi4/libdiis/diisentry.cc
+++ b/psi4/src/psi4/libdiis/diisentry.cc
@@ -32,7 +32,7 @@ PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.hpp"
 #include "diisentry.h"
-#include <math.h>
+#include <cmath>
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 #include <sstream>

--- a/psi4/src/psi4/libdisp/dispersion.cc
+++ b/psi4/src/psi4/libdisp/dispersion.cc
@@ -46,7 +46,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 #include <sstream>
 #include <vector>

--- a/psi4/src/psi4/libfilesystem/path.cc
+++ b/psi4/src/psi4/libfilesystem/path.cc
@@ -69,7 +69,7 @@ static int SYSTEM_TRUNCATE(const char *path, off_t length) {
 #define PATH_SEPARATOR "/"
 #endif
 #include <sys/stat.h>
-#include <limits.h>
+#include <climits>
 
 namespace psi {
 namespace filesystem {

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -46,8 +46,8 @@
 #include <sstream>
 #include <cstdio>
 #include <limits>
-#include <ctype.h>
-#include <assert.h>
+#include <cctype>
+#include <cassert>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/psi4/src/psi4/libmints/chartab.cc
+++ b/psi4/src/psi4/libmints/chartab.cc
@@ -82,7 +82,7 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/exception.h"
 
-#include <ctype.h>
+#include <cctype>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -46,8 +46,8 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <memory>
 #include <array>

--- a/psi4/src/psi4/libmints/intvector.cc
+++ b/psi4/src/psi4/libmints/intvector.cc
@@ -27,7 +27,7 @@
  */
 
 #include <cstdlib>
-#include <string.h>
+#include <cstring>
 #include "psi4/libqt/qt.h"
 #include "matrix.h"
 #include "vector.h"

--- a/psi4/src/psi4/libmints/irrep.cc
+++ b/psi4/src/psi4/libmints/irrep.cc
@@ -78,7 +78,7 @@
 #include "psi4/libmints/pointgrp.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libmints/petitelist.h
+++ b/psi4/src/psi4/libmints/petitelist.h
@@ -34,7 +34,7 @@
 
 #include <map>
 #include <cstdio>
-#include <stdint.h>
+#include <cstdint>
 
 #include "psi4/pragma.h"
 PRAGMA_WARNING_PUSH

--- a/psi4/src/psi4/libmints/pointgrp.cc
+++ b/psi4/src/psi4/libmints/pointgrp.cc
@@ -85,7 +85,7 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <ctype.h>
+#include <cctype>
 #include <cmath>
 
 namespace psi {

--- a/psi4/src/psi4/libmints/pointgrp.h
+++ b/psi4/src/psi4/libmints/pointgrp.h
@@ -83,9 +83,9 @@
 #include "psi4/libmints/vector3.h"
 #include "psi4/psi4-dec.h"
 
-#include <string.h>
+#include <cstring>
 #include <cstdio>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <map>
 

--- a/psi4/src/psi4/libmints/solidharmonics.cc
+++ b/psi4/src/psi4/libmints/solidharmonics.cc
@@ -29,7 +29,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 
 #include "matrix.h"
 #include "integral.h"

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -35,8 +35,8 @@
 #include <algorithm>
 #include <numeric>
 #include <cstdlib>
-#include <string.h>
-#include <math.h>
+#include <cstring>
+#include <cmath>
 
 namespace psi {
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -33,7 +33,7 @@
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libmints/dimension.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <vector>
 #include <array>
 #include <memory>

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -36,7 +36,7 @@
 #include <iomanip>
 #include <sstream>
 #include <numeric>
-#include <assert.h>
+#include <cassert>
 
 #include "liboptions.h"
 #include "liboptions_python.h"

--- a/psi4/src/psi4/liboptions/print.cc
+++ b/psi4/src/psi4/liboptions/print.cc
@@ -36,7 +36,7 @@
 #include <iomanip>
 #include <sstream>
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include "psi4/pragma.h"
 PRAGMA_WARNING_PUSH
 PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS

--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -33,7 +33,7 @@
 #include <exception>
 #include <stdexcept>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 
 #if defined(__GNUC__) || (defined(__ICC) && (__ICC >= 600))
 #define PSI4_CURRENT_FUNCTION __PRETTY_FUNCTION__

--- a/psi4/src/psi4/libpsi4util/stl_string.cc
+++ b/psi4/src/psi4/libpsi4util/stl_string.cc
@@ -32,11 +32,11 @@
 #include <algorithm>
 #include <cstdio>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <regex>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <limits.h>
+#include <climits>
 
 #include "libpsi4util.h"
 

--- a/psi4/src/psi4/libqt/blas_intfc.cc
+++ b/psi4/src/psi4/libqt/blas_intfc.cc
@@ -51,7 +51,7 @@
 */
 
 #include <cstdio>
-#include <limits.h>
+#include <climits>
 #include <cmath>
 
 #include "psi4/pragma.h"

--- a/psi4/src/psi4/libqt/dx_write.cc
+++ b/psi4/src/psi4/libqt/dx_write.cc
@@ -26,8 +26,8 @@
  * @END LICENSE
  */
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 #include "psi4/psi4-dec.h"
 
 #include "psi4/libciomr/libciomr.h"

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.cc
@@ -28,7 +28,7 @@
 
 #include "sapt2p3.h"
 #include "psi4/physconst.h"
-#include <math.h>
+#include <cmath>
 
 namespace psi {
 namespace sapt {

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -42,9 +42,9 @@
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/libdiis/diisentry.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
 #include <algorithm>
 #include <vector>
 #include <utility>

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -27,9 +27,9 @@
  */
 
 #include <ctime>
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
 #include <algorithm>
 #include <vector>
 #include <utility>

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -27,9 +27,9 @@
  */
 
 #include <ctime>
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/psi4/src/psi4/libtrans/integraltransform_tei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei.cc
@@ -31,9 +31,9 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 #include "psi4/psifiles.h"
 #include "mospace.h"
 

--- a/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
@@ -38,9 +38,9 @@
 #include "psi4/psifiles.h"
 #include "psi4/libdpd/dpd.h"
 
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
@@ -38,9 +38,9 @@
 #include "psi4/psifiles.h"
 #include "psi4/libdpd/dpd.h"
 
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libtrans/integraltransform_tpdm.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tpdm.cc
@@ -37,9 +37,9 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/psifiles.h"
 
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libtrans/integraltransform_tpdm_restricted.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tpdm_restricted.cc
@@ -38,9 +38,9 @@
 #include "psi4/psifiles.h"
 #include "psi4/libdpd/dpd.h"
 
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libtrans/integraltransform_tpdm_unrestricted.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tpdm_unrestricted.cc
@@ -38,9 +38,9 @@
 #include "psi4/psifiles.h"
 #include "psi4/libdpd/dpd.h"
 
-#include <math.h>
-#include <ctype.h>
-#include <stdio.h>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
 
 using namespace psi;
 

--- a/psi4/src/psi4/occ/arrays.cc
+++ b/psi4/src/psi4/occ/arrays.cc
@@ -34,7 +34,7 @@
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <cmath>
 
 using namespace psi;

--- a/psi4/src/psi4/optking/bend.cc
+++ b/psi4/src/psi4/optking/bend.cc
@@ -33,7 +33,7 @@
 #include "bend.h"
 
 #include <sstream>
-#include <math.h>
+#include <cmath>
 
 #include "v3d.h"
 #include "psi4/optking/physconst.h"

--- a/psi4/src/psi4/optking/io.h
+++ b/psi4/src/psi4/optking/io.h
@@ -36,7 +36,7 @@
 
 #include "package.h"
 
-#include <stddef.h>
+#include <cstddef>
 
 namespace opt {
 


### PR DESCRIPTION
## Description
Uses `clang-tidy` to find and fix uses of deprecated C headers. Fixes applied with:
```
cd <build-dir>/psi4-core-prefix/src/psi4-core-build
run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-deprecated-headers' -fix
```
Based on #1312 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `clang-tidy` find and fix with `modernize-deprecated-headers`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge

