### PR TITLE
Make failing "psi4 --test" to return non-zero status

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -189,8 +189,8 @@ if args['plugin_name']:
     sys.exit()
 
 if args["test"]:
-    psi4.test('smoke')
-    sys.exit()
+    retcode = psi4.test('smoke')
+    sys.exit(retcode)
 
 if not os.path.isfile(args["input"]):
     raise KeyError("The file %s does not exist." % args["input"])


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Make failing `psi4 --test` to return non-zero status

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
