### PR TITLE
Adds back LAPACK target to bin/lib modules

### DIFF
--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -57,6 +57,12 @@ macro(psi4_add_module binlib libname sources)
       VISIBILITY_INLINES_HIDDEN 1
     )
 
+  # This provides OpenMP flags and access to BLAS/LAPACK headers
+  target_link_libraries(${libname} 
+    PRIVATE 
+      tgt::lapack
+    )
+
   # library modules get their headers installed
   if(${binlib} MATCHES lib)
     install(


### PR DESCRIPTION
## Description
During the CMake cleanup the LAPACK target was removed from the bin/lib modules. This resulted in OpenMP flags not being passed to the compiler.  This PR adds the library target back.

## Status
- [x] Ready for review
- [x] Ready for merge
