### PR TITLE
fixes incorrect CBS delta correction for fno-ccsd

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -833,7 +833,7 @@ def return_energy_components():
     VARH['fno-ccsd(t)'] = {
                              'hf': 'HF TOTAL ENERGY',
                             'mp2': 'MP2 TOTAL ENERGY',
-                           'ccsd': 'CCSD TOTAL ENERGY',
+                       'fno-ccsd': 'CCSD TOTAL ENERGY',
                     'fno-ccsd(t)': 'CCSD(T) TOTAL ENERGY'}
     VARH['qcisd(t)'] = {
                              'hf': 'HF TOTAL ENERGY',


### PR DESCRIPTION
## Description
Fixes an error involving a FNO-(T) delta correction for CBS as in `energy('fno-ccsd/cc-pVDZ+D:fno-ccsd(t)/cc-pVDZ'`


## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
