### PR TITLE
Fix bug with setting double options to integers

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -541,8 +541,8 @@ bool py_psi_set_local_option_int(std::string const& module, std::string const& k
     std::string nonconst_key = to_upper(key);
     Data& data = Process::environment.options[nonconst_key];
 
-    if (data.type() == "double" && specifies_convergence(nonconst_key)) {
-        double val = pow(10.0, -value);
+    if (data.type() == "double") {
+        double val = (specifies_convergence(nonconst_key)) ? pow(10.0, -value) : double(value);
         Process::environment.options.set_double(module, nonconst_key, val);
     } else if (data.type() == "boolean") {
         Process::environment.options.set_bool(module, nonconst_key, value ? true : false);

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -582,8 +582,8 @@ bool py_psi_set_global_option_int(std::string const& key, int value) {
     std::string nonconst_key = to_upper(key);
     Data& data = Process::environment.options[nonconst_key];
 
-    if (data.type() == "double" && specifies_convergence(nonconst_key)) {
-        double val = pow(10.0, -value);
+    if (data.type() == "double") {
+        double val = (specifies_convergence(nonconst_key)) ? pow(10.0, -value) : double(value);
         Process::environment.options.set_global_double(nonconst_key, val);
     } else if (data.type() == "boolean") {
         Process::environment.options.set_global_bool(nonconst_key, value ? true : false);


### PR DESCRIPTION
## Description
Fixes a bug where the following input file crashes:
```
molecule {
O
H 1 1 
H 1 1 2 104.5
}

set basis sto-3g

set scf {
    damping_percentage 20
}

energy('scf')
```

`damping_percentage` is defined as a _double_. Before this commit, Psi would naively set the relevant keyword to be the int the user gave it and then complain when it tried to read options later. It now knows to cast to double.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixes type conversion bug in options system

## Checklist
- [x] No tests run beyond Travis and that the input file up top. This PR doesn't need it.

## Status
- [x] Ready for review
- [x] Ready for merge
