### PR TITLE
default compute_points

### DIFF
--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -201,7 +201,7 @@ void export_functional(py::module &m) {
         .def("set_ansatz", &PointFunctions::set_ansatz, "docstring")
         .def("set_pointers", matrix_set1(&PointFunctions::set_pointers), "docstring")
         .def("set_pointers", matrix_set2(&PointFunctions::set_pointers), "docstring")
-        .def("compute_points", &PointFunctions::compute_points, py::arg("force_compute") = true, "docstring")
+        .def("compute_points", &PointFunctions::compute_points, py::arg("block"), py::arg("force_compute") = true, "docstring")
         .def("point_values", &PointFunctions::point_values, "docstring")
         .def("orbital_values", &PointFunctions::orbital_values, "docstring");
 

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -201,7 +201,7 @@ void export_functional(py::module &m) {
         .def("set_ansatz", &PointFunctions::set_ansatz, "docstring")
         .def("set_pointers", matrix_set1(&PointFunctions::set_pointers), "docstring")
         .def("set_pointers", matrix_set2(&PointFunctions::set_pointers), "docstring")
-        .def("compute_points", &PointFunctions::compute_points, "docstring")
+        .def("compute_points", &PointFunctions::compute_points, py::arg("force_compute") = True, "docstring")
         .def("point_values", &PointFunctions::point_values, "docstring")
         .def("orbital_values", &PointFunctions::orbital_values, "docstring");
 

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -201,7 +201,7 @@ void export_functional(py::module &m) {
         .def("set_ansatz", &PointFunctions::set_ansatz, "docstring")
         .def("set_pointers", matrix_set1(&PointFunctions::set_pointers), "docstring")
         .def("set_pointers", matrix_set2(&PointFunctions::set_pointers), "docstring")
-        .def("compute_points", &PointFunctions::compute_points, py::arg("force_compute") = True, "docstring")
+        .def("compute_points", &PointFunctions::compute_points, py::arg("force_compute") = true, "docstring")
         .def("point_values", &PointFunctions::point_values, "docstring")
         .def("orbital_values", &PointFunctions::orbital_values, "docstring");
 


### PR DESCRIPTION
## Description
Add the C++ default to `PointFunctions::compute_points` so I don't have to try/except psi4numpy

## Status
- [x] Ready for review
- [x] Ready for merge
