### PR TITLE
Raise no-stability-check error early

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -429,6 +429,11 @@ def scf_finalize_energy(self):
     # Perform wavefunction stability analysis before doing
     # anything on a wavefunction that may not be truly converged.
     if core.get_option('SCF', 'STABILITY_ANALYSIS') != "NONE":
+
+        # Don't bother computing needed integrals if we can't do anything with them.
+        if self.functional().needs_xc():
+            raise ValidationError("Stability analysis not yet supported for XC functionals.")
+
         # We need the integral file, make sure it is written and
         # compute it if needed
         if core.get_option('SCF', 'REFERENCE') != "UHF":


### PR DESCRIPTION
Raise the error that we can't do stability analysis on DFT "wavefunctions" before we bother to compute the (potentially very expensive) integrals necessary for this. The same error message is getting raised C-side under the same condition. This commit just raises it sooner, because spending the better part of an an hour computing integrals for no reason is annoying.

## Checklist
- [x] No tests run in addition to quicktests, since this is so simple and mirroring a C-side operation

## Status
- [x] Ready for review
- [x] Ready for merge
