### PR TITLE
CI for Windows on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,116 @@
+# Psi4 pipeline
+
+trigger:
+  - master
+
+jobs:
+
+  # Configure, build, install, and test job
+  - job: 'build'
+    pool:
+      vmImage: 'vs2015-win2012r2'
+    timeoutInMinutes: 90
+    steps:
+
+      # Install Chocolatey (https://chocolatey.org/install#install-with-powershellexe)
+      - powershell: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+          Write-Host "##vso[task.setvariable variable=PATH]$env:PATH"
+          choco --version
+        displayName: "Install Chocolatey"
+
+      # Install Miniconda
+      - script: |
+          choco install miniconda3 --yes
+          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library\bin;%PATH%
+          echo '##vso[task.setvariable variable=PATH]%PATH%'
+          set LIB=C:\tools\miniconda3\Library\lib;%LIB%
+          echo '##vso[task.setvariable variable=LIB]%LIB%'
+          conda --version
+        displayName: "Install Miniconda"
+
+      # Create conda enviroment
+      # Note: conda activate doesn't work here, because it creates a new shell!
+      - script: |
+          conda config --set always_yes yes
+          conda install --channel conda-forge ^
+                        cmake ^
+                        deepdiff ^
+                        intel-openmp=2018.0.3 ^
+                        mkl-devel=2018.0.3 ^
+                        mpmath ^
+                        networkx ^
+                        ninja ^
+                        numpy ^
+                        pint ^
+                        pybind11 ^
+                        pytest ^
+                        python=3.6
+          conda list
+        displayName: "Install conda packages"
+
+      # Install LLVM
+      # Note: LLVM distributed by conda is too old
+      - script: |
+          choco install llvm --yes
+          set PATH=C:\Program Files\LLVM\bin;%PATH%
+          echo '##vso[task.setvariable variable=PATH]%PATH%'
+          clang-cl --version
+        displayName: "Install LLVM"
+
+      # Configure
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          mkdir build & cd build
+          cmake -G Ninja ^
+                -DCMAKE_BUILD_TYPE=Debug ^
+                -DCMAKE_INSTALL_PREFIX=../install ^
+                -DCMAKE_C_COMPILER=clang-cl ^
+                -DCMAKE_CXX_COMPILER=clang-cl ^
+                -DENABLE_XHOST=OFF ^
+                -DMAX_AM_ERI=6 ^
+                $(Build.SourcesDirectory)
+        displayName: "Configure Psi4"
+        workingDirectory: $(Build.BinariesDirectory)
+
+      # Build
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          cmake --build . ^
+                --config Debug ^
+                -- -j %NUMBER_OF_PROCESSORS%
+        displayName: "Build Psi4"
+        workingDirectory: $(Build.BinariesDirectory)/build
+
+      # Install
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          cmake --build . ^
+                --config Debug ^
+                --target install ^
+                -- -j %NUMBER_OF_PROCESSORS%
+        displayName: "Install Psi4"
+        workingDirectory: $(Build.BinariesDirectory)/build
+
+      # Test (ctest)
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          ctest --build-config Debug ^
+                --exclude-regex "^(ci-property)$" ^
+                --label-regex quick ^
+                --output-on-failure ^
+                --parallel %NUMBER_OF_PROCESSORS%
+          ctest --build-config Debug ^
+                --tests-regex "^(ci-property)$" ^
+                --output-on-failure ^
+                --parallel %NUMBER_OF_PROCESSORS% & exit 0
+        displayName: "Test Psi4 (ctest)"
+        workingDirectory: $(Build.BinariesDirectory)/build
+
+      # Test (built-in)
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          python psi4 --test
+        displayName: "Test Psi4 (bullt-in)"
+        workingDirectory: $(Build.BinariesDirectory)/install/bin


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

This is intended as a replacement for *Appveyor*, which has 60 min limit. *Azure* allow to run up to 360 min!

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] CI for Windows on *Azure*

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
