### PR TITLE
Moves to C++14 and fixes a SAPT memory bug

### DIFF
--- a/.scripts/miniconda.sh
+++ b/.scripts/miniconda.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "-- Installing latest Miniconda"
+if [ -d "$HOME/Deps/miniconda/bin" ]; then
+    echo "-- Miniconda latest version FOUND in cache"
+else
+    cd "$HOME"/Downloads
+    echo "-- Miniconda latest version NOT FOUND in cache"
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
+    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > miniconda.sh
+    fi
+    # Travis creates the cached directories for us.
+    # This is problematic when wanting to install Anaconda for the first time...
+    rm -rf "$HOME"/Deps/miniconda
+    bash miniconda.sh -b -p "$HOME"/Deps/miniconda > /dev/null 2>&1
+    touch "$HOME"/Deps/miniconda/conda-meta/pinned
+    PATH=$HOME/Deps/miniconda/bin${PATH:+:$PATH}
+    hash -r
+    conda config --set show_channel_urls True > /dev/null 2>&1
+    conda config --set always_yes yes > /dev/null 2>&1
+    conda config --set changeps1 no > /dev/null 2>&1
+    conda update --all --yes > /dev/null 2>&1
+    conda clean -tipy > /dev/null 2>&1
+    conda info -a
+    cd "$TRAVIS_BUILD_DIR"
+    rm -f "$HOME"/Downloads/miniconda.sh
+fi
+echo "-- Done with latest Miniconda"

--- a/.scripts/miniconda.sh
+++ b/.scripts/miniconda.sh
@@ -1,32 +1,47 @@
-#!/usr/bin/env bash
-
 set -eu -o pipefail
 
+# Temporarily change directory to $HOME to install software
+pushd .
+cd "$HOME"
+
+# Install Miniconda
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # Make OSX md5 mimic md5sum from linux, alias does not work
+    md5sum () {
+        command md5 -r "$@"
+    }
+    MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
+else
+    MINICONDA=Miniconda3-latest-Linux-x86_64.sh
+fi
+MINICONDA_HOME=$HOME/miniconda
+
 echo "-- Installing latest Miniconda"
-if [ -d "$HOME/Deps/miniconda/bin" ]; then
+if [ -d "$MINICONDA_HOME/bin" ]; then
     echo "-- Miniconda latest version FOUND in cache"
 else
-    cd "$HOME"/Downloads
+    MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
     echo "-- Miniconda latest version NOT FOUND in cache"
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > miniconda.sh
+    wget -q https://repo.continuum.io/miniconda/$MINICONDA
+    if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+        echo "Miniconda MD5 mismatch"
+        exit 1
     fi
     # Travis creates the cached directories for us.
     # This is problematic when wanting to install Anaconda for the first time...
-    rm -rf "$HOME"/Deps/miniconda
-    bash miniconda.sh -b -p "$HOME"/Deps/miniconda > /dev/null 2>&1
-    touch "$HOME"/Deps/miniconda/conda-meta/pinned
-    PATH=$HOME/Deps/miniconda/bin${PATH:+:$PATH}
-    hash -r
-    conda config --set show_channel_urls True > /dev/null 2>&1
-    conda config --set always_yes yes > /dev/null 2>&1
-    conda config --set changeps1 no > /dev/null 2>&1
-    conda update --all --yes > /dev/null 2>&1
-    conda clean -tipy > /dev/null 2>&1
-    conda info -a
-    cd "$TRAVIS_BUILD_DIR"
-    rm -f "$HOME"/Downloads/miniconda.sh
+    rm -rf "$MINICONDA_HOME"
+    bash $MINICONDA -b -p "$MINICONDA_HOME"
+
+    # Configure miniconda
+    export PIP_ARGS="-U"
+    export PATH=$MINICONDA_HOME/bin:$PATH
+
+    conda config --set always_yes yes --set changeps1 no
+    conda update --q conda
+
+    rm -f $MINICONDA
 fi
 echo "-- Done with latest Miniconda"
+
+# Restore original directory
+popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
+dist: xenial
 language: cpp
 sudo: false
+python: 3.6.5
+cache:
+  timeout: 1000
+  directories:
+    - $HOME/Deps/miniconda
+
+env:
+  global:
+    - CTEST_OUTPUT_ON_FAILURE=1
+
 matrix:
   #allow_failures:
   #  - compiler: clang
@@ -9,8 +20,6 @@ matrix:
   #      - C_COMPILER='clang-3.9'
   #      - Fortran_COMPILER='gfortran'
   #      - BUILD_TYPE='release'
-  #      - NAME='clang'
-  #      - VERSION='3.9'
 
   include:
 
@@ -18,23 +27,17 @@ matrix:
     compiler: clang
     addons: &1
       apt:
-        sources:
-        - llvm-toolchain-precise-3.6
-        - ubuntu-toolchain-r-test
         packages:
         - liblapack-dev
         - clang-3.6
         - libhdf5-serial-dev
         - gfortran
-        - g++-4.9
     env:
       - CXX_COMPILER='clang++-3.6'
       - PYTHON_VER='3.6'
       - C_COMPILER='clang-3.6'
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
-      - NAME='clang'
-      - VERSION='3.6'
 
   #- os: linux
   #  compiler: clang
@@ -54,32 +57,22 @@ matrix:
   #    - C_COMPILER='clang-3.9'
   #    - Fortran_COMPILER='gfortran'
   #    - BUILD_TYPE='release'
-  #    - NAME='clang'
-  #    - VERSION='3.9'
 
   - os: linux
     compiler: gcc
     addons: &3
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
         - python-numpy
-        - cmake
-        - cmake-data
         - liblapack-dev
         - libhdf5-serial-dev
-        - g++-4.9
-        - gcc-4.9
-        - gfortran-4.9
+        - gfortran
     env:
-      - CXX_COMPILER='g++-4.9'
+      - CXX_COMPILER='g++'
       - PYTHON_VER='3.7'
-      - C_COMPILER='gcc-4.9'
-      - Fortran_COMPILER='gfortran-4.9'
+      - C_COMPILER='gcc'
+      - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
-      - NAME='gcc'
-      - VERSION='4.9'
 
   - os: linux
     compiler: gcc
