### PR TITLE
Fix 1288: ODC Compatible with Other OO Code

### DIFF
--- a/psi4/src/psi4/dcft/dcft_gradient_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_gradient_UHF.cc
@@ -1466,7 +1466,7 @@ double DCFTSolver::compute_response_coupling() {
     // zI_IJ = (IJ|KC) z_KC
     global_dpd_->file2_init(&zI, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "zI <O|O>");
     global_dpd_->file2_init(&z, PSIF_DCFT_DPD, 0, ID('O'), ID('V'), "z <O|V>");
-    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[O,V]"), ID("[O,O]"), ID("[O,V]"), 0,
+    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[O,V]"), ID("[O>=O]+"), ID("[O,V]"), 0,
                            "MO Ints (OO|OV)");
     global_dpd_->contract422(&I, &z, &zI, 0, 0, 1.0, 0.0);
     global_dpd_->buf4_close(&I);
@@ -1498,7 +1498,7 @@ double DCFTSolver::compute_response_coupling() {
     // zI_ij = (ij|kc) z_kc
     global_dpd_->file2_init(&zI, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "zI <o|o>");
     global_dpd_->file2_init(&z, PSIF_DCFT_DPD, 0, ID('o'), ID('v'), "z <o|v>");
-    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[o,v]"), ID("[o,o]"), ID("[o,v]"), 0,
+    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[o,v]"), ID("[o>=o]+"), ID("[o,v]"), 0,
                            "MO Ints (oo|ov)");
     global_dpd_->contract422(&I, &z, &zI, 0, 0, 1.0, 0.0);
     global_dpd_->buf4_close(&I);

--- a/psi4/src/psi4/dcft/dcft_integrals_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_integrals_UHF.cc
@@ -359,7 +359,7 @@ void DCFTSolver::sort_OOOV_integrals() {
 
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[O,O]"), ID("[V,O]"), ID("[O>=O]+"), 0,
                            "MO Ints (VO|OO)");
-    global_dpd_->buf4_sort(&I, PSIF_LIBTRANS_DPD, rsqp, ID("[O,O]"), ID("[O,V]"), "MO Ints (OO|OV)");
+    global_dpd_->buf4_sort(&I, PSIF_LIBTRANS_DPD, rsqp, ID("[O>=O]+"), ID("[O,V]"), "MO Ints (OO|OV)");
     global_dpd_->buf4_close(&I);
 
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[O,O]"), ID("[V,O]"), ID("[O,O]"), 0,
@@ -419,7 +419,7 @@ void DCFTSolver::sort_OOOV_integrals() {
 
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[v,o]"), ID("[o,o]"), ID("[v,o]"), ID("[o>=o]+"), 0,
                            "MO Ints (vo|oo)");
-    global_dpd_->buf4_sort(&I, PSIF_LIBTRANS_DPD, rsqp, ID("[o,o]"), ID("[o,v]"), "MO Ints (oo|ov)");
+    global_dpd_->buf4_sort(&I, PSIF_LIBTRANS_DPD, rsqp, ID("[o>=o]+"), ID("[o,v]"), "MO Ints (oo|ov)");
     global_dpd_->buf4_close(&I);
 
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[v,o]"), ID("[o,o]"), ID("[v,o]"), ID("[o,o]"), 0,

--- a/psi4/src/psi4/dcft/dcft_qc.cc
+++ b/psi4/src/psi4/dcft/dcft_qc.cc
@@ -1427,7 +1427,7 @@ void DCFTSolver::compute_sigma_vector_cum_orb() {
     // DI_IJ = (IJ|KC) D_KC
     global_dpd_->file2_init(&DI, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "DI <O|O>");
     global_dpd_->file2_init(&D2, PSIF_DCFT_DPD, 0, ID('O'), ID('V'), "D2 <O|V>");
-    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[O,V]"), ID("[O,O]"), ID("[O,V]"), 0,
+    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[O,V]"), ID("[O>=O]+"), ID("[O,V]"), 0,
                            "MO Ints (OO|OV)");
     global_dpd_->contract422(&I, &D2, &DI, 0, 0, 1.0, 0.0);
     global_dpd_->buf4_close(&I);
@@ -1459,7 +1459,7 @@ void DCFTSolver::compute_sigma_vector_cum_orb() {
     // DI_ij = (ij|kc) D_kc
     global_dpd_->file2_init(&DI, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "DI <o|o>");
     global_dpd_->file2_init(&D2, PSIF_DCFT_DPD, 0, ID('o'), ID('v'), "D2 <o|v>");
-    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[o,v]"), ID("[o,o]"), ID("[o,v]"), 0,
+    global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[o,v]"), ID("[o>=o]+"), ID("[o,v]"), 0,
                            "MO Ints (oo|ov)");
     global_dpd_->contract422(&I, &D2, &DI, 0, 0, 1.0, 0.0);
     global_dpd_->buf4_close(&I);


### PR DESCRIPTION
## Description
Fixes #1288. The trouble was that Bozkaya's code used libtrans to transform integrals, and those were written to disk in their antisymmetrized, redundancy-free form, as libtrans does. The DCT code gets different integrals from libtrans but then sorts those to get the same blocks as Bozkaya wrote earlier in the redundant form. Because the DCT-sorted integral block had antisymmetry redundancies, it was larger than the libtrans block that did not have those redundancies.

Fixed by changing the code to use a block without those redundancies.

I imagine this is of interest to @amjames and @ssh2.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixes 1288

## Checklist
- [x] DCFT tests run

## Status
- [x] Ready for review
- [x] Ready for merge
