### PR TITLE
makes relativistic basis visible for SO integrals

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -452,6 +452,9 @@ def scf_finalize_energy(self):
             #   so forcibly recomputing for now until stability revamp
             core.print_out("    SO Integrals not on disk. Computing...")
             mints = core.MintsHelper(self.basisset())
+            #next 2 lines fix a bug that prohibits relativistic stability analysis
+            if core.get_global_option('RELATIVISTIC') in ['X2C', 'DKH']:
+                mints.set_rel_basisset(self.get_basisset('BASIS_RELATIVISTIC'))
             mints.integrals()
             core.print_out("done.\n")
 


### PR DESCRIPTION
## Description
Fixes a bug that prohibits computing stability analysis for wfns with an X2C Hamiltonian.
Previously the relativistic basis was not set which made mints unhappy.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
