### PR TITLE
clang-tidy apply modernize-use-noexcept fixes

### DIFF
--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -1007,8 +1007,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      *
      * \returns true if a vector is added, false otherwise
      */
-    bool schmidt_add_row(int h, int rows, Vector& v) throw();
-    bool schmidt_add_row(int h, int rows, double* v) throw();
+    bool schmidt_add_row(int h, int rows, Vector& v) noexcept;
+    bool schmidt_add_row(int h, int rows, double* v) noexcept;
     /// @}
 
     /*! Calls libqt schmidt function */

--- a/psi4/src/psi4/libpsi4util/exception.cc
+++ b/psi4/src/psi4/libpsi4util/exception.cc
@@ -39,7 +39,7 @@
 
 namespace psi {
 
-PsiException::PsiException(std::string msg, const char *_file, int _line) throw() : runtime_error(msg) {
+PsiException::PsiException(std::string msg, const char *_file, int _line) noexcept : runtime_error(msg) {
     file_ = _file;
     line_ = _line;
 
@@ -85,12 +85,12 @@ PsiException::PsiException(std::string msg, const char *_file, int _line) throw(
     msg_ = message.str();
 }
 
-PsiException::PsiException(const PsiException &copy) throw()
+PsiException::PsiException(const PsiException &copy) noexcept
     : runtime_error(copy.msg_), msg_(copy.msg_), file_(strdup(copy.file_)), line_(copy.line_) {}
 
-void PsiException::rewrite_msg(std::string msg) throw() { msg_ = msg; }
+void PsiException::rewrite_msg(std::string msg) noexcept { msg_ = msg; }
 
-const char *PsiException::what() const throw() {
+const char *PsiException::what() const noexcept {
     // stringstream sstr;
     // sstr << msg_ << "\n";
     // sstr << location();
@@ -98,60 +98,60 @@ const char *PsiException::what() const throw() {
     return msg_.c_str();
 }
 
-const char *PsiException::file() const throw() { return file_; }
+const char *PsiException::file() const noexcept { return file_; }
 
-int PsiException::line() const throw() { return line_; }
+int PsiException::line() const noexcept { return line_; }
 
-const char *PsiException::location() const throw() {
+const char *PsiException::location() const noexcept {
     std::stringstream sstr;
     sstr << "file: " << file_ << "\n";
     sstr << "line: " << line_;
     return sstr.str().c_str();
 }
 
-PsiException::~PsiException() throw() {}
+PsiException::~PsiException() noexcept {}
 
-SanityCheckError::SanityCheckError(std::string message, const char *_file, int _line) throw()
+SanityCheckError::SanityCheckError(std::string message, const char *_file, int _line) noexcept
     : PsiException(message, _file, _line) {
     std::stringstream sstr;
     sstr << "sanity check failed! " << message;
     rewrite_msg(sstr.str());
 }
 
-SanityCheckError::~SanityCheckError() throw() {}
+SanityCheckError::~SanityCheckError() noexcept {}
 
-SystemError::SystemError(int eno, const char *_file, int _line) throw() : PsiException("", _file, _line) {
+SystemError::SystemError(int eno, const char *_file, int _line) noexcept : PsiException("", _file, _line) {
     std::stringstream sstr;
     sstr << "SystemError:  " << strerror(eno);
     rewrite_msg(sstr.str());
 }
 
-SystemError::~SystemError() throw() {}
+SystemError::~SystemError() noexcept {}
 
-InputException::InputException(std::string msg, std::string param_name, int value, const char *_file, int _line) throw()
+InputException::InputException(std::string msg, std::string param_name, int value, const char *_file, int _line) noexcept
     : PsiException(msg, _file, _line) {
     write_input_msg<int>(msg, param_name, value);
 }
 
 InputException::InputException(std::string msg, std::string param_name, std::string value, const char *_file,
-                               int _line) throw()
+                               int _line) noexcept
     : PsiException(msg, _file, _line) {
     write_input_msg<std::string>(msg, param_name, value);
 }
 
 InputException::InputException(std::string msg, std::string param_name, double value, const char *_file,
-                               int _line) throw()
+                               int _line) noexcept
     : PsiException(msg, _file, _line) {
     write_input_msg<double>(msg, param_name, value);
 }
 
-InputException::InputException(std::string msg, std::string param_name, const char *_file, int _line) throw()
+InputException::InputException(std::string msg, std::string param_name, const char *_file, int _line) noexcept
     : PsiException(msg, _file, _line) {
     write_input_msg<std::string>(msg, param_name, "in input");
 }
 
 template <class T>
-void InputException::write_input_msg(std::string msg, std::string param_name, T value) throw() {
+void InputException::write_input_msg(std::string msg, std::string param_name, T value) noexcept {
     std::stringstream sstr;
     sstr << msg << "\n";
     sstr << "value " << value << " is incorrect"
@@ -161,22 +161,22 @@ void InputException::write_input_msg(std::string msg, std::string param_name, T 
 }
 
 template <class T>
-StepSizeError<T>::StepSizeError(std::string value_name, T max, T actual, const char *_file, int _line) throw()
+StepSizeError<T>::StepSizeError(std::string value_name, T max, T actual, const char *_file, int _line) noexcept
     : LimitExceeded<T>(value_name + " step size", max, actual, _file, _line) {}
 
 template <class T>
-StepSizeError<T>::~StepSizeError() throw() {}
+StepSizeError<T>::~StepSizeError() noexcept {}
 
 template <class T>
-MaxIterationsExceeded<T>::MaxIterationsExceeded(std::string routine_name, T max, const char *_file, int _line) throw()
+MaxIterationsExceeded<T>::MaxIterationsExceeded(std::string routine_name, T max, const char *_file, int _line) noexcept
     : LimitExceeded<T>(routine_name + " iterations", max, max, _file, _line) {}
 
 template <class T>
-MaxIterationsExceeded<T>::~MaxIterationsExceeded() throw() {}
+MaxIterationsExceeded<T>::~MaxIterationsExceeded() noexcept {}
 
 template <class T>
 ConvergenceError<T>::ConvergenceError(std::string routine_name, T max, double _desired_accuracy,
-                                      double _actual_accuracy, const char *_file, int _line) throw()
+                                      double _actual_accuracy, const char *_file, int _line) noexcept
     : MaxIterationsExceeded<T>(routine_name + " iterations", max, _file, _line),
       desired_acc_(_desired_accuracy),
       actual_acc_(_actual_accuracy) {
@@ -188,15 +188,15 @@ ConvergenceError<T>::ConvergenceError(std::string routine_name, T max, double _d
 }
 
 template <class T>
-ConvergenceError<T>::~ConvergenceError() throw() {}
+ConvergenceError<T>::~ConvergenceError() noexcept {}
 
 template <class T>
-double ConvergenceError<T>::desired_accuracy() const throw() {
+double ConvergenceError<T>::desired_accuracy() const noexcept {
     return desired_acc_;
 }
 
 template <class T>
-double ConvergenceError<T>::actual_accuracy() const throw() {
+double ConvergenceError<T>::actual_accuracy() const noexcept {
     return actual_acc_;
 }
 

--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -64,7 +64,7 @@ class PSI_API PsiException : public std::runtime_error {
     * Override default message for exception throw in what
     * @param msg The message for what to throw
     */
-    void rewrite_msg(std::string msg) throw();
+    void rewrite_msg(std::string msg) noexcept;
 
    public:
     /**
@@ -73,11 +73,11 @@ class PSI_API PsiException : public std::runtime_error {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    PsiException(std::string message, const char *file, int line) throw();
+    PsiException(std::string message, const char *file, int line) noexcept;
 
-    PsiException(const PsiException &copy) throw();
+    PsiException(const PsiException &copy) noexcept;
 
-    virtual ~PsiException() throw();
+    virtual ~PsiException() noexcept;
 
     PsiException &operator=(const PsiException &other) {
         if (this != &other) {
@@ -92,25 +92,25 @@ class PSI_API PsiException : public std::runtime_error {
     * Override of runtime_error's virtual what method
     * @return Description of exception
     */
-    const char *what() const throw();
+    const char *what() const noexcept;
 
     /**
     * Accessor method
     * @return File that threw the exception
     */
-    const char *file() const throw();
+    const char *file() const noexcept;
 
     /**
     * Accessor method
     * @return A string description of line and file that threw exception
     */
-    const char *location() const throw();
+    const char *location() const noexcept;
 
     /**
     * Accessor method
     * @return The line number that threw the exception
     */
-    int line() const throw();
+    int line() const noexcept;
 };
 
 class NotImplementedException_ : public PsiException {
@@ -130,9 +130,9 @@ class PSI_API SanityCheckError : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    SanityCheckError(std::string message, const char *file, int line) throw();
+    SanityCheckError(std::string message, const char *file, int line) noexcept;
 
-    virtual ~SanityCheckError() throw();
+    virtual ~SanityCheckError() noexcept;
 };
 
 /**
@@ -146,9 +146,9 @@ class SystemError : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    SystemError(int eno, const char *file, int line) throw();
+    SystemError(int eno, const char *file, int line) noexcept;
 
-    virtual ~SystemError() throw();
+    virtual ~SystemError() noexcept;
 };
 
 /**
@@ -163,9 +163,9 @@ class FeatureNotImplemented : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    FeatureNotImplemented(std::string module, std::string feature, const char *file, int line) throw();
+    FeatureNotImplemented(std::string module, std::string feature, const char *file, int line) noexcept;
 
-    virtual ~FeatureNotImplemented() throw();
+    virtual ~FeatureNotImplemented() noexcept;
 };
 
 /**
@@ -183,7 +183,7 @@ class LimitExceeded : public PsiException {
     * Accessor method
     * @return A string description of the limit that was exceeded
     */
-    const char *description() const throw() {
+    const char *description() const noexcept {
         std::stringstream sstr;
         sstr << "value for " << resource_name_ << " exceeded.\n"
              << "allowed: " << maxval_ << " actual: " << errorval_;
@@ -199,16 +199,16 @@ class LimitExceeded : public PsiException {
     * @param f The file that threw the exception (use __FILE__ macro)
     * @param l The line number that threw the exception (use __LINE__ macro)
     */
-    LimitExceeded(std::string resource_name, T maxval, T errorval, const char *f, int l) throw()
+    LimitExceeded(std::string resource_name, T maxval, T errorval, const char *f, int l) noexcept
         : PsiException(resource_name, f, l), maxval_(maxval), errorval_(errorval), resource_name_(resource_name) {
         rewrite_msg(description());
     }
 
-    T max_value() const throw() { return maxval_; }
+    T max_value() const noexcept { return maxval_; }
 
-    T actual_value() const throw() { return errorval_; }
+    T actual_value() const noexcept { return errorval_; }
 
-    virtual ~LimitExceeded<T>() throw(){};
+    virtual ~LimitExceeded<T>() noexcept{};
 };
 
 /**
@@ -227,9 +227,9 @@ class StepSizeError : public LimitExceeded<T> {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    StepSizeError(std::string resource_name, T max, T actual, const char *file, int line) throw();
+    StepSizeError(std::string resource_name, T max, T actual, const char *file, int line) noexcept;
 
-    virtual ~StepSizeError() throw();
+    virtual ~StepSizeError() noexcept;
 };
 
 /**
@@ -247,9 +247,9 @@ class MaxIterationsExceeded : public LimitExceeded<T> {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    MaxIterationsExceeded(std::string routine_name, T max, const char *file, int line) throw();
+    MaxIterationsExceeded(std::string routine_name, T max, const char *file, int line) noexcept;
 
-    virtual ~MaxIterationsExceeded() throw();
+    virtual ~MaxIterationsExceeded() noexcept;
 };
 
 /**
@@ -268,19 +268,19 @@ class ConvergenceError : public MaxIterationsExceeded<T> {
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
     ConvergenceError(std::string routine_name, T max, double desired_accuracy, double actual_accuracy, const char *file,
-                     int line) throw();
+                     int line) noexcept;
 
     /** Accessor method
     *  @return The accuracy you wish to achieve
     */
-    double desired_accuracy() const throw();
+    double desired_accuracy() const noexcept;
 
     /** Accessor method
     *  @return The accuracy you actually got
     */
-    double actual_accuracy() const throw();
+    double actual_accuracy() const noexcept;
 
-    virtual ~ConvergenceError() throw();
+    virtual ~ConvergenceError() noexcept;
 
    private:
     double desired_acc_;
@@ -300,9 +300,9 @@ class ResourceAllocationError : public LimitExceeded<T> {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    ResourceAllocationError(std::string resource_name, T max, T actual, const char *file, int line) throw();
+    ResourceAllocationError(std::string resource_name, T max, T actual, const char *file, int line) noexcept;
 
-    virtual ~ResourceAllocationError() throw();
+    virtual ~ResourceAllocationError() noexcept;
 };
 
 /**
@@ -314,7 +314,7 @@ class InputException : public PsiException {
     * Template method for writing generic input exception message
     */
     template <class T>
-    void write_input_msg(std::string msg, std::string param_name, T val) throw();
+    void write_input_msg(std::string msg, std::string param_name, T val) noexcept;
 
    public:
     /**
@@ -325,7 +325,7 @@ class InputException : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    InputException(std::string msg, std::string param_name, int value, const char *file, int line) throw();
+    InputException(std::string msg, std::string param_name, int value, const char *file, int line) noexcept;
 
     /**
     * Constructor
@@ -335,7 +335,7 @@ class InputException : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    InputException(std::string msg, std::string param_name, double value, const char *file, int line) throw();
+    InputException(std::string msg, std::string param_name, double value, const char *file, int line) noexcept;
 
     /**
     * Constructor
@@ -345,7 +345,7 @@ class InputException : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    InputException(std::string msg, std::string param_name, std::string value, const char *file, int line) throw();
+    InputException(std::string msg, std::string param_name, std::string value, const char *file, int line) noexcept;
 
     /**
     * Constructor
@@ -354,7 +354,7 @@ class InputException : public PsiException {
     * @param file The file that threw the exception (use __FILE__ macro)
     * @param line The line number that threw the exception (use __LINE__ macro)
     */
-    InputException(std::string msg, std::string param_name, const char *file, int line) throw();
+    InputException(std::string msg, std::string param_name, const char *file, int line) noexcept;
 };
 
 }  // end namespace psi exception


### PR DESCRIPTION
## Description
Uses `clang-tidy` to find and fix instances where `noexcept` can be used instead of `throw()`. Fixes applied with:
```
cd <build-dir>/psi4-core-prefix/src/psi4-core-build
run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-noexcept' -fix
```
Based on #1312 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `clang-tidy` find and fix with `modernize-use-noexcept`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge


