### PR TITLE
clang-tidy apply modernize-use-override fixes

### DIFF
--- a/doc/sphinxman/source/prog_style_c.rst
+++ b/doc/sphinxman/source/prog_style_c.rst
@@ -46,7 +46,7 @@ use ``nullptr`` to signal the null pointer. The correct overload/template
 parameter will then be deduced. Using ``nullptr`` also makes the code more
 readable, especially if ``auto`` is used consistently throughout.
 
-*Reference:* Item 8 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+*Reference:* Item 8 in `[Effective Modern C++] <https://isbnsearch.org/isbn/9781491903995>`_
 
 
 .. _`faq:automakeshared`:
@@ -77,7 +77,7 @@ Using ``std::make_shared``:
     // Performs ONE allocation
     auto F = std::make_shared<Matrix>("Fock matrix", nso, nso);
 
-*Reference:* Item 21 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+*Reference:* Item 21 in `[Effective Modern C++] <https://isbnsearch.org/isbn/9781491903995>`_
 
 
 .. _`faq:autodecl`:
@@ -108,8 +108,15 @@ Using ``auto`` reduces and/or avoids:
     unsigned sz = v.size();  // might not be correct on some compiler/machines
     auto size = v.size();  // size is ALWAYS of the correct type
 
-*Reference:* Items 2 and 5 in `[Effective Modern C++] <https://edisciplinas.usp.br/pluginfile.php/1995323/mod_resource/content/1/Effective%20Modern%20C%2B%2B%202014.pdf>`_
+*Reference:* Items 2 and 5 in `[Effective Modern C++] <https://isbnsearch.org/isbn/9781491903995>`_
 
+Mark virtual functions in derived classes with override
+-------------------------------------------------------
+
+The ``override`` keyword introduced in C++11 is used to mark a function in a
+derived class and guarantee that it is overloadinga function *with the same
+signature* in the base class.  This behavior is `checked at compile time
+<https://en.cppreference.com/w/cpp/language/override>`_.
 
 .. _`faq:printmem`:
 

--- a/doc/sphinxman/source/prog_style_c.rst
+++ b/doc/sphinxman/source/prog_style_c.rst
@@ -114,7 +114,7 @@ Mark virtual functions in derived classes with override
 -------------------------------------------------------
 
 The ``override`` keyword introduced in C++11 is used to mark a function in a
-derived class and guarantee that it is overloadinga function *with the same
+derived class and guarantee that it is overloading a function *with the same
 signature* in the base class.  This behavior is `checked at compile time
 <https://en.cppreference.com/w/cpp/language/override>`_.
 

--- a/psi4/src/psi4/adc/adc.h
+++ b/psi4/src/psi4/adc/adc.h
@@ -65,8 +65,8 @@ struct pole {
 class ADCWfn : public Wavefunction {
    public:
     ADCWfn(SharedWavefunction ref_wfn, Options &options);
-    ~ADCWfn();
-    double compute_energy();
+    ~ADCWfn() override;
+    double compute_energy() override;
 
    protected:
     void init();

--- a/psi4/src/psi4/cc/cclambda/cclambda.h
+++ b/psi4/src/psi4/cc/cclambda/cclambda.h
@@ -43,9 +43,9 @@ namespace cclambda {
 class CCLambdaWavefunction final : public psi::ccenergy::CCEnergyWavefunction {
    public:
     CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
-    virtual ~CCLambdaWavefunction();
+    ~CCLambdaWavefunction() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    private:
     void init();

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -51,9 +51,9 @@ namespace ccenergy {
 class CCEnergyWavefunction : public Wavefunction {
    public:
     CCEnergyWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
-    virtual ~CCEnergyWavefunction();
+    ~CCEnergyWavefunction() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    private:
     /* setup, info and teardown */

--- a/psi4/src/psi4/dcft/dcft.h
+++ b/psi4/src/psi4/dcft/dcft.h
@@ -59,9 +59,9 @@ namespace dcft {
 class DCFTSolver : public Wavefunction {
    public:
     DCFTSolver(SharedWavefunction ref_wfn, Options &options);
-    ~DCFTSolver();
+    ~DCFTSolver() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    protected:
     IntegralTransform *_ints;

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -74,9 +74,9 @@ class CIWavefunction : public Wavefunction {
    public:
     CIWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
     explicit CIWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction);
-    virtual ~CIWavefunction();
+    ~CIWavefunction() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
     /// Simple accessors
     size_t ndet();

--- a/psi4/src/psi4/dfmp2/corr_grad.h
+++ b/psi4/src/psi4/dfmp2/corr_grad.h
@@ -182,11 +182,11 @@ class DFCorrGrad : public CorrGrad {
 
    public:
     DFCorrGrad(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
-    virtual ~DFCorrGrad();
+    ~DFCorrGrad() override;
 
-    void compute_gradient();
+    void compute_gradient() override;
 
-    void print_header() const;
+    void print_header() const override;
 
     /**
      * Minimum relative eigenvalue to retain in fitting inverse

--- a/psi4/src/psi4/dfmp2/mp2.h
+++ b/psi4/src/psi4/dfmp2/mp2.h
@@ -113,9 +113,9 @@ class DFMP2 : public Wavefunction {
 
    public:
     DFMP2(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<PSIO> psio);
-    virtual ~DFMP2();
+    ~DFMP2() override;
 
-    double compute_energy();
+    double compute_energy() override;
     virtual SharedMatrix compute_gradient();
 };
 
@@ -134,43 +134,43 @@ class RDFMP2 : public DFMP2 {
     void common_init();
 
     // Print additional header
-    virtual void print_header();
+    void print_header() override;
     // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
-    virtual void form_Aia();
+    void form_Aia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
-    virtual void form_Qia();
+    void form_Qia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia) and J_QA^-1 (A|ia)
-    virtual void form_Qia_gradient();
+    void form_Qia_gradient() override;
     // Transpose the integrals to (ai|Q)
-    virtual void form_Qia_transpose();
+    void form_Qia_transpose() override;
     // Form the energy contributions
-    virtual void form_energy();
+    void form_energy() override;
     // Form the energy contributions and gradients
-    virtual void form_Pab();
+    void form_Pab() override;
     // Form the energy contributions and gradients
-    virtual void form_Pij();
+    void form_Pij() override;
     // Form the small gamma
-    virtual void form_gamma();
+    void form_gamma() override;
     // Transpose the G
-    virtual void form_G_transpose();
+    void form_G_transpose() override;
     // Form the (A|B)^x contribution to the gradient
-    virtual void form_AB_x_terms();
+    void form_AB_x_terms() override;
     // Form the (A|mn)^x contribution to the gradient
-    virtual void form_Amn_x_terms();
+    void form_Amn_x_terms() override;
     // Form the Lma and Lmi matrices
-    virtual void form_L();
+    void form_L() override;
     // Form the unrelaxed OPDM
-    virtual void form_P();
+    void form_P() override;
     // Form the unrelaxed energy-weighted OPDM
-    virtual void form_W();
+    void form_W() override;
     // Form the full Lagrangian, solve the Z-vector equations, and apply final corrections to W and P
-    virtual void form_Z();
+    void form_Z() override;
     // Manage the formation of W and P contributions to the gradient
-    virtual void form_gradient();
+    void form_gradient() override;
 
    public:
     RDFMP2(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<PSIO> psio);
-    virtual ~RDFMP2();
+    ~RDFMP2() override;
 };
 
 class UDFMP2 : public DFMP2 {
@@ -188,43 +188,43 @@ class UDFMP2 : public DFMP2 {
     void common_init();
 
     // Print additional header
-    virtual void print_header();
+    void print_header() override;
     // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
-    virtual void form_Aia();
+    void form_Aia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
-    virtual void form_Qia();
+    void form_Qia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia) and J_QA^-1 (A|ia)
-    virtual void form_Qia_gradient();
+    void form_Qia_gradient() override;
     // Transpose the integrals to (ai|Q)
-    virtual void form_Qia_transpose();
+    void form_Qia_transpose() override;
     // Form the energy contributions
-    virtual void form_energy();
+    void form_energy() override;
     // Form the energy contributions and gradients
-    virtual void form_Pab();
+    void form_Pab() override;
     // Form the energy contributions and gradients
-    virtual void form_Pij();
+    void form_Pij() override;
     // Form the small gamma
-    virtual void form_gamma();
+    void form_gamma() override;
     // Transpose the G
-    virtual void form_G_transpose();
+    void form_G_transpose() override;
     // Form the (A|B)^x contribution to the gradient
-    virtual void form_AB_x_terms();
+    void form_AB_x_terms() override;
     // Form the (A|mn)^x contribution to the gradient
-    virtual void form_Amn_x_terms();
+    void form_Amn_x_terms() override;
     // Form the Lma and Lmi matrices
-    virtual void form_L();
+    void form_L() override;
     // Form the unrelaxed OPDM
-    virtual void form_P();
+    void form_P() override;
     // Form the unrelaxed energy-weighted OPDM
-    virtual void form_W();
+    void form_W() override;
     // Form the full Lagrangian, solve the Z-vector equations, and apply final corrections to W and P
-    virtual void form_Z();
+    void form_Z() override;
     // Manage the formation of W and P contributions to the gradient
-    virtual void form_gradient();
+    void form_gradient() override;
 
    public:
     UDFMP2(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<PSIO> psio);
-    virtual ~UDFMP2();
+    ~UDFMP2() override;
 };
 
 class RODFMP2 : public UDFMP2 {
@@ -232,11 +232,11 @@ class RODFMP2 : public UDFMP2 {
     void common_init();
 
     // Print additional header
-    virtual void print_header();
+    void print_header() override;
 
    public:
     RODFMP2(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<PSIO> psio);
-    virtual ~RODFMP2();
+    ~RODFMP2() override;
 };
 
 }  // namespace dfmp2

--- a/psi4/src/psi4/dfocc/dfocc.h
+++ b/psi4/src/psi4/dfocc/dfocc.h
@@ -47,9 +47,9 @@ class DFOCC : public Wavefunction {
    public:
     DFOCC(SharedWavefunction ref_wfn, Options &options);
 
-    virtual ~DFOCC();
+    ~DFOCC() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
    protected:
     void mem_release();

--- a/psi4/src/psi4/fnocc/ccsd.h
+++ b/psi4/src/psi4/fnocc/ccsd.h
@@ -45,9 +45,9 @@ namespace fnocc {
 class CoupledCluster : public Wavefunction {
    public:
     CoupledCluster(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
-    ~CoupledCluster();
+    ~CoupledCluster() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    protected:
     int iter;
@@ -218,9 +218,9 @@ class CoupledCluster : public Wavefunction {
 class PSI_API DFCoupledCluster : public CoupledCluster {
    public:
     DFCoupledCluster(SharedWavefunction ref_wfn, Options &options);
-    ~DFCoupledCluster();
+    ~DFCoupledCluster() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    protected:
     void finalize();
@@ -231,7 +231,7 @@ class PSI_API DFCoupledCluster : public CoupledCluster {
     void WriteBanner();
 
     /// allocate memory
-    virtual void AllocateMemory();
+    void AllocateMemory() override;
 
     /// update t1 amplitudes
     void UpdateT1();
@@ -279,9 +279,9 @@ class PSI_API DFCoupledCluster : public CoupledCluster {
 class CoupledPair : public CoupledCluster {
    public:
     CoupledPair(std::shared_ptr<psi::Wavefunction> wfn, Options &options);
-    ~CoupledPair();
+    ~CoupledPair() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
    protected:
     /// coupled pair iterations

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.h
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.h
@@ -38,9 +38,9 @@ namespace fnocc {
 class FrozenNO : public Wavefunction {
    public:
     FrozenNO(std::shared_ptr<Wavefunction> wfn, Options& options);
-    ~FrozenNO();
+    ~FrozenNO() override;
 
-    double compute_energy();
+    double compute_energy() override;
     void ComputeNaturalOrbitals();
 
    protected:
@@ -54,9 +54,9 @@ class FrozenNO : public Wavefunction {
 class PSI_API DFFrozenNO : public FrozenNO {
    public:
     DFFrozenNO(std::shared_ptr<Wavefunction> wfn, Options& options);
-    ~DFFrozenNO();
+    ~DFFrozenNO() override;
 
-    double compute_energy();
+    double compute_energy() override;
 
     /// computes MP2 natural orbitals
     void ComputeNaturalOrbitals();

--- a/psi4/src/psi4/lib3index/cholesky.h
+++ b/psi4/src/psi4/lib3index/cholesky.h
@@ -85,11 +85,11 @@ protected:
     SharedMatrix A_;
 public:
     CholeskyMatrix(SharedMatrix A, double delta, size_t memory);
-    virtual ~CholeskyMatrix();
+    ~CholeskyMatrix() override;
 
-    virtual size_t N();
-    virtual void compute_diagonal(double* target);
-    virtual void compute_row(int row, double* target);
+    size_t N() override;
+    void compute_diagonal(double* target) override;
+    void compute_row(int row, double* target) override;
 };
 
 class PSI_API CholeskyERI : public Cholesky {
@@ -100,11 +100,11 @@ protected:
     std::shared_ptr<TwoBodyAOInt> integral_;
 public:
     CholeskyERI(std::shared_ptr<TwoBodyAOInt> integral, double schwarz, double delta, size_t memory);
-    virtual ~CholeskyERI();
+    ~CholeskyERI() override;
 
-    virtual size_t N();
-    virtual void compute_diagonal(double* target);
-    virtual void compute_row(int row, double* target);
+    size_t N() override;
+    void compute_diagonal(double* target) override;
+    void compute_row(int row, double* target) override;
 };
 
 class CholeskyMP2 : public Cholesky {
@@ -118,11 +118,11 @@ public:
     CholeskyMP2(SharedMatrix Qia, std::shared_ptr<Vector> eps_aocc,
         std::shared_ptr<Vector> eps_avir, bool symmetric,
         double delta, size_t memory);
-    virtual ~CholeskyMP2();
+    ~CholeskyMP2() override;
 
-    virtual size_t N();
-    virtual void compute_diagonal(double* target);
-    virtual void compute_row(int row, double* target);
+    size_t N() override;
+    void compute_diagonal(double* target) override;
+    void compute_row(int row, double* target) override;
 };
 
 class CholeskyDelta : public Cholesky {
@@ -134,11 +134,11 @@ public:
     CholeskyDelta(std::shared_ptr<Vector> eps_aocc,
         std::shared_ptr<Vector> eps_avir,
         double delta, size_t memory);
-    virtual ~CholeskyDelta();
+    ~CholeskyDelta() override;
 
-    virtual size_t N();
-    virtual void compute_diagonal(double* target);
-    virtual void compute_row(int row, double* target);
+    size_t N() override;
+    void compute_diagonal(double* target) override;
+    void compute_row(int row, double* target) override;
 };
 
 class CholeskyLocal : public Cholesky {
@@ -148,11 +148,11 @@ protected:
 public:
     CholeskyLocal(SharedMatrix C,
         double delta, size_t memory);
-    virtual ~CholeskyLocal();
+    ~CholeskyLocal() override;
 
-    virtual size_t N();
-    virtual void compute_diagonal(double* target);
-    virtual void compute_row(int row, double* target);
+    size_t N() override;
+    void compute_diagonal(double* target) override;
+    void compute_row(int row, double* target) override;
 };
 
 } // Namespace psi

--- a/psi4/src/psi4/lib3index/denominator.h
+++ b/psi4/src/psi4/lib3index/denominator.h
@@ -74,11 +74,11 @@ protected:
     // Fully split denominator (w in rows, a in columns)
     SharedMatrix denominator_vir_;
 
-    void decompose();
+    void decompose() override;
 public:
     LaplaceDenominator(std::shared_ptr<Vector> eps_occ_, std::shared_ptr<Vector> eps_vir, double delta);
-    ~LaplaceDenominator();
-    void debug();
+    ~LaplaceDenominator() override;
+    void debug() override;
     SharedMatrix denominator_occ() const { return denominator_occ_; }
     SharedMatrix denominator_vir() const { return denominator_vir_; }
 
@@ -87,11 +87,11 @@ public:
 class CholeskyDenominator : public Denominator {
 
 protected:
-    void decompose();
+    void decompose() override;
 public:
     CholeskyDenominator(std::shared_ptr<Vector> eps_occ_, std::shared_ptr<Vector> eps_vir, double delta);
-    ~CholeskyDenominator();
-    void debug();
+    ~CholeskyDenominator() override;
+    void debug() override;
 
 };
 
@@ -152,15 +152,15 @@ protected:
     // Fully split denominator (w in rows, s in columns) (monomer B)
     SharedMatrix denominator_virB_;
 
-    void decompose();
+    void decompose() override;
     void check_split(std::shared_ptr<Vector>, std::shared_ptr<Vector>,
       SharedMatrix, SharedMatrix);
 public:
     SAPTLaplaceDenominator(std::shared_ptr<Vector>, std::shared_ptr<Vector>,
       std::shared_ptr<Vector>, std::shared_ptr<Vector>, double, bool debug = false);
-    ~SAPTLaplaceDenominator();
+    ~SAPTLaplaceDenominator() override;
 
-    void debug();
+    void debug() override;
     SharedMatrix denominator_occA() const { return denominator_occA_; }
     SharedMatrix denominator_virA() const { return denominator_virA_; }
     SharedMatrix denominator_occB() const { return denominator_occB_; }
@@ -171,11 +171,11 @@ public:
 class SAPTCholeskyDenominator : public SAPTDenominator {
 
 protected:
-    void decompose();
+    void decompose() override;
 public:
     SAPTCholeskyDenominator(std::shared_ptr<Vector>, std::shared_ptr<Vector>,
       std::shared_ptr<Vector>, std::shared_ptr<Vector>, double, bool debug = false);
-    ~SAPTCholeskyDenominator();
+    ~SAPTCholeskyDenominator() override;
 };
 
 class TLaplaceDenominator {

--- a/psi4/src/psi4/libfock/PK_workers.h
+++ b/psi4/src/psi4/libfock/PK_workers.h
@@ -401,7 +401,7 @@ private:
     /// Internal buffer index
     size_t buf_;
 
-    virtual void initialize_task();
+    void initialize_task() override;
 
 public:
     /// Constructor
@@ -409,7 +409,7 @@ public:
                 std::shared_ptr<AIOHandler> AIO, int target_file,
                 size_t buffer_size, size_t nbuffer);
     /// Destructor
-    ~PKWrkrReord();
+    ~PKWrkrReord() override;
 
     /// Reallocating memory for wK
     /// We make sure the deallocated buffers have been written to disk
@@ -453,7 +453,7 @@ private:
     double* K_bufp_;
     double* wK_bufp_;
 
-    virtual void initialize_task();
+    void initialize_task() override;
 
 public:
     PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve sieve,
@@ -506,7 +506,7 @@ public:
               size_t buf_size, std::vector< int > &bufforpq,
               std::shared_ptr<std::vector<size_t>> pos);
     /// Destructor
-    ~PKWrkrIWL();
+    ~PKWrkrIWL() override;
 
     /// Preparing for wK pre-sorting to file
     virtual void allocate_wK(std::shared_ptr<std::vector<size_t>> pos, int wKfile);
@@ -524,12 +524,12 @@ public:
     /// Inserting a wK value back into a buffer
     virtual void insert_value_wK(size_t bufid, double val, size_t i, size_t j, size_t k, size_t l);
     /// Flushing all buffers for current worker
-    virtual void flush();
+    void flush() override;
     /// Flushing all wK buffers for current worker
-    virtual void flush_wK();
+    void flush_wK() override;
 
     /// Functions that are not used here
-    virtual void initialize_task() {
+    void initialize_task() override {
         throw PSIEXCEPTION("initialize_task not implemented for this class\n");
     }
     virtual void write(std::vector<size_t> min_ind, std::vector<size_t> max_ind,

--- a/psi4/src/psi4/libfock/PKmanagers.h
+++ b/psi4/src/psi4/libfock/PKmanagers.h
@@ -280,7 +280,7 @@ public:
     PKMgrDisk(std::shared_ptr<PSIO> psio, std::shared_ptr<BasisSet> primary,
               size_t memory, Options &options);
     /// Destructor for PKMgrDisk, does nothing
-    virtual ~PKMgrDisk() {}
+    ~PKMgrDisk() override {}
 
     /// Setter/Getter functions
     void set_writing(bool tmp) { writing_ = tmp; }
@@ -295,13 +295,13 @@ public:
     std::shared_ptr< PSIO > psio() const { return psio_; }
 
     /// Finalize the PK file formation
-    virtual void finalize_PK();
+    void finalize_PK() override;
 
     /// Initialize sequence for Disk algorithms
-    virtual void initialize();
+    void initialize() override;
     /// Initialize wK PK supermatrix, has to be called after
     /// initialize()
-    virtual void initialize_wK();
+    void initialize_wK() override;
     /// Allocating new buffers for wK integrals
     virtual void allocate_buffers_wK()=0;
     /// Prepare the JK formation for disk algorithms
@@ -311,7 +311,7 @@ public:
     /// Determining the batch sizes
     void batch_sizing();
     /// Printing out the batches
-    virtual void print_batches();
+    void print_batches() override;
 
     /// Opening files for integral storage
     virtual void prestripe_files()=0;
@@ -319,9 +319,9 @@ public:
     virtual void prestripe_files_wK() = 0;
 
     /// Write integrals on disk
-    virtual void write();
+    void write() override;
     /// Write wK integrals on disk
-    virtual void write_wK();
+    void write_wK() override;
 
     /// Opening the PK file
     void open_PK_file();
@@ -333,7 +333,7 @@ public:
                         std::vector<SharedMatrix> K = std::vector<SharedMatrix>());
 
     /// Finalize JK matrix formation
-    virtual void finalize_JK();
+    void finalize_JK() override;
 };
 
 /**
@@ -362,27 +362,27 @@ public:
     PKMgrReorder(std::shared_ptr<PSIO> psio, std::shared_ptr<BasisSet> primary,
                  size_t memory, Options &options);
     /// Destructor
-    virtual ~PKMgrReorder() {}
+    ~PKMgrReorder() override {}
 
     /// Sequence of operations to form PK for reorder algo
-    virtual void form_PK();
+    void form_PK() override;
     /// Forming PK for wK integrals
-    virtual void form_PK_wK();
+    void form_PK_wK() override;
 
     /// Pre-striping the PK file
-    virtual void prestripe_files();
+    void prestripe_files() override;
     /// Pre-striping PK file for wK integrals
-    virtual void prestripe_files_wK();
+    void prestripe_files_wK() override;
 
     /// Allocating the buffers for each thread
-    virtual void allocate_buffers();
+    void allocate_buffers() override;
     /// De-allocating buffer space for J/K supermatrices and
     /// allocating space for wK. Allows us to use buffers twice as big
-    virtual void allocate_buffers_wK();
+    void allocate_buffers_wK() override;
     /// Finalize PK: synchronize AIO writing, delete thread
     /// buffers, keep PK file open since we are going to
     /// use it immediately
-    virtual void finalize_PK();
+    void finalize_PK() override;
 
 };
 
@@ -419,33 +419,33 @@ public:
     PKMgrYoshimine(std::shared_ptr<PSIO> psio, std::shared_ptr<BasisSet> primary,
                    size_t memory, Options &options);
     /// Destructor
-    virtual ~PKMgrYoshimine() {}
+    ~PKMgrYoshimine() override {}
 
     /// Pre-striping the IWL pre-sorted bucket files
     //TODO: Optimize the vastly excessive amount of pre-striping for the K file
-    virtual void prestripe_files();
+    void prestripe_files() override;
     /// Pre-striping for IWL wK pre-sorted files
-    virtual void prestripe_files_wK();
+    void prestripe_files_wK() override;
 
     /// Gather all steps to form PK
-    virtual void form_PK();
+    void form_PK() override;
     /// Steps to form the supermatrix for wK
-    virtual void form_PK_wK();
+    void form_PK_wK() override;
 
     /// Allocating the buffers for each thread
-    virtual void allocate_buffers();
+    void allocate_buffers() override;
     /// Allocating buffers for wK integrals
-    virtual void allocate_buffers_wK();
+    void allocate_buffers_wK() override;
 
     /// Computing the integrals
-    virtual void compute_integrals(bool wK = false);
+    void compute_integrals(bool wK = false) override;
     /// computing wK integrals
-    virtual void compute_integrals_wK();
+    void compute_integrals_wK() override;
 
     /// Writing of the last partially filled buffers
-    virtual void write();
+    void write() override;
     /// Writing of the last partially filled buffers for wK
-    virtual void write_wK();
+    void write_wK() override;
 
     /// Reading and sorting integrals to generate PK file
     void sort_ints(bool wK = false);
@@ -488,16 +488,16 @@ public:
     PKMgrInCore(std::shared_ptr<BasisSet> primary, size_t memory,
                 Options &options) : wK_ints_(nullptr), PKManager(primary,memory,options) {}
     /// Destructor for in-core class
-    virtual ~PKMgrInCore() {}
+    ~PKMgrInCore() override {}
 
     /// Initialize sequence for in-core algorithm
-    virtual void initialize();
+    void initialize() override;
     /// Initialize the wK integrals
-    virtual void initialize_wK();
+    void initialize_wK() override;
     /// Sequence of steps to form PK matrix
-    virtual void form_PK();
+    void form_PK() override;
     /// Sequence of steps to form wK PK matrix
-    virtual void form_PK_wK();
+    void form_PK_wK() override;
     /// Steps to prepare JK formation
     virtual void prepare_JK(std::vector<SharedMatrix> D,std::vector<SharedMatrix> Cl,
                             std::vector<SharedMatrix> Cr);
@@ -506,20 +506,20 @@ public:
     virtual void form_J(std::vector<SharedMatrix> J, std::string exch = "",
                         std::vector<SharedMatrix> K = std::vector<SharedMatrix>());
     /// Finalize JK formation
-    virtual void finalize_JK();
+    void finalize_JK() override;
 
     /// No disk write, only finalizes integral arrays
-    virtual void write();
+    void write() override;
     /// Finalize integral arrays for wK
-    virtual void write_wK();
+    void write_wK() override;
 
     /// Printing the algorithm header
-    virtual void print_batches();
+    void print_batches() override;
 
     /// Allocate the buffer threads
-    virtual void allocate_buffers();
+    void allocate_buffers() override;
     /// Finalize PK, i.e. deallocate buffers
-    virtual void finalize_PK();
+    void finalize_PK() override;
 
 };
 

--- a/psi4/src/psi4/libfock/apps.h
+++ b/psi4/src/psi4/libfock/apps.h
@@ -75,13 +75,13 @@ public:
     RBase(SharedWavefunction ref_wfn, Options& options, bool use_symmetry=true);
     // TODO: Remove AS SOON AS POSSIBLE, such a dirty hack
     RBase(bool flag);
-    virtual ~RBase();
+    ~RBase() override;
 
     virtual bool same_a_b_orbs() const { return true; }
     virtual bool same_a_b_dens() const { return true; }
 
     // TODO: Remove AS SOON AS POSSIBLE, such a dirty hack
-    virtual double compute_energy() { return 0.0; }
+    double compute_energy() override { return 0.0; }
 
     void set_print(int print) { print_ = print; }
 
@@ -159,9 +159,9 @@ protected:
 
 public:
     RCIS(SharedWavefunction ref_wfn, Options& options);
-    virtual ~RCIS();
+    ~RCIS() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
 };
 
@@ -180,9 +180,9 @@ protected:
 
 public:
     RTDHF(SharedWavefunction ref_wfn, Options& options);
-    virtual ~RTDHF();
+    ~RTDHF() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
 };
 
@@ -207,10 +207,10 @@ protected:
 
 public:
     RCPHF(SharedWavefunction ref_wfn, Options& options, bool use_symmetry=true);
-    virtual ~RCPHF();
+    ~RCPHF() override;
 
     /// Solve for all perturbations currently in b
-    virtual double compute_energy();
+    double compute_energy() override;
 
     /// Perturbation vector queue, shove tasks onto this guy before compute_energy
     std::map<std::string, SharedMatrix>& b() { return b_; }
@@ -225,37 +225,37 @@ public:
 class RCPKS : public RCPHF {
 
 protected:
-    virtual void print_header();
+    void print_header() override;
 
 public:
     RCPKS(SharedWavefunction ref_wfn, Options& options);
-    virtual ~RCPKS();
+    ~RCPKS() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 };
 
 class RTDA : public RCIS {
 
 protected:
-    virtual void print_header();
+    void print_header() override;
 
 public:
     RTDA(SharedWavefunction ref_wfn, Options& options);
-    virtual ~RTDA();
+    ~RTDA() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 };
 
 class RTDDFT : public RTDHF {
 
 protected:
-    virtual void print_header();
+    void print_header() override;
 
 public:
     RTDDFT(SharedWavefunction ref_wfn, Options& options);
-    virtual ~RTDDFT();
+    ~RTDDFT() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 };
 
 }

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -196,7 +196,7 @@ public:
     PseudospectralGrid(std::shared_ptr<Molecule> molecule,
                        std::shared_ptr<BasisSet> primary,
                        Options& options);
-    virtual ~PseudospectralGrid();
+    ~PseudospectralGrid() override;
 
 };
 
@@ -216,7 +216,7 @@ public:
     DFTGrid(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary,
          std::map<std::string, int> int_opts_map, std::map<std::string, std::string> opts_map,
          Options& options);
-virtual ~DFTGrid();
+~DFTGrid() override;
 };
 
 class RadialGrid {

--- a/psi4/src/psi4/libfock/gridblocker.h
+++ b/psi4/src/psi4/libfock/gridblocker.h
@@ -112,9 +112,9 @@ public:
     NaiveGridBlocker(const int npoints_ref, double const* x_ref, double const* y_ref, double const* z_ref,
         double const* w_ref, int const* index_ref, const int max_points, const int min_points, const double max_radius,
         std::shared_ptr<BasisExtents> extents);
-    virtual ~NaiveGridBlocker();
+    ~NaiveGridBlocker() override;
 
-    virtual void block();
+    void block() override;
 };
 
 /**
@@ -127,9 +127,9 @@ public:
     OctreeGridBlocker(const int npoints_ref, double const* x_ref, double const* y_ref, double const* z_ref,
         double const* w_ref, int const* index_ref, const int max_points, const int min_points, const double max_radius,
         std::shared_ptr<BasisExtents> extents);
-    virtual ~OctreeGridBlocker();
+    ~OctreeGridBlocker() override;
 
-    virtual void block();
+    void block() override;
 };
 
 }

--- a/psi4/src/psi4/libfock/hamiltonian.h
+++ b/psi4/src/psi4/libfock/hamiltonian.h
@@ -116,7 +116,7 @@ public:
     RHamiltonian(std::shared_ptr<JK> jk);
     RHamiltonian(std::shared_ptr<JK> jk, std::shared_ptr<VBase> v);
     /// Destructor
-    virtual ~RHamiltonian();
+    ~RHamiltonian() override;
 
     // => Required Methods <= //
 
@@ -150,7 +150,7 @@ public:
     UHamiltonian(std::shared_ptr<JK> jk);
     UHamiltonian(std::shared_ptr<JK> jk, std::shared_ptr<VBase> v);
     /// Destructor
-    virtual ~UHamiltonian();
+    ~UHamiltonian() override;
 
     // => Required Methods <= //
 
@@ -187,9 +187,9 @@ protected:
 public:
 
     MatrixRHamiltonian(SharedMatrix M);
-    virtual ~MatrixRHamiltonian();
+    ~MatrixRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::shared_ptr<Vector> diagonal();
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
@@ -205,9 +205,9 @@ protected:
 public:
 
     MatrixUHamiltonian(std::pair<SharedMatrix, SharedMatrix > M);
-    virtual ~MatrixUHamiltonian();
+    ~MatrixUHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::pair<std::shared_ptr<Vector>,
                       std::shared_ptr<Vector> > diagonal();
     virtual void product(const std::vector<std::pair<std::shared_ptr<Vector>, std::shared_ptr<Vector> > >& x,
@@ -232,9 +232,9 @@ public:
                     std::shared_ptr<Vector> eps_aocc,
                     std::shared_ptr<Vector> eps_avir,
                     std::shared_ptr<VBase> v = std::shared_ptr<VBase>());
-    virtual ~CISRHamiltonian();
+    ~CISRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::shared_ptr<Vector> diagonal();
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
@@ -262,9 +262,9 @@ public:
                     std::shared_ptr<Vector> eps_aocc,
                     std::shared_ptr<Vector> eps_avir,
                     std::shared_ptr<VBase> v = std::shared_ptr<VBase>());
-    virtual ~TDHFRHamiltonian();
+    ~TDHFRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::shared_ptr<Vector> diagonal();
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
@@ -288,9 +288,9 @@ public:
                      std::shared_ptr<Vector> eps_aocc,
                      std::shared_ptr<Vector> eps_avir,
                      std::shared_ptr<VBase> v = std::shared_ptr<VBase>());
-    virtual ~CPHFRHamiltonian();
+    ~CPHFRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::shared_ptr<Vector> diagonal();
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
@@ -313,9 +313,9 @@ public:
                     SharedMatrix Cavir,
                     std::shared_ptr<Vector> eps_aocc,
                     std::shared_ptr<Vector> eps_avir);
-    virtual ~TDARHamiltonian();
+    ~TDARHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
 };
@@ -334,9 +334,9 @@ public:
                     SharedMatrix Cavir,
                     std::shared_ptr<Vector> eps_aocc,
                     std::shared_ptr<Vector> eps_avir);
-    virtual ~TDDFTRHamiltonian();
+    ~TDDFTRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
 };
@@ -355,9 +355,9 @@ public:
                     SharedMatrix Cavir,
                     std::shared_ptr<Vector> eps_aocc,
                     std::shared_ptr<Vector> eps_avir);
-    virtual ~CPKSRHamiltonian();
+    ~CPKSRHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual void product(const std::vector<std::shared_ptr<Vector> >& x,
                                std::vector<std::shared_ptr<Vector> >& b);
 };
@@ -389,9 +389,9 @@ public:
                      std::shared_ptr<Vector> eps_occb,
                      std::shared_ptr<Vector> eps_virb,
                      std::shared_ptr<VBase> v = std::shared_ptr<VBase>());
-    virtual ~USTABHamiltonian();
+    ~USTABHamiltonian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
     virtual std::pair<std::shared_ptr<Vector>,
                       std::shared_ptr<Vector> > diagonal();
     virtual void product(const std::vector<std::pair<std::shared_ptr<Vector>, std::shared_ptr<Vector> > >& x,

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -536,13 +536,13 @@ class DiskJK : public JK {
     Options& options_;
 
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const { return false; }
+    bool C1() const override { return false; }
     /// Setup integrals, files, etc
-    virtual void preiterations();
+    void preiterations() override;
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations();
+    void postiterations() override;
 
     /// Common initialization
     void common_init();
@@ -559,7 +559,7 @@ class DiskJK : public JK {
      */
     DiskJK(std::shared_ptr<BasisSet> primary, Options& options);
     /// Destructor
-    virtual ~DiskJK();
+    ~DiskJK() override;
 
     // => Accessors <= //
 
@@ -567,7 +567,7 @@ class DiskJK : public JK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 };
 
 /**
@@ -593,13 +593,13 @@ class PSI_API PKJK : public JK {
     std::shared_ptr<pk::PKManager> PKmanager_;
 
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const;
+    bool C1() const override;
     /// Setup integrals, files, etc
-    virtual void preiterations();
+    void preiterations() override;
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations();
+    void postiterations() override;
 
     /// Common initialization
     void common_init();
@@ -624,7 +624,7 @@ class PSI_API PKJK : public JK {
      */
     PKJK(std::shared_ptr<BasisSet> primary, Options& options);
     /// Destructor
-    virtual ~PKJK();
+    ~PKJK() override;
 
     // => Accessors <= //
 
@@ -632,7 +632,7 @@ class PSI_API PKJK : public JK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 };
 
 /**
@@ -656,13 +656,13 @@ class DirectJK : public JK {
     // => Required Algorithm-Specific Methods <= //
 
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const { return true; }
+    bool C1() const override { return true; }
     /// Setup integrals, files, etc
-    virtual void preiterations();
+    void preiterations() override;
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations();
+    void postiterations() override;
 
     /// Build the J and K matrices for this integral class
     void build_JK(std::vector<std::shared_ptr<TwoBodyAOInt> >& ints, std::vector<std::shared_ptr<Matrix> >& D,
@@ -683,7 +683,7 @@ class DirectJK : public JK {
      */
     DirectJK(std::shared_ptr<BasisSet> primary);
     /// Destructor
-    virtual ~DirectJK();
+    ~DirectJK() override;
 
     // => Knobs <= //
 
@@ -699,7 +699,7 @@ class DirectJK : public JK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 };
 
 /** \brief Derived class extending the JK object to GTFock
@@ -723,15 +723,15 @@ class GTFockJK : public JK {
 
    protected:
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const { return true; }
+    bool C1() const override { return true; }
     /// Setup integrals, files, etc
-    virtual void preiterations() {}
+    void preiterations() override {}
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations() {}
+    void postiterations() override {}
     /// I don't fell the need to further clutter the output...
-    virtual void print_header() const {}
+    void print_header() const override {}
 
    public:
     /** \brief Your public interface to GTFock
@@ -806,13 +806,13 @@ class PSI_API DiskDFJK : public JK {
     // => Required Algorithm-Specific Methods <= //
 
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const { return true; }
+    bool C1() const override { return true; }
     /// Setup integrals, files, etc
-    virtual void preiterations();
+    void preiterations() override;
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations();
+    void postiterations() override;
 
     /// Common initialization
     void common_init();
@@ -856,7 +856,7 @@ class PSI_API DiskDFJK : public JK {
     DiskDFJK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
 
     /// Destructor
-    virtual ~DiskDFJK();
+    ~DiskDFJK() override;
 
     /**
      * Method to provide (ia|ia) integrals for
@@ -898,7 +898,7 @@ class PSI_API DiskDFJK : public JK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 };
 /**
  * Class CDJK
@@ -916,9 +916,9 @@ class CDJK : public DiskDFJK {
     virtual bool is_core() { return true; }
 
     // => J <= //
-    virtual void initialize_JK_core();
-    virtual void initialize_JK_disk();
-    virtual void manage_JK_core();
+    void initialize_JK_core() override;
+    void initialize_JK_disk() override;
+    void manage_JK_core() override;
 
     double cholesky_tolerance_;
 
@@ -928,7 +928,7 @@ class CDJK : public DiskDFJK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 
    public:
     // => Constructors < = //
@@ -944,7 +944,7 @@ class CDJK : public DiskDFJK {
     CDJK(std::shared_ptr<BasisSet> primary, double cholesky_tolerance);
 
     /// Destructor
-    virtual ~CDJK();
+    ~CDJK() override;
 };
 
 /**
@@ -974,14 +974,14 @@ class MemDFJK : public JK {
 
     int max_nocc() const;
     /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const { return true; }
+    bool C1() const override { return true; }
     /// Setup integrals, files, etc
     /// calls initialize(), JK_blocking
-    virtual void preiterations();
+    void preiterations() override;
     /// Compute J/K for current C/D
-    virtual void compute_JK();
+    void compute_JK() override;
     /// Delete integrals, files, etc
-    virtual void postiterations();
+    void postiterations() override;
 
     /// Common initialization
     void common_init();
@@ -997,7 +997,7 @@ class MemDFJK : public JK {
     MemDFJK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
 
     /// Destructor
-    virtual ~MemDFJK();
+    ~MemDFJK() override;
     
     
     // => Knobs <= //
@@ -1024,7 +1024,7 @@ class MemDFJK : public JK {
     * Print header information regarding JK
     * type on output file
     */
-    virtual void print_header() const;
+    void print_header() const override;
 
     /**
      * Returns the DFHelper object

--- a/psi4/src/psi4/libfock/points.h
+++ b/psi4/src/psi4/libfock/points.h
@@ -122,7 +122,7 @@ public:
     // => Constructors <= //
 
     PointFunctions(std::shared_ptr<BasisSet> primary, int max_points, int max_functions);
-    virtual ~PointFunctions();
+    ~PointFunctions() override;
 
     // => Setters <= //
     void set_cache_map(std::unordered_map<size_t, std::map<std::string, SharedMatrix>>* cache_map) { cache_map_ = cache_map; }
@@ -178,7 +178,7 @@ protected:
     /// Build temporary work arrays
     void build_temps();
     /// Allocate registers
-    void allocate();
+    void allocate() override;
 
     // => Orbital Collocation <= //
 
@@ -189,7 +189,7 @@ protected:
 
 public:
     RKSFunctions(std::shared_ptr<BasisSet> primary, int max_points, int max_functions);
-    virtual ~RKSFunctions();
+    ~RKSFunctions() override;
 
     void set_pointers(SharedMatrix Da_occ_AO);
     void set_pointers(SharedMatrix Da_occ_AO, SharedMatrix Db_occ_AO);
@@ -231,7 +231,7 @@ protected:
     /// Build temporary work arrays
     void build_temps();
     /// Allocate registers
-    void allocate();
+    void allocate() override;
 
     // => Orbital Collocation <= //
 
@@ -246,7 +246,7 @@ protected:
 
 public:
     UKSFunctions(std::shared_ptr<BasisSet> primary, int max_points, int max_functions);
-    virtual ~UKSFunctions();
+    ~UKSFunctions() override;
 
     void set_pointers(SharedMatrix Da_occ_AO);
     void set_pointers(SharedMatrix Da_occ_AO, SharedMatrix Db_occ_AO);

--- a/psi4/src/psi4/libfock/solver.h
+++ b/psi4/src/psi4/libfock/solver.h
@@ -145,7 +145,7 @@ public:
 
     RSolver(std::shared_ptr<RHamiltonian> H);
     /// Destructor
-    virtual ~RSolver();
+    ~RSolver() override;
 
     // => Accessors <= //
 
@@ -174,7 +174,7 @@ public:
     /// Reference to underlying RHamiltonian
     USolver(std::shared_ptr<UHamiltonian> H);
     /// Destructor
-    virtual ~USolver();
+    ~USolver() override;
 
     // => Accessors <= //
 
@@ -249,7 +249,7 @@ protected:
 public:
 
     CGRSolver(std::shared_ptr<RHamiltonian> H);
-    virtual ~CGRSolver();
+    ~CGRSolver() override;
 
     /// Static constructor, uses Options object
     static std::shared_ptr<CGRSolver> build_solver(Options& options,
@@ -259,10 +259,10 @@ public:
     std::vector<std::shared_ptr<Vector> >& b() { return b_; }
 
     void print_header() const;
-    size_t memory_estimate();
-    void initialize();
-    void solve();
-    void finalize();
+    size_t memory_estimate() override;
+    void initialize() override;
+    void solve() override;
+    void finalize() override;
 
     void set_shifts(const std::vector<std::vector<double> >& shifts) { shifts_ = shifts; }
     void set_A(SharedMatrix A, const std::vector<std::vector<int> > inds) { A_ = A; A_inds_ = inds; }
@@ -352,7 +352,7 @@ public:
     /// Constructor
     DLRSolver(std::shared_ptr<RHamiltonian> H);
     /// Destructor
-    virtual ~DLRSolver();
+    ~DLRSolver() override;
 
     /// Static constructor, uses Options object
     static std::shared_ptr<DLRSolver> build_solver(Options& options,
@@ -360,11 +360,11 @@ public:
 
     // => Required Methods <= //
 
-    virtual void print_header() const;
-    virtual size_t memory_estimate();
-    virtual void initialize();
-    void solve();
-    void finalize();
+    void print_header() const override;
+    size_t memory_estimate() override;
+    void initialize() override;
+    void solve() override;
+    void finalize() override;
 
     // => Accessors <= //
 
@@ -399,7 +399,7 @@ protected:
     std::string quantity_;
 
     // Find correctors (Like, the most advanced correctors ever)
-    void correctors();
+    void correctors() override;
 
 public:
 
@@ -408,7 +408,7 @@ public:
     /// Constructor
     RayleighRSolver(std::shared_ptr<RHamiltonian> H);
     /// Destructor
-    virtual ~RayleighRSolver();
+    ~RayleighRSolver() override;
 
     /// Static constructor, uses Options object
     static std::shared_ptr<RayleighRSolver> build_solver(Options& options,
@@ -416,9 +416,9 @@ public:
 
     // => Required Methods <= //
 
-    void print_header() const;
-    void initialize();
-    void finalize();
+    void print_header() const override;
+    void initialize() override;
+    void finalize() override;
 
     void set_precondition_maxiter(int maxiter) { precondition_maxiter_ = maxiter; }
     void set_precondition_steps(const std::string& steps) { precondition_steps_ = steps; }
@@ -504,7 +504,7 @@ public:
     /// Constructor
     DLRXSolver(std::shared_ptr<RHamiltonian> H);
     /// Destructor
-    virtual ~DLRXSolver();
+    ~DLRXSolver() override;
 
     /// Static constructor, uses Options object
     static std::shared_ptr<DLRXSolver> build_solver(Options& options,
@@ -512,11 +512,11 @@ public:
 
     // => Required Methods <= //
 
-    void print_header() const;
-    size_t memory_estimate();
-    void initialize();
-    void solve();
-    void finalize();
+    void print_header() const override;
+    size_t memory_estimate() override;
+    void initialize() override;
+    void solve() override;
+    void finalize() override;
 
     // => Accessors <= //
 
@@ -625,7 +625,7 @@ public:
     /// Constructor
     DLUSolver(std::shared_ptr<UHamiltonian> H);
     /// Destructor
-    virtual ~DLUSolver();
+    ~DLUSolver() override;
 
     /// Static constructor, uses Options object
     static std::shared_ptr<DLUSolver> build_solver(Options& options,
@@ -633,11 +633,11 @@ public:
 
     // => Required Methods <= //
 
-    virtual void print_header() const;
-    virtual size_t memory_estimate(){ return 0;};
-    virtual void initialize();
-    void solve();
-    void finalize();
+    void print_header() const override;
+    size_t memory_estimate() override{ return 0;};
+    void initialize() override;
+    void solve() override;
+    void finalize() override;
 
     // => Accessors <= //
 

--- a/psi4/src/psi4/libfock/soscf.h
+++ b/psi4/src/psi4/libfock/soscf.h
@@ -284,13 +284,13 @@ public:
     DFSOMCSCF(std::shared_ptr<JK> jk, std::shared_ptr<DFHelper> df, SharedMatrix AOTOSO,
             SharedMatrix H);
 
-    virtual ~DFSOMCSCF();
+    ~DFSOMCSCF() override;
 
 protected:
 
     std::shared_ptr<DFHelper> dfh_;
-    virtual void transform(bool approx_only);
-    virtual void set_act_MO();
+    void transform(bool approx_only) override;
+    void set_act_MO() override;
     virtual SharedMatrix compute_Q(SharedMatrix TPDM);
     virtual SharedMatrix compute_Qk(SharedMatrix TPDM, SharedMatrix U, SharedMatrix Uact);
 
@@ -311,14 +311,14 @@ public:
      */
     DiskSOMCSCF(std::shared_ptr<JK> jk, std::shared_ptr<IntegralTransform> ints, SharedMatrix AOTOSO, SharedMatrix H);
 
-    virtual ~DiskSOMCSCF();
+    ~DiskSOMCSCF() override;
 
 protected:
 
     std::shared_ptr<IntegralTransform> ints_;
     std::shared_ptr<PSIO>  psio_;
-    virtual void transform(bool approx_only);
-    virtual void set_act_MO();
+    void transform(bool approx_only) override;
+    void set_act_MO() override;
     virtual SharedMatrix compute_Q(SharedMatrix TPDM);
     virtual SharedMatrix compute_Qk(SharedMatrix TPDM, SharedMatrix U, SharedMatrix Uact);
 
@@ -340,12 +340,12 @@ public:
      */
     IncoreSOMCSCF(std::shared_ptr<JK> jk, SharedMatrix AOTOSO, SharedMatrix H);
 
-    virtual ~IncoreSOMCSCF();
+    ~IncoreSOMCSCF() override;
     virtual void set_eri_tensors(SharedMatrix aaaa, SharedMatrix aaar);
 
 protected:
 
-    virtual void set_act_MO();
+    void set_act_MO() override;
     virtual SharedMatrix compute_Q(SharedMatrix TPDM);
     virtual SharedMatrix compute_Qk(SharedMatrix TPDM, SharedMatrix U, SharedMatrix Uact);
 

--- a/psi4/src/psi4/libfock/v.h
+++ b/psi4/src/psi4/libfock/v.h
@@ -163,17 +163,17 @@ public:
     RV(std::shared_ptr<SuperFunctional> functional,
         std::shared_ptr<BasisSet> primary,
         Options& options);
-    virtual ~RV();
+    ~RV() override;
 
-    virtual void initialize();
-    virtual void finalize();
+    void initialize() override;
+    void finalize() override;
 
     virtual void compute_V(std::vector<SharedMatrix> ret);
     virtual void compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret);
-    virtual SharedMatrix compute_gradient();
-    virtual SharedMatrix compute_hessian();
+    SharedMatrix compute_gradient() override;
+    SharedMatrix compute_hessian() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
 };
 
 class UV : public VBase {
@@ -184,16 +184,16 @@ public:
     UV(std::shared_ptr<SuperFunctional> functional,
         std::shared_ptr<BasisSet> primary,
         Options& options);
-    virtual ~UV();
+    ~UV() override;
 
-    virtual void initialize();
-    virtual void finalize();
+    void initialize() override;
+    void finalize() override;
 
     virtual void compute_V(std::vector<SharedMatrix> ret);
     virtual void compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret);
-    virtual SharedMatrix compute_gradient();
+    SharedMatrix compute_gradient() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
 };
 
 

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -69,7 +69,7 @@ private:
 public:
 
     LibXCFunctional(std::string xc_name, bool unpolarized);
-    virtual ~LibXCFunctional();
+    ~LibXCFunctional() override;
 
     virtual void compute_functional(const std::map<std::string, SharedVector>& in,
                                     const std::map<std::string, SharedVector>& out, int npoints,

--- a/psi4/src/psi4/libmints/angularmomentum.h
+++ b/psi4/src/psi4/libmints/angularmomentum.h
@@ -53,7 +53,7 @@ class AngularMomentumInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     //! Computes the dipole between two gaussian shells.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     //! Computes the dipole derivative between two gaussian shells.
     //    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
 
@@ -62,10 +62,10 @@ class AngularMomentumInt : public OneBodyAOInt {
     AngularMomentumInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                        int deriv = 0);
     //! Virtual destructor
-    virtual ~AngularMomentumInt();
+    ~AngularMomentumInt() override;
 
     //! Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -96,11 +96,11 @@ class NumberValue : public CoordValue {
 
    public:
     NumberValue(double value, bool fixed = false) : CoordValue(fixed, true), value_(value) {}
-    double compute() { return value_; }
-    void set(double val) {
+    double compute() override { return value_; }
+    void set(double val) override {
         if (!fixed_) value_ = val;
     }
-    CoordValueType type() { return NumberType; }
+    CoordValueType type() override { return NumberType; }
     std::shared_ptr<CoordValue> clone(std::map<std::string, double>& /*map*/) {
         return std::make_shared<NumberValue>(value_, fixed_);
     }
@@ -119,15 +119,15 @@ class VariableValue : public CoordValue {
     VariableValue(const std::string name, std::map<std::string, double>& geometryVariables, bool negate = false,
                   bool fixed = false)
         : CoordValue(fixed, true), name_(name), geometryVariables_(geometryVariables), negate_(negate) {}
-    double compute();
+    double compute() override;
     bool negated() const { return negate_; }
     const std::string& name() const { return name_; }
-    void set(double val) {
+    void set(double val) override {
         if (!fixed_) {
             geometryVariables_[name_] = negate_ ? -val : val;
         }
     }
-    CoordValueType type() { return VariableType; }
+    CoordValueType type() override { return VariableType; }
     std::shared_ptr<CoordValue> clone(std::map<std::string, double>& map) {
         return std::make_shared<VariableValue>(name_, map, negate_, fixed_);
     }
@@ -292,12 +292,12 @@ class CartesianEntry : public CoordEntry {
                    std::shared_ptr<CoordValue> z, const std::map<std::string, std::string>& basis,
                    const std::map<std::string, std::string>& shells);
 
-    const Vector3& compute();
-    void set_coordinates(double x, double y, double z);
-    CoordEntryType type() { return CartesianCoord; }
-    void print_in_input_format();
+    const Vector3& compute() override;
+    void set_coordinates(double x, double y, double z) override;
+    CoordEntryType type() override { return CartesianCoord; }
+    void print_in_input_format() override;
     std::string string_in_input_format();
-    void invalidate() {
+    void invalidate() override {
         computed_ = false;
         x_->invalidate();
         y_->invalidate();
@@ -338,18 +338,18 @@ class ZMatrixEntry : public CoordEntry {
                  std::shared_ptr<CoordEntry> dto = std::shared_ptr<CoordEntry>(),
                  std::shared_ptr<CoordValue> dval = std::shared_ptr<CoordValue>());
 
-    virtual ~ZMatrixEntry();
-    void invalidate() {
+    ~ZMatrixEntry() override;
+    void invalidate() override {
         computed_ = false;
         if (rval_ != 0) rval_->invalidate();
         if (aval_ != 0) aval_->invalidate();
         if (dval_ != 0) dval_->invalidate();
     }
-    const Vector3& compute();
-    void print_in_input_format();
+    const Vector3& compute() override;
+    void print_in_input_format() override;
     std::string string_in_input_format();
-    void set_coordinates(double x, double y, double z);
-    CoordEntryType type() { return ZMatrixCoord; }
+    void set_coordinates(double x, double y, double z) override;
+    CoordEntryType type() override { return ZMatrixCoord; }
     std::shared_ptr<CoordEntry> clone(std::vector<std::shared_ptr<CoordEntry> >& atoms,
                                       std::map<std::string, double>& map) {
         std::shared_ptr<CoordEntry> temp;

--- a/psi4/src/psi4/libmints/dipole.h
+++ b/psi4/src/psi4/libmints/dipole.h
@@ -50,18 +50,18 @@ class PSI_API DipoleInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     //! Computes the dipole between two gaussian shells.
-    void compute_pair(const GaussianShell &, const GaussianShell &);
+    void compute_pair(const GaussianShell &, const GaussianShell &) override;
     //! Computes the dipole derivative between two gaussian shells.
-    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &);
+    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &) override;
 
    public:
     //! Constructor. Do not call directly use an IntegralFactory.
     DipoleInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
     //! Virtual destructor
-    virtual ~DipoleInt();
+    ~DipoleInt() override;
 
     //! Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 
     /// Returns the nuclear contribution to the dipole moment
     static SharedVector nuclear_contribution(std::shared_ptr<Molecule> mol, const Vector3 &origin);

--- a/psi4/src/psi4/libmints/ecpint.h
+++ b/psi4/src/psi4/libmints/ecpint.h
@@ -340,7 +340,7 @@ class ECPInt : public OneBodyAOInt {
                ShellPairData &data, FiveIndex<double> &CA, FiveIndex<double> &CB, ThreeIndex<double> &values);
 
     /// Overridden shell-pair integral calculation over all ECP centers
-    void compute_pair(const GaussianShell &shellA, const GaussianShell &shellB);
+    void compute_pair(const GaussianShell &shellA, const GaussianShell &shellB) override;
 
     /// Computes the overall ECP integrals over the given ECP center and shell pair
     void compute_shell_pair(const GaussianShell &U, const GaussianShell &shellA, const GaussianShell &shellB,
@@ -353,7 +353,7 @@ class ECPInt : public OneBodyAOInt {
      * @paramm maxLB - the maximum angular momentum in the orbital basis
      */
     ECPInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
-    virtual ~ECPInt();
+    ~ECPInt() override;
 };
 
 class ECPSOInt : public OneBodySOInt {

--- a/psi4/src/psi4/libmints/efpmultipolepotential.h
+++ b/psi4/src/psi4/libmints/efpmultipolepotential.h
@@ -84,14 +84,14 @@ class EFPMultipolePotentialInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterEFPRecursion mvi_recur_;
 
     //! Computes the electric field between two gaussian shells.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
 
    public:
     //! Constructor. Do not call directly use an IntegralFactory.
     EFPMultipolePotentialInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                              int deriv = 0);
     //! Virtual destructor
-    virtual ~EFPMultipolePotentialInt();
+    ~EFPMultipolePotentialInt() override;
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/electricfield.h
+++ b/psi4/src/psi4/libmints/electricfield.h
@@ -51,20 +51,20 @@ class ElectricFieldInt : public OneBodyAOInt {
     int natom_;
 
     //! Computes the electric field between two gaussian shells.
-    void compute_pair(const GaussianShell &, const GaussianShell &);
+    void compute_pair(const GaussianShell &, const GaussianShell &) override;
 
     //! Computes the electric field gradient between two gaussian shells.
-    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &);
+    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &) override;
 
    public:
     //! Constructor. Do not call directly use an IntegralFactory.
     ElectricFieldInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                      int deriv = 0);
     //! Virtual destructor
-    virtual ~ElectricFieldInt();
+    ~ElectricFieldInt() override;
 
     //! Does the method provide first derivatives?
-    bool has_deriv1() { return false; }
+    bool has_deriv1() override { return false; }
 
     static Vector3 nuclear_contribution(const Vector3 &origin, std::shared_ptr<Molecule> mol);
     static SharedMatrix nuclear_contribution_to_gradient(const Vector3 &origin, std::shared_ptr<Molecule> mol);

--- a/psi4/src/psi4/libmints/electrostatic.h
+++ b/psi4/src/psi4/libmints/electrostatic.h
@@ -46,13 +46,13 @@ class Vector3;
  * Use an IntegralFactory to create this object.
  */
 class ElectrostaticInt : public PotentialInt {
-    void compute_pair(const GaussianShell&, const GaussianShell&) {}
+    void compute_pair(const GaussianShell&, const GaussianShell&) override {}
 
    public:
     /// Constructor
     ElectrostaticInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                      int deriv = 0);
-    ~ElectrostaticInt();
+    ~ElectrostaticInt() override;
 
 // Intel C++ 12 thinks we're trying to overload the "void compute_shell(int, int)" and warns us about it.
 // The following line is to shut it up.
@@ -69,7 +69,7 @@ class ElectrostaticInt : public PotentialInt {
     PRAGMA_WARNING_POP
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return false; }
+    bool has_deriv1() override { return false; }
 
     static SharedVector nuclear_contribution(std::shared_ptr<Molecule> mol);
 };

--- a/psi4/src/psi4/libmints/eri.h
+++ b/psi4/src/psi4/libmints/eri.h
@@ -123,7 +123,7 @@ class TwoElectronInt : public TwoBodyAOInt {
     //! Constructor. Use an IntegralFactory to create this object.
     TwoElectronInt(const IntegralFactory* integral, int deriv = 0, bool use_shell_pairs = false);
 
-    virtual ~TwoElectronInt();
+    ~TwoElectronInt() override;
 
     /// Compute ERIs between 4 shells. Result is stored in buffer.
     size_t compute_shell(const AOShellCombinationsIterator&);
@@ -141,48 +141,48 @@ class TwoElectronInt : public TwoBodyAOInt {
 class ERI : public TwoElectronInt {
    public:
     ERI(const IntegralFactory* integral, int deriv = 0, bool use_shell_pairs = false);
-    virtual ~ERI();
+    ~ERI() override;
 };
 
 class F12 : public TwoElectronInt {
    public:
     F12(std::shared_ptr<CorrelationFactor> cf, const IntegralFactory* integral, int deriv = 0,
         bool use_shell_pairs = false);
-    virtual ~F12();
+    ~F12() override;
 };
 
 class F12Scaled : public TwoElectronInt {
    public:
     F12Scaled(std::shared_ptr<CorrelationFactor> cf, const IntegralFactory* integral, int deriv = 0,
               bool use_shell_pairs = false);
-    virtual ~F12Scaled();
+    ~F12Scaled() override;
 };
 
 class F12Squared : public TwoElectronInt {
    public:
     F12Squared(std::shared_ptr<CorrelationFactor> cf, const IntegralFactory* integral, int deriv = 0,
                bool use_shell_pairs = false);
-    virtual ~F12Squared();
+    ~F12Squared() override;
 };
 
 class F12G12 : public TwoElectronInt {
    public:
     F12G12(std::shared_ptr<CorrelationFactor> cf, const IntegralFactory* integral, int deriv = 0,
            bool use_shell_pairs = false);
-    virtual ~F12G12();
+    ~F12G12() override;
 };
 
 class F12DoubleCommutator : public TwoElectronInt {
    public:
     F12DoubleCommutator(std::shared_ptr<CorrelationFactor> cf, const IntegralFactory* integral, int deriv = 0,
                         bool use_shell_pairs = false);
-    virtual ~F12DoubleCommutator();
+    ~F12DoubleCommutator() override;
 };
 
 class ErfERI : public TwoElectronInt {
    public:
     ErfERI(double omega, const IntegralFactory* integral, int deriv = 0, bool use_shell_pairs = false);
-    virtual ~ErfERI();
+    ~ErfERI() override;
 
     void setOmega(double omega);
 };
@@ -190,7 +190,7 @@ class ErfERI : public TwoElectronInt {
 class ErfComplementERI : public TwoElectronInt {
    public:
     ErfComplementERI(double omega, const IntegralFactory* integral, int deriv = 0, bool use_shell_pairs = false);
-    virtual ~ErfComplementERI();
+    ~ErfComplementERI() override;
 
     void setOmega(double omega);
 };

--- a/psi4/src/psi4/libmints/fjt.h
+++ b/psi4/src/psi4/libmints/fjt.h
@@ -84,9 +84,9 @@ class Taylor_Fjt : public Fjt {
     static const int max_interp_order = 8;
 
     Taylor_Fjt(size_t jmax, double accuracy);
-    virtual ~Taylor_Fjt();
+    ~Taylor_Fjt() override;
     /// Implements Fjt::values()
-    double* values(int J, double T);
+    double* values(int J, double T) override;
 
    private:
     double** grid_;    /* Table of "exact" Fm(T) values. Row index corresponds to
@@ -123,9 +123,9 @@ class FJT : public Fjt {
 
    public:
     FJT(int n);
-    virtual ~FJT();
+    ~FJT() override;
     /// implementation of Fjt::values()
-    double* values(int J, double T);
+    double* values(int J, double T) override;
 };
 
 class GaussianFundamental : public Fjt {
@@ -136,10 +136,10 @@ class GaussianFundamental : public Fjt {
 
    public:
     GaussianFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~GaussianFundamental();
+    ~GaussianFundamental() override;
 
-    virtual double* values(int J, double T) = 0;
-    void set_rho(double rho);
+    double* values(int J, double T) override = 0;
+    void set_rho(double rho) override;
 };
 
 /**
@@ -148,8 +148,8 @@ class GaussianFundamental : public Fjt {
 class F12Fundamental : public GaussianFundamental {
    public:
     F12Fundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~F12Fundamental();
-    double* values(int J, double T);
+    ~F12Fundamental() override;
+    double* values(int J, double T) override;
 };
 
 /**
@@ -158,15 +158,15 @@ class F12Fundamental : public GaussianFundamental {
 class F12ScaledFundamental : public GaussianFundamental {
    public:
     F12ScaledFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~F12ScaledFundamental();
-    double* values(int J, double T);
+    ~F12ScaledFundamental() override;
+    double* values(int J, double T) override;
 };
 
 class F12SquaredFundamental : public GaussianFundamental {
    public:
     F12SquaredFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~F12SquaredFundamental();
-    double* values(int J, double T);
+    ~F12SquaredFundamental() override;
+    double* values(int J, double T) override;
 };
 
 class F12G12Fundamental : public GaussianFundamental {
@@ -175,15 +175,15 @@ class F12G12Fundamental : public GaussianFundamental {
 
    public:
     F12G12Fundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~F12G12Fundamental();
-    double* values(int J, double T);
+    ~F12G12Fundamental() override;
+    double* values(int J, double T) override;
 };
 
 class F12DoubleCommutatorFundamental : public GaussianFundamental {
    public:
     F12DoubleCommutatorFundamental(std::shared_ptr<CorrelationFactor> cf, int max);
-    virtual ~F12DoubleCommutatorFundamental();
-    double* values(int J, double T);
+    ~F12DoubleCommutatorFundamental() override;
+    double* values(int J, double T) override;
 };
 
 class ErfFundamental : public GaussianFundamental {
@@ -193,8 +193,8 @@ class ErfFundamental : public GaussianFundamental {
 
    public:
     ErfFundamental(double omega, int max);
-    virtual ~ErfFundamental();
-    double* values(int J, double T);
+    ~ErfFundamental() override;
+    double* values(int J, double T) override;
     void setOmega(double omega) { omega_ = omega; }
 };
 
@@ -205,8 +205,8 @@ class ErfComplementFundamental : public GaussianFundamental {
 
    public:
     ErfComplementFundamental(double omega, int max);
-    virtual ~ErfComplementFundamental();
-    double* values(int J, double T);
+    ~ErfComplementFundamental() override;
+    double* values(int J, double T) override;
     void setOmega(double omega) { omega_ = omega; }
 };
 

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -145,7 +145,7 @@ class SphericalTransform {
 class ISphericalTransform : public SphericalTransform {
    protected:
     ISphericalTransform();
-    virtual void init();
+    void init() override;
 
    public:
     ISphericalTransform(int l, int subl = -1);

--- a/psi4/src/psi4/libmints/integralparameters.h
+++ b/psi4/src/psi4/libmints/integralparameters.h
@@ -52,7 +52,7 @@ class CorrelationFactor : public IntegralParameters {
    public:
     CorrelationFactor(size_t nparam);
     CorrelationFactor(std::shared_ptr<Vector> coeff, std::shared_ptr<Vector> exponent);
-    virtual ~CorrelationFactor();
+    ~CorrelationFactor() override;
 
     virtual double slater_exponent() const { return 1.0; }
     void set_params(std::shared_ptr<Vector> coeff, std::shared_ptr<Vector> exponent);
@@ -65,7 +65,7 @@ class FittedSlaterCorrelationFactor : public CorrelationFactor {
     double slater_exponent_;
 
    public:
-    virtual double slater_exponent() const { return slater_exponent_; }
+    double slater_exponent() const override { return slater_exponent_; }
 
     FittedSlaterCorrelationFactor(double exponent);
     double exponent() { return slater_exponent_; }

--- a/psi4/src/psi4/libmints/kinetic.h
+++ b/psi4/src/psi4/libmints/kinetic.h
@@ -55,22 +55,22 @@ class KineticInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     //! Computes the kinetic integral between two gaussian shells.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     //! Computes the kinetic derivatve between two gaussian shells.
-    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
-    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&);
+    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&) override;
+    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&) override;
 
    public:
     //! Constructor. Do not call directly, use an IntegralFactory.
     KineticInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
     //! Virtual destructor.
-    virtual ~KineticInt();
+    ~KineticInt() override;
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 
     /// Does the method provide first derivatives?
-    bool has_deriv2() { return true; }
+    bool has_deriv2() override { return true; }
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/local.h
+++ b/psi4/src/psi4/libmints/local.h
@@ -131,11 +131,11 @@ class PSI_API BoysLocalizer : public Localizer {
    public:
     BoysLocalizer(std::shared_ptr<BasisSet> primary, std::shared_ptr<Matrix> C);
 
-    virtual ~BoysLocalizer();
+    ~BoysLocalizer() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
 
-    virtual void localize();
+    void localize() override;
 };
 
 class PMLocalizer : public Localizer {
@@ -146,11 +146,11 @@ class PMLocalizer : public Localizer {
    public:
     PMLocalizer(std::shared_ptr<BasisSet> primary, std::shared_ptr<Matrix> C);
 
-    virtual ~PMLocalizer();
+    ~PMLocalizer() override;
 
-    virtual void print_header() const;
+    void print_header() const override;
 
-    virtual void localize();
+    void localize() override;
 };
 
 }  // Namespace psi

--- a/psi4/src/psi4/libmints/multipoles.h
+++ b/psi4/src/psi4/libmints/multipoles.h
@@ -48,10 +48,10 @@ class MultipoleInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterMIRecursion mi_recur_;
 
     //! Computes the multipole integrals between two gaussian shells.
-    void compute_pair(const GaussianShell &, const GaussianShell &);
+    void compute_pair(const GaussianShell &, const GaussianShell &) override;
 
     //! Computes the multipole derivative between two gaussian shells.
-    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &) { throw PSIEXCEPTION("NYI"); }
+    void compute_pair_deriv1(const GaussianShell &, const GaussianShell &) override { throw PSIEXCEPTION("NYI"); }
 
     //! The order of multipole moment to compute
     int order_;
@@ -61,10 +61,10 @@ class MultipoleInt : public OneBodyAOInt {
     MultipoleInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int order,
                  int deriv = 0);
     //! Virtual destructor
-    virtual ~MultipoleInt();
+    ~MultipoleInt() override;
 
     //! Does the method provide first derivatives?
-    bool has_deriv1() { return false; }
+    bool has_deriv1() override { return false; }
 
     /// Returns the nuclear contribution to the multipole moments, with angular momentum up to order
     static SharedVector nuclear_contribution(std::shared_ptr<Molecule> mol, int order, const Vector3 &origin);

--- a/psi4/src/psi4/libmints/nabla.h
+++ b/psi4/src/psi4/libmints/nabla.h
@@ -53,7 +53,7 @@ class NablaInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     //! Computes the dipole between two gaussian shells.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     //! Computes the dipole derivative between two gaussian shells.
     //    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
 
@@ -61,10 +61,10 @@ class NablaInt : public OneBodyAOInt {
     //! Constructor. Do not call directly use an IntegralFactory.
     NablaInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
     //! Virtual destructor
-    virtual ~NablaInt();
+    ~NablaInt() override;
 
     //! Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -313,7 +313,7 @@ class PopulationAnalysisCalc : public Prop {
    public:
     typedef std::shared_ptr<std::vector<double>> SharedStdVector;
     PopulationAnalysisCalc(std::shared_ptr<Wavefunction> wfn);
-    virtual ~PopulationAnalysisCalc();
+    ~PopulationAnalysisCalc() override;
     /// Compute Mulliken Charges
     std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_mulliken_charges(bool print_output = false);
     /// Compute Lowdin Charges
@@ -361,7 +361,7 @@ class ESPPropCalc : public Prop {
     /// Constructor
     ESPPropCalc(std::shared_ptr<Wavefunction> wfn);
     /// Destructor
-    virtual ~ESPPropCalc();
+    ~ESPPropCalc() override;
 
     std::vector<double> const& Vvals() const { return Vvals_; }
     std::vector<double> const& Exvals() const { return Exvals_; }
@@ -395,7 +395,7 @@ class OEProp : public TaskListComputer {
     /// Common initialization
     void common_init();
     /// Print header and information
-    void print_header();
+    void print_header() override;
 
     // Compute routines
     /// Compute dipole
@@ -441,7 +441,7 @@ class OEProp : public TaskListComputer {
     /// Constructor, uses globals
     OEProp(std::shared_ptr<Wavefunction> wfn);
     /// Destructor
-    virtual ~OEProp();
+    ~OEProp() override;
 
     /// Python issue
     void oepy_add(const std::string& task) { add(task); }
@@ -449,7 +449,7 @@ class OEProp : public TaskListComputer {
     void oepy_set_title(const std::string& title) { set_title(title); }
 
     /// Compute and print/save the properties
-    void compute();
+    void compute() override;
 
     std::vector<double> const& Vvals() const { return epc_.Vvals(); }
     std::vector<double> const& Exvals() const { return epc_.Exvals(); }

--- a/psi4/src/psi4/libmints/osrecur.h
+++ b/psi4/src/psi4/libmints/osrecur.h
@@ -159,13 +159,13 @@ class ObaraSaikaTwoCenterVIDerivRecursion : public ObaraSaikaTwoCenterVIRecursio
 
    public:
     ObaraSaikaTwoCenterVIDerivRecursion(int max_am1, int max_am2);
-    virtual ~ObaraSaikaTwoCenterVIDerivRecursion();
+    ~ObaraSaikaTwoCenterVIDerivRecursion() override;
 
-    double ***vx() const { return vx_; }
-    double ***vy() const { return vy_; }
-    double ***vz() const { return vz_; }
+    double ***vx() const override { return vx_; }
+    double ***vy() const override { return vy_; }
+    double ***vz() const override { return vz_; }
 
-    virtual void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2);
+    void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2) override;
 };
 
 /*! \ingroup MINTS
@@ -189,16 +189,16 @@ class ObaraSaikaTwoCenterVIDeriv2Recursion : public ObaraSaikaTwoCenterVIDerivRe
 
    public:
     ObaraSaikaTwoCenterVIDeriv2Recursion(int max_am1, int max_am2);
-    virtual ~ObaraSaikaTwoCenterVIDeriv2Recursion();
+    ~ObaraSaikaTwoCenterVIDeriv2Recursion() override;
 
-    double ***vxx() const { return vxx_; }
-    double ***vxy() const { return vxy_; }
-    double ***vxz() const { return vxz_; }
-    double ***vyy() const { return vyy_; }
-    double ***vyz() const { return vyz_; }
-    double ***vzz() const { return vzz_; }
+    double ***vxx() const override { return vxx_; }
+    double ***vxy() const override { return vxy_; }
+    double ***vxz() const override { return vxz_; }
+    double ***vyy() const override { return vyy_; }
+    double ***vyz() const override { return vyz_; }
+    double ***vzz() const override { return vzz_; }
 
-    virtual void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2);
+    void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2) override;
 };
 
 /*! \ingroup MINTS
@@ -220,14 +220,14 @@ class ObaraSaikaTwoCenterElectricField : public ObaraSaikaTwoCenterVIRecursion {
 
    public:
     ObaraSaikaTwoCenterElectricField(int max_am1, int max_am2);
-    virtual ~ObaraSaikaTwoCenterElectricField();
+    ~ObaraSaikaTwoCenterElectricField() override;
 
     // We could also add the getter for the q_ (potential ints here)
     double ***x() const { return x_; }
     double ***y() const { return y_; }
     double ***z() const { return z_; }
 
-    virtual void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2);
+    void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2) override;
 };
 
 /*! \ingroup MINTS
@@ -251,13 +251,13 @@ class ObaraSaikaTwoCenterElectricFieldGradient : public ObaraSaikaTwoCenterElect
 
    public:
     ObaraSaikaTwoCenterElectricFieldGradient(int max_am1, int max_am2);
-    virtual ~ObaraSaikaTwoCenterElectricFieldGradient();
+    ~ObaraSaikaTwoCenterElectricFieldGradient() override;
 
     double ***ex() const { return x_; }
     double ***ey() const { return y_; }
     double ***ez() const { return z_; }
 
-    virtual void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2);
+    void compute(double PA[3], double PB[3], double PC[3], double zeta, int am1, int am2) override;
 };
 
 /*! \ingroup MINTS

--- a/psi4/src/psi4/libmints/overlap.h
+++ b/psi4/src/psi4/libmints/overlap.h
@@ -49,19 +49,19 @@ class OverlapInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     /// Computes the overlap between a given shell pair.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
-    void compute_pair_deriv1(const GaussianShell& s1, const GaussianShell& s2);
-    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
+    void compute_pair_deriv1(const GaussianShell& s1, const GaussianShell& s2) override;
+    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&) override;
 
    public:
     /// Constructor, it assumes you are not computing derivatives by default
     OverlapInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
-    virtual ~OverlapInt();
+    ~OverlapInt() override;
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
     /// Does the method provide second derivatives?
-    bool has_deriv2() { return true; }
+    bool has_deriv2() override { return true; }
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/potential.h
+++ b/psi4/src/psi4/libmints/potential.h
@@ -49,11 +49,11 @@ class CdSalcList;
  */
 class PotentialInt : public OneBodyAOInt {
     /// Computes integrals between two shell objects.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     /// Computes integrals between two shell objects.
     void compute_pair_deriv1_no_charge_term(const GaussianShell&, const GaussianShell&);
-    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
-    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&);
+    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&) override;
+    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&) override;
 
    protected:
     /// Recursion object that does the heavy lifting.
@@ -65,7 +65,7 @@ class PotentialInt : public OneBodyAOInt {
    public:
     /// Constructor. Assumes nuclear centers/charges as the potential
     PotentialInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, int deriv = 0);
-    virtual ~PotentialInt();
+    ~PotentialInt() override;
 
     /// Computes the first derivatives and stores them in result
     virtual void compute_deriv1(std::vector<SharedMatrix>& result);
@@ -86,7 +86,7 @@ class PotentialInt : public OneBodyAOInt {
     SharedMatrix charge_field() const { return Zxyz_; }
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 };
 
 class PotentialSOInt : public OneBodySOInt {

--- a/psi4/src/psi4/libmints/pseudospectral.h
+++ b/psi4/src/psi4/libmints/pseudospectral.h
@@ -51,9 +51,9 @@ class SphericalTransform;
  */
 class PseudospectralInt : public OneBodyAOInt {
     /// Computes integrals between two shell objects.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     /// Computes integrals between two shell objects.
-    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
+    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&) override;
 
    protected:
     /// Use range-separation or not? Defaults to false. If so, produce <m|erf(\omega r) / r|n> integrals
@@ -73,10 +73,10 @@ class PseudospectralInt : public OneBodyAOInt {
     /// Constructor
     PseudospectralInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                       int deriv = 0);
-    ~PseudospectralInt();
+    ~PseudospectralInt() override;
 
     /// Computes integrals between two shells.
-    void compute_shell_deriv1(int, int);
+    void compute_shell_deriv1(int, int) override;
 
     /// Set integration point
     void set_point(double x, double y, double z) {
@@ -95,7 +95,7 @@ class PseudospectralInt : public OneBodyAOInt {
     void use_omega(bool yes) { use_omega_ = yes; }
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return false; }
+    bool has_deriv1() override { return false; }
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/quadrupole.h
+++ b/psi4/src/psi4/libmints/quadrupole.h
@@ -48,11 +48,11 @@ class QuadrupoleInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     // This the work horse function.
-    void compute_pair(const GaussianShell &, const GaussianShell &);
+    void compute_pair(const GaussianShell &, const GaussianShell &) override;
 
    public:
     QuadrupoleInt(std::vector<SphericalTransform> &, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>);
-    virtual ~QuadrupoleInt();
+    ~QuadrupoleInt() override;
 
     static SharedVector nuclear_contribution(std::shared_ptr<Molecule> mol, const Vector3 &origin);
 };

--- a/psi4/src/psi4/libmints/rel_potential.h
+++ b/psi4/src/psi4/libmints/rel_potential.h
@@ -52,10 +52,10 @@ class CdSalcList;
  */
 class RelPotentialInt : public OneBodyAOInt {
     /// Computes integrals between two shell objects.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
     /// Computes integrals between two shell objects.
-    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&);
-    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&);
+    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&) override;
+    void compute_pair_deriv2(const GaussianShell&, const GaussianShell&) override;
 
    protected:
     /// Recursion object that does the heavy lifting.
@@ -68,7 +68,7 @@ class RelPotentialInt : public OneBodyAOInt {
     /// Constructor. Assumes nuclear centers/charges as the potential
     RelPotentialInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                     int deriv = 0);
-    virtual ~RelPotentialInt();
+    ~RelPotentialInt() override;
 
     /// Computes the first derivatives and stores them in result
     virtual void compute_deriv1(std::vector<SharedMatrix>& result);
@@ -83,7 +83,7 @@ class RelPotentialInt : public OneBodyAOInt {
     SharedMatrix charge_field() const { return Zxyz_; }
 
     /// Does the method provide first derivatives?
-    bool has_deriv1() { return true; }
+    bool has_deriv1() override { return true; }
 };
 
 class RelPotentialSOInt : public OneBodySOInt {

--- a/psi4/src/psi4/libmints/tracelessquadrupole.h
+++ b/psi4/src/psi4/libmints/tracelessquadrupole.h
@@ -53,11 +53,11 @@ class TracelessQuadrupoleInt : public OneBodyAOInt {
     ObaraSaikaTwoCenterRecursion overlap_recur_;
 
     // This the work horse function.
-    void compute_pair(const GaussianShell&, const GaussianShell&);
+    void compute_pair(const GaussianShell&, const GaussianShell&) override;
 
    public:
     TracelessQuadrupoleInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>);
-    virtual ~TracelessQuadrupoleInt();
+    ~TracelessQuadrupoleInt() override;
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/liboptions/liboptions.h
+++ b/psi4/src/psi4/liboptions/liboptions.h
@@ -127,17 +127,17 @@ class BooleanDataType : public DataType {
    public:
     BooleanDataType();
     BooleanDataType(bool b);
-    virtual ~BooleanDataType();
+    ~BooleanDataType() override;
 
     virtual std::string type() const;
 
     virtual std::string to_string() const;
-    virtual int to_integer() const;
-    virtual double to_double() const;
+    int to_integer() const override;
+    double to_double() const override;
 
-    virtual void assign(bool b);
-    virtual void assign(int i);
-    virtual void assign(double d);
+    void assign(bool b) override;
+    void assign(int i) override;
+    void assign(double d) override;
     virtual void assign(std::string s);
 };
 
@@ -150,17 +150,17 @@ class IntDataType : public DataType {
    public:
     IntDataType();
     IntDataType(int i);
-    virtual ~IntDataType();
+    ~IntDataType() override;
 
     virtual std::string type() const;
 
     virtual std::string to_string() const;
-    virtual int to_integer() const;
-    virtual double to_double() const;
+    int to_integer() const override;
+    double to_double() const override;
 
-    virtual void assign(bool b);
-    virtual void assign(int i);
-    virtual void assign(double d);
+    void assign(bool b) override;
+    void assign(int i) override;
+    void assign(double d) override;
     virtual void assign(std::string s);
 };
 
@@ -173,17 +173,17 @@ class DoubleDataType : public DataType {
    public:
     DoubleDataType();
     DoubleDataType(double d);
-    virtual ~DoubleDataType();
+    ~DoubleDataType() override;
 
     virtual std::string type() const;
 
     virtual std::string to_string() const;
-    virtual int to_integer() const;
-    virtual double to_double() const;
+    int to_integer() const override;
+    double to_double() const override;
 
-    virtual void assign(bool b);
-    virtual void assign(int i);
-    virtual void assign(double d);
+    void assign(bool b) override;
+    void assign(int i) override;
+    void assign(double d) override;
     virtual void assign(std::string s);
 };
 
@@ -199,19 +199,19 @@ class StringDataType : public DataType {
     StringDataType(std::string s);
     StringDataType(std::string s, std::string c);
 
-    virtual ~StringDataType();
+    ~StringDataType() override;
 
     virtual void add_choices(std::string str);
 
     virtual std::string type() const;
 
     virtual std::string to_string() const;
-    virtual int to_integer() const;
-    virtual double to_double() const;
+    int to_integer() const override;
+    double to_double() const override;
 
-    virtual void assign(bool b);
-    virtual void assign(int i);
-    virtual void assign(double d);
+    void assign(bool b) override;
+    void assign(int i) override;
+    void assign(double d) override;
     virtual void assign(std::string s);
 };
 
@@ -226,19 +226,19 @@ class IStringDataType : public DataType {
     IStringDataType();
     IStringDataType(std::string s);
     IStringDataType(std::string s, std::string c);
-    virtual ~IStringDataType();
+    ~IStringDataType() override;
 
     virtual void add_choices(std::string str);
 
     virtual std::string type() const;
 
     virtual std::string to_string() const;
-    virtual int to_integer() const;
-    virtual double to_double() const;
+    int to_integer() const override;
+    double to_double() const override;
 
-    virtual void assign(bool b);
-    virtual void assign(int i);
-    virtual void assign(double d);
+    void assign(bool b) override;
+    void assign(int i) override;
+    void assign(double d) override;
     virtual void assign(std::string s);
 };
 
@@ -302,22 +302,22 @@ class PSI_API ArrayType : public DataType {
 
     virtual std::string type() const;
 
-    virtual void add(DataType* data);
-    virtual void add(bool b);
-    virtual void add(int i);
-    virtual void add(double d);
+    void add(DataType* data) override;
+    void add(bool b) override;
+    void add(int i) override;
+    void add(double d) override;
     virtual void add(std::string s, std::string c = "");
-    virtual void assign(DataType* data);
+    void assign(DataType* data) override;
 
-    virtual Data& operator[](size_t i);
+    Data& operator[](size_t i) override;
     virtual Data& operator[](std::string s);
-    virtual bool is_array() const;
+    bool is_array() const override;
 
-    virtual size_t size() const;
+    size_t size() const override;
 
     virtual std::string to_string() const;
 
-    virtual void reset();
+    void reset() override;
     std::vector<Data> data() { return array_; }
 };
 
@@ -343,9 +343,9 @@ class MapType : public DataType {
     virtual bool exists(std::string key);
 
     virtual Data& operator[](std::string s);
-    virtual bool is_array() const;
+    bool is_array() const override;
 
-    virtual size_t size() const;
+    size_t size() const override;
 
     virtual std::string to_string() const;
 };

--- a/psi4/src/psi4/liboptions/liboptions_python.h
+++ b/psi4/src/psi4/liboptions/liboptions_python.h
@@ -41,7 +41,7 @@ class PythonDataType : public DataType {
    public:
     PythonDataType();
     PythonDataType(const py::object& p);
-    virtual ~PythonDataType();
+    ~PythonDataType() override;
 
     virtual std::string type() const;
 

--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -132,7 +132,7 @@ class PSI_API SanityCheckError : public PsiException {
     */
     SanityCheckError(std::string message, const char *file, int line) noexcept;
 
-    virtual ~SanityCheckError() noexcept;
+    ~SanityCheckError() noexcept override;
 };
 
 /**
@@ -148,7 +148,7 @@ class SystemError : public PsiException {
     */
     SystemError(int eno, const char *file, int line) noexcept;
 
-    virtual ~SystemError() noexcept;
+    ~SystemError() noexcept override;
 };
 
 /**
@@ -165,7 +165,7 @@ class FeatureNotImplemented : public PsiException {
     */
     FeatureNotImplemented(std::string module, std::string feature, const char *file, int line) noexcept;
 
-    virtual ~FeatureNotImplemented() noexcept;
+    ~FeatureNotImplemented() noexcept override;
 };
 
 /**
@@ -208,7 +208,7 @@ class LimitExceeded : public PsiException {
 
     T actual_value() const noexcept { return errorval_; }
 
-    virtual ~LimitExceeded<T>() noexcept{};
+    ~LimitExceeded<T>() noexcept override {};
 };
 
 /**

--- a/psi4/src/psi4/libsapt_solver/sapt.h
+++ b/psi4/src/psi4/libsapt_solver/sapt.h
@@ -121,9 +121,9 @@ class SAPT : public Wavefunction {
    public:
     SAPT(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunction MonomerB, Options &options,
          std::shared_ptr<PSIO> psio);
-    virtual ~SAPT();
+    ~SAPT() override;
 
-    virtual double compute_energy() = 0;
+    double compute_energy() override = 0;
 };
 
 class CPHFDIIS {

--- a/psi4/src/psi4/libsapt_solver/sapt0.h
+++ b/psi4/src/psi4/libsapt_solver/sapt0.h
@@ -157,9 +157,9 @@ class SAPT0 : public SAPT {
    public:
     SAPT0(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunction MonomerB, Options &options,
           std::shared_ptr<PSIO> psio);
-    virtual ~SAPT0();
+    ~SAPT0() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
     void elst10();
     void exch10();

--- a/psi4/src/psi4/libsapt_solver/sapt2.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2.h
@@ -171,9 +171,9 @@ class SAPT2 : public SAPT {
    public:
     SAPT2(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunction MonomerB, Options &options,
           std::shared_ptr<PSIO> psio);
-    virtual ~SAPT2();
+    ~SAPT2() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
     virtual void amplitudes();
 

--- a/psi4/src/psi4/libsapt_solver/sapt2p.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p.h
@@ -36,8 +36,8 @@ namespace sapt {
 
 class SAPT2p : public SAPT2 {
    private:
-    virtual void print_header();
-    virtual void print_results();
+    void print_header() override;
+    void print_results() override;
 
    protected:
     double e_disp21_;
@@ -134,11 +134,11 @@ class SAPT2p : public SAPT2 {
    public:
     SAPT2p(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunction MonomerB, Options &options,
            std::shared_ptr<PSIO> psio);
-    virtual ~SAPT2p();
+    ~SAPT2p() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
-    virtual void amplitudes();
+    void amplitudes() override;
 
     // PT Dispersion
 

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.h
@@ -36,8 +36,8 @@ namespace sapt {
 
 class SAPT2p3 : public SAPT2p {
    private:
-    virtual void print_header();
-    virtual void print_results();
+    void print_header() override;
+    void print_results() override;
 
     bool third_order_;
 
@@ -96,11 +96,11 @@ class SAPT2p3 : public SAPT2p {
    public:
     SAPT2p3(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunction MonomerB, Options &options,
             std::shared_ptr<PSIO> psio);
-    virtual ~SAPT2p3();
+    ~SAPT2p3() override;
 
-    virtual double compute_energy();
+    double compute_energy() override;
 
-    virtual void amplitudes();
+    void amplitudes() override;
 
     void elst13();
     void ind30();

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -80,9 +80,9 @@ class CUHF : public HF {
     SharedVector No_;
 
     void form_initialF();
-    double compute_initial_E();
+    double compute_initial_E() override;
 
-    void compute_spin_contamination();
+    void compute_spin_contamination() override;
 
     void common_init();
 
@@ -90,21 +90,21 @@ class CUHF : public HF {
     CUHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
     CUHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional, Options& options,
          std::shared_ptr<PSIO> psio);
-    virtual ~CUHF();
+    ~CUHF() override;
 
-    bool diis();
-    void save_density_and_energy();
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors);
+    bool diis() override;
+    void save_density_and_energy() override;
+    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
-    void form_C();
-    void form_D();
-    void form_F();
-    void form_G();
-    double compute_E();
-    void finalize();
+    void form_C() override;
+    void form_D() override;
+    void form_F() override;
+    void form_G() override;
+    double compute_E() override;
+    void finalize() override;
 
-    void damping_update(double);
-    bool stability_analysis();
+    void damping_update(double) override;
+    bool stability_analysis() override;
 
     std::shared_ptr<CUHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -227,7 +227,7 @@ class HF : public Wavefunction {
     HF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> funct, Options& options,
        std::shared_ptr<PSIO> psio);
 
-    virtual ~HF();
+    ~HF() override;
 
     /// Get and set current iteration
     int iteration() const { return iteration_; }

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -46,7 +46,7 @@ class RHF : public HF {
     SharedMatrix K_;
     SharedMatrix wK_;
 
-    double compute_initial_E();
+    double compute_initial_E() override;
 
     void common_init();
 
@@ -54,28 +54,28 @@ class RHF : public HF {
     RHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
     RHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional, Options& options,
         std::shared_ptr<PSIO> psio);
-    virtual ~RHF();
+    ~RHF() override;
 
     virtual SharedMatrix Da() const;
 
     virtual bool same_a_b_orbs() const { return true; }
     virtual bool same_a_b_dens() const { return true; }
 
-    bool diis();
-    void save_density_and_energy();
-    double compute_orbital_gradient(bool save_fock, int max_diis_vectors);
+    bool diis() override;
+    void save_density_and_energy() override;
+    double compute_orbital_gradient(bool save_fock, int max_diis_vectors) override;
 
-    void form_C();
-    void form_D();
-    void form_F();
-    void form_G();
-    void form_V();
-    double compute_E();
-    void finalize();
+    void form_C() override;
+    void form_D() override;
+    void form_F() override;
+    void form_G() override;
+    void form_V() override;
+    double compute_E() override;
+    void finalize() override;
 
-    void damping_update(double);
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print);
-    bool stability_analysis();
+    void damping_update(double) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    bool stability_analysis() override;
 
     /// Hessian-vector computers and solvers
     virtual std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x);

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -53,15 +53,15 @@ class ROHF : public HF {
     SharedMatrix moFb_;
 
     void form_initialF();
-    void form_initial_C();
-    double compute_initial_E();
-    virtual void prepare_canonical_orthogonalization();
-    void semicanonicalize();
+    void form_initial_C() override;
+    double compute_initial_E() override;
+    void prepare_canonical_orthogonalization() override;
+    void semicanonicalize() override;
 
     // Second-order convergence code
     void Hx(SharedMatrix x, SharedMatrix ret);
 
-    void format_guess();
+    void format_guess() override;
 
     void common_init();
 
@@ -69,26 +69,26 @@ class ROHF : public HF {
     ROHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
     ROHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional, Options& options,
          std::shared_ptr<PSIO> psio);
-    virtual ~ROHF();
+    ~ROHF() override;
 
     SharedMatrix moFeff() const { return moFeff_; }
     SharedMatrix moFa() const { return moFa_; }
     SharedMatrix moFb() const { return moFb_; }
 
-    bool diis();
-    void save_density_and_energy();
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors);
+    bool diis() override;
+    void save_density_and_energy() override;
+    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
-    void form_C();
-    void form_D();
-    void form_F();
-    void form_G();
-    double compute_E();
-    void finalize();
+    void form_C() override;
+    void form_D() override;
+    void form_F() override;
+    void form_G() override;
+    double compute_E() override;
+    void finalize() override;
 
-    void damping_update(double);
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print);
-    bool stability_analysis();
+    void damping_update(double) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    bool stability_analysis() override;
 
     std::shared_ptr<ROHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -42,7 +42,7 @@ class UHF : public HF {
     SharedMatrix Ga_, Gb_, J_, Ka_, Kb_, wKa_, wKb_;
 
     void form_initialF();
-    double compute_initial_E();
+    double compute_initial_E() override;
     bool stability_analysis_pk();
 
     void common_init();
@@ -65,26 +65,26 @@ class UHF : public HF {
     UHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
     UHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional, Options& options,
         std::shared_ptr<PSIO> psio);
-    virtual ~UHF();
+    ~UHF() override;
 
     virtual bool same_a_b_orbs() const { return false; }
     virtual bool same_a_b_dens() const { return false; }
 
-    bool diis();
-    void save_density_and_energy();
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors);
+    bool diis() override;
+    void save_density_and_energy() override;
+    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
-    void form_C();
-    void form_D();
-    void form_F();
-    void form_G();
-    void form_V();
-    double compute_E();
-    void finalize();
+    void form_C() override;
+    void form_D() override;
+    void form_F() override;
+    void form_G() override;
+    void form_V() override;
+    double compute_E() override;
+    void finalize() override;
 
-    void damping_update(double);
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print);
-    bool stability_analysis();
+    void damping_update(double) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    bool stability_analysis() override;
 
     /// Hessian-vector computers and solvers
     virtual std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x);

--- a/psi4/src/psi4/mcscf/scf.h
+++ b/psi4/src/psi4/mcscf/scf.h
@@ -46,8 +46,8 @@ enum ReferenceType { rhf, rohf, uhf, tcscf };
 class SCF : public Wavefunction {
    public:
     explicit SCF(SharedWavefunction ref_wfn, Options& options_, std::shared_ptr<PSIO> psio);
-    ~SCF();
-    double compute_energy();
+    ~SCF() override;
+    double compute_energy() override;
 
    private:
     ReferenceType reference;

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -50,8 +50,8 @@ class OCCWave : public Wavefunction
 public:
     OCCWave(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
 
-    virtual ~OCCWave();
-    virtual double compute_energy();
+    ~OCCWave() override;
+    double compute_energy() override;
 
 protected:
     // General

--- a/psi4/src/psi4/optking/bend.h
+++ b/psi4/src/psi4/optking/bend.h
@@ -52,22 +52,22 @@ class BEND : public SIMPLE_COORDINATE {
 
     BEND(int A_in, int B_in, int C_in, bool freeze_in=false);
 
-    ~BEND() { ; } //calls ~SIMPLE_COORDINATE()
+    ~BEND() override { ; } //calls ~SIMPLE_COORDINATE()
 
-    double value(GeomType geom) const;
+    double value(GeomType geom) const override;
 
     // compute and return array of first derivative (B marix elements)
-    double **DqDx(GeomType geom) const;
+    double **DqDx(GeomType geom) const override;
 
     // compute and return array of second derivative (B' matrix elements)
-    double **Dq2Dx2(GeomType geom) const;
+    double **Dq2Dx2(GeomType geom) const override;
 
     void print(std::string psi_fp, FILE *qc_fp, GeomType geom, int atom_offset=0) const;
     void print_intco_dat(std::string psi_fp, FILE *qc_fp, int atom_offset=0) const;
     void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const;
     void print_disp(std::string psi_fp, FILE *qc_fp, const double old_q, const double f_q,
       const double dq, const double new_q, int atom_offset=0) const;
-    bool operator==(const SIMPLE_COORDINATE & s2) const;
+    bool operator==(const SIMPLE_COORDINATE & s2) const override;
     std::string get_definition_string(int atom_offset=0) const;
 
     void make_lb_normal()     { _bend_type = 1; }
@@ -77,7 +77,7 @@ class BEND : public SIMPLE_COORDINATE {
     bool is_lb_normal() const     { return (_bend_type == 1); }
     bool is_lb_complement() const { return (_bend_type == 2); }
 
-    int  g_bend_type() const { return _bend_type; }
+    int  g_bend_type() const override { return _bend_type; }
     void compute_axes(GeomType geom) const;
     void fix_axes()   { axes_fixed = true; }
     void unfix_axes() { axes_fixed = false; }

--- a/psi4/src/psi4/optking/cart.h
+++ b/psi4/src/psi4/optking/cart.h
@@ -46,26 +46,26 @@ class CART : public SIMPLE_COORDINATE {
 
     CART(int A_in, int xyz_in, bool freeze_in=false);
 
-    ~CART() { } // also calls ~SIMPLE_COORDINATE()
+    ~CART() override { } // also calls ~SIMPLE_COORDINATE()
 
-    double value(GeomType geom) const;
+    double value(GeomType geom) const override;
 
     // compute and return array of first derivative (B matrix elements)
     // returned matrix is [atom][x,y,z]
-    double **DqDx(GeomType geom) const;
+    double **DqDx(GeomType geom) const override;
 
-    int g_xyz() const { return xyz; }
+    int g_xyz() const override { return xyz; }
 
     // compute and return array of second derivative (B' matrix elements)
     // returned matrix is order 3N cart by 3N cart
-    double **Dq2Dx2(GeomType geom) const;
+    double **Dq2Dx2(GeomType geom) const override;
 
     void print(std::string psi_fp, FILE *qc_fp, GeomType geom, int atom_offset=0) const;
     void print_intco_dat(std::string psi_fp, FILE *qc_fp, int atom_offset=0) const;
     void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const;
     void print_disp(std::string psi_fp, FILE *qc_fp, const double old_q, const double f_q,
       const double dq, const double new_q, int atom_offset = 0) const;
-    bool operator==(const SIMPLE_COORDINATE & s2) const;
+    bool operator==(const SIMPLE_COORDINATE & s2) const override;
     std::string get_definition_string(int atom_offset=0) const;
 
 };

--- a/psi4/src/psi4/optking/oofp.h
+++ b/psi4/src/psi4/optking/oofp.h
@@ -50,25 +50,25 @@ class OOFP : public SIMPLE_COORDINATE {
 
     OOFP(int A_in, int B_in, int C_in, int D_in, bool freeze_in=false);
 
-    ~OOFP() { } // also calls ~SIMPLE_COORDINATE
+    ~OOFP() override { } // also calls ~SIMPLE_COORDINATE
 
-    double value(GeomType geom) const;
+    double value(GeomType geom) const override;
 
     // compute and return array of first derivative (B marix elements)
-    double ** DqDx(GeomType geom) const;
+    double ** DqDx(GeomType geom) const override;
 
     // compute and return array of second derivative (B' matrix elements)
-    double ** Dq2Dx2(GeomType geom) const;
+    double ** Dq2Dx2(GeomType geom) const override;
 
     void print(std::string psi_fp, FILE *qc_fp, GeomType geom, int atom_offset=0) const;
     void print_intco_dat(std::string psi_fp, FILE *qc_fp, int atom_offset=0) const;
     void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const;
     void print_disp(std::string psi_fp, FILE *qc_fp, const double old_q, const double f_q, 
       const double dq, const double new_q, int atom_offset=0) const;
-    bool operator==(const SIMPLE_COORDINATE & s2) const;
+    bool operator==(const SIMPLE_COORDINATE & s2) const override;
     std::string get_definition_string(int atom_offset=0) const;
 
-    void fix_oofp_near_180(GeomType geom);
+    void fix_oofp_near_180(GeomType geom) override;
 };
 
 }

--- a/psi4/src/psi4/optking/stre.h
+++ b/psi4/src/psi4/optking/stre.h
@@ -47,30 +47,30 @@ class STRE : public SIMPLE_COORDINATE {
 
     STRE(int A_in, int B_in, bool freeze_in=false);
 
-    ~STRE() { } // also calls ~SIMPLE_COORDINATE()
+    ~STRE() override { } // also calls ~SIMPLE_COORDINATE()
 
-    double value(GeomType geom) const;
+    double value(GeomType geom) const override;
 
     // compute and return array of first derivative (B matrix elements)
     // returned matrix is [atom][x,y,z]
-    double **DqDx(GeomType geom) const;
+    double **DqDx(GeomType geom) const override;
 
     // compute and return array of second derivative (B' matrix elements)
     // returned matrix is order 3N cart by 3N cart
-    double **Dq2Dx2(GeomType geom) const;
+    double **Dq2Dx2(GeomType geom) const override;
 
     void print(std::string psi_fp, FILE *qc_fp, GeomType geom, int atom_offset=0) const;
     void print_intco_dat(std::string psi_fp, FILE *qc_fp, int atom_offset=0) const;
     void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const;
     void print_disp(std::string psi_fp, FILE *qc_fp, const double old_q, const double f_q,
       const double dq, const double new_q, int atom_offset = 0) const;
-    bool operator==(const SIMPLE_COORDINATE & s2) const;
+    bool operator==(const SIMPLE_COORDINATE & s2) const override;
     std::string get_definition_string(int atom_offset=0) const;
 
-    void set_hbond(bool val) { hbond = val; }
-    bool is_hbond() const { return hbond; }
+    void set_hbond(bool val) override { hbond = val; }
+    bool is_hbond() const override { return hbond; }
     void make_inverse_stre() { inverse_stre = true; }
-    bool is_inverse_stre() const { return inverse_stre; }
+    bool is_inverse_stre() const override { return inverse_stre; }
 
 };
 

--- a/psi4/src/psi4/optking/tors.h
+++ b/psi4/src/psi4/optking/tors.h
@@ -50,26 +50,26 @@ class TORS : public SIMPLE_COORDINATE {
 
     TORS(int A_in, int B_in, int C_in, int D_in, bool freeze_in=false);
 
-    ~TORS() { } // also calls ~SIMPLE_COORDINATE
+    ~TORS() override { } // also calls ~SIMPLE_COORDINATE
 
-    double value(GeomType geom) const;
+    double value(GeomType geom) const override;
     //bool fix_tors_value_corrected(GeomType geom) const;
 
     // compute and return array of first derivative (B marix elements)
-    double ** DqDx(GeomType geom) const;
+    double ** DqDx(GeomType geom) const override;
 
     // compute and return array of second derivative (B' matrix elements)
-    double ** Dq2Dx2(GeomType geom) const;
+    double ** Dq2Dx2(GeomType geom) const override;
 
     void print(std::string psi_fp, FILE *qc_fp, GeomType geom, int atom_offset=0) const;
     void print_intco_dat(std::string psi_fp, FILE *qc_fp, int atom_offset=0) const;
     void print_s(std::string psi_fp, FILE *qc_fp, GeomType geom) const;
     void print_disp(std::string psi_fp, FILE *qc_fp, const double old_q, const double f_q, 
       const double dq, const double new_q, int atom_offset=0) const;
-    bool operator==(const SIMPLE_COORDINATE & s2) const;
+    bool operator==(const SIMPLE_COORDINATE & s2) const override;
     std::string get_definition_string(int atom_offset=0) const;
 
-    void fix_tors_near_180(GeomType geom);
+    void fix_tors_near_180(GeomType geom) override;
 
     //bool check_tors_for_bad_angles(GeomType geom) const;
 

--- a/psi4/src/psi4/psimrcc/idmrpt2.h
+++ b/psi4/src/psi4/psimrcc/idmrpt2.h
@@ -49,7 +49,7 @@ class Updater;
 class IDMRPT2 : public CCManyBody {
    public:
     IDMRPT2(SharedWavefunction ref_wfn, Options& options);
-    virtual ~IDMRPT2();
+    ~IDMRPT2() override;
     void compute_mrpt2_energy(Updater* updater);
 
    private:

--- a/psi4/src/psi4/psimrcc/mp2_ccsd.h
+++ b/psi4/src/psi4/psimrcc/mp2_ccsd.h
@@ -40,7 +40,7 @@ namespace psimrcc {
 class MP2_CCSD : public CCManyBody {
    public:
     MP2_CCSD(SharedWavefunction ref_wfn, Options &options);
-    virtual ~MP2_CCSD();
+    ~MP2_CCSD() override;
     void compute_mp2_ccsd_energy();
 
    private:

--- a/psi4/src/psi4/psimrcc/mrcc.h
+++ b/psi4/src/psi4/psimrcc/mrcc.h
@@ -42,7 +42,7 @@ class CCMRCC : public CCManyBody {
    public:
     // Constructor and destructor
     CCMRCC(SharedWavefunction ref_wfn, Options &options);
-    virtual ~CCMRCC();
+    ~CCMRCC() override;
 
     // CCSD
     void compute_energy(Updater *updater);

--- a/psi4/src/psi4/psimrcc/updater.h
+++ b/psi4/src/psi4/psimrcc/updater.h
@@ -61,15 +61,15 @@ class Updater {
 class MkUpdater : public Updater {
    public:
     MkUpdater(Options &options);
-    virtual ~MkUpdater();
-    virtual void update(int cycle, Hamiltonian *heff);
+    ~MkUpdater() override;
+    void update(int cycle, Hamiltonian *heff) override;
 };
 
 class BWUpdater : public Updater {
    public:
     BWUpdater(Options &options);
-    virtual ~BWUpdater();
-    virtual void update(int cycle, Hamiltonian *heff);
+    ~BWUpdater() override;
+    void update(int cycle, Hamiltonian *heff) override;
 };
 
 }  // namespace psimrcc

--- a/psi4/src/psi4/scfgrad/jk_grad.h
+++ b/psi4/src/psi4/scfgrad/jk_grad.h
@@ -195,12 +195,12 @@ protected:
 
 public:
     DFJKGrad(int deriv, std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
-    virtual ~DFJKGrad();
+    ~DFJKGrad() override;
 
-    void compute_gradient();
-    void compute_hessian();
+    void compute_gradient() override;
+    void compute_hessian() override;
 
-    void print_header() const;
+    void print_header() const override;
 
     /**
      * Minimum relative eigenvalue to retain in fitting inverse
@@ -245,12 +245,12 @@ protected:
     std::map<std::string, std::shared_ptr<Matrix> > compute2(std::vector<std::shared_ptr<TwoBodyAOInt> >& ints);
 public:
     DirectJKGrad(int deriv, std::shared_ptr<BasisSet> primary);
-    virtual ~DirectJKGrad();
+    ~DirectJKGrad() override;
 
-    void compute_gradient();
-    void compute_hessian();
+    void compute_gradient() override;
+    void compute_hessian() override;
 
-    void print_header() const;
+    void print_header() const override;
 
     /**
      * What number of threads to compute integrals on

--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -51,9 +51,9 @@ protected:
 
 public:
     SCFGrad(SharedWavefunction ref_wfn, Options& options);
-    virtual ~SCFGrad();
+    ~SCFGrad() override;
 
-    double compute_energy() { throw PSIEXCEPTION("SCFGrad needs a rehash, call Rob."); }
+    double compute_energy() override { throw PSIEXCEPTION("SCFGrad needs a rehash, call Rob."); }
 
     SharedMatrix compute_gradient();
 


### PR DESCRIPTION
## Description
Uses `clang-tidy` to find and fix uses of `virtual` that can be replaced by the `override` keyword introduced in C++11 and later standards. Fixes applied with:
```
cd <build-dir>/psi4-core-prefix/src/psi4-core-build
run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-override' -fix
```
Based on #1312 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `clang-tidy` find and fix with `modernize-use-override`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
