### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -365,7 +365,7 @@ def py_psi_set_global_option_python(key, EXTERN):
     if (key != "EXTERN"):
         raise ValidationError("Options: set_global_option_python does not recognize keyword %s" % key)
 
-    if EXTERN == None:
+    if EXTERN is None:
         core.EXTERN = None
         core.set_global_option("EXTERN", False)
     elif isinstance(EXTERN, core.ExternalPotential):

--- a/psi4/driver/qcdb/libmintscoordentry.py
+++ b/psi4/driver/qcdb/libmintscoordentry.py
@@ -487,15 +487,15 @@ class ZMatrixEntry(CoordEntry):
     def print_in_input_format(self):
         """Prints the updated geometry, in the format provided by the user"""
         text = ""
-        if self.rto == None and self.ato == None and self.dto == None:
+        if self.rto is None and self.ato is None and self.dto is None:
             # The first atom
             text += "\n"
-        elif self.ato == None and self.dto == None:
+        elif self.ato is None and self.dto is None:
             # The second atom
             now_rto = self.rto.entry_number() + 1
             now_rval = self.rval.variable_to_string(10)
             text += "  %5d %11s\n" % (now_rto, now_rval)
-        elif self.dto == None:
+        elif self.dto is None:
             # The third atom
             now_rto = self.rto.entry_number() + 1
             now_rval = self.rval.variable_to_string(10)
@@ -518,15 +518,15 @@ class ZMatrixEntry(CoordEntry):
     def print_in_input_format_cfour(self):
         """Prints the updated geometry, in the format provided by the user"""
         text = ""
-        if self.rto == None and self.ato == None and self.dto == None:
+        if self.rto is None and self.ato is None and self.dto is None:
             # The first atom
             text += "\n"
-        elif self.ato == None and self.dto == None:
+        elif self.ato is None and self.dto is None:
             # The second atom
             now_rto = self.rto.entry_number() + 1
             now_rval = self.rval.variable_to_string(10)
             text += " %d %s\n" % (now_rto, now_rval)
-        elif self.dto == None:
+        elif self.dto is None:
             # The third atom
             now_rto = self.rto.entry_number() + 1
             now_rval = self.rval.variable_to_string(10)
@@ -594,13 +594,13 @@ class ZMatrixEntry(CoordEntry):
             return self.coordinates
 
         # place first atom at the origin
-        if self.rto == None and self.ato == None and self.dto == None:
+        if self.rto is None and self.ato is None and self.dto is None:
             self.coordinates[0] = 0.0
             self.coordinates[1] = 0.0
             self.coordinates[2] = 0.0
 
         # place second atom directly above the first
-        elif self.ato == None and self.dto == None:
+        elif self.ato is None and self.dto is None:
             self.coordinates[0] = 0.0
             self.coordinates[1] = 0.0
             self.coordinates[2] = self.rval.compute()
@@ -608,7 +608,7 @@ class ZMatrixEntry(CoordEntry):
         # place third atom pointing upwards
         #    this       rTo   rVal  aTo  aVal
         #      A         B           C
-        elif self.dto == None:
+        elif self.dto is None:
             r = self.rval.compute()
             a = self.aval.compute() * math.pi / 180.0
             cosABC = math.cos(a)

--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -1781,7 +1781,7 @@ class LibmintsMolecule():
         """
         rot_const = self.rotational_constants()
         for i in range(3):
-            if rot_const[i] == None:
+            if rot_const[i] is None:
                 rot_const[i] = 0.0
 
         # Determine degeneracy of rotational constants.

--- a/psi4/driver/qcdb/psiutil.py
+++ b/psi4/driver/qcdb/psiutil.py
@@ -299,7 +299,7 @@ def query_yes_no(question, default=True):
     yes = re.compile(r'^(y|yes|true|on|1)', re.IGNORECASE)
     no = re.compile(r'^(n|no|false|off|0)', re.IGNORECASE)
 
-    if default == None:
+    if default is None:
         prompt = " [y/n] "
     elif default == True:
         prompt = " [Y/n] "


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations