### PR TITLE
CoordValue/CoordEntry Cleanup and 1325 Fix

### DIFF
--- a/psi4/driver/qcdb/libmintscoordentry.py
+++ b/psi4/driver/qcdb/libmintscoordentry.py
@@ -52,10 +52,8 @@ class CoordValue(object):
     """
 
     def __init__(self, fixed=False, computed=False):
-        # Fixed coordinate?
+        # Fixed coordinate? For a fixed value, the reset method does nothing.
         self.PYfixed = fixed
-        # Whether the current value is up to date or not
-        self.computed = computed
 
     def set_fixed(self, fixed):
         """Set whether the coordinate value is fixed or not"""
@@ -64,10 +62,6 @@ class CoordValue(object):
     def fixed(self):
         """Get whether the coordinate value is fixed or not"""
         return self.PYfixed
-
-    def invalidate(self):
-        """Flag the current value as outdated"""
-        self.computed = False
 
     def everything(self):
         print('\nCoordValue\n  Fixed = %s\n  Computed = %s\n\n' % (self.PYfixed, self.computed))
@@ -103,8 +97,8 @@ class NumberValue(CoordValue):
         return "%*.*f" % (precision + 5, precision, self.compute())
 
     def everything(self):
-        print('\nNumberValue\n  Fixed = %s\n  Computed = %s\n  Type = %s\n  Value = %f\n  FValue = %s\n\n' %
-            (self.PYfixed, self.computed, self.type(), self.value, self.variable_to_string(4)))
+        print('\nNumberValue\n  Fixed = %s\n  Type = %s\n  Value = %f\n  FValue = %s\n\n' %
+            (self.PYfixed, self.type(), self.value, self.variable_to_string(4)))
 
 
 class VariableValue(CoordValue):
@@ -163,8 +157,8 @@ class VariableValue(CoordValue):
             return self.PYname
 
     def everything(self):
-        print('\nVariableValue\n  Fixed = %s\n  Computed = %s\n  Type = %s\n  Value = %f\n  FValue = %s\n  Name = %s\n  Negated = %s\n  Map = %s\n\n' %
-            (self.PYfixed, self.computed, self.type(), self.compute(), self.variable_to_string(4), self.name(), self.negated(), self.geometryVariables))
+        print('\nVariableValue\n  Fixed = %s\n  Type = %s\n  Value = %f\n  FValue = %s\n  Name = %s\n  Negated = %s\n  Map = %s\n\n' %
+            (self.PYfixed, self.type(), self.compute(), self.variable_to_string(4), self.name(), self.negated(), self.geometryVariables))
 
 
 class CoordEntry(object):
@@ -371,6 +365,10 @@ class CoordEntry(object):
         """Returns shells sets to atom map"""
         return self.PYshells
 
+    def invalidate(self):
+        """Flags the current coordinates as being outdated."""
+        self.computed = False
+
     def everything(self):
         print('\nCoordEntry\n  Entry Number = %d\n  Computed = %s\n  Z = %d\n  Charge = %f\n  Mass = %f\n  Symbol = %s\n  Label = %s\n  A = %d\n  Ghosted = %s\n  Coordinates = %s\n  Basissets = %s\n\n  Shells = %s\n\n' %
             (self.entry_number(), self.is_computed(), self.Z(), self.charge(),
@@ -441,13 +439,6 @@ class CartesianEntry(CoordEntry):
         return " %17s %17s %17s\n" % (xstr, ystr, zstr)
         # should go to outfile
 
-    def invalidate(self):
-        """Flags the current coordinates as being outdated."""
-        self.computed = False
-        self.x.invalidate()
-        self.y.invalidate()
-        self.z.invalidate()
-
     def clone(self):
         """Returns new, independent CartesianEntry object"""
         return copy.deepcopy(self)
@@ -473,16 +464,6 @@ class ZMatrixEntry(CoordEntry):
         self.aval = aval
         self.dto = dto
         self.dval = dval
-
-    def invalidate(self):
-        """Flags the current coordinates as being outdated"""
-        self.computed = False
-        if self.rval != 0:
-            self.rval.invalidate()
-        if self.aval != 0:
-            self.aval.invalidate()
-        if self.dval != 0:
-            self.dval.invalidate()
 
     def print_in_input_format(self):
         """Prints the updated geometry, in the format provided by the user"""

--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -1046,6 +1046,7 @@ class LibmintsMolecule():
         else:
             raise ValidationError("Molecule::add_atom: Adding atom on top of an existing atom.")
 
+    # For use with atoms defined with ZMAT or variable values, i.e., not Cartesian and NumberValue
     def add_unsettled_atom(self, Z, anchor, symbol, mass=0.0, charge=0.0, label='', A=-1):
         self.lock_frame = False
         numEntries = len(anchor)

--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -52,15 +52,11 @@ class CoordValue {
    protected:
     /// Fixed coordinate?
     bool fixed_;
-    /// Whether the current value is up to date or not
-    bool computed_;
 
    public:
-    CoordValue() : fixed_(false), computed_(false) {}
+    CoordValue() : fixed_(false) {}
 
-    CoordValue(bool fixed) : fixed_(fixed), computed_(false) {}
-
-    CoordValue(bool fixed, bool computed) : fixed_(fixed), computed_(computed) {}
+    CoordValue(bool fixed) : fixed_(fixed) {}
 
     virtual ~CoordValue() {}
 
@@ -79,8 +75,6 @@ class CoordValue {
     virtual void set(double val) = 0;
     /// The type of variable representation
     virtual CoordValueType type() = 0;
-    /// Flag the current value as outdated
-    void invalidate() { computed_ = false; }
     /// Clones the current object, using a user-provided variable array, for deep copying
     virtual std::shared_ptr<CoordValue> clone(std::map<std::string, double>& map) = 0;
 };
@@ -92,7 +86,7 @@ class NumberValue : public CoordValue {
     double value_;
 
    public:
-    NumberValue(double value, bool fixed = false) : CoordValue(fixed, true), value_(value) {}
+    NumberValue(double value, bool fixed = false) : CoordValue(fixed), value_(value) {}
     double compute() override { return value_; }
     void set(double val) override {
         if (!fixed_) value_ = val;
@@ -115,7 +109,7 @@ class VariableValue : public CoordValue {
    public:
     VariableValue(const std::string name, std::map<std::string, double>& geometryVariables, bool negate = false,
                   bool fixed = false)
-        : CoordValue(fixed, true), name_(name), geometryVariables_(geometryVariables), negate_(negate) {}
+        : CoordValue(fixed), name_(name), geometryVariables_(geometryVariables), negate_(negate) {}
     double compute() override;
     bool negated() const { return negate_; }
     const std::string& name() const { return name_; }
@@ -210,7 +204,9 @@ class CoordEntry {
     /// Whether this atom has the same mass and basis sets as another atom
     bool is_equivalent_to(const std::shared_ptr<CoordEntry>& other) const;
     /// Flags the current coordinates as being outdated.
-    virtual void invalidate() = 0;
+    void invalidate() {
+        computed_ = false;
+    }
     /// Clones the current object, using a user-provided variable array, for deep copying
     virtual std::shared_ptr<CoordEntry> clone(std::vector<std::shared_ptr<CoordEntry> >& atoms,
                                               std::map<std::string, double>& map) = 0;
@@ -290,12 +286,6 @@ class CartesianEntry : public CoordEntry {
     CoordEntryType type() override { return CartesianCoord; }
     void print_in_input_format() override;
     std::string string_in_input_format() override;
-    void invalidate() override {
-        computed_ = false;
-        x_->invalidate();
-        y_->invalidate();
-        z_->invalidate();
-    }
     std::shared_ptr<CoordEntry> clone(std::vector<std::shared_ptr<CoordEntry> >& /*atoms*/,
                                       std::map<std::string, double>& map) override {
         std::shared_ptr<CoordEntry> temp =
@@ -332,12 +322,6 @@ class ZMatrixEntry : public CoordEntry {
                  std::shared_ptr<CoordValue> dval = std::shared_ptr<CoordValue>());
 
     ~ZMatrixEntry() override;
-    void invalidate() override {
-        computed_ = false;
-        if (rval_ != 0) rval_->invalidate();
-        if (aval_ != 0) aval_->invalidate();
-        if (dval_ != 0) dval_->invalidate();
-    }
     const Vector3& compute() override;
     void print_in_input_format() override;
     std::string string_in_input_format() override;

--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -291,6 +291,7 @@ class CartesianEntry : public CoordEntry {
         std::shared_ptr<CoordEntry> temp =
             std::make_shared<CartesianEntry>(entry_number_, Z_, charge_, mass_, symbol_, label_, A_, x_->clone(map),
                                              y_->clone(map), z_->clone(map), basissets_, shells_);
+        if (computed_) temp->compute(); // The constructor sets the coords we want, so this just sets computed_.
         return temp;
     }
 };

--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -43,9 +43,6 @@ PRAGMA_WARNING_POP
 
 namespace psi {
 
-/// masks for classes of fragments to be acted upon by molecule functions
-/// The next fragment type should be 4, and ALL should be 7.
-
 /**
  * An abstract class to handle storage of Cartesian coordinate values, which
  * may be defined in terms of other variables through this mechanism, greatly
@@ -134,10 +131,6 @@ class VariableValue : public CoordValue {
 };
 
 class CoordEntry {
-    template <class Archive>
-    friend void save(Archive& ar, const psi::Vector3& t, size_t /*version*/);
-    template <class Archive>
-    friend void load(Archive& ar, psi::Vector3& t, size_t /*version*/);
 
    protected:
     int entry_number_;

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -335,6 +335,10 @@ void Molecule::add_unsettled_atom(double Z, std::vector<std::string> anchor, std
     } else {
         throw PSIEXCEPTION("Illegal geometry specification (neither Cartesian nor Z-Matrix)");
     }
+
+    if ((label != "X") && (label != "x")) {
+        atoms_.push_back(full_atoms_.back());
+    }
 }
 
 double Molecule::mass(int atom) const {

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -217,6 +217,8 @@ class PSI_API Molecule {
      * \param charge charge to use if non standard
      * \param lbl extended atomic symbol
      * \param A mass number
+     *
+     * add_atom is for Cartesians with NumberValue coordinates. Use add_unsettled_atom otherwise (ZMAT, VariableValue).
      */
     void add_atom(double Z, double x, double y, double z, std::string sym = "", double mass = 0.0, double charge = 0.0,
                   std::string lbl = "", int A = -1);


### PR DESCRIPTION
## Description
My debugging efforts indicate the problem with #1325 is that when attempting to clone a molecule with an atom with ZMAT and Cartesian coordinates, when that ZMatrixEntry atom is cloned, its `rto_`, `ato_`, `dto_` CoordEntries are Cartesian. This somehow leads to the parent ZMatrixEntry having `computed_` true, but not for `rto_` and friends. So, we somehow have a bug in molecule creation.

To avoid creating new bugs, I want to understand exactly what is going on before trying to implement a fix. Unfortunately, this part of the code is not in great shape. I'll hopefully include a fix for the bug in here, but in the meantime, I'm submitting the code cleanup I'm doing as I try to follow this part of the code. We do not want `libmints` changes to escape a thorough vetting process.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Cleanup `CoordValue` and `CoordEntry`
- [x] Document `add_atom` and `add_unsettled_atom`
- [x] Actually fix #1325 

## Checklist
- [ ] Is it worth adding a test for this bugfix? This should be a quick one to test, but it looks like we're seeing timeouts due to test overload again.
- [x] Tested this fixes #1325 
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests) obsessively - everything in ctest except the dft benchmarks and python-vibanalysis

## Status
- [x] Ready for review
- [ ] Ready for merge. (After the question of whether to add a test.)
