### PR TITLE
Make psi4 compatible with C++17

### DIFF
--- a/psi4/src/psi4/libdpd/split.cc
+++ b/psi4/src/psi4/libdpd/split.cc
@@ -42,13 +42,13 @@ namespace psi {
 
 // trim from start
 static inline std::string &dpd_ltrim(std::string &s) {
-    s.erase(s.begin(), find_if(s.begin(), s.end(), not1(std::ptr_fun<int, int>(isspace))));
+    s.erase(s.begin(), find_if(s.begin(), s.end(), [](int c) {return !std::isspace(c);}));
     return s;
 }
 
 // trim from end
 static inline std::string &dpd_rtrim(std::string &s) {
-    s.erase(find_if(s.rbegin(), s.rend(), not1(std::ptr_fun<int, int>(isspace))).base(), s.end());
+    s.erase(find_if(s.rbegin(), s.rend(), [](int c) {return !std::isspace(c);}).base(), s.end());
     return s;
 }
 

--- a/psi4/src/psi4/libdpd/split.cc
+++ b/psi4/src/psi4/libdpd/split.cc
@@ -31,6 +31,7 @@
     \brief String parsing code for orbital indices, taken from Justin Turney's AMBIT code.
 */
 
+#include <cctype>
 #include <algorithm>
 #include <iterator>
 #include <string>


### PR DESCRIPTION
## Description
Allow psi4 to be compiled with C++17. Default compilation still uses C++11.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Ready for C++17

## Checklist
- [x] All cc tests run

## Status
- [x] Ready for review
- [x] Ready for merge
