### PR TITLE
mild clang-format for dfocc and dmrg

### DIFF
--- a/psi4/src/psi4/dfocc/ccsd_triples.cc
+++ b/psi4/src/psi4/dfocc/ccsd_triples.cc
@@ -1736,8 +1736,8 @@ void DFOCC::ccsd_canonic_triples_grad2() {
     Miabd = SharedTensor2d(new Tensor2d("M[I] <AB|D>", navirA * navirA, navirA));
 
     // progress counter
-    std::time_t stop,start = std::time(nullptr);
-    long int ind =0;
+    std::time_t stop, start = std::time(nullptr);
+    long int ind = 0;
     double step_print = 10.0;
     double next_print = step_print;
 
@@ -2104,14 +2104,14 @@ void DFOCC::ccsd_canonic_triples_grad2() {
                                 (j * naoccA * navirA * navirA) + (k * navirA * navirA), 1.0, 1.0);
 
                 // progress counter
-                ind+=1;
-                double percent = static_cast<double>(ind)/static_cast<double>(Nijk)*100.0;
-                if (percent >= next_print){
+                ind += 1;
+                double percent = static_cast<double>(ind) / static_cast<double>(Nijk) * 100.0;
+                if (percent >= next_print) {
                     stop = std::time(nullptr);
                     next_print += step_print;
-                    outfile->Printf("              %5.1lf  %8d s\n",percent,static_cast<int>(stop)-static_cast<int>(start));
+                    outfile->Printf("              %5.1lf  %8d s\n", percent,
+                                    static_cast<int>(stop) - static_cast<int>(start));
                 }
-
 
             }  // k
         }      // j

--- a/psi4/src/psi4/dfocc/ccsdl_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccsdl_iterations.cc
@@ -159,8 +159,7 @@ void DFOCC::ccsdl_iterations() {
         }
 
         // print
-        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  %12.2e \n", itr_occ, EcorrL, DE, rms_t2,
-                        rms_t1);
+        outfile->Printf(" %3d      %13.10f         %13.10f     %12.2e  %12.2e \n", itr_occ, EcorrL, DE, rms_t2, rms_t1);
 
         if (itr_occ >= cc_maxiter) {
             conver = 0;  // means iterations were NOT converged

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -65,7 +65,8 @@ void DFOCC::get_moinfo() {
         natom = molecule_->natom();
 
         // Read in nuclear repulsion energy
-        Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(reference_wavefunction_->get_dipole_field_strength());
+        Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
+            reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
         Escf = reference_wavefunction_->reference_energy();
@@ -170,7 +171,8 @@ void DFOCC::get_moinfo() {
         natom = molecule_->natom();
 
         // Read in nuclear repulsion energy
-        Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(reference_wavefunction_->get_dipole_field_strength());
+        Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
+            reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
         Escf = reference_wavefunction_->reference_energy();
@@ -340,28 +342,28 @@ void DFOCC::get_moinfo() {
     /************************** Create all required matrice *************************************/
     /********************************************************************************************/
     // Build Hso
-    //Hso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis One-electron Ints", nso_, nso_));
-    //Tso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Kinetic Energy Ints", nso_, nso_));
-    //Vso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Potential Energy Ints", nso_, nso_));
-    //Sso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Overlap Ints", nso_, nso_));
-    //Hso_->zero();
-    //Tso_->zero();
-    //Vso_->zero();
-    //Sso_->zero();
+    // Hso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis One-electron Ints", nso_, nso_));
+    // Tso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Kinetic Energy Ints", nso_, nso_));
+    // Vso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Potential Energy Ints", nso_, nso_));
+    // Sso_ = std::shared_ptr<Matrix>(new Matrix("SO-basis Overlap Ints", nso_, nso_));
+    // Hso_->zero();
+    // Tso_->zero();
+    // Vso_->zero();
+    // Sso_->zero();
 
     //// Read SO-basis one-electron integrals
-    //double *so_ints = init_array(ntri_so);
-    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_T, so_ints, ntri_so, 0, 0, "outfile");
-    //Tso_->set(so_ints);
-    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_V, so_ints, ntri_so, 0, 0, "outfile");
-    //Vso_->set(so_ints);
-    //IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_S, so_ints, ntri_so, 0, 0, "outfile");
-    //Sso_->set(so_ints);
-    //free(so_ints);
-    //Hso_->copy(Tso_);
-    //Hso_->add(Vso_);
-    //Tso_.reset();
-    //Vso_.reset();
+    // double *so_ints = init_array(ntri_so);
+    // IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_T, so_ints, ntri_so, 0, 0, "outfile");
+    // Tso_->set(so_ints);
+    // IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_V, so_ints, ntri_so, 0, 0, "outfile");
+    // Vso_->set(so_ints);
+    // IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_S, so_ints, ntri_so, 0, 0, "outfile");
+    // Sso_->set(so_ints);
+    // free(so_ints);
+    // Hso_->copy(Tso_);
+    // Hso_->add(Vso_);
+    // Tso_.reset();
+    // Vso_.reset();
     // CDS: Migrate these from disk reads to grabbing off Wavefunction
     Hso = SharedTensor2d(new Tensor2d("SO-basis One-electron Ints", nso_, nso_));
     Hso->set(H_);

--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -25,6 +25,8 @@
  *
  * @END LICENSE
  */
+
+// clang-format off
 #ifdef USING_CheMPS2
 
 //#include <libplugin/plugin.h>
@@ -1141,3 +1143,4 @@ SharedWavefunction dmrg(SharedWavefunction wfn, Options& options)
 
 }} // End Namespaces
 #endif
+// clang-format on


### PR DESCRIPTION
## Description
Part of #1144. DFOCC was already formatted in #797, so there's very few changes. DMRG we want to avoid formatting so can easily diff with the plugin in the CheMPS2 repo.

## Status
- [x] Ready for review
- [x] Ready for merge
