### PR TITLE
clang-tidy apply modernize-use-bool-literals fixes

### DIFF
--- a/psi4/src/psi4/dcft/dcft_scf_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_RHF.cc
@@ -411,7 +411,7 @@ void DCFTSolver::process_so_ints_RHF() {
         } /* end loop through current buffer */
         if (!lastBuffer) iwl->fetch();
     } while (!lastBuffer);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
     if (buildTensors) {
         if (print_ > 1) {

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -891,7 +891,7 @@ void DCFTSolver::process_so_ints() {
         } /* end loop through current buffer */
         if (!lastBuffer) iwl->fetch();
     } while (!lastBuffer);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
     if (buildTensors) {
         if (print_ > 1) {
@@ -1289,7 +1289,7 @@ void DCFTSolver::build_AO_tensors() {
         } /* end loop through current buffer */
         if (!lastBuffer) iwl->fetch();
     } while (!lastBuffer);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
     if (print_ > 1) {
         outfile->Printf("Processed %d SO integrals each for AA, BB, and AB\n", counter);
@@ -1715,7 +1715,7 @@ void DCFTSolver::build_G() {
         } /* end loop through current buffer */
         if (!lastBuffer) iwl->fetch();
     } while (!lastBuffer);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
 
     // Build the Fock matrices from the H and G matrices

--- a/psi4/src/psi4/dcft/dcft_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/dcft/dcft_sort_mo_tpdm.cc
@@ -161,7 +161,7 @@ void DCFTSolver::presort_mo_tpdm_AB() {
                 dpdFiller(p, q, r, s, value);
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirrep_; ++h) {
@@ -315,7 +315,7 @@ void DCFTSolver::presort_mo_tpdm_AA() {
 
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirrep_; ++h) {

--- a/psi4/src/psi4/detci/mitrush_iter.cc
+++ b/psi4/src/psi4/detci/mitrush_iter.cc
@@ -319,7 +319,7 @@ void CIWavefunction::mitrush_iter(CIvect &Hd, struct stringwr **alplist, struct 
         last = 0;
     }
 
-    while (1) {
+    while (true) {
         Cvec.buf_lock(buffer1);
         Sigma.buf_lock(buffer2);
         Cvec.read(curr, 0);

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -699,7 +699,7 @@ void DFFrozenNO::FourIndexIntegrals() {
         }
     }
     iwl->flush(1);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
 
     free(Qmo);

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -464,7 +464,7 @@ void DiskJK::compute_JK()
             if (K_[N]->symmetry()) K_[N]->transpose_this();
         }
     }
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
 
     if(do_wK_){
@@ -590,7 +590,7 @@ void DiskJK::compute_JK()
         for (size_t N = 0; N < wK_.size(); N++) {
             if (wK_[N]->symmetry()) wK_[N]->transpose_this();
         }
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
     }
 }

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -120,7 +120,7 @@ BasisSet::BasisSet() {
     shell_center_[0] = 0;
     center_to_nshell_[0] = 1;
     center_to_shell_[0] = 0;
-    puream_ = 0;
+    puream_ = false;
     max_am_ = 0;
     max_nprimitive_ = 1;
     xyz_[0] = 0.0;

--- a/psi4/src/psi4/libmints/petitelist.cc
+++ b/psi4/src/psi4/libmints/petitelist.cc
@@ -442,7 +442,7 @@ void PetiteList::init(double tol) {
     group_ = ct.bits();
 
     // initialize private members
-    c1_ = 0;
+    c1_ = false;
     ng_ = ct.order();
     natom_ = mol.natom();
     nshell_ = gbs.nshell();  // full number of shells
@@ -450,7 +450,7 @@ void PetiteList::init(double tol) {
 
     // if point group is C1, then zero everything
     if (ng_ == 1) {
-        c1_ = 1;
+        c1_ = true;
         nblocks_ = 1;
 
         p1_ = nullptr;

--- a/psi4/src/psi4/libqt/pople.cc
+++ b/psi4/src/psi4/libqt/pople.cc
@@ -254,7 +254,7 @@ int pople(double **A, double *x, int dimen, int /*num_vecs*/, double tolerance, 
             for (I = 0; I < dimen; I++) Bmat[L + 1][I] /= norm;
 
             /* check orthogonality of subspace */
-            if (0) {
+            if (false) {
                 for (i = 0; i <= L + 1; i++) {
                     for (j = 0; j <= i; j++) {
                         // dot_arr(Bmat[i], Bmat[j], dimen, &tval);

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -105,9 +105,9 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
 
     // Compare pointers
     if (ribasis_ == elstbasis_) {
-        elst_basis_ = 0;
+        elst_basis_ = false;
     } else {
-        elst_basis_ = 1;
+        elst_basis_ = true;
     }
 
     zero_ = std::shared_ptr<BasisSet>(BasisSet::zero_ao_basis_set());

--- a/psi4/src/psi4/libtrans/integraltransform_functors.h
+++ b/psi4/src/psi4/libtrans/integraltransform_functors.h
@@ -569,7 +569,7 @@ void iwl_integrals(IWL *iwl, DPDFunctor &dpd, FockFunctor &fock) {
         } /* end loop through current buffer */
         if (!lastBuffer) iwl->fetch();
     } while (!lastBuffer);
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -46,7 +46,7 @@ void IntegralTransform::common_initialize() {
     abIntName_ = "";
     bbIntName_ = "";
 
-    keepHtInts_ = 0;
+    keepHtInts_ = false;
 
     nTriSo_ = nso_ * (nso_ + 1) / 2;
     nTriMo_ = nmo_ * (nmo_ + 1) / 2;

--- a/psi4/src/psi4/libtrans/integraltransform_oei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_oei.cc
@@ -324,7 +324,7 @@ void IntegralTransform::generate_oei() {
                                aFzcOp, bFzcOp, aD, bD, aFock, bFock);
         } /* end loop through current buffer */
     } /* end loop over reading buffers */
-    iwl->set_keep_flag(1);
+    iwl->set_keep_flag(true);
     delete iwl;
 
     double *moInts = init_array(nTriMo_);

--- a/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
@@ -163,7 +163,7 @@ void IntegralTransform::presort_mo_tpdm_restricted() {
                 dpdFiller(p, q, r, s, value);
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirreps_; ++h) {
@@ -313,7 +313,7 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
                 aaDpdFiller(p, q, r, s, value);
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirreps_; ++h) {
@@ -361,7 +361,7 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
                 abDpdFiller(p, q, r, s, value);
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirreps_; ++h) {
@@ -407,7 +407,7 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
                 bbDpdFiller(p, q, r, s, value);
             }               /* end loop through current buffer */
         } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         delete iwl;
 
         for (int h = 0; h < nirreps_; ++h) {

--- a/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
@@ -208,7 +208,7 @@ void IntegralTransform::transform_tei_second_half(const std::shared_ptr<MOSpace>
 
     if (useIWL_) {
         iwl->flush(1);
-        iwl->set_keep_flag(1);
+        iwl->set_keep_flag(true);
         // This closes the file too
         delete iwl;
     }
@@ -322,7 +322,7 @@ void IntegralTransform::transform_tei_second_half(const std::shared_ptr<MOSpace>
 
         if (useIWL_) {
             iwl->flush(1);
-            iwl->set_keep_flag(1);
+            iwl->set_keep_flag(true);
             // This closes the file too
             delete iwl;
         }
@@ -443,7 +443,7 @@ void IntegralTransform::transform_tei_second_half(const std::shared_ptr<MOSpace>
 
         if (useIWL_) {
             iwl->flush(1);
-            iwl->set_keep_flag(1);
+            iwl->set_keep_flag(true);
             // This closes the file too
             delete iwl;
         }

--- a/psi4/src/psi4/mcscf/scf_read_so_tei.cc
+++ b/psi4/src/psi4/mcscf/scf_read_so_tei.cc
@@ -137,7 +137,7 @@ void SCF::read_so_tei_form_PK() {
         int ilsti, nbuf, fi, index;
 
         IWL ERIIN(psio_.get(), PSIF_SO_TEI, 0.0, 1, 1);
-        ERIIN.set_keep_flag(1);
+        ERIIN.set_keep_flag(true);
         do {
             ilsti = ERIIN.last_buffer();
             nbuf = ERIIN.buffer_count();
@@ -215,7 +215,7 @@ void SCF::read_so_tei_form_PK_and_K() {
         int ilsti, nbuf, fi, index;
 
         IWL ERIIN(psio_.get(), PSIF_SO_TEI, 0.0, 1, 1);
-        ERIIN.set_keep_flag(1);
+        ERIIN.set_keep_flag(true);
 
         do {
             ilsti = ERIIN.last_buffer();

--- a/psi4/src/psi4/occ/trans_ints_rhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_rhf.cc
@@ -48,7 +48,7 @@ void OCCWave::trans_ints_rhf()
 /********************************************************************************************/
     ints->update_orbitals();
     ints->set_print(print_ - 2 >= 0 ? print_ - 2 : 0);
-    ints->set_keep_dpd_so_ints(1);
+    ints->set_keep_dpd_so_ints(true);
 
     // Trans (OO|OO)
     timer_on("Trans (OO|OO)");

--- a/psi4/src/psi4/occ/trans_ints_rmp2.cc
+++ b/psi4/src/psi4/occ/trans_ints_rmp2.cc
@@ -45,7 +45,7 @@ void OCCWave::trans_ints_rmp2()
 /********************************************************************************************/
     ints->update_orbitals();
     ints->set_print(print_ - 2 >= 0 ? print_ - 2 : 0);
-    ints->set_keep_dpd_so_ints(1);
+    ints->set_keep_dpd_so_ints(true);
 
     // Trans (OV|OV)
     timer_on("Trans (OV|OV)");

--- a/psi4/src/psi4/occ/trans_ints_uhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_uhf.cc
@@ -46,7 +46,7 @@ void OCCWave::trans_ints_uhf()
 /********************************************************************************************/
     ints->update_orbitals();
     ints->set_print(print_ - 2 >= 0 ? print_ - 2 : 0);
-    ints->set_keep_dpd_so_ints(1);
+    ints->set_keep_dpd_so_ints(true);
 
     // Trans (OO|OO)
     timer_on("Trans (OO|OO)");

--- a/psi4/src/psi4/occ/trans_ints_ump2.cc
+++ b/psi4/src/psi4/occ/trans_ints_ump2.cc
@@ -45,7 +45,7 @@ void OCCWave::trans_ints_ump2()
 /********************************************************************************************/
     ints->update_orbitals();
     ints->set_print(print_ - 2 >= 0 ? print_ - 2 : 0);
-    ints->set_keep_dpd_so_ints(1);
+    ints->set_keep_dpd_so_ints(true);
 
     // Trans (OV|OV)
     timer_on("Trans (OV|OV)");

--- a/psi4/src/psi4/optking/IRC_data.h
+++ b/psi4/src/psi4/optking/IRC_data.h
@@ -112,8 +112,8 @@ class IRC_DATA {
 
     IRC_DATA() {
       sphere_step = 0;
-      go = 1;
-      in_min_range = 0;
+      go = true;
+      in_min_range = false;
       step_dist = 0;
       arc_dist = 0;
       line_dist = 0;

--- a/psi4/src/psi4/optking/frag_disp.cc
+++ b/psi4/src/psi4/optking/frag_disp.cc
@@ -285,12 +285,12 @@ bool FRAG::displace_util(double *dq, bool focus_on_constraints) {
     //   dx = Bt (B Bt)^-1 dq
     //   dx = Bt G^-1 dq, where G = B B^t.
     compute_B(B,0,0);
-    opt_matrix_mult(B, 0, B, 1, G, 0, Nints, Ncarts, Nints, 0);
+    opt_matrix_mult(B, false, B, true, G, false, Nints, Ncarts, Nints, false);
 
     // u B^t (G_inv dq) = dx
     G_inv = symm_matrix_inv(G, Nints, true);
-    opt_matrix_mult(G_inv, 0, &dq, 1, &tmp_v_Nints, 1, Nints, Nints, 1, 0);
-    opt_matrix_mult(B, 1, &tmp_v_Nints, 1, &dx, 1, Ncarts, Nints, 1, 0);
+    opt_matrix_mult(G_inv, false, &dq, true, &tmp_v_Nints, true, Nints, Nints, 1, false);
+    opt_matrix_mult(B, true, &tmp_v_Nints, true, &dx, true, Ncarts, Nints, 1, false);
     free_matrix(G_inv);
 
     for (i=0; i<Ncarts; ++i)

--- a/psi4/src/psi4/optking/interfrag_orient.cc
+++ b/psi4/src/psi4/optking/interfrag_orient.cc
@@ -364,7 +364,7 @@ void rotate_vecs(double *w, double phi, double **v, int num_v) {
   R[2][2] =     cos(phi) + wz*wz*cp;
 
   v_new = init_matrix(num_v,3);
-  opt_matrix_mult(R, 0, v, 1, v_new, 1, 3, 3, num_v, 0);
+  opt_matrix_mult(R, false, v, true, v_new, true, 3, 3, num_v, false);
 
   for (int i=0; i<num_v; ++i)
     for (int j=0; j<3; ++j)

--- a/psi4/src/psi4/optking/lindh_guess.cc
+++ b/psi4/src/psi4/optking/lindh_guess.cc
@@ -263,7 +263,7 @@ in this set of internals. */
   //oprint_array_out(g_x,3*natom);
 
   double *temp_arr = init_array(Nintco);
-  opt_matrix_mult(B, 0, &g_x, 1, &temp_arr, 1, Nintco, 3*natom, 1, 0);
+  opt_matrix_mult(B, false, &g_x, true, &temp_arr, true, Nintco, 3*natom, 1, false);
   free_array(g_x);
 
   double **G = init_matrix(Nintco, Nintco);
@@ -272,11 +272,11 @@ in this set of internals. */
       for (int j=0; j<Nintco; ++j)
         G[i][j] += B[i][k] * B[j][k];
   free_matrix(B);
-  double **G_inv = symm_matrix_inv(G, Nintco, 1);
+  double **G_inv = symm_matrix_inv(G, Nintco, true);
   free_matrix(G);
 
   double *g_q = init_array(Nintco);
-  opt_matrix_mult(G_inv, 0, &temp_arr, 1, &g_q, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(G_inv, false, &temp_arr, true, &g_q, true, Nintco, Nintco, 1, false);
   free_matrix(G_inv);
   free_array(temp_arr);
   // Done computing g_q

--- a/psi4/src/psi4/optking/linear_algebra.cc
+++ b/psi4/src/psi4/optking/linear_algebra.cc
@@ -253,8 +253,8 @@ double ** symm_matrix_inv(double **A, int dim, bool redundant) {
   double ** A_temp = init_matrix(dim, dim);
 
   // A^-1 = P^t D^-1 P
-  opt_matrix_mult(A_inv, 0, A_evects, 0, A_temp, 0, dim, dim, dim,0);
-  opt_matrix_mult(A_evects, 1, A_temp, 0, A_inv, 0, dim, dim, dim, 0);
+  opt_matrix_mult(A_inv, false, A_evects, false, A_temp, false, dim, dim, dim,false);
+  opt_matrix_mult(A_evects, true, A_temp, false, A_inv, false, dim, dim, dim, false);
 
   free_matrix(A_temp);
   free_array(evals);

--- a/psi4/src/psi4/optking/molecule.cc
+++ b/psi4/src/psi4/optking/molecule.cc
@@ -105,7 +105,7 @@ void MOLECULE::forces() {
     oprint_matrix_out(B, Nintco, Ncart);
   }
   temp_arr = init_array(Nintco);
-  opt_matrix_mult(B, 0, &f_x, 1, &temp_arr, 1, Nintco, Ncart, 1, 0);
+  opt_matrix_mult(B, false, &f_x, true, &temp_arr, true, Nintco, Ncart, 1, false);
   free_array(f_x);
 
   // G^-1 = (BuBt)^-1
@@ -116,11 +116,11 @@ void MOLECULE::forces() {
         G[i][j] += B[i][k] * /* u[k] * */ B[j][k];
   free_matrix(B);
 
-  G_inv = symm_matrix_inv(G, Nintco, 1);
+  G_inv = symm_matrix_inv(G, Nintco, true);
   free_matrix(G);
 
   double * f_q = p_Opt_data->g_forces_pointer();
-  opt_matrix_mult(G_inv, 0, &temp_arr, 1, &f_q, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(G_inv, false, &temp_arr, true, &f_q, true, Nintco, Nintco, 1, false);
   free_matrix(G_inv);
   free_array(temp_arr);
 
@@ -227,9 +227,9 @@ void MOLECULE::project_f_and_H() {
       G[g_fb_fragment_coord_offset(I) + i][g_fb_fragment_coord_offset(I) + i] = 1.0;
 
   // compute P = G G^-1
-  double **G_inv = symm_matrix_inv(G, Nintco, 1);
+  double **G_inv = symm_matrix_inv(G, Nintco, true);
   double **P = init_matrix(Nintco, Nintco);
-  opt_matrix_mult(G, 0, G_inv, 0, P, 0, Nintco, Nintco, Nintco, 0);
+  opt_matrix_mult(G, false, G_inv, false, P, false, Nintco, Nintco, Nintco, false);
   free_matrix(G);
   free_matrix(G_inv);
 
@@ -249,16 +249,16 @@ void MOLECULE::project_f_and_H() {
   // P = P' - P' C (CPC)^-1 C P'
   if (constraints_present) {
     double **T = init_matrix(Nintco,Nintco);
-    opt_matrix_mult(P, 0, C, 0,  T, 0, Nintco, Nintco, Nintco, 0);
+    opt_matrix_mult(P, false, C, false,  T, false, Nintco, Nintco, Nintco, false);
     double **T2 = init_matrix(Nintco,Nintco);
-    opt_matrix_mult(C, 0, T, 0, T2, 0, Nintco, Nintco, Nintco, 0);
-    double **T3 = symm_matrix_inv(T2, Nintco, 1);
+    opt_matrix_mult(C, false, T, false, T2, false, Nintco, Nintco, Nintco, false);
+    double **T3 = symm_matrix_inv(T2, Nintco, true);
 
-    opt_matrix_mult( C, 0,  P, 0,  T, 0, Nintco, Nintco, Nintco, 0);
-    opt_matrix_mult(T3, 0,  T, 0, T2, 0, Nintco, Nintco, Nintco, 0);
+    opt_matrix_mult( C, false,  P, false,  T, false, Nintco, Nintco, Nintco, false);
+    opt_matrix_mult(T3, false,  T, false, T2, false, Nintco, Nintco, Nintco, false);
     free_matrix(T);
-    opt_matrix_mult( C, 0, T2, 0, T3, 0, Nintco, Nintco, Nintco, 0);
-    opt_matrix_mult( P, 0, T3, 0, T2, 0, Nintco, Nintco, Nintco, 0);
+    opt_matrix_mult( C, false, T2, false, T3, false, Nintco, Nintco, Nintco, false);
+    opt_matrix_mult( P, false, T3, false, T2, false, Nintco, Nintco, Nintco, false);
     free_matrix(T3);
     for (int i=0; i<Nintco; ++i)
       for (int j=0; j<Nintco; ++j)
@@ -273,7 +273,7 @@ void MOLECULE::project_f_and_H() {
   double *f_q = p_Opt_data->g_forces_pointer();
   // f_q~ = P f_q
   double * temp_arr = init_array(Nintco);
-  opt_matrix_mult(P, 0, &f_q, 1, &temp_arr, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(P, false, &f_q, true, &temp_arr, true, Nintco, Nintco, 1, false);
   array_copy(temp_arr, f_q, Ncoord());
   free_array(temp_arr);
 
@@ -291,8 +291,8 @@ void MOLECULE::project_f_and_H() {
 
   double **H = p_Opt_data->g_H_pointer();
   double **temp_mat = init_matrix(Nintco, Nintco);
-  opt_matrix_mult(H, 0, P, 0, temp_mat, 0, Nintco, Nintco, Nintco, 0);
-  opt_matrix_mult(P, 0, temp_mat, 0, H, 0, Nintco, Nintco, Nintco, 0);
+  opt_matrix_mult(H, false, P, false, temp_mat, false, Nintco, Nintco, Nintco, false);
+  opt_matrix_mult(P, false, temp_mat, false, H, false, Nintco, Nintco, Nintco, false);
   free_matrix(temp_mat);
 
   /*for (int i=0; i<Nintco;++i)
@@ -327,7 +327,7 @@ void MOLECULE::project_dq(double *dq) {
 
   //double **G = compute_G(true);
   double **G = init_matrix(Ncart, Ncart);
-  opt_matrix_mult(B, 1, B, 0, G, 0, Ncart, Nintco, Ncart, 0);
+  opt_matrix_mult(B, true, B, false, G, false, Ncart, Nintco, Ncart, false);
 
 /*  will need fixed if this function ever helps
 #if defined (OPTKING_PACKAGE_QCHEM)
@@ -341,20 +341,20 @@ void MOLECULE::project_dq(double *dq) {
   // B dx = dq
   // B^t B dx = B^t dq
   // dx = (B^t B)^-1 B^t dq
-  double **G_inv = symm_matrix_inv(G, Ncart, 1);
+  double **G_inv = symm_matrix_inv(G, Ncart, true);
   free_matrix(G);
 
   double **B_inv = init_matrix(Ncart, Nintco);
-  opt_matrix_mult(G_inv, 0, B, 1, B_inv, 0, Ncart, Ncart, Nintco, 0);
+  opt_matrix_mult(G_inv, false, B, true, B_inv, false, Ncart, Ncart, Nintco, false);
   free_matrix(G_inv);
 
   double **P = init_matrix(Nintco, Nintco);
-  opt_matrix_mult(B, 0, B_inv, 0, P, 0, Nintco, Ncart, Nintco, 0);
+  opt_matrix_mult(B, false, B_inv, false, P, false, Nintco, Ncart, Nintco, false);
   free_matrix(B);
   free_matrix(B_inv);
 
   double * temp_arr = init_array(Nintco);
-  opt_matrix_mult(P, 0, &dq, 1, &temp_arr, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(P, false, &dq, true, &temp_arr, true, Nintco, Nintco, 1, false);
   array_copy(temp_arr, dq, Ncoord());
   free_array(temp_arr);
   free_matrix(P);
@@ -494,20 +494,20 @@ bool MOLECULE::cartesian_H_to_internals(double **H_cart) const {
   // compute A = u B^t (B u B^t)^-1 where u=unit matrix and -1 is generalized inverse
   double **B = compute_B();
   double **G = init_matrix(Nintco, Nintco);
-  opt_matrix_mult(B, 0, B, 1, G, 0, Nintco, Ncart, Nintco, 0);
+  opt_matrix_mult(B, false, B, true, G, false, Nintco, Ncart, Nintco, false);
 
   double **G_inv = symm_matrix_inv(G, Nintco, true);
   free_matrix(G);
 
   double **A = init_matrix(Ncart, Nintco);
-  opt_matrix_mult(B, 1, G_inv, 0, A, 0, Ncart, Nintco, Nintco, 0);
+  opt_matrix_mult(B, true, G_inv, false, A, false, Ncart, Nintco, Nintco, false);
   free_matrix(G_inv);
   free_matrix(B);
 
   // compute gradient in internal coordinates, A^t g_x = g_q
   double *grad_x = g_grad_array();
   double *grad_q = init_array(Nintco);
-  opt_matrix_mult(A, 1, &grad_x, 1, &grad_q, 1, Nintco, Ncart, 1, 0);
+  opt_matrix_mult(A, true, &grad_x, true, &grad_q, true, Nintco, Ncart, 1, false);
   free_array(grad_x);
 
   // read in cartesian H
@@ -529,11 +529,11 @@ bool MOLECULE::cartesian_H_to_internals(double **H_cart) const {
   free_array(grad_q);
 
   double **temp_mat = init_matrix(Ncart, Nintco);
-  opt_matrix_mult(H_cart, 0, A, 0, temp_mat, 0, Ncart, Ncart, Nintco, 0);
+  opt_matrix_mult(H_cart, false, A, false, temp_mat, false, Ncart, Ncart, Nintco, false);
   //free_matrix(H_cart);
 
   //double **H_int = init_matrix(Nintco, Nintco);
-  opt_matrix_mult(A, 1, temp_mat, 0, H_int, 0, Nintco, Ncart, Nintco, 0);
+  opt_matrix_mult(A, true, temp_mat, false, H_int, false, Nintco, Ncart, Nintco, false);
   free_matrix(temp_mat);
 
   free_matrix(A);
@@ -726,7 +726,7 @@ double ** MOLECULE::compute_G(bool use_masses) const {
     free_array(u);
   }
 
-  opt_matrix_mult(B, 0, B, 1, G, 0, Nintco, Ncart, Nintco, 0);
+  opt_matrix_mult(B, false, B, true, G, false, Nintco, Ncart, Nintco, false);
   free_matrix(B);
 
   //oprintf_out("G matrix\n");

--- a/psi4/src/psi4/optking/molecule_irc_step.cc
+++ b/psi4/src/psi4/optking/molecule_irc_step.cc
@@ -194,14 +194,14 @@ void MOLECULE::irc_step()
   int Nintco = Ncoord();
   int Natom = g_natom();
   int Ncart = 3 * Natom;
-  bool answer = 1;
+  bool answer = true;
 
 
   int opt_iter = p_Opt_data->g_iteration() - 1;
   if(opt_iter > 2 && p_irc_data->in_min_range) {
     if(    std::fabs(p_Opt_data->g_energy(opt_iter)     - p_Opt_data->g_energy(opt_iter - 2)) < 0.01e-03
         && std::fabs(p_Opt_data->g_energy(opt_iter - 1) - p_Opt_data->g_energy(opt_iter - 3)) < 0.01e-03 ) {
-      p_irc_data->go = 0;
+      p_irc_data->go = false;
     }
   }
 
@@ -216,7 +216,7 @@ void MOLECULE::irc_step()
       double u_f_q_dot = array_dot(u_f_q, u_f_q_0, Nintco);
 
       if(u_f_q_dot < -0.5) {
-        p_irc_data->in_min_range = 1;
+        p_irc_data->in_min_range = true;
       }
 
       if (u_f_q_dot < -0.7 ||
@@ -231,7 +231,7 @@ void MOLECULE::irc_step()
           std::cin >> answer;
         }
         if(Opt_params.IRC_stop == OPT_PARAMS::STOP || !answer) {
-          p_irc_data->go = 0;
+          p_irc_data->go = false;
         }
       }
 
@@ -240,10 +240,10 @@ void MOLECULE::irc_step()
     }
 
   //The G matrix, its square root, and its inverse square root
-  double **G         = compute_G(1);                          //G = BUB^t
+  double **G         = compute_G(true);                          //G = BUB^t
 
   double **rootG_reg = matrix_return_copy(G, Nintco, Nintco); //G^1/2
-  matrix_root(rootG_reg, Nintco, 0);
+  matrix_root(rootG_reg, Nintco, false);
 
   if (Opt_params.print_lvl > 2) {
     oprintf_out( "\n@IRC rootG matrix:\n");
@@ -251,7 +251,7 @@ void MOLECULE::irc_step()
   }
 
   double **rootG_inv = matrix_return_copy(G, Nintco, Nintco); //G^-1/2
-  matrix_root(rootG_inv, Nintco, 1);
+  matrix_root(rootG_inv, Nintco, true);
 
   if (Opt_params.print_lvl > 2) {
     oprintf_out( "@IRC G matrix:\n");
@@ -263,9 +263,9 @@ void MOLECULE::irc_step()
   double **H_m = init_matrix(Nintco, Nintco);
   double **T = init_matrix(Nintco, Nintco);
   // T = HG^1/2
-  opt_matrix_mult(H, 0, rootG_reg, 0, T, 0, Nintco, Nintco, Nintco, 0);
+  opt_matrix_mult(H, false, rootG_reg, false, T, false, Nintco, Nintco, Nintco, false);
   // H_m = (G^1/2)H(G^1/2) = (G^1/2)T
-  opt_matrix_mult(rootG_reg, 0, T, 0, H_m, 0, Nintco, Nintco, Nintco, 0);
+  opt_matrix_mult(rootG_reg, false, T, false, H_m, false, Nintco, Nintco, Nintco, false);
   free_matrix(T);
 
   if (Opt_params.print_lvl > 2) {
@@ -497,8 +497,8 @@ void MOLECULE::irc_step()
   for(int i=0; i<Nintco; i++)
     g_m0[i] = array_dot(rootG_reg[i], g_0, Nintco);
 
-  if(0 && p_irc_data->sphere_step > 1) {
-    if(0)
+  if(false && p_irc_data->sphere_step > 1) {
+    if(false)
       //GS_interpolation(p_m, p_m0, g_m, g_m0, s, Nintco);
       GS_interpolation(p_m, p_m0, g_m, g_m0, Nintco);
     else
@@ -638,18 +638,18 @@ void MOLECULE::irc_step()
   // Compute (H_m - lambda * I)^(-1)
   for(int i=0; i<Nintco; i++)
     H_m[i][i] -= lambda;
-  double **H_m_lag_inv = symm_matrix_inv(H_m, Nintco, 1);
+  double **H_m_lag_inv = symm_matrix_inv(H_m, Nintco, true);
 
   double *g_lag_p = init_array(Nintco);
   for(int i=0; i<Nintco; i++)
     g_lag_p[i] = lambda * p_m[i] - g_m[i];
 
-  opt_matrix_mult(H_m_lag_inv, 0, &g_lag_p, 1, &dq_m, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(H_m_lag_inv, false, &g_lag_p, true, &dq_m, true, Nintco, Nintco, 1, false);
 
   free_matrix(H_m_lag_inv);
 
 //5. find dq ( = (G^1/2)dq_m) and do displacements
-  opt_matrix_mult(rootG_reg, 0, &dq_m, 1, &dq, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(rootG_reg, false, &dq_m, true, &dq, true, Nintco, Nintco, 1, false);
 
 
   // Do displacements for each fragment separately.

--- a/psi4/src/psi4/optking/molecule_nr_step.cc
+++ b/psi4/src/psi4/optking/molecule_nr_step.cc
@@ -74,8 +74,8 @@ void MOLECULE::nr_step() {
   oprintf_out("\tTaking NR optimization step.\n");
 
   // Hinv fq = dq
-  H_inv = symm_matrix_inv(H, Nintco, 1);
-  opt_matrix_mult(H_inv, 0, &fq, 1, &dq, 1, Nintco, Nintco, 1, 0);
+  H_inv = symm_matrix_inv(H, Nintco, true);
+  opt_matrix_mult(H_inv, false, &fq, true, &dq, true, Nintco, Nintco, 1, false);
   free_matrix(H_inv);
 
   // Zero steps for frozen fragment

--- a/psi4/src/psi4/optking/molecule_prfo_step.cc
+++ b/psi4/src/psi4/optking/molecule_prfo_step.cc
@@ -120,7 +120,7 @@ void MOLECULE::prfo_step() {
 
   // transform gradient
   double *f_q_Hevect_basis = init_array(Nintco);
-  opt_matrix_mult(H_evects, 0, &fq, 1, &f_q_Hevect_basis, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(H_evects, false, &fq, true, &f_q_Hevect_basis, true, Nintco, Nintco, 1, false);
   if (Opt_params.print_lvl >= 2) {
     oprintf_out("\tInternal forces in au,\n");
     oprint_array_out(fq, Nintco);
@@ -237,7 +237,7 @@ void MOLECULE::prfo_step() {
 
   // transform back into original basis.
   // write to old dq pointer ?
-  opt_matrix_mult(H_evects, 1, &rfo_step_Hevect_basis, 1, &dq, 1, Nintco, Nintco, 1, 0);
+  opt_matrix_mult(H_evects, true, &rfo_step_Hevect_basis, true, &dq, true, Nintco, Nintco, 1, false);
 
   if (Opt_params.print_lvl >= 2) {
     oprintf_out( "\nRFO step in original basis\n");

--- a/psi4/src/psi4/optking/opt_data.cc
+++ b/psi4/src/psi4/optking/opt_data.cc
@@ -109,7 +109,7 @@ bool OPT_DATA::conv_check(opt::MOLECULE &mol) const {
   double *f =  g_forces_pointer();
 
   if (Opt_params.opt_type == OPT_PARAMS::IRC)
-    if (!p_irc_data->go) { return 1; }
+    if (!p_irc_data->go) { return true; }
 
   // Save forces and put back in below.
   double *f_backup;
@@ -120,7 +120,7 @@ bool OPT_DATA::conv_check(opt::MOLECULE &mol) const {
 
   // for IRC only consider forces tangent to the hypersphere search surface
   if (Opt_params.opt_type == OPT_PARAMS::IRC) {
-    double **G = mol.compute_G(1);
+    double **G = mol.compute_G(true);
     double **Ginv = symm_matrix_inv(G, Nintco, Nintco); 
     free_matrix(G);
 


### PR DESCRIPTION
## Description
Uses `clang-tidy` to find and fix uses of `0`/`1` instead of `false`/`true`. Fixes applied with:
```
cd <build-dir>/psi4-core-prefix/src/psi4-core-build
run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-bool-literals' -fix
```
Based on #1312 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `clang-tidy` find and fix with `modernize-use-bool-literals`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge

