### PR TITLE
Resolves configure issue in libqt wrt lapack

### DIFF
--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -28,13 +28,15 @@ if(WIN32)
   set(_has_dggsvd3 TRUE)
   set(_has_dggsvp3 TRUE)
 else()
-  include(CheckFortranFunctionExists)
-  set(CMAKE_REQUIRED_LIBRARIES tgt::lapack)
-  # Check whether DGGSVD3 is available
-  check_fortran_function_exists(DGGSVD3 _has_dggsvd3)
-  # Check whether DGGSVP3 is available
-  check_fortran_function_exists(DGGSVP3 _has_dggsvp3)
-  unset(CMAKE_REQUIRED_LIBRARIES)
+  if(Fortran_ENABLED)
+    include(CheckFortranFunctionExists)
+    set(CMAKE_REQUIRED_LIBRARIES tgt::lapk)
+    # Check whether DGGSVD3 is available
+    check_fortran_function_exists(DGGSVD3 _has_dggsvd3)
+    # Check whether DGGSVP3 is available
+    check_fortran_function_exists(DGGSVP3 _has_dggsvp3)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+  endif()
 endif()
 
 psi4_add_module(lib qt sources_list psio ciomr mints)


### PR DESCRIPTION
Wraps new lapack function tests in a Fortran_ENABLED block; and resolves OpenMP linking issues.

Ultimately, we'd want to change the detection from a Fortran function to a C function.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
