### PR TITLE
extra findif freq file clean

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -165,6 +165,9 @@ def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, *
     geom_array = np.reshape(displacement["geometry"], (-1, 3))
     molecule.set_geometry(core.Matrix.from_array(geom_array))
 
+    # clean possibly necessary for n=1 if its irrep (unsorted in displacement list) different from initial G0 for freq
+    core.clean()
+
     # Perform the derivative calculation
     derivative, wfn = derivfunc(method, return_wfn=True, molecule=molecule, **kwargs)
     displacement["energy"] = core.get_variable('CURRENT ENERGY')

--- a/psi4/driver/qcdb/interface_gcp.py
+++ b/psi4/driver/qcdb/interface_gcp.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 import os
 import re
 import uuid
+import shutil
 import socket
 import subprocess
 
@@ -278,11 +279,12 @@ def run_gcp(self, func=None, dertype=None, verbose=False):  # dashlvl=None, dash
 #    if defmoved is True:
 #        os.rename(defaultfile + '_hide', defaultfile)
 
+    # clean up files and remove scratch directory
     os.chdir('..')
-#    try:
-#        shutil.rmtree(dftd3_tmpdir)
-#    except OSError as e:
-#        ValidationError('Unable to remove dftd3 temporary directory %s' % e)
+    try:
+        shutil.rmtree(gcp_tmpdir)
+    except OSError as err:
+        raise OSError('Unable to remove gcp temporary directory: {}'.format(gcp_tmpdir)) from err
     os.chdir(current_directory)
 
     # return -D & d(-D)/dx


### PR DESCRIPTION
## Description
Make tests run reliably and a bit cleaner.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] @JonathonMisiewicz, @amjames so the continuation of the `cc3` saga is that it continued flaky, usually running clean but sometimes throwing PSIO errors at first findif freq, sometimes throwing PSIO errors at second findif freq. Finally figured out that the G0 calc was leaving scratch files before findif launched and findif was only cleaning _after_ each displacement. Previously this was nearly always safe b/c G0 had full symmetry and first findif displacement was totally symmetric (bet we were never testing partial freq on a susceptible mol). But now findif displacements appear in random order, and if the first one up has a lower irrep, it doesn't like those totally symmetric leftovers, so PSIO error. There's any number of places one could put the `clean` -- I chose least obtrusive.
- [x] `gcp` calcs weren't deleting their directories in scratch, so made them.

## Checklist
- [ ] ~Tests added for any new features~
- [x] full tests less bench run

## Status
- [x] Ready for review
- [x] Ready for merge