@@ -89,8 +82,6 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - python-numpy
-        - cmake
-        - cmake-data
         - libhdf5-serial-dev
         - liblapack-dev
         - g++-6
@@ -102,8 +93,6 @@ matrix:
       - C_COMPILER='gcc-6'
       - Fortran_COMPILER='gfortran-6'
       - BUILD_TYPE='release'
-      - NAME='gcc'
-      - VERSION=6
 
 #  - os: linux
 #    compiler: gcc
@@ -126,26 +115,22 @@ matrix:
 #      - C_COMPILER='gcc-6'
 #      - Fortran_COMPILER='gfortran-6'
 #      - BUILD_TYPE='release'
-#      - NAME='gcc'
-#      - VERSION=6
 
 before_install:
   - uname -a
   - free -m
   - df -h
   - ulimit -a
+  - mkdir -p $HOME/Downloads $HOME/Deps
+
 install:
-- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
-- source activate p4env
-- conda install dftd3 gcp resp pylibefp pybind11=2.2.3 -c psi4/label/dev  # snsmp2
-- conda list
+  - ./.scripts/miniconda.sh
+  - export PATH="$HOME/Deps/miniconda/bin:$PATH"
+  - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
+  - source activate p4env
+  - conda install dftd3 gcp resp pylibefp pybind11=2.2.3 -c psi4/label/dev # snsmp2
+  - conda list
+
 before_script:
 - python -V
 - python -c 'import numpy; print(numpy.version.version)'
@@ -153,7 +138,6 @@ before_script:
 - export CXX=${CXX_COMPILER}
 - export CC=${C_COMPILER}
 - export FC=${Fortran_COMPILER}
-- export CTEST_OUTPUT_ON_FAILURE=1
 - ${CXX_COMPILER} --version
 - ${Fortran_COMPILER} --version
 - ${C_COMPILER} --version
@@ -167,7 +151,7 @@ before_script:
     -DCMAKE_C_COMPILER=${C_COMPILER}
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
-    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
+    -DPYTHON_EXECUTABLE="${HOME}/Deps/miniconda/envs/p4env/bin/python"
     -DENABLE_CheMPS2=OFF
     -DENABLE_dkh=ON
     -DENABLE_libefp=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ before_install:
 
 install:
   - ./.scripts/miniconda.sh
+  - export PATH="$HOME/miniconda/bin:$PATH"
   - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
   - source activate p4env
   - conda install dftd3 gcp resp pylibefp pybind11=2.2.3 -c psi4/label/dev # snsmp2

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ before_script:
     -DCMAKE_C_COMPILER=${C_COMPILER}
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
     -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
-    -DPYTHON_EXECUTABLE="${HOME}/Deps/miniconda/envs/p4env/bin/python"
+    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
     -DENABLE_CheMPS2=OFF
     -DENABLE_dkh=ON
     -DENABLE_libefp=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: 3.6.5
 cache:
   timeout: 1000
   directories:
-    - $HOME/Deps/miniconda
+    - $HOME/miniconda
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,7 @@ script:
 - PYTHONPATH=stage/lib/ pytest -v -rws --durations=5 stage/lib/psi4/tests/
 
 after_success:
+  - source deactivate
   - conda remove --name p4env --all
 
 # safelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,11 +121,10 @@ before_install:
   - free -m
   - df -h
   - ulimit -a
-  - mkdir -p $HOME/Downloads $HOME/Deps
+  - mkdir -p $HOME/miniconda
 
 install:
   - ./.scripts/miniconda.sh
-  - export PATH="$HOME/Deps/miniconda/bin:$PATH"
   - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
   - source activate p4env
   - conda install dftd3 gcp resp pylibefp pybind11=2.2.3 -c psi4/label/dev # snsmp2

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,10 @@ before_install:
 install:
   - ./.scripts/miniconda.sh
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
+  - >
+    if [[ ! "$(conda env list)" =~ "p4env" ]]; then
+      conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
+    fi
   - source activate p4env
   - conda install dftd3 gcp resp pylibefp pybind11=2.2.3 -c psi4/label/dev # snsmp2
   - conda list
@@ -170,10 +173,6 @@ script:
 - python ../.scripts/travis_run_test.py
 - python ../.scripts/travis_print_failing.py
 - PYTHONPATH=stage/lib/ pytest -v -rws --durations=5 stage/lib/psi4/tests/
-
-after_success:
-  - source deactivate
-  - conda remove --name p4env --all
 
 # safelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,9 @@ script:
 - python ../.scripts/travis_print_failing.py
 - PYTHONPATH=stage/lib/ pytest -v -rws --durations=5 stage/lib/psi4/tests/
 
+after_success:
+  - conda remove --name p4env --all
+
 # safelist
 branches:
   only:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed
 option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed" /)
 option_with_default(ENABLE_GENERIC "Enables mostly static linking of language libraries for shared library" OFF)
 option_with_default(CMAKE_INSTALL_MESSAGE "Specify verbosity of installation messages" LAZY)
-option_with_default(psi4_CXX_STANDARD "Specify C++ standard for core Psi4" 11)
+option_with_default(psi4_CXX_STANDARD "Specify C++ standard for core Psi4" 14)
 option_with_default(SIMINT_VECTOR "Vectorization type to use for simint (scalar sse avx avxfma micavx512)" avx)
 option_with_default(SPHINX_THEME "Theme for Sphinx documentation and extensions" sphinx_psi_theme)
 

--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -1,5 +1,7 @@
-# We require C++14 support from the compiler and standard library.
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)  # support IN_LISTS
 
+# We require C++14 support from the compiler and standard library.
 list(APPEND _allowed_cxx_standards 14 17)
 if(NOT psi4_CXX_STANDARD IN_LIST _allowed_cxx_standards)
   message(FATAL_ERROR "Psi4 requires C++14 at least")
@@ -68,3 +70,5 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
 else()
     message(WARNING "Please add a check in custom_cxxstandard.cmake for ${CMAKE_CXX_COMPILER_ID}.")
 endif()
+
+cmake_policy(POP)

--- a/cmake/custom_cxxstandard.cmake
+++ b/cmake/custom_cxxstandard.cmake
@@ -1,8 +1,13 @@
-# We require C++11 support from the compiler and standard library.
+# We require C++14 support from the compiler and standard library.
+
+list(APPEND _allowed_cxx_standards 14 17)
+if(NOT psi4_CXX_STANDARD IN_LIST _allowed_cxx_standards)
+  message(FATAL_ERROR "Psi4 requires C++14 at least")
+endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-        message(FATAL_ERROR "GCC version must be at least 4.9!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+        message(FATAL_ERROR "GCC version must be at least 5.0!")
     endif()
 
 elseif (CMAKE_CXX_COMPILER_ID MATCHES Intel)

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -46,12 +46,9 @@ endif()
 
 #  <<  Pybind11 & Python  >>
 if(MSVC)
-    # As for MSVC 14.0, it is not possible to set anything bellow C++14, so just use defaults
-    set(PYBIND11_CPP_STANDARD "/std:c++14")
-    # FIXME Uncomment when we switch to C++14, since it will work also when selecting C++17
-    #set(PYBIND11_CPP_STANDARD "/std:c++${CMAKE_CXX_STANDARD}")
+  set(PYBIND11_CPP_STANDARD "/std:c++${CMAKE_CXX_STANDARD}")
 else()
-    set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
+  set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
 endif()
 find_package(pybind11 2.2.3 CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")

--- a/psi4/psi4Config.cmake.in
+++ b/psi4/psi4Config.cmake.in
@@ -113,10 +113,10 @@ endif()
 #-----------------------------------------------------------------------------
 if(NOT TARGET ${PN}::core)
     include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
-    set(PYBIND11_CPP_STANDARD -std=c++@CMAKE_CXX_STANDARD@)
+    set(PYBIND11_CPP_STANDARD "-std=c++@CMAKE_CXX_STANDARD@")
     find_package(pybind11 CONFIG REQUIRED)
     if(NOT DEFINED ENABLE_OPENMP)
-        set(ENABLE_OPENMP "@ENABLE_OPENMP@")
+      set(ENABLE_OPENMP "@ENABLE_OPENMP@")
     endif()
     find_package(TargetLAPACK CONFIG REQUIRED)
     # No more ${PN} since defined in above find_package
@@ -126,18 +126,18 @@ function(add_psi4_plugin TARGET SOURCES)
     # remove ${TARGET} from ${ARGV} to use ${ARGV} as SOURCES
     list(REMOVE_AT ARGV 0)
 
-    # checks compiler (and gcc, if necessary) C++11 compliant
+    set(psi4_CXX_STANDARD @CMAKE_CXX_STANDARD@)
+    # checks compiler (and gcc, if necessary) C++14 compliant
     include(custom_cxxstandard)
 
     add_library(${TARGET} MODULE ${ARGV})
     target_link_libraries(${TARGET} PRIVATE psi4::core)
     target_link_libraries(${TARGET} PRIVATE tgt::MathOpenMP)
     set_target_properties(${TARGET} PROPERTIES PREFIX "")
-    if (APPLE)
-        set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    if(APPLE)
+      set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     endif()
 endfunction()
 
 # make detectable the various cmake modules exported by psi4
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-

--- a/psi4/src/psi4/libsapt_solver/amplitudes.cc
+++ b/psi4/src/psi4/libsapt_solver/amplitudes.cc
@@ -29,6 +29,11 @@
 #include "sapt2.h"
 #include "sapt2p.h"
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -1481,5 +1486,5 @@ void SAPT2p3::disp30_amps(int ampfile, const char *amplabel, int AAintfile, cons
 
     free_block(tARBS);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp20.cc
+++ b/psi4/src/psi4/libsapt_solver/disp20.cc
@@ -28,6 +28,10 @@
 
 #include "sapt0.h"
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -156,8 +160,9 @@ void SAPT2::disp20() {
                 for (int b = 0, bs = 0; b < aoccB_; b++) {
                     for (int s = 0; s < no_nvirB_; s++, bs++) {
                         double tval = vARBS[ar][bs];
-                        e_no_disp20_ += 4.0 * tval * tval / (no_evalsA_[a + foccA_] + no_evalsB_[b + foccB_] -
-                                                             no_evalsA_[r + noccA_] - no_evalsB_[s + noccB_]);
+                        e_no_disp20_ += 4.0 * tval * tval /
+                                        (no_evalsA_[a + foccA_] + no_evalsB_[b + foccB_] - no_evalsA_[r + noccA_] -
+                                         no_evalsB_[s + noccB_]);
                     }
                 }
             }
@@ -322,5 +327,5 @@ void SAPT0::disp20()
   psio_->close(PSIF_SAPT_TEMP,0);
 }
 */
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp21.cc
+++ b/psi4/src/psi4/libsapt_solver/disp21.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -91,5 +95,5 @@ double SAPT2p::disp21_2(int ampfile, const char *tlabel, const char *thetalabel,
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp22sdq.cc
+++ b/psi4/src/psi4/libsapt_solver/disp22sdq.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -505,5 +509,5 @@ double SAPT2p::disp220q_4(int ampfile, const char *tARARlabel, const char *tARBS
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp22t.cc
+++ b/psi4/src/psi4/libsapt_solver/disp22t.cc
@@ -29,6 +29,11 @@
 #include <ctime>
 
 #include "sapt2p.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -487,5 +492,5 @@ double SAPT2p::disp220tccd(int AAnum, const char *AA_label, int Rnum, const char
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp2ccd.cc
+++ b/psi4/src/psi4/libsapt_solver/disp2ccd.cc
@@ -27,9 +27,14 @@
  */
 
 #include "sapt2p.h"
+#include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsio/aiohandler.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 #include <cmath>
 
@@ -2155,5 +2160,5 @@ std::shared_ptr<Matrix> SAPT2p::mo2no(int ampfile, const char *VV_opdm, int nvir
 
     return U;
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/disp30.cc
+++ b/psi4/src/psi4/libsapt_solver/disp30.cc
@@ -27,6 +27,11 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -272,5 +277,5 @@ double SAPT2p3::disp30_2(int ampfile, const char *amplabel, int AAintfile, const
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/elst10.cc
+++ b/psi4/src/psi4/libsapt_solver/elst10.cc
@@ -28,6 +28,8 @@
 
 #include "sapt0.h"
 #include "sapt2.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -47,5 +49,5 @@ void SAPT2::elst10() {
         outfile->Printf("    Elst10,r            = %18.12lf [Eh]\n", e_elst10_);
     }
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/elst12.cc
+++ b/psi4/src/psi4/libsapt_solver/elst12.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -87,5 +91,5 @@ double SAPT2::elst120(double **wBAA, double **wBRR, double **CHFA, int ampfile, 
 
     return (e1 + e2 + e3);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/elst13.cc
+++ b/psi4/src/psi4/libsapt_solver/elst13.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -87,5 +91,5 @@ double SAPT2p3::elst130(double **wBAA, double **wBRR, double **CHFA, int ampfile
 
     return (e1 + e2 + e3);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch-disp20.cc
+++ b/psi4/src/psi4/libsapt_solver/exch-disp20.cc
@@ -28,6 +28,11 @@
 
 #include "sapt0.h"
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -1945,5 +1950,5 @@ void SAPT2::exch_disp20() {
 
     free_block(yARBS);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch-disp30.cc
+++ b/psi4/src/psi4/libsapt_solver/exch-disp30.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -494,5 +498,5 @@ double SAPT2p3::exch_disp30_22() {
 
     return (2.0 * energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch-ind-disp30.cc
+++ b/psi4/src/psi4/libsapt_solver/exch-ind-disp30.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -971,5 +975,5 @@ double SAPT2p3::exch_ind_disp30_12(double **sBS) {
 
     return (2.0 * energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch-ind20.cc
+++ b/psi4/src/psi4/libsapt_solver/exch-ind20.cc
@@ -28,6 +28,10 @@
 
 #include "sapt0.h"
 #include "sapt2.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -1139,5 +1143,5 @@ void SAPT2::exch_ind20rB_A() {
     free_block(uBS);
     free_block(vBS);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch-ind30.cc
+++ b/psi4/src/psi4/libsapt_solver/exch-ind30.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -310,5 +314,5 @@ double SAPT2p3::exch_ind30_3(double **sBS) {
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch10.cc
+++ b/psi4/src/psi4/libsapt_solver/exch10.cc
@@ -28,6 +28,9 @@
 
 #include "sapt0.h"
 #include "sapt2.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -756,5 +759,5 @@ void SAPT2::exch10() {
         outfile->Printf("    Exch10              = %18.12lf [Eh]\n", e_exch10_);
     }
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch11.cc
+++ b/psi4/src/psi4/libsapt_solver/exch11.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -188,5 +192,5 @@ double SAPT2::exch101(int ampfile, const char *thetalabel) {
 
     return (e1 + e2 + e3 + e4);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/exch12.cc
+++ b/psi4/src/psi4/libsapt_solver/exch12.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -1895,5 +1899,5 @@ double SAPT2::exch102_k11u_6() {
 
     return (-energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -481,5 +481,5 @@ SharedMatrix FDDS_Dispersion::form_unc_amplitude(std::string monomer, double ome
 
     return ret;
 }
-}
-}  // End namespace
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.h
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.h
@@ -107,7 +107,7 @@ class FDDS_Dispersion {
     SharedMatrix aux_overlap() { return aux_overlap_; }
 
 };  // End FDDS_Dispersion
-}
-}  // End namespace
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/ind-disp30.cc
+++ b/psi4/src/psi4/libsapt_solver/ind-disp30.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2p3.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -77,5 +81,5 @@ void SAPT2p3::ind_disp30() {
         outfile->Printf("    Ind-Disp30          = %18.12lf [Eh]\n", e_ind_disp30_);
     }
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/ind20.cc
+++ b/psi4/src/psi4/libsapt_solver/ind20.cc
@@ -32,7 +32,11 @@
 
 #include "psi4/pragma.h"
 
+#include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/aiohandler.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
 
 #include "sapt0.h"
 #include "sapt2.h"
@@ -1013,5 +1017,5 @@ void SAPT2::cphf_solver(double **tAR, double **wBAR, double *evals, int intfile,
     free(ipiv);
     free_block(Amat);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/ind22.cc
+++ b/psi4/src/psi4/libsapt_solver/ind22.cc
@@ -27,6 +27,10 @@
  */
 
 #include "sapt2.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace sapt {
@@ -455,5 +459,5 @@ double SAPT2::ind220_7(int AAfile, const char *AAlabel, const char *ARlabel, con
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/ind30.cc
+++ b/psi4/src/psi4/libsapt_solver/ind30.cc
@@ -28,6 +28,11 @@
 
 #include "sapt2p3.h"
 
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
 namespace psi {
 namespace sapt {
 
@@ -171,5 +176,5 @@ double SAPT2p3::ind30r_1(double **cAR, double **cBS, double **wBAA, double **wBR
 
     return (energy);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -27,6 +27,8 @@
  */
 
 #include "sapt.h"
+#include "psi4/lib3index/3index.h"
+#include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/factory.h"
@@ -34,6 +36,9 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/potential.h"
 #include "psi4/libmints/basisset.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/liboptions/liboptions.h"
+#include "psi4/libqt/qt.h"
 
 #include <cstring>
 
@@ -370,5 +375,5 @@ void CPHFDIIS::get_new_vector(double *t_vec) {
     free(Cvec);
     free_block(Bmat);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt.h
+++ b/psi4/src/psi4/libsapt_solver/sapt.h
@@ -33,7 +33,6 @@
 
 #ifdef _OPENMP
 #include <omp.h>
-#include "psi4/libpsi4util/process.h"
 #endif
 
 #ifdef USING_LAPACK_MKL
@@ -42,17 +41,11 @@
 
 #define INDEX(i, j) ((i >= j) ? (ioff_[i] + j) : (ioff_[j] + i))
 
-#include "psi4/libpsio/psio.h"
-#include "psi4/libpsio/psio.hpp"
-#include "psi4/libpsio/aiohandler.h"
-#include "psi4/libciomr/libciomr.h"
-#include "psi4/libqt/qt.h"
-#include "psi4/lib3index/3index.h"
 #include "psi4/libmints/wavefunction.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/libpsi4util/process.h"
 
 namespace psi {
+
+class SAPTDenominator;
 namespace sapt {
 
 class SAPT : public Wavefunction {
@@ -145,7 +138,7 @@ class CPHFDIIS {
     void store_vectors(double *, double *);
     void get_new_vector(double *);
 };
-}
-}
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -566,10 +566,10 @@ void SAPT0::df_integrals() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
-    const auto **buffer = new const double *[nthreads];
+    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
+        eri[i] = rifactory->eri();
         buffer[i] = eri[i]->buffer();
     }
 
@@ -864,7 +864,7 @@ void SAPT0::df_integrals() {
     free(PQ_stop);
     free(block_length);
 
-    for (int i = 0; i < nthreads; ++i) eri[i].reset();
+    delete[] buffer;
 
     psio_->close(PSIF_SAPT_TEMP, 0);
 }
@@ -1034,10 +1034,10 @@ void SAPT0::df_integrals_aio() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
-    const auto **buffer = new const double *[nthreads];
+    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
+        eri[i] = rifactory->eri();
         buffer[i] = eri[i]->buffer();
     }
 
@@ -1385,7 +1385,7 @@ void SAPT0::df_integrals_aio() {
     free(PQ_stop);
     free(block_length);
 
-    for (int i = 0; i < nthreads; ++i) eri[i].reset();
+    delete[] buffer;
 
     psio_->close(PSIF_SAPT_TEMP, 0);
 }
@@ -1532,10 +1532,10 @@ void SAPT0::oo_df_integrals() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
-    const auto **buffer = new const double *[nthreads];
+    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
+        eri[i] = rifactory->eri();
         buffer[i] = eri[i]->buffer();
     }
 
@@ -1788,6 +1788,8 @@ void SAPT0::oo_df_integrals() {
     }
 
     C_p_BB.done();
+
+    delete[] buffer;
 }
 }  // namespace sapt
 }  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -27,11 +27,18 @@
  */
 
 #include "sapt0.h"
+#include "psi4/lib3index/3index.h"
 #include "psi4/physconst.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/twobody.h"
 #include "psi4/libmints/integral.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -559,7 +566,7 @@ void SAPT0::df_integrals() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[ nthreads ];
+    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
     const auto **buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
@@ -1027,7 +1034,7 @@ void SAPT0::df_integrals_aio() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[ nthreads ];
+    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
     const auto **buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
@@ -1525,7 +1532,7 @@ void SAPT0::oo_df_integrals() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[ nthreads ];
+    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
     const auto **buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
@@ -1782,5 +1789,5 @@ void SAPT0::oo_df_integrals() {
 
     C_p_BB.done();
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -566,9 +566,11 @@ void SAPT0::df_integrals() {
 #endif
     int rank = 0;
 
-    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
+    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = rifactory->eri();
+        eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
+        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -612,7 +614,7 @@ void SAPT0::df_integrals() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
+                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
                                         }
                                     }
                                 }
@@ -627,7 +629,7 @@ void SAPT0::df_integrals() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
+                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
                                         }
                                     }
                                 }
@@ -1030,9 +1032,11 @@ void SAPT0::df_integrals_aio() {
 #endif
     int rank = 0;
 
-    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
+    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = rifactory->eri();
+        eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
+        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -1081,7 +1085,7 @@ void SAPT0::df_integrals_aio() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
                                         }
                                     }
                                 }
@@ -1096,7 +1100,7 @@ void SAPT0::df_integrals_aio() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
                                         }
                                     }
                                 }
@@ -1524,9 +1528,11 @@ void SAPT0::oo_df_integrals() {
 #endif
     int rank = 0;
 
-    auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
+    auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
+    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
-        eri[i] = rifactory->eri();
+        eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
+        buffer[i] = eri[i]->buffer();
     }
 
     int *MUNUtoMU = init_int_array(nshelltri);
@@ -1585,8 +1591,8 @@ void SAPT0::oo_df_integrals() {
                             for (int nu = 0; nu < numnu; ++nu, ++index) {
                                 int onu = basisset_->shell(NU).function_index() + nu;
 
-                                temp[P][omu * nso_ + onu] = eri[rank]->buffer()[index];
-                                temp[P][onu * nso_ + omu] = eri[rank]->buffer()[index];
+                                temp[P][omu * nso_ + onu] = buffer[rank][index];
+                                temp[P][onu * nso_ + omu] = buffer[rank][index];
                             }
                         }
                     }

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -567,10 +567,8 @@ void SAPT0::df_integrals() {
     int rank = 0;
 
     auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
-    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = rifactory->eri();
-        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -614,7 +612,7 @@ void SAPT0::df_integrals() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -629,7 +627,7 @@ void SAPT0::df_integrals() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -864,8 +862,6 @@ void SAPT0::df_integrals() {
     free(PQ_stop);
     free(block_length);
 
-    delete[] buffer;
-
     psio_->close(PSIF_SAPT_TEMP, 0);
 }
 
@@ -1035,10 +1031,8 @@ void SAPT0::df_integrals_aio() {
     int rank = 0;
 
     auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
-    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = rifactory->eri();
-        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -1087,7 +1081,7 @@ void SAPT0::df_integrals_aio() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -1102,7 +1096,7 @@ void SAPT0::df_integrals_aio() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -1385,8 +1379,6 @@ void SAPT0::df_integrals_aio() {
     free(PQ_stop);
     free(block_length);
 
-    delete[] buffer;
-
     psio_->close(PSIF_SAPT_TEMP, 0);
 }
 
@@ -1533,10 +1525,8 @@ void SAPT0::oo_df_integrals() {
     int rank = 0;
 
     auto eri = std::make_unique<TwoBodyAOInt *[]>(nthreads);
-    auto buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = rifactory->eri();
-        buffer[i] = eri[i]->buffer();
     }
 
     int *MUNUtoMU = init_int_array(nshelltri);
@@ -1595,8 +1585,8 @@ void SAPT0::oo_df_integrals() {
                             for (int nu = 0; nu < numnu; ++nu, ++index) {
                                 int onu = basisset_->shell(NU).function_index() + nu;
 
-                                temp[P][omu * nso_ + onu] = buffer[rank][index];
-                                temp[P][onu * nso_ + omu] = buffer[rank][index];
+                                temp[P][omu * nso_ + onu] = eri[rank]->buffer()[index];
+                                temp[P][onu * nso_ + omu] = eri[rank]->buffer()[index];
                             }
                         }
                     }
@@ -1788,8 +1778,6 @@ void SAPT0::oo_df_integrals() {
     }
 
     C_p_BB.done();
-
-    delete[] buffer;
 }
 }  // namespace sapt
 }  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -418,10 +418,9 @@ void SAPT0::df_integrals() {
     double maxSchwartz = 0.0;
     double *Schwartz = init_array(basisset_->nshell() * (basisset_->nshell() + 1) / 2);
 
-    std::shared_ptr<IntegralFactory> ao_eri_factory =
+    auto ao_eri_factory =
         std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
-    std::shared_ptr<TwoBodyAOInt> ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
-    const double *ao_buffer = ao_eri->buffer();
+    auto ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
 
     for (int P = 0, PQ = 0; P < basisset_->nshell(); P++) {
         int numw = basisset_->shell(P).nfunction();
@@ -434,8 +433,8 @@ void SAPT0::df_integrals() {
             for (int w = 0; w < numw; w++) {
                 for (int x = 0; x < numx; x++) {
                     int index = (((w * numx + x) * numw + w) * numx + x);
-                    tei = ao_buffer[index];
-                    if (std::fabs(tei) > max) max = std::fabs(tei);
+                    tei = ao_eri->buffer()[index];
+                    if (std::abs(tei) > max) max = std::abs(tei);
                 }
             }
             Schwartz[PQ] = max;
@@ -448,10 +447,9 @@ void SAPT0::df_integrals() {
 
     double *DFSchwartz = init_array(ribasis_->nshell());
 
-    std::shared_ptr<IntegralFactory> df_eri_factory =
+    auto df_eri_factory =
         std::make_shared<IntegralFactory>(ribasis_, zero_, ribasis_, zero_);
-    std::shared_ptr<TwoBodyAOInt> df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
-    const double *df_buffer = df_eri->buffer();
+    auto df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
 
     for (int P = 0; P < ribasis_->nshell(); P++) {
         int numw = ribasis_->shell(P).nfunction();
@@ -460,8 +458,8 @@ void SAPT0::df_integrals() {
         df_eri->compute_shell(P, 0, P, 0);
 
         for (int w = 0; w < numw; w++) {
-            tei = df_buffer[w];
-            if (std::fabs(tei) > max) max = std::fabs(tei);
+            tei = df_eri->buffer()[w];
+            if (std::abs(tei) > max) max = std::abs(tei);
         }
         DFSchwartz[P] = max;
     }
@@ -557,7 +555,7 @@ void SAPT0::df_integrals() {
         outfile->Printf("\n");
     }
 
-    std::shared_ptr<IntegralFactory> rifactory =
+    auto rifactory =
         std::make_shared<IntegralFactory>(ribasis_, zero_, basisset_, basisset_);
 
     int nthreads = 1;
@@ -567,10 +565,8 @@ void SAPT0::df_integrals() {
     int rank = 0;
 
     auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
-    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
-        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -614,7 +610,7 @@ void SAPT0::df_integrals() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -629,7 +625,7 @@ void SAPT0::df_integrals() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -884,10 +880,9 @@ void SAPT0::df_integrals_aio() {
     double maxSchwartz = 0.0;
     double *Schwartz = init_array(basisset_->nshell() * (basisset_->nshell() + 1) / 2);
 
-    std::shared_ptr<IntegralFactory> ao_eri_factory =
+    auto ao_eri_factory =
         std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
-    std::shared_ptr<TwoBodyAOInt> ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
-    const double *ao_buffer = ao_eri->buffer();
+    auto ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
 
     for (int P = 0, PQ = 0; P < basisset_->nshell(); P++) {
         int numw = basisset_->shell(P).nfunction();
@@ -900,8 +895,8 @@ void SAPT0::df_integrals_aio() {
             for (int w = 0; w < numw; w++) {
                 for (int x = 0; x < numx; x++) {
                     int index = (((w * numx + x) * numw + w) * numx + x);
-                    tei = ao_buffer[index];
-                    if (std::fabs(tei) > max) max = std::fabs(tei);
+                    tei = ao_eri->buffer()[index];
+                    if (std::abs(tei) > max) max = std::abs(tei);
                 }
             }
             Schwartz[PQ] = max;
@@ -914,10 +909,9 @@ void SAPT0::df_integrals_aio() {
 
     double *DFSchwartz = init_array(ribasis_->nshell());
 
-    std::shared_ptr<IntegralFactory> df_eri_factory =
+    auto df_eri_factory =
         std::make_shared<IntegralFactory>(ribasis_, zero_, ribasis_, zero_);
-    std::shared_ptr<TwoBodyAOInt> df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
-    const double *df_buffer = df_eri->buffer();
+    auto df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
 
     for (int P = 0; P < ribasis_->nshell(); P++) {
         int numw = ribasis_->shell(P).nfunction();
@@ -926,8 +920,8 @@ void SAPT0::df_integrals_aio() {
         df_eri->compute_shell(P, 0, P, 0);
 
         for (int w = 0; w < numw; w++) {
-            tei = df_buffer[w];
-            if (std::fabs(tei) > max) max = std::fabs(tei);
+            tei = df_eri->buffer()[w];
+            if (std::abs(tei) > max) max = std::abs(tei);
         }
         DFSchwartz[P] = max;
     }
@@ -1023,7 +1017,7 @@ void SAPT0::df_integrals_aio() {
         outfile->Printf("\n");
     }
 
-    std::shared_ptr<IntegralFactory> rifactory =
+    auto rifactory =
         std::make_shared<IntegralFactory>(ribasis_, zero_, basisset_, basisset_);
 
     int nthreads = 1;
@@ -1033,10 +1027,8 @@ void SAPT0::df_integrals_aio() {
     int rank = 0;
 
     auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
-    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
-        buffer[i] = eri[i]->buffer();
     }
 
     zero_disk(PSIF_SAPT_TEMP, "AO RI Integrals", ndf_, nsotri_screened);
@@ -1085,7 +1077,7 @@ void SAPT0::df_integrals_aio() {
                                         for (int nu = 0; nu < numnu; ++nu, ++index, ++munu) {
                                             int onu = basisset_->shell(NU).function_index() + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -1100,7 +1092,7 @@ void SAPT0::df_integrals_aio() {
                                             int onu = basisset_->shell(NU).function_index() + nu;
                                             int index = P * nummu * nummu + mu * nummu + nu;
 
-                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = buffer[rank][index];
+                                            AO_RI[curr_block % 2][munu + munu_offset][oP] = eri[rank]->buffer()[index];
                                         }
                                     }
                                 }
@@ -1466,10 +1458,9 @@ void SAPT0::oo_df_integrals() {
     int nshelltri = basisset_->nshell() * (basisset_->nshell() + 1) / 2;
     double *Schwartz = init_array(basisset_->nshell() * (basisset_->nshell() + 1) / 2);
 
-    std::shared_ptr<IntegralFactory> ao_eri_factory =
+    auto ao_eri_factory =
         std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
-    std::shared_ptr<TwoBodyAOInt> ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
-    const double *ao_buffer = ao_eri->buffer();
+    auto ao_eri = std::shared_ptr<TwoBodyAOInt>(ao_eri_factory->eri());
 
     for (int P = 0, PQ = 0; P < basisset_->nshell(); P++) {
         int numw = basisset_->shell(P).nfunction();
@@ -1482,8 +1473,8 @@ void SAPT0::oo_df_integrals() {
             for (int w = 0; w < numw; w++) {
                 for (int x = 0; x < numx; x++) {
                     int index = (((w * numx + x) * numw + w) * numx + x);
-                    tei = ao_buffer[index];
-                    if (std::fabs(tei) > max) max = std::fabs(tei);
+                    tei = ao_eri->buffer()[index];
+                    if (std::abs(tei) > max) max = std::abs(tei);
                 }
             }
             Schwartz[PQ] = max;
@@ -1496,10 +1487,9 @@ void SAPT0::oo_df_integrals() {
 
     double *DFSchwartz = init_array(elstbasis_->nshell());
 
-    std::shared_ptr<IntegralFactory> df_eri_factory =
+    auto df_eri_factory =
         std::make_shared<IntegralFactory>(elstbasis_, zero_, elstbasis_, zero_);
-    std::shared_ptr<TwoBodyAOInt> df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
-    const double *df_buffer = df_eri->buffer();
+    auto df_eri = std::shared_ptr<TwoBodyAOInt>(df_eri_factory->eri());
 
     for (int P = 0; P < elstbasis_->nshell(); P++) {
         int numw = elstbasis_->shell(P).nfunction();
@@ -1508,8 +1498,8 @@ void SAPT0::oo_df_integrals() {
         df_eri->compute_shell(P, 0, P, 0);
 
         for (int w = 0; w < numw; w++) {
-            tei = df_buffer[w];
-            if (std::fabs(tei) > max) max = std::fabs(tei);
+            tei = df_eri->buffer()[w];
+            if (std::abs(tei) > max) max = std::abs(tei);
         }
         DFSchwartz[P] = max;
     }
@@ -1519,7 +1509,7 @@ void SAPT0::oo_df_integrals() {
 
     int maxPshell = elstbasis_->max_function_per_shell();
 
-    std::shared_ptr<IntegralFactory> rifactory =
+    auto rifactory =
         std::make_shared<IntegralFactory>(elstbasis_, zero_, basisset_, basisset_);
 
     int nthreads = 1;
@@ -1529,10 +1519,8 @@ void SAPT0::oo_df_integrals() {
     int rank = 0;
 
     auto eri = std::vector<std::unique_ptr<TwoBodyAOInt>>(nthreads);
-    auto buffer = std::vector<const double *>(nthreads, nullptr);
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::unique_ptr<TwoBodyAOInt>(rifactory->eri());
-        buffer[i] = eri[i]->buffer();
     }
 
     int *MUNUtoMU = init_int_array(nshelltri);
@@ -1591,8 +1579,8 @@ void SAPT0::oo_df_integrals() {
                             for (int nu = 0; nu < numnu; ++nu, ++index) {
                                 int onu = basisset_->shell(NU).function_index() + nu;
 
-                                temp[P][omu * nso_ + onu] = buffer[rank][index];
-                                temp[P][onu * nso_ + omu] = buffer[rank][index];
+                                temp[P][omu * nso_ + onu] = eri[rank]->buffer()[index];
+                                temp[P][onu * nso_ + omu] = eri[rank]->buffer()[index];
                             }
                         }
                     }

--- a/psi4/src/psi4/libsapt_solver/sapt0.h
+++ b/psi4/src/psi4/libsapt_solver/sapt0.h
@@ -189,13 +189,13 @@ struct SAPTDFInts {
 
     SharedMatrix BpMat_;
     SharedMatrix BdMat_;
-    double **B_p_ = nullptr;
-    double **B_d_ = nullptr;
+    double **B_p_{nullptr};
+    double **B_d_{nullptr};
 
     int filenum_;
     const char *label_;
 
-    psio_address next_DF_ = PSIO_ZERO;
+    psio_address next_DF_{PSIO_ZERO};
 
     SAPTDFInts() {
         next_DF_ = PSIO_ZERO;

--- a/psi4/src/psi4/libsapt_solver/sapt0.h
+++ b/psi4/src/psi4/libsapt_solver/sapt0.h
@@ -30,6 +30,9 @@
 #define SAPT0_H
 
 #include "sapt.h"
+#include "psi4/libpsio/aiohandler.h"
+#include "psi4/libpsio/config.h"
+#include "psi4/libmints/matrix.h"
 
 namespace psi {
 namespace sapt {
@@ -184,13 +187,15 @@ struct SAPTDFInts {
     size_t i_start_;
     size_t j_start_;
 
-    double **B_p_;
-    double **B_d_;
+    SharedMatrix BpMat_;
+    SharedMatrix BdMat_;
+    double **B_p_ = nullptr;
+    double **B_d_ = nullptr;
 
     int filenum_;
     const char *label_;
 
-    psio_address next_DF_;
+    psio_address next_DF_ = PSIO_ZERO;
 
     SAPTDFInts() {
         next_DF_ = PSIO_ZERO;
@@ -198,18 +203,18 @@ struct SAPTDFInts {
         B_d_ = nullptr;
     };
     ~SAPTDFInts() {
-        if (B_p_ != nullptr) free_block(B_p_);
-        if (B_d_ != nullptr) free_block(B_d_);
+        B_p_ == nullptr;
+        B_d_ == nullptr;
     };
     void rewind() { next_DF_ = PSIO_ZERO; };
     void clear() {
-        free_block(B_p_);
+        BpMat_.reset();
         B_p_ = nullptr;
         next_DF_ = PSIO_ZERO;
     };
     void done() {
-        free_block(B_p_);
-        if (dress_) free_block(B_d_);
+        BpMat_.reset();
+        if (dress_) BdMat_.reset();
         B_p_ = nullptr;
         B_d_ = nullptr;
     };
@@ -217,18 +222,17 @@ struct SAPTDFInts {
 
 struct Iterator {
     size_t num_blocks;
-    int *block_size;
+    std::vector<int> block_size;
 
     size_t curr_block;
     long int curr_size;
 
-    ~Iterator() { free(block_size); };
     void rewind() {
         curr_block = 1;
         curr_size = 0;
     };
 };
-}
-}
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/sapt0.h
+++ b/psi4/src/psi4/libsapt_solver/sapt0.h
@@ -203,8 +203,8 @@ struct SAPTDFInts {
         B_d_ = nullptr;
     };
     ~SAPTDFInts() {
-        B_p_ == nullptr;
-        B_d_ == nullptr;
+        B_p_ = nullptr;
+        B_d_ = nullptr;
     };
     void rewind() { next_DF_ = PSIO_ZERO; };
     void clear() {

--- a/psi4/src/psi4/libsapt_solver/sapt0.h
+++ b/psi4/src/psi4/libsapt_solver/sapt0.h
@@ -195,7 +195,7 @@ struct SAPTDFInts {
     int filenum_;
     const char *label_;
 
-    psio_address next_DF_{PSIO_ZERO};
+    psio_address next_DF_ = PSIO_ZERO;
 
     SAPTDFInts() {
         next_DF_ = PSIO_ZERO;

--- a/psi4/src/psi4/libsapt_solver/sapt2.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2.cc
@@ -27,11 +27,18 @@
  */
 
 #include "sapt2.h"
+#include "psi4/lib3index/3index.h"
 #include "psi4/physconst.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/twobody.h"
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/matrix.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libqt/qt.h"
 
 namespace psi {
 namespace sapt {
@@ -435,7 +442,7 @@ void SAPT2::df_integrals() {
 #endif
     int rank = 0;
 
-    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[ nthreads ];
+    std::shared_ptr<TwoBodyAOInt> *eri = new std::shared_ptr<TwoBodyAOInt>[nthreads];
     const auto **buffer = new const double *[nthreads];
     for (int i = 0; i < nthreads; ++i) {
         eri[i] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
@@ -1050,5 +1057,5 @@ void SAPT2::natural_orbitalify_df_ints() {
     free_block(C_p_SS);
     free_block(D_p_SS);
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt2.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2.h
@@ -189,7 +189,7 @@ class SAPT2 : public SAPT {
     void exch12();
     void ind22();
 };
-}
-}
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/sapt2p.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2p.cc
@@ -27,7 +27,10 @@
  */
 
 #include "sapt2p.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/physconst.h"
+#include "psi4/libqt/qt.h"
 
 #include <cmath>
 
@@ -473,5 +476,5 @@ void SAPT2p::print_results() {
         }
     }
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt2p.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p.h
@@ -181,7 +181,7 @@ class SAPTDIIS {
     void store_vectors();
     void get_new_vector();
 };
-}
-}
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.cc
@@ -28,6 +28,8 @@
 
 #include "sapt2p3.h"
 #include "psi4/physconst.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libqt/qt.h"
 #include <cmath>
 
 namespace psi {
@@ -696,5 +698,5 @@ void SAPT2p3::print_results() {
         }
     }
 }
-}
-}
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.h
@@ -111,7 +111,7 @@ class SAPT2p3 : public SAPT2p {
     void disp30();
     void exch_disp30();
 };
-}
-}
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libsapt_solver/usapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/usapt0.cc
@@ -2407,5 +2407,5 @@ void USAPT0::mp2_terms() {
     outfile->Printf("    Exch-Disp20         = %18.12lf H\n", ExchDisp20);
     outfile->Printf("\n");
 }
-}
-}  // End namespaces
+}  // namespace sapt
+}  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/usapt0.h
+++ b/psi4/src/psi4/libsapt_solver/usapt0.h
@@ -397,7 +397,7 @@ class CPKS_USAPT0 {
 
     void compute_cpks();
 };
-}
-}  // end namespaces
+}  // namespace sapt
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/sapt/wrapper.cc
+++ b/psi4/src/psi4/sapt/wrapper.cc
@@ -35,8 +35,10 @@
 #include "psi4/libsapt_solver/sapt2p.h"
 #include "psi4/libsapt_solver/sapt2p3.h"
 
+#include "psi4/libciomr/libciomr.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsio/psio.hpp"
 
 //#include <libsapt_solver/sapt_dft.h>
 


### PR DESCRIPTION
## Description
Set the minimum required C++ standard to C++14. Lower bounds on compilers can be found [here](https://en.cppreference.com/w/cpp/compiler_support#cpp14).  Also addresses a bug in the SAPT code that resulted in a double free.

## About the SAPT bug
The Iterator class in SAPT contained an `int *` array that was cleaned up by the class's destructor.  Iterator objects are constructed by a builder routine that first creates a local Iterator object, fills it, then returns it by value.  The C++98 behavior of this design is problematic; a copy of the local temp Iterator is made and that copy is returned to the caller.  When that copy is made, both the local temp and its copy have `int *` pointers that point to the same pool of memory because no deep-copy copy constructor exists for Iterator.  Upon returning, the local temp object is destroyed, triggering the memory pointed to by the `int *` to be freed, causing the returned object to point to freed memory which is undefined behavior.  When that returned object eventually goes out of scope, it will try to free the memory again, leading to the double free memory error we observed.  Because we use C++11 most compilers appear to be able to correctly elide the copy, by implementing move semantics, so we haven't seen this before.  The switch to C++14 with GCC5.4 caused consistent segfaults, revealing the issue.  The fix is simple; don't use raw `int *`, but `std::vector<int>` instead; the lifetime of these is correctly managed automatically and the various move constructor/copy constructor/destructor can be generated correctly by the compiler.  RAII for the win!

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix C++14 compliance CMake-side
- [x] Fix memory bug in SAPT code
- [x] Move Travis to Xenial

## Status
- [x] Ready for review
- [x] Ready for merge
