### PR TITLE
Update syntax for PsiPEP002

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -170,7 +170,7 @@ def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, *
 
     # Perform the derivative calculation
     derivative, wfn = derivfunc(method, return_wfn=True, molecule=molecule, **kwargs)
-    displacement["energy"] = core.get_variable('CURRENT ENERGY')
+    displacement["energy"] = core.variable('CURRENT ENERGY')
 
     # If we computed a first or higher order derivative, set it.
     if derivfunc == gradient:
@@ -558,9 +558,9 @@ def energy(name, **kwargs):
             core.print_out("\n\nWarning! %s does not have an associated derived wavefunction." % name)
             core.print_out("The returned wavefunction is the dimer SCF wavefunction.\n\n")
 
-        return (core.get_variable('CURRENT ENERGY'), wfn)
+        return (core.variable('CURRENT ENERGY'), wfn)
     else:
-        return core.get_variable('CURRENT ENERGY')
+        return core.variable('CURRENT ENERGY')
 
 
 def gradient(name, **kwargs):
@@ -816,9 +816,9 @@ def properties(*args, **kwargs):
     optstash.restore()
 
     if return_wfn:
-        return (core.get_variable('CURRENT ENERGY'), wfn)
+        return (core.variable('CURRENT ENERGY'), wfn)
     else:
-        return core.get_variable('CURRENT ENERGY')
+        return core.variable('CURRENT ENERGY')
 
 
 def optimize(name, **kwargs):
@@ -1033,12 +1033,12 @@ def optimize(name, **kwargs):
 
         # Before computing gradient, save previous molecule and wavefunction if this is an IRC optimization
         if (n > 1) and (core.get_option('OPTKING', 'OPT_TYPE') == 'IRC'):
-            old_thisenergy = core.get_variable('CURRENT ENERGY')
+            old_thisenergy = core.variable('CURRENT ENERGY')
 
         # Compute the gradient - preserve opt data despite core.clean calls in gradient
         core.IOManager.shared_object().set_specific_retention(1, True)
         G, wfn = gradient(lowername, return_wfn=True, molecule=moleculeclone, **kwargs)
-        thisenergy = core.get_variable('CURRENT ENERGY')
+        thisenergy = core.variable('CURRENT ENERGY')
 
         # above, used to be getting energy as last of energy list from gradient()
         # thisenergy below should ultimately be testing on wfn.energy()
@@ -1464,9 +1464,9 @@ def frequency(name, **kwargs):
         postcallback(lowername, wfn=wfn, **kwargs)
 
     if return_wfn:
-        return (core.get_variable('CURRENT ENERGY'), wfn)
+        return (core.variable('CURRENT ENERGY'), wfn)
     else:
-        return core.get_variable('CURRENT ENERGY')
+        return core.variable('CURRENT ENERGY')
 
 
 def vibanal_wfn(wfn, hess=None, irrep=None, molecule=None, project_trans=True, project_rot=True):
@@ -1550,7 +1550,7 @@ def vibanal_wfn(wfn, hess=None, irrep=None, molecule=None, project_trans=True, p
             sigma=rsn,
             rotor_type=mol.rotor_type(),
             rot_const=np.asarray(mol.rotational_constants()),
-            E0=core.get_variable('CURRENT ENERGY'))  # someday, wfn.energy()
+            E0=core.variable('CURRENT ENERGY'))  # someday, wfn.energy()
         vibrec.update({k: qca.to_dict() for k, qca in therminfo.items()})
 
         core.set_variable("ZPVE", therminfo['ZPE_corr'].data)

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1587,12 +1587,12 @@ def cbs(func, label, **kwargs):
             mc['f_energy'] = response
         elif ptype == 'gradient':
             mc['f_gradient'] = response
-            mc['f_energy'] = core.get_variable('CURRENT ENERGY')
+            mc['f_energy'] = core.variable('CURRENT ENERGY')
             if verbose > 1:
                 mc['f_gradient'].print_out()
         elif ptype == 'hessian':
             mc['f_hessian'] = response
-            mc['f_energy'] = core.get_variable('CURRENT ENERGY')
+            mc['f_energy'] = core.variable('CURRENT ENERGY')
             if verbose > 1:
                 mc['f_hessian'].print_out()
         Njobs += 1
@@ -1609,7 +1609,7 @@ def cbs(func, label, **kwargs):
                 for job in JOBS_EXT:
                     if (wfn == job['f_wfn']) and (mc['f_basis'] == job['f_basis']) and \
                        (mc['f_options'] == job['f_options']):
-                        job['f_energy'] = core.get_variable(VARH[wfn][wfn])
+                        job['f_energy'] = core.variable(VARH[wfn][wfn])
 
         if verbose > 1:
             core.print_variables()

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -294,10 +294,10 @@ def nbody_gufunc(func, method_string, **kwargs):
             if d in dicts:
                 for var, value in r[d].items():
                     try:
-                        wfn.set_variable(str(var), value)
-                        core.set_variable(str(var), value)
+                        wfn.set_scalar_variable(str(var), value)
+                        core.set_scalar_variable(str(var), value)
                     except:
-                        wfn.set_array(d.split('_')[0].upper() + ' ' + str(var), core.Matrix.from_array(value))
+                        wfn.set_array_variable(d.split('_')[0].upper() + ' ' + str(var), core.Matrix.from_array(value))
 
     core.set_variable("CURRENT ENERGY", nbody_results['ret_energy'])
     wfn.set_variable("CURRENT ENERGY", nbody_results['ret_energy'])
@@ -476,11 +476,11 @@ def compute_nbody_components(func, method_string, metadata):
             # Save energies info
             ptype_dict[pair], wfn = func(method_string, molecule=current_mol, return_wfn=True, **kwargs)
             core.set_global_option_python('EXTERN', None)
-            energies_dict[pair] = core.get_variable("CURRENT ENERGY")
+            energies_dict[pair] = core.variable("CURRENT ENERGY")
             gradients_dict[pair] = wfn.gradient()
             var_key = "N-BODY (%s)@(%s) TOTAL ENERGY" % (', '.join([str(i) for i in pair[0]]), ', '.join(
                 [str(i) for i in pair[1]]))
-            intermediates_dict[var_key] = core.get_variable("CURRENT ENERGY")
+            intermediates_dict[var_key] = core.variable("CURRENT ENERGY")
             core.print_out("\n       N-Body: Complex Energy (fragments = %s, basis = %s: %20.14f)\n" % (str(
                 pair[0]), str(pair[1]), energies_dict[pair]))
             # Flip this off for now, needs more testing

--- a/psi4/driver/driver_nbody_helper.py
+++ b/psi4/driver/driver_nbody_helper.py
@@ -91,16 +91,16 @@ def multi_level(func, **kwargs):
             # Subtract the (n-1)-body contribution from the n-body contribution to get the n-body effect
             sign = (-1)**(1 - m // n)
             for b in kwargs['bsse_type']:
-                energy_bsse_dict[b] += sign * wfn.get_variable('%i%s' % (m, b.lower()))
+                energy_bsse_dict[b] += sign * wfn.variable('%i%s' % (m, b.lower()))
             if ptype in ['gradient', 'hessian']:
-                gradient_result += sign * np.array(wfn.get_array('GRADIENT ' + str(m)))
+                gradient_result += sign * np.array(wfn.variable('GRADIENT ' + str(m)))
                 # Keep 1-body contribution to compute interaction data
                 if n == 1:
-                    gradient1 = np.array(wfn.get_array('GRADIENT ' + str(m)))
+                    gradient1 = np.array(wfn.variable('GRADIENT ' + str(m)))
             if ptype == 'hessian':
-                hessian_result += sign * np.array(wfn.get_array('HESSIAN ' + str(m)))
+                hessian_result += sign * np.array(wfn.variable('HESSIAN ' + str(m)))
                 if n == 1:
-                    hessian1 = np.array(wfn.get_array('HESSIAN ' + str(m)))
+                    hessian1 = np.array(wfn.variable('HESSIAN ' + str(m)))
         energy_result += energy_bsse_dict[kwargs['bsse_type'][0]]
         for b in kwargs['bsse_type']:
             energy_body_contribution[b][n] = energy_bsse_dict[b]
@@ -118,15 +118,15 @@ def multi_level(func, **kwargs):
         kwargs_copy['max_nbody'] = max(levels)
         # Subtract lower order effects to avoid double counting
         ret, wfn = nbody_gufunc(func, supersystem, **kwargs_copy)
-        energy_result += wfn_super.energy() - wfn.get_variable(str(max(levels)))
+        energy_result += wfn_super.energy() - wfn.variable(str(max(levels)))
         for b in kwargs['bsse_type']:
-            energy_body_contribution[b][molecule.nfragments()] = wfn_super.energy() - wfn.get_variable(
+            energy_body_contribution[b][molecule.nfragments()] = wfn_super.energy() - wfn.variable(
                 str(max(levels)))
 
         if ptype in ['gradient', 'hessian']:
-            gradient_result += np.array(wfn_super.gradient()) - np.array(wfn.get_array('GRADIENT ' + str(max(levels))))
+            gradient_result += np.array(wfn_super.gradient()) - np.array(wfn.variable('GRADIENT ' + str(max(levels))))
         if ptype == 'hessian':
-            hessian_result += np.array(wfn_super.hessian()) - np.array(wfn.get_array('HESSIAN ' + str(max(levels))))
+            hessian_result += np.array(wfn_super.hessian()) - np.array(wfn.variable('HESSIAN ' + str(max(levels))))
         levels['supersystem'] = supersystem
 
     for b in kwargs['bsse_type']:

--- a/psi4/driver/frac.py
+++ b/psi4/driver/frac.py
@@ -188,7 +188,7 @@ def frac_traverse(name, **kwargs):
         E, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule, **kwargs)
         C = 1
         if E == 0.0:
-            E = core.get_variable('SCF ITERATION ENERGY')
+            E = core.variable('SCF ITERATION ENERGY')
             C = 0
 
         if LUMO > 0:
@@ -237,7 +237,7 @@ def frac_traverse(name, **kwargs):
         E, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule, **kwargs)
         C = 1
         if E == 0.0:
-            E = core.get_variable('SCF ITERATION ENERGY')
+            E = core.variable('SCF ITERATION ENERGY')
             C = 0
 
         if LUMO > 0:
@@ -395,7 +395,7 @@ def frac_nuke(name, **kwargs):
             E, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule, **kwargs)
             C = 1
             if E == 0.0:
-                E = core.get_variable('SCF ITERATION ENERGY')
+                E = core.variable('SCF ITERATION ENERGY')
                 C = 0
 
             if HOMO > 0:

--- a/psi4/driver/gaussian_n.py
+++ b/psi4/driver/gaussian_n.py
@@ -64,9 +64,9 @@ def run_gaussian_2(name, **kwargs):
     scf_e, ref = driver.frequency('scf', return_wfn=True)
 
     # thermodynamic properties
-    du = core.get_variable('THERMAL ENERGY CORRECTION')
-    dh = core.get_variable('ENTHALPY CORRECTION')
-    dg = core.get_variable('GIBBS FREE ENERGY CORRECTION')
+    du = core.variable('THERMAL ENERGY CORRECTION')
+    dh = core.variable('ENTHALPY CORRECTION')
+    dg = core.variable('GIBBS FREE ENERGY CORRECTION')
 
     freqs   = ref.frequencies()
     nfreq   = freqs.dim(0)
@@ -102,30 +102,30 @@ def run_gaussian_2(name, **kwargs):
     # hlc of gaussian-1
     hlc1 = -0.00614 * nalpha
 
-    eqci_6311gdp = core.get_variable("QCISD(T) TOTAL ENERGY")
-    emp4_6311gd  = core.get_variable("MP4 TOTAL ENERGY")
-    emp2_6311gd  = core.get_variable("MP2 TOTAL ENERGY")
+    eqci_6311gdp = core.variable("QCISD(T) TOTAL ENERGY")
+    emp4_6311gd  = core.variable("MP4 TOTAL ENERGY")
+    emp2_6311gd  = core.variable("MP2 TOTAL ENERGY")
     core.clean()
 
     # correction for diffuse functions
     core.set_global_option('BASIS',"6-311+G(D_P)")
     driver.energy('mp4')
-    emp4_6311pg_dp = core.get_variable("MP4 TOTAL ENERGY")
-    emp2_6311pg_dp = core.get_variable("MP2 TOTAL ENERGY")
+    emp4_6311pg_dp = core.variable("MP4 TOTAL ENERGY")
+    emp2_6311pg_dp = core.variable("MP2 TOTAL ENERGY")
     core.clean()
 
     # correction for polarization functions
     core.set_global_option('BASIS',"6-311G(2DF_P)")
     driver.energy('mp4')
-    emp4_6311g2dfp = core.get_variable("MP4 TOTAL ENERGY")
-    emp2_6311g2dfp = core.get_variable("MP2 TOTAL ENERGY")
+    emp4_6311g2dfp = core.variable("MP4 TOTAL ENERGY")
+    emp2_6311g2dfp = core.variable("MP2 TOTAL ENERGY")
     core.clean()
 
     # big basis mp2
     core.set_global_option('BASIS',"6-311+G(3DF_2P)")
     #run_fnocc('_mp2',**kwargs)
     driver.energy('mp2')
-    emp2_big = core.get_variable("MP2 TOTAL ENERGY")
+    emp2_big = core.variable("MP2 TOTAL ENERGY")
     core.clean()
     eqci       = eqci_6311gdp
     e_delta_g2 = emp2_big + emp2_6311gd - emp2_6311g2dfp - emp2_6311pg_dp

--- a/psi4/driver/json_wrapper.py
+++ b/psi4/driver/json_wrapper.py
@@ -187,13 +187,13 @@ def run_json_qc_schema(json_data, clean):
         if "quadrupole" in kwargs["properties"]:
             ret["quadrupole"] = [psi_props[mtd + " QUADRUPOLE " + x] for x in ["XX", "XY", "XZ", "YY", "YZ", "ZZ"]]
         if "mulliken_charges" in kwargs["properties"]:
-            ret["mulliken_charges"] = wfn.get_array("MULLIKEN_CHARGES").np.ravel().tolist()
+            ret["mulliken_charges"] = wfn.variable("MULLIKEN_CHARGES").np.ravel().tolist()
         if "lowdin_charges" in kwargs["properties"]:
-            ret["lowdin_charges"] = wfn.get_array("LOWDIN_CHARGES").np.ravel().tolist()
+            ret["lowdin_charges"] = wfn.variable("LOWDIN_CHARGES").np.ravel().tolist()
         if "wiberg_lowdin_indices" in kwargs["properties"]:
-            ret["wiberg_lowdin_indices"] = wfn.get_array("WIBERG_LOWDIN_INDICES").np.ravel().tolist()
+            ret["wiberg_lowdin_indices"] = wfn.variable("WIBERG_LOWDIN_INDICES").np.ravel().tolist()
         if "mayer_indices" in kwargs["properties"]:
-            ret["mayer_indices"] = wfn.get_array("MAYER_INDICES").np.ravel().tolist()
+            ret["mayer_indices"] = wfn.variable("MAYER_INDICES").np.ravel().tolist()
 
         json_data["return_result"] = ret
     else:
@@ -406,7 +406,7 @@ def run_json_original_v1_1(json_data, clean):
     else:
         raise TypeError("Unrecognized return value of type %s\n" % type(val))
 
-    json_data["variables"] = core.get_variables()
+    json_data["variables"] = core.scalar_variables()
     json_data["success"] = True
 
     # Reset state

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -434,7 +434,7 @@ def expand_psivars(pvdefs):
         if verbose >= 2:
             print("""building %s %s""" % (pvar, '.' * (50 - len(pvar))), end='')
 
-        psivars = core.get_variables()
+        psivars = core.scalar_variables()
         data_rich_args = []
 
         for pv in action['args']:

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -184,9 +184,9 @@ def _core_wavefunction_from_file(wfn_data):
 
     # some of the wavefunction's variables can be changed directly
     for k, v in wfn_floatvar.items():
-        wfn.set_variable(k,v)
+        wfn.set_variable(k, v)
     for k, v in wfn_matrixarr.items():
-        wfn.set_array(k,v)
+        wfn.set_variable(k, v)
 
     return wfn
 
@@ -260,8 +260,8 @@ def _core_wavefunction_to_file(wfn, filename=None):
             'dipole_field_y': wfn.get_dipole_field_strength()[1],
             'dipole_field_z': wfn.get_dipole_field_strength()[2]
         },
-        'floatvar': wfn.variables(),
-        'matrixarr': {k: v.to_array() for k, v in wfn.arrays().items()},
+        'floatvar' : wfn.scalar_variables(),
+        'matrixarr' : {k: v.to_array() for k, v in wfn.array_variables().items()}
     }  # yapf: disable
 
     if filename is not None:

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -670,4 +670,4 @@ def compare_csx():
             enedict = csx2endict()
             compare_integers(len(enedict) >= 2, True, 'CSX harvested')
             for pv, en in enedict.items():
-                compare_values(core.get_variable(pv), en, 6, 'CSX ' + pv + ' ' + str(round(en, 4)))
+                compare_values(core.variable(pv), en, 6, 'CSX ' + pv + ' ' + str(round(en, 4)))

--- a/psi4/driver/procrouting/interface_cfour.py
+++ b/psi4/driver/procrouting/interface_cfour.py
@@ -374,7 +374,7 @@ def run_cfour(name, **kwargs):
         core.get_gradient().print_out()
 
     # Quit if Cfour threw error
-    if core.get_variable('CFOUR ERROR CODE'):
+    if core.variable('CFOUR ERROR CODE'):
         raise ValidationError("""Cfour exited abnormally.""")
 
     P4C4_INFO.clear()

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -157,7 +157,7 @@ def mcscf_solver(ref_wfn):
 
         ciwfn.form_opdm()
         ciwfn.form_tpdm()
-        ci_grad_rms = core.get_variable("DETCI AVG DVEC NORM")
+        ci_grad_rms = core.variable("DETCI AVG DVEC NORM")
 
         # Update MCSCF object
         Cocc = ciwfn.get_orbitals("DOCC")
@@ -167,7 +167,7 @@ def mcscf_solver(ref_wfn):
         tpdm = ciwfn.get_tpdm("SUM", True)
         mcscf_obj.update(Cocc, Cact, Cvir, opdm, tpdm)
 
-        current_energy = core.get_variable("MCSCF TOTAL ENERGY")
+        current_energy = core.variable("MCSCF TOTAL ENERGY")
 
         orb_grad_rms = mcscf_obj.gradient_rms()
         ediff = current_energy - eold
@@ -373,7 +373,7 @@ def mcscf_solver(ref_wfn):
     proc_util.print_ci_results(ciwfn, "MCSCF", scf_energy, current_energy, print_opdm_no=True)
 
     # Set final energy
-    core.set_variable("CURRENT ENERGY", core.get_variable("MCSCF TOTAL ENERGY"))
+    core.set_variable("CURRENT ENERGY", core.variable("MCSCF TOTAL ENERGY"))
 
     # What do we need to cleanup?
     if core.get_option("DETCI", "MCSCF_CI_CLEANUP"):

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1385,7 +1385,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         oeprop.compute()
         for obj in [core]:
             for xyz in 'XYZ':
-                obj.set_variable('CURRENT DIPOLE ' + xyz, obj.get_variable('SCF DIPOLE ' + xyz))
+                obj.set_variable('CURRENT DIPOLE ' + xyz, obj.variable('SCF DIPOLE ' + xyz))
 
     # Write out MO's
     if core.get_option("SCF", "PRINT_MOS"):
@@ -2020,7 +2020,7 @@ def run_scf(name, **kwargs):
 
 
     scf_wfn = scf_helper(name, post_scf=False, **kwargs)
-    returnvalue = core.get_variable('CURRENT ENERGY')
+    returnvalue = core.variable('CURRENT ENERGY')
 
     ssuper = scf_wfn.functional()
 
@@ -2037,12 +2037,12 @@ def run_scf(name, **kwargs):
             dfmp2_wfn = core.dfmp2(scf_wfn)
             dfmp2_wfn.compute_energy()
 
-            vdh = core.get_variable('SCS-MP2 CORRELATION ENERGY')
+            vdh = core.variable('SCS-MP2 CORRELATION ENERGY')
 
         else:
             dfmp2_wfn = core.dfmp2(scf_wfn)
             dfmp2_wfn.compute_energy()
-            vdh = ssuper.c_alpha() * core.get_variable('MP2 CORRELATION ENERGY')
+            vdh = ssuper.c_alpha() * core.variable('MP2 CORRELATION ENERGY')
 
         # TODO: delete these variables, since they don't mean what they look to mean?
         # 'MP2 TOTAL ENERGY',
@@ -2088,7 +2088,7 @@ def run_scf_gradient(name, **kwargs):
 
     if hasattr(ref_wfn, "_disp_functor"):
         disp_grad = ref_wfn._disp_functor.compute_gradient(ref_wfn.molecule())
-        ref_wfn.set_array("-D Gradient", disp_grad)
+        ref_wfn.set_variable("-D Gradient", disp_grad)
 
     grad = core.scfgrad(ref_wfn)
 
@@ -2156,7 +2156,7 @@ def run_scf_hessian(name, **kwargs):
 
     if hasattr(ref_wfn, "_disp_functor"):
         disp_hess = ref_wfn._disp_functor.compute_hessian(ref_wfn.molecule())
-        ref_wfn.set_array("-D Hessian", disp_hess)
+        ref_wfn.set_variable("-D Hessian", disp_hess)
 
     H = core.scfhess(ref_wfn)
     ref_wfn.set_hessian(H)
@@ -2442,8 +2442,8 @@ def run_bccd(name, **kwargs):
         sort_func(ref_wfn)
 
         ref_wfn = core.ccenergy(ref_wfn)
-        core.print_out('Brueckner convergence check: %s\n' % bool(core.get_variable('BRUECKNER CONVERGED')))
-        if (core.get_variable('BRUECKNER CONVERGED') == True):
+        core.print_out('Brueckner convergence check: %s\n' % bool(core.variable('BRUECKNER CONVERGED')))
+        if (core.variable('BRUECKNER CONVERGED') == True):
             break
 
         if bcc_iter_cnt >= core.get_option('CCENERGY', 'BCCD_MAXITER'):
@@ -2523,7 +2523,7 @@ def run_scf_property(name, **kwargs):
 
     # Always must set SCF dipole
     for cart in ["X", "Y", "Z"]:
-        core.set_variable("SCF DIPOLE " + cart, core.get_variable(name + " DIPOLE " + cart))
+        core.set_variable("SCF DIPOLE " + cart, core.variable(name + " DIPOLE " + cart))
 
     # Run Linear Respsonse
     if len(linear_response):
@@ -2675,24 +2675,24 @@ def run_cc_property(name, **kwargs):
         if name.startswith('eom'):
             # copy GS CC DIP/QUAD ... to CC ROOT 0 DIP/QUAD ... if we are doing multiple roots
             if 'dipole' in one:
-                core.set_variable("CC ROOT 0 DIPOLE X", core.get_variable("CC DIPOLE X"))
-                core.set_variable("CC ROOT 0 DIPOLE Y", core.get_variable("CC DIPOLE Y"))
-                core.set_variable("CC ROOT 0 DIPOLE Z", core.get_variable("CC DIPOLE Z"))
+                core.set_variable("CC ROOT 0 DIPOLE X", core.variable("CC DIPOLE X"))
+                core.set_variable("CC ROOT 0 DIPOLE Y", core.variable("CC DIPOLE Y"))
+                core.set_variable("CC ROOT 0 DIPOLE Z", core.variable("CC DIPOLE Z"))
             if 'quadrupole' in one:
-                core.set_variable("CC ROOT 0 QUADRUPOLE XX", core.get_variable("CC QUADRUPOLE XX"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE XY", core.get_variable("CC QUADRUPOLE XY"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE XZ", core.get_variable("CC QUADRUPOLE XZ"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE YY", core.get_variable("CC QUADRUPOLE YY"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE YZ", core.get_variable("CC QUADRUPOLE YZ"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE ZZ", core.get_variable("CC QUADRUPOLE ZZ"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE XX", core.variable("CC QUADRUPOLE XX"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE XY", core.variable("CC QUADRUPOLE XY"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE XZ", core.variable("CC QUADRUPOLE XZ"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE YY", core.variable("CC QUADRUPOLE YY"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE YZ", core.variable("CC QUADRUPOLE YZ"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE ZZ", core.variable("CC QUADRUPOLE ZZ"))
 
             n_root = sum(core.get_global_option("ROOTS_PER_IRREP"))
             for rn in range(n_root):
                 oe.set_title("CC ROOT {}".format(rn + 1))
-                Da = ccwfn.get_array("CC ROOT {} Da".format(rn + 1))
+                Da = ccwfn.variable("CC ROOT {} Da".format(rn + 1))
                 oe.set_Da_so(Da)
                 if core.get_global_option("REFERENCE") == "UHF":
-                    Db = ccwfn.get_array("CC ROOT {} Db".format(rn + 1))
+                    Db = ccwfn.variable("CC ROOT {} Db".format(rn + 1))
                     oe.set_Db_so(Db)
                 oe.compute()
 
@@ -2750,11 +2750,11 @@ def run_dfmp2_property(name, **kwargs):
     grad = dfmp2_wfn.compute_gradient()
 
     if name == 'scs-mp2':
-        core.set_variable('CURRENT ENERGY', core.get_variable('SCS-MP2 TOTAL ENERGY'))
-        core.set_variable('CURRENT CORRELATION ENERGY', core.get_variable('SCS-MP2 CORRELATION ENERGY'))
+        core.set_variable('CURRENT ENERGY', core.variable('SCS-MP2 TOTAL ENERGY'))
+        core.set_variable('CURRENT CORRELATION ENERGY', core.variable('SCS-MP2 CORRELATION ENERGY'))
     elif name == 'mp2':
-        core.set_variable('CURRENT ENERGY', core.get_variable('MP2 TOTAL ENERGY'))
-        core.set_variable('CURRENT CORRELATION ENERGY', core.get_variable('MP2 CORRELATION ENERGY'))
+        core.set_variable('CURRENT ENERGY', core.variable('MP2 TOTAL ENERGY'))
+        core.set_variable('CURRENT CORRELATION ENERGY', core.variable('MP2 CORRELATION ENERGY'))
 
     # Run OEProp
     oe = core.OEProp(dfmp2_wfn)
@@ -3066,9 +3066,9 @@ def run_detci(name, **kwargs):
         oeprop.add("DIPOLE")
         oeprop.compute()
         ciwfn.oeprop = oeprop
-        core.set_variable("CURRENT DIPOLE X", core.get_variable(name.upper() + " DIPOLE X"))
-        core.set_variable("CURRENT DIPOLE Y", core.get_variable(name.upper() + " DIPOLE Y"))
-        core.set_variable("CURRENT DIPOLE Z", core.get_variable(name.upper() + " DIPOLE Z"))
+        core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
+        core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
+        core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
 
     ciwfn.cleanup_ci()
     ciwfn.cleanup_dpd()
@@ -3113,11 +3113,11 @@ def run_dfmp2(name, **kwargs):
     dfmp2_wfn.compute_energy()
 
     if name == 'scs-mp2':
-        core.set_variable('CURRENT ENERGY', core.get_variable('SCS-MP2 TOTAL ENERGY'))
-        core.set_variable('CURRENT CORRELATION ENERGY', core.get_variable('SCS-MP2 CORRELATION ENERGY'))
+        core.set_variable('CURRENT ENERGY', core.variable('SCS-MP2 TOTAL ENERGY'))
+        core.set_variable('CURRENT CORRELATION ENERGY', core.variable('SCS-MP2 CORRELATION ENERGY'))
     elif name == 'mp2':
-        core.set_variable('CURRENT ENERGY', core.get_variable('MP2 TOTAL ENERGY'))
-        core.set_variable('CURRENT CORRELATION ENERGY', core.get_variable('MP2 CORRELATION ENERGY'))
+        core.set_variable('CURRENT ENERGY', core.variable('MP2 TOTAL ENERGY'))
+        core.set_variable('CURRENT CORRELATION ENERGY', core.variable('MP2 CORRELATION ENERGY'))
 
     optstash.restore()
     core.tstop()
@@ -3225,7 +3225,7 @@ def run_dfep2(name, **kwargs):
         core.set_variable("CURRENT ENERGY", ip_vals[-1])
     if len(ea_vals):
         core.set_variable("EP2 ELECTRON AFFINITY", ea_vals[0])
-        if core.get_variable("EP2 IONIZATION POTENTIAL") == 0.0:
+        if core.variable("EP2 IONIZATION POTENTIAL") == 0.0:
             core.set_variable("CURRENT ENERGY", ea_vals[0])
 
     core.print_out("  EP2 has completed successfully!\n\n")
@@ -3358,7 +3358,7 @@ def run_sapt(name, **kwargs):
     dimer_wfn = scf_helper('RHF', molecule=sapt_dimer, **kwargs)
     if do_delta_mp2:
         select_mp2(name, ref_wfn=dimer_wfn, **kwargs)
-        mp2_corl_interaction_e = core.get_variable('MP2 CORRELATION ENERGY')
+        mp2_corl_interaction_e = core.variable('MP2 CORRELATION ENERGY')
 
     if (sapt_basis == 'dimer') and (ri == 'DF'):
         core.set_global_option('DF_INTS_IO', 'LOAD')
@@ -3374,7 +3374,7 @@ def run_sapt(name, **kwargs):
     monomerA_wfn = scf_helper('RHF', molecule=monomerA, **kwargs)
     if do_delta_mp2:
         select_mp2(name, ref_wfn=monomerA_wfn, **kwargs)
-        mp2_corl_interaction_e -= core.get_variable('MP2 CORRELATION ENERGY')
+        mp2_corl_interaction_e -= core.variable('MP2 CORRELATION ENERGY')
 
     # Compute Monomer B wavefunction
     if (sapt_basis == 'dimer') and (ri == 'DF'):
@@ -3388,7 +3388,7 @@ def run_sapt(name, **kwargs):
     # Delta MP2
     if do_delta_mp2:
         select_mp2(name, ref_wfn=monomerB_wfn, **kwargs)
-        mp2_corl_interaction_e -= core.get_variable('MP2 CORRELATION ENERGY')
+        mp2_corl_interaction_e -= core.variable('MP2 CORRELATION ENERGY')
         core.set_variable('SAPT MP2 CORRELATION ENERGY', mp2_corl_interaction_e)
     core.set_global_option('DF_INTS_IO', df_ints_io)
 
@@ -3464,11 +3464,11 @@ def run_sapt(name, **kwargs):
 
     for term in ['ELST', 'EXCH', 'DISP', 'TOTAL']:
         core.set_variable(' '.join(['SAPT', term, 'ENERGY']),
-            core.get_variable(' '.join([name.upper(), term, 'ENERGY'])))
+            core.variable(' '.join([name.upper(), term, 'ENERGY'])))
     # Special induction case
     core.set_variable(' '.join(['SAPT', target_ind, 'ENERGY']),
-        core.get_variable(' '.join([name.upper(), which_ind, 'ENERGY'])))
-    core.set_variable('CURRENT ENERGY', core.get_variable('SAPT TOTAL ENERGY'))
+        core.variable(' '.join([name.upper(), which_ind, 'ENERGY'])))
+    core.set_variable('CURRENT ENERGY', core.variable('SAPT TOTAL ENERGY'))
 
     return dimer_wfn
 
@@ -3598,7 +3598,7 @@ def run_sapt_ct(name, **kwargs):
     core.IO.change_file_namespace(psif.PSIF_SAPT_MONOMERA, 'monomerA', 'dimer')
     core.IO.change_file_namespace(psif.PSIF_SAPT_MONOMERB, 'monomerB', 'dimer')
     e_sapt = core.sapt(dimer_wfn, monomerA_wfn, monomerB_wfn)
-    CTd = core.get_variable('SAPT CT ENERGY')
+    CTd = core.variable('SAPT CT ENERGY')
 
     core.print_out('\n')
     p4util.banner('Monomer Basis SAPT')
@@ -3606,7 +3606,7 @@ def run_sapt_ct(name, **kwargs):
     core.IO.change_file_namespace(psif.PSIF_SAPT_MONOMERA, 'monomerAm', 'dimer')
     core.IO.change_file_namespace(psif.PSIF_SAPT_MONOMERB, 'monomerBm', 'dimer')
     e_sapt = core.sapt(dimer_wfn, monomerAm_wfn, monomerBm_wfn)
-    CTm = core.get_variable('SAPT CT ENERGY')
+    CTm = core.variable('SAPT CT ENERGY')
     CT = CTd - CTm
 
     units = (1000.0, constants.hartree2kcalmol, constants.hartree2kJmol)
@@ -3699,7 +3699,7 @@ def run_mrcc(name, **kwargs):
     ref_wfn = kwargs.get('ref_wfn', None)
     if ref_wfn is None:
         ref_wfn = scf_helper(name, **kwargs)
-    vscf = core.get_variable('SCF TOTAL ENERGY')
+    vscf = core.variable('SCF TOTAL ENERGY')
 
     # The parse_arbitrary_order method provides us the following information
     # We require that level be provided. level is a dictionary
@@ -4033,33 +4033,33 @@ def run_fnocc(name, **kwargs):
 
     # set current correlation energy and total energy.  only need to treat mpn here.
     if name == 'mp3':
-        emp3 = core.get_variable("MP3 TOTAL ENERGY")
-        cemp3 = core.get_variable("MP3 CORRELATION ENERGY")
+        emp3 = core.variable("MP3 TOTAL ENERGY")
+        cemp3 = core.variable("MP3 CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp3)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp3)
     elif name == 'fno-mp3':
-        emp3 = core.get_variable("MP3 TOTAL ENERGY")
-        cemp3 = core.get_variable("MP3 CORRELATION ENERGY")
+        emp3 = core.variable("MP3 TOTAL ENERGY")
+        cemp3 = core.variable("MP3 CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp3)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp3)
     elif name == 'mp4(sdq)':
-        emp4sdq = core.get_variable("MP4(SDQ) TOTAL ENERGY")
-        cemp4sdq = core.get_variable("MP4(SDQ) CORRELATION ENERGY")
+        emp4sdq = core.variable("MP4(SDQ) TOTAL ENERGY")
+        cemp4sdq = core.variable("MP4(SDQ) CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp4sdq)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp4sdq)
     elif name == 'fno-mp4(sdq)':
-        emp4sdq = core.get_variable("MP4(SDQ) TOTAL ENERGY")
-        cemp4sdq = core.get_variable("MP4(SDQ) CORRELATION ENERGY")
+        emp4sdq = core.variable("MP4(SDQ) TOTAL ENERGY")
+        cemp4sdq = core.variable("MP4(SDQ) CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp4sdq)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp4sdq)
     elif name == 'fno-mp4':
-        emp4 = core.get_variable("MP4 TOTAL ENERGY")
-        cemp4 = core.get_variable("MP4 CORRELATION ENERGY")
+        emp4 = core.variable("MP4 TOTAL ENERGY")
+        cemp4 = core.variable("MP4 CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp4)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp4)
     elif name == 'mp4':
-        emp4 = core.get_variable("MP4 TOTAL ENERGY")
-        cemp4 = core.get_variable("MP4 CORRELATION ENERGY")
+        emp4 = core.variable("MP4 TOTAL ENERGY")
+        cemp4 = core.variable("MP4 CORRELATION ENERGY")
         core.set_variable("CURRENT ENERGY", emp4)
         core.set_variable("CURRENT CORRELATION ENERGY", cemp4)
 
@@ -4246,9 +4246,9 @@ def run_detcas(name, **kwargs):
     oeprop.add("DIPOLE")
     oeprop.compute()
     ciwfn.oeprop = oeprop
-    core.set_variable("CURRENT DIPOLE X", core.get_variable(name.upper() + " DIPOLE X"))
-    core.set_variable("CURRENT DIPOLE Y", core.get_variable(name.upper() + " DIPOLE Y"))
-    core.set_variable("CURRENT DIPOLE Z", core.get_variable(name.upper() + " DIPOLE Z"))
+    core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
+    core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
+    core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
 
     optstash.restore()
     return ciwfn
@@ -4299,6 +4299,6 @@ def run_efp(name, **kwargs):
 
         torq = efpobj.get_gradient()
         torq = core.Matrix.from_array(np.asarray(torq).reshape(-1, 6))
-        core.set_array_variable('EFP TORQUE', torq)
+        core.set_variable('EFP TORQUE', torq)
 
     return ene['total']

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -172,7 +172,7 @@ def print_ci_results(ciwfn, rname, scf_e, ci_e, print_opdm_no=False):
         core.print_out("\n   ==> %s root %d information <==\n\n" % (rname, root))
 
         # Print total energy
-        root_e = core.get_variable("CI ROOT %d TOTAL ENERGY" % (root))
+        root_e = core.variable("CI ROOT %d TOTAL ENERGY" % (root))
         core.print_out("    %s Root %d energy =  %20.15f\n" % (rname, root, root_e))
 
         # Print natural occupations

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -122,7 +122,7 @@ def run_sapt_dft(name, **kwargs):
         core.timer_on("SAPT(DFT): Dimer SCF")
         hf_data = {}
         hf_wfn_dimer = scf_helper("SCF", molecule=sapt_dimer, banner="SAPT(DFT): delta HF Dimer", **kwargs)
-        hf_data["HF DIMER"] = core.get_variable("CURRENT ENERGY")
+        hf_data["HF DIMER"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT): Dimer SCF")
 
         core.timer_on("SAPT(DFT): Monomer A SCF")
@@ -130,7 +130,7 @@ def run_sapt_dft(name, **kwargs):
             core.IO.change_file_namespace(97, 'dimer', 'monomerA')
 
         hf_wfn_A = scf_helper("SCF", molecule=monomerA, banner="SAPT(DFT): delta HF Monomer A", **kwargs)
-        hf_data["HF MONOMER A"] = core.get_variable("CURRENT ENERGY")
+        hf_data["HF MONOMER A"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT): Monomer A SCF")
 
         core.timer_on("SAPT(DFT): Monomer B SCF")
@@ -139,7 +139,7 @@ def run_sapt_dft(name, **kwargs):
             core.IO.change_file_namespace(97, 'monomerA', 'monomerB')
 
         hf_wfn_B = scf_helper("SCF", molecule=monomerB, banner="SAPT(DFT): delta HF Monomer B", **kwargs)
-        hf_data["HF MONOMER B"] = core.get_variable("CURRENT ENERGY")
+        hf_data["HF MONOMER B"] = core.variable("CURRENT ENERGY")
         core.set_global_option("SAVE_JK", False)
         core.timer_off("SAPT(DFT): Monomer B SCF")
 
@@ -192,7 +192,7 @@ def run_sapt_dft(name, **kwargs):
         core.print_out("\n")
         core.print_out(print_sapt_hf_summary(hf_data, "SAPT(HF)", delta_hf=dhf_value))
 
-        data["Delta HF Correction"] = core.get_variable("SAPT(DFT) Delta HF")
+        data["Delta HF Correction"] = core.variable("SAPT(DFT) Delta HF")
         sapt_jk.finalize()
 
         del hf_wfn_A, hf_wfn_B, sapt_jk
@@ -216,7 +216,7 @@ def run_sapt_dft(name, **kwargs):
     core.IO.set_default_namespace('monomerA')
     wfn_A = scf_helper(
         sapt_dft_functional, post_scf=False, molecule=monomerA, banner="SAPT(DFT): DFT Monomer A", **kwargs)
-    data["DFT MONOMERA"] = core.get_variable("CURRENT ENERGY")
+    data["DFT MONOMERA"] = core.variable("CURRENT ENERGY")
 
     core.set_global_option("DFT_GRAC_SHIFT", 0.0)
     core.timer_off("SAPT(DFT): Monomer A DFT")
@@ -233,7 +233,7 @@ def run_sapt_dft(name, **kwargs):
     core.IO.set_default_namespace('monomerB')
     wfn_B = scf_helper(
         sapt_dft_functional, post_scf=False, molecule=monomerB, banner="SAPT(DFT): DFT Monomer B", **kwargs)
-    data["DFT MONOMERB"] = core.get_variable("CURRENT ENERGY")
+    data["DFT MONOMERB"] = core.variable("CURRENT ENERGY")
 
     # Save JK object
     sapt_jk = wfn_B.jk()

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -507,9 +507,9 @@ def vpt2_sow_files(item, linkage, isC4notP4, isC4fully, zmat, inputSansMol, inpu
     inputReapOrders = r"""
 print_variables()
 
-print_out('VPT2 RESULT: linkage {0} for item {1} yields CURRENT ENERGY being %r\n' % (get_variable('CURRENT ENERGY')))
+print_out('VPT2 RESULT: linkage {0} for item {1} yields CURRENT ENERGY being %r\n' % (variable('CURRENT ENERGY')))
 print_out('VPT2 RESULT: linkage {0} for item {1} yields CURRENT GRADIENT being %r\n' % (p4util.mat2arr(core.get_gradient())))
-print_out('VPT2 RESULT: linkage {0} for item {1} yields CURRENT DIPOLE being [%r, %r, %r]\n' % (get_variable('CURRENT DIPOLE X'), get_variable('CURRENT DIPOLE Y'), get_variable('CURRENT DIPOLE Z')))
+print_out('VPT2 RESULT: linkage {0} for item {1} yields CURRENT DIPOLE being [%r, %r, %r]\n' % (variable('CURRENT DIPOLE X'), variable('CURRENT DIPOLE Y'), variable('CURRENT DIPOLE Z')))
 """.format(linkage, item)
 
     # Direct Cfour for gradients
@@ -597,11 +597,11 @@ def vpt2_reaprun_files(item, linkage, isSowReap, isC4notP4, isC4fully, zmat, out
             energy('cfour', path=c4scrdir + '/scr.' + item)
 #            os.chdir(scrdir + '/scr.' + item)
 
-            fje = core.get_variable('CURRENT ENERGY')
+            fje = core.variable('CURRENT ENERGY')
             fjgrd = p4util.mat2arr(core.get_gradient())
-            fjdip = [core.get_variable('CURRENT DIPOLE X') / constants.dipmom_au2debye,
-                     core.get_variable('CURRENT DIPOLE Y') / constants.dipmom_au2debye,
-                     core.get_variable('CURRENT DIPOLE Z') / constants.dipmom_au2debye]
+            fjdip = [core.variable('CURRENT DIPOLE X') / constants.dipmom_au2debye,
+                     core.variable('CURRENT DIPOLE Y') / constants.dipmom_au2debye,
+                     core.variable('CURRENT DIPOLE Z') / constants.dipmom_au2debye]
             c4mol = qcdb.Molecule(core.get_active_molecule().create_psi4_string_from_molecule())
             c4mol.update_geometry()
 
@@ -647,11 +647,11 @@ def vpt2_reaprun_files(item, linkage, isSowReap, isC4notP4, isC4fully, zmat, out
             molecule.update_geometry()
             gradient(lowername, **kwargs)
 
-            fje = core.get_variable('CURRENT ENERGY')
+            fje = core.variable('CURRENT ENERGY')
             fjgrd = p4util.mat2arr(core.get_gradient())
-            fjdip = [core.get_variable('CURRENT DIPOLE X') / constants.dipmom_au2debye,
-                     core.get_variable('CURRENT DIPOLE Y') / constants.dipmom_au2debye,
-                     core.get_variable('CURRENT DIPOLE Z') / constants.dipmom_au2debye]
+            fjdip = [core.variable('CURRENT DIPOLE X') / constants.dipmom_au2debye,
+                     core.variable('CURRENT DIPOLE Y') / constants.dipmom_au2debye,
+                     core.variable('CURRENT DIPOLE Z') / constants.dipmom_au2debye]
 
         # Transform results into C4 orientation (defined by c4mol) & forge FJOBARC file
         fjobarc = qcdb.cfour.format_fjobarc(fje,

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -551,7 +551,7 @@ def database(name, db_name, **kwargs):
             core.print_variables()
             exec(actives)
             for envv in db_tabulate:
-                VRGT[rgt][envv.upper()] = core.get_variable(envv)
+                VRGT[rgt][envv.upper()] = core.variable(envv)
             core.set_global_option("REFERENCE", user_reference)
             core.clean()
             #core.opt_clean()
@@ -577,7 +577,7 @@ def database(name, db_name, **kwargs):
                 for envv in db_tabulate:
                     freagent.write("""core.print_out('DATABASE RESULT: computation %d for reagent %s """
                         % (os.getpid(), rgt))
-                    freagent.write("""yields variable value    %20.12f for variable %s\\n' % (core.get_variable(""")
+                    freagent.write("""yields variable value    %20.12f for variable %s\\n' % (core.variable(""")
                     freagent.write("""'%s'), '%s'))\n""" % (envv.upper(), envv.upper()))
 
         elif db_mode == 'reap':

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -94,11 +94,11 @@ set {
 energy('sapt0')
 
 compare_values(85.189064531275775, dimer.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
-compare_values(-0.00343130969, psi4.get_variable("SSAPT0 ELST ENERGY"), 6, "sSAPT0 elst")
-compare_values( 0.00368418323, psi4.get_variable("SSAPT0 EXCH ENERGY"), 6, "sSAPT0 exch")
-compare_values(-0.00093297498, psi4.get_variable("SSAPT0 IND ENERGY"), 6, "sSAPT0 ind")
-compare_values(-0.00231534918, psi4.get_variable("SSAPT0 DISP ENERGY"), 6, "sSAPT0 disp")
-compare_values(-0.00299545062, psi4.get_variable("SSAPT0 TOTAL ENERGY"), 6, "sSAPT0")
+compare_values(-0.00343130969, psi4.variable("SSAPT0 ELST ENERGY"), 6, "sSAPT0 elst")
+compare_values( 0.00368418323, psi4.variable("SSAPT0 EXCH ENERGY"), 6, "sSAPT0 exch")
+compare_values(-0.00093297498, psi4.variable("SSAPT0 IND ENERGY"), 6, "sSAPT0 ind")
+compare_values(-0.00231534918, psi4.variable("SSAPT0 DISP ENERGY"), 6, "sSAPT0 disp")
+compare_values(-0.00299545062, psi4.variable("SSAPT0 TOTAL ENERGY"), 6, "sSAPT0")
 """
 
     tfn = '_thread_test_input_psi4_yo'
@@ -173,8 +173,8 @@ set {
 }
 
 e, wfn = energy('plugdfmp2', return_wfn=True)
-compare_values(-1.6309450762271729, wfn.get_variable('MP2 CORRELATION ENERGY'), 5, 'df-mp2 energy')  # aug-cc-pvdz
-#compare_values(-1.5720781831194317, wfn.get_variable('MP2 CORRELATION ENERGY'), 5, 'df-mp2 energy')  # cc-pvdz
+compare_values(-1.6309450762271729, wfn.variable('MP2 CORRELATION ENERGY'), 5, 'df-mp2 energy')  # aug-cc-pvdz
+#compare_values(-1.5720781831194317, wfn.variable('MP2 CORRELATION ENERGY'), 5, 'df-mp2 energy')  # cc-pvdz
 """ % (args.module)
 
     tfn = '_dfmp2_plugin_thread_test_input_psi4_yo'

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -372,7 +372,7 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
                 auto ref_Da_so = ref_wfn->Da();
                 ref_Da_so->copy(Pa_so);
             } else {
-                ref_wfn->set_array("CC ROOT " + std::to_string(i) + " Da", Pa_so);
+                ref_wfn->set_array_variable("CC ROOT " + std::to_string(i) + " Da", Pa_so);
             }
         } else {
             auto Pa_so = Matrix::triplet(ref_wfn->Ca(), Pa, ref_wfn->Ca(), false, false, true);
@@ -383,8 +383,8 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
                 ref_Da_so->copy(Pa_so);
                 ref_Db_so->copy(Pb_so);
             } else {
-                ref_wfn->set_array("CC ROOT " + std::to_string(i) + " Da", Pa_so);
-                ref_wfn->set_array("CC ROOT " + std::to_string(i) + " Db", Pb_so);
+                ref_wfn->set_array_variable("CC ROOT " + std::to_string(i) + " Da", Pa_so);
+                ref_wfn->set_array_variable("CC ROOT " + std::to_string(i) + " Db", Pb_so);
             }
         }
 

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -123,8 +123,8 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
     double epcm = 0.0;
 #ifdef USING_PCMSolver
     if (options.get_bool("PCM")) {
-        epcm = ref->reference_wavefunction() ? ref->reference_wavefunction()->get_variable("PCM POLARIZATION ENERGY")
-                                             : ref->get_variable("PCM POLARIZATION ENERGY");
+        epcm = ref->reference_wavefunction() ? ref->reference_wavefunction()->scalar_variable("PCM POLARIZATION ENERGY")
+                                             : ref->scalar_variable("PCM POLARIZATION ENERGY");
     }
 #endif
 

--- a/psi4/src/psi4/gdma_interface/wrapper.cc
+++ b/psi4/src/psi4/gdma_interface/wrapper.cc
@@ -80,9 +80,9 @@ SharedWavefunction gdma_interface(SharedWavefunction ref_wfn, Options& options, 
     Process::environment.arrays["DMA TOTAL MULTIPOLES"] = totvals;
     outfile->Printf(
         "\n  DMA results are available in the Python driver through the\n"
-        "\t  get_array_variable('DMA DISTRIBUTED MULTIPOLES')\n"
+        "\t  variable('DMA DISTRIBUTED MULTIPOLES')\n"
         "  and\n"
-        "\t  get_array_variable('DMA TOTAL MULTIPOLES')\n"
+        "\t  variable('DMA TOTAL MULTIPOLES')\n"
         "  commands.\n\n");
 
     return ref_wfn;

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1579,7 +1579,7 @@ void OEProp::compute_mulliken_charges() {
     for (size_t i = 0; i < apcs->size(); i++) {
         vec_apcs->set(0, i, (*apcs)[i]);
     }
-    wfn_->set_array("MULLIKEN_CHARGES", vec_apcs);
+    wfn_->set_array_variable("MULLIKEN_CHARGES", vec_apcs);
 }
 
 std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
@@ -1674,7 +1674,7 @@ void OEProp::compute_lowdin_charges() {
     for (size_t i = 0; i < apcs->size(); i++) {
         vec_apcs->set(0, i, (*apcs)[i]);
     }
-    wfn_->set_array("LOWDIN_CHARGES", vec_apcs);
+    wfn_->set_array_variable("LOWDIN_CHARGES", vec_apcs);
 }
 
 std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
@@ -1768,7 +1768,7 @@ void OEProp::compute_mayer_indices() {
     SharedVector MBI_valence;
     std::tie(MBI_total, MBI_alpha, MBI_beta, MBI_valence) = pac_.compute_mayer_indices(true);
 
-    wfn_->set_array("MAYER_INDICES", MBI_total);
+    wfn_->set_array_variable("MAYER_INDICES", MBI_total);
 }
 
 std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> PopulationAnalysisCalc::compute_mayer_indices(
@@ -1889,7 +1889,7 @@ void OEProp::compute_wiberg_lowdin_indices() {
     SharedMatrix WBI_total, WBI_alpha, WBI_beta;
     SharedVector WBI_valence;
     std::tie(WBI_total, WBI_alpha, WBI_beta, WBI_valence) = pac_.compute_wiberg_lowdin_indices(true);
-    wfn_->set_array("WIBERG_LOWDIN_INDICES", WBI_total);
+    wfn_->set_array_variable("WIBERG_LOWDIN_INDICES", WBI_total);
 }
 
 std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector>

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -151,19 +151,19 @@ double SAPT0::compute_energy() {
         print_results();
     }
 
-    set_variable("E Elst10", e_elst10_);
-    set_variable("E Exch10", e_exch10_);
-    set_variable("E Exch10(S^2)", e_exch10_s2_);
-    set_variable("E Ind20", e_ind20_);
-    set_variable("E Exch-Ind20", e_exch_ind20_);
-    set_variable("E Disp20", e_disp20_);
-    set_variable("E Exch-Disp20", e_exch_disp20_);
-    set_variable("E Disp20(SS)", e_disp20_ss_);
-    set_variable("E Disp20(OS)", e_disp20_os_);
-    set_variable("E Exch-Disp20(SS)", e_exch_disp20_ss_);
-    set_variable("E Exch-Disp20(OS)", e_exch_disp20_os_);
-    set_variable("E SAPT0", e_sapt0_);
-    set_variable("E SCS-SAPT0", e_sapt0_scs_);
+    set_scalar_variable("E Elst10", e_elst10_);
+    set_scalar_variable("E Exch10", e_exch10_);
+    set_scalar_variable("E Exch10(S^2)", e_exch10_s2_);
+    set_scalar_variable("E Ind20", e_ind20_);
+    set_scalar_variable("E Exch-Ind20", e_exch_ind20_);
+    set_scalar_variable("E Disp20", e_disp20_);
+    set_scalar_variable("E Exch-Disp20", e_exch_disp20_);
+    set_scalar_variable("E Disp20(SS)", e_disp20_ss_);
+    set_scalar_variable("E Disp20(OS)", e_disp20_os_);
+    set_scalar_variable("E Exch-Disp20(SS)", e_exch_disp20_ss_);
+    set_scalar_variable("E Exch-Disp20(OS)", e_exch_disp20_os_);
+    set_scalar_variable("E SAPT0", e_sapt0_);
+    set_scalar_variable("E SCS-SAPT0", e_sapt0_scs_);
 
     return (e_sapt0_);
 }

--- a/psi4/src/psi4/sapt/wrapper.cc
+++ b/psi4/src/psi4/sapt/wrapper.cc
@@ -66,8 +66,8 @@ PsiReturnType sapt(SharedWavefunction Dimer, SharedWavefunction MonomerA, Shared
             SAPT0 sapt(Dimer, MonomerA, MonomerB, options, psio);
             sapt.compute_energy();
             // Copy back over the variables
-            for (const auto& kv : sapt.variables()) {
-                Dimer->set_variable(kv.first, kv.second);
+            for (const auto& kv : sapt.scalar_variables()) {
+                Dimer->set_scalar_variable(kv.first, kv.second);
             }
 
         } else {

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -65,10 +65,10 @@ SCFGrad::SCFGrad(SharedWavefunction ref_wfn, Options& options) :
     functional_ = scfwfn->functional();
     potential_ = scfwfn->V_potential();
     if (ref_wfn->has_array_variable("-D Gradient")) {
-        gradients_["-D Gradient"] = ref_wfn->get_array("-D Gradient");
+        gradients_["-D Gradient"] = ref_wfn->array_variable("-D Gradient");
     }
     if (ref_wfn->has_array_variable("-D Hessian")) {
-        hessians_["-D Hessian"] = ref_wfn->get_array("-D Hessian");
+        hessians_["-D Hessian"] = ref_wfn->array_variable("-D Hessian");
     }
 
 }

--- a/tests/ao-casscf-sp/input.dat
+++ b/tests/ao-casscf-sp/input.dat
@@ -18,5 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017296555283, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/ao-dfcasscf-sp/input.dat
+++ b/tests/ao-dfcasscf-sp/input.dat
@@ -18,5 +18,5 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017259983350470, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073736807922970, casscf_energy, 6, 'AO-DFCASSCF Energy')  #TEST

--- a/tests/casscf-fzc-sp/input.dat
+++ b/tests/casscf-fzc-sp/input.dat
@@ -18,7 +18,7 @@ set {
 casscf_energy = energy('casscf')
 
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017296555283, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073773094606, casscf_energy, 6, 'FZC CASSCF Energy')  #TEST
 
 
@@ -29,5 +29,5 @@ set {
 casscf_energy = energy('casscf')
 
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017296555283, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073773094606, casscf_energy, 6, 'RSP-FZC CASSCF Energy')  #TEST

--- a/tests/casscf-sa-sp/input.dat
+++ b/tests/casscf-sa-sp/input.dat
@@ -52,8 +52,8 @@ set detci {
 
 
 casscf_energy = energy('casscf')
-compare_values(-75.375529547673, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
-compare_values(-75.604189023004, psi4.get_variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
-compare_values(-75.477044791109, psi4.get_variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
+compare_values(-75.375529547673, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-75.604189023004, psi4.variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
+compare_values(-75.477044791109, psi4.variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
 compare_values(-75.540616907115, casscf_energy, 6, 'CASSCF Energy')  #TEST
 

--- a/tests/casscf-semi/input.dat
+++ b/tests/casscf-semi/input.dat
@@ -18,5 +18,5 @@ set {
 
 cas_e, cas_wfn = energy("CASSCF", return_wfn=True)
 
-compare_values(-76.017296555283, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017296555283, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.072158733148, cas_e, 8, 'FZC/FZV CASSCF Energy')                       #TEST

--- a/tests/castup2/input.dat
+++ b/tests/castup2/input.dat
@@ -12,8 +12,8 @@ molecule zinc {
 
 set basis 6-31g*
 
-print_stdout('                                     local    global   used')  #TEST
-print_stdout('                    prelims          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+print('                                     local    global   used')  #TEST
+print('                    prelims          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 
 set scf_type pk
 banner('ITEM 1')

--- a/tests/castup2/input.dat
+++ b/tests/castup2/input.dat
@@ -18,7 +18,7 @@ print_stdout('                    prelims          %s %s %s %s %s %s' % (get_loc
 set scf_type pk
 banner('ITEM 1')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[1]     scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[1]     scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type pk
@@ -26,7 +26,7 @@ set basis_guess on
 set df_basis_guess yes
 banner('ITEM 2')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[2]     scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[2]     scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -36,7 +36,7 @@ clean()
 set scf_type df
 banner('ITEM 3')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[3]  df-scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[3]  df-scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type df
@@ -44,7 +44,7 @@ set basis_guess true
 set df_basis_guess true
 banner('ITEM 4')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[4]  df-scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[4]  df-scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -55,7 +55,7 @@ set scf_type pk
 set puream true
 banner('ITEM 5')
 energy('scf')
-compare_values(-37.5882734783, get_variable('SCF TOTAL ENERGY'), 6, '[5]     scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882734783, variable('SCF TOTAL ENERGY'), 6, '[5]     scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type pk
@@ -64,7 +64,7 @@ set basis_guess true
 set df_basis_guess true
 banner('ITEM 6')
 energy('scf')
-compare_values(-37.5882734783, get_variable('SCF TOTAL ENERGY'), 6, '[6]     scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882734783, variable('SCF TOTAL ENERGY'), 6, '[6]     scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -75,7 +75,7 @@ set scf_type df
 set puream true
 banner('ITEM 7')
 energy('scf')
-compare_values(-37.5882728035, get_variable('SCF TOTAL ENERGY'), 6, '[7]  df-scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882728035, variable('SCF TOTAL ENERGY'), 6, '[7]  df-scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type df
@@ -84,7 +84,7 @@ set basis_guess true
 set df_basis_guess true
 banner('ITEM 8')
 energy('scf')
-compare_values(-37.5882728035, get_variable('SCF TOTAL ENERGY'), 6, '[8]  df-scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882728035, variable('SCF TOTAL ENERGY'), 6, '[8]  df-scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -95,7 +95,7 @@ set scf_type pk
 set puream false
 banner('ITEM 9')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[9]     scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[9]     scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type pk
@@ -104,7 +104,7 @@ set basis_guess true
 set df_basis_guess true
 banner('ITEM 10')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[10]    scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[10]    scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -115,7 +115,7 @@ set scf_type df
 set puream false
 banner('ITEM 11')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[11] df-scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[11] df-scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf_type df
@@ -124,7 +124,7 @@ set basis_guess true
 set df_basis_guess true
 banner('ITEM 12')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[12] df-scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[12] df-scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')

--- a/tests/castup3/input.dat
+++ b/tests/castup3/input.dat
@@ -13,8 +13,8 @@ molecule zinc {
 set basis 6-31g*
 set df_basis_scf cc-pvdz-jkfit
 
-print_stdout('                                     local    global   used')  #TEST
-print_stdout('                    prelims          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+print('                                     local    global   used')  #TEST
+print('                    prelims          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 
 set scf scf_type pk
 banner('ITEM 1')

--- a/tests/castup3/input.dat
+++ b/tests/castup3/input.dat
@@ -19,7 +19,7 @@ print_stdout('                    prelims          %s %s %s %s %s %s' % (get_loc
 set scf scf_type pk
 banner('ITEM 1')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[1]     scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[1]     scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type pk
@@ -27,7 +27,7 @@ set basis_guess on
 set df_basis_guess yes
 banner('ITEM 2')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[2]     scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[2]     scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -37,7 +37,7 @@ clean()
 set scf scf_type df
 banner('ITEM 3')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[3]  df-scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[3]  df-scf default          %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type df
@@ -45,7 +45,7 @@ set basis_guess 3-21G
 set df_basis_guess true
 banner('ITEM 4')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[4]  df-scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[4]  df-scf default   castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -56,7 +56,7 @@ set scf scf_type pk
 set puream true
 banner('ITEM 5')
 energy('scf')
-compare_values(-37.5882734783, get_variable('SCF TOTAL ENERGY'), 6, '[5]     scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882734783, variable('SCF TOTAL ENERGY'), 6, '[5]     scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type pk
@@ -65,7 +65,7 @@ set df_basis_guess true
 set puream true
 banner('ITEM 6')
 energy('scf')
-compare_values(-37.5882734783, get_variable('SCF TOTAL ENERGY'), 6, '[6]     scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882734783, variable('SCF TOTAL ENERGY'), 6, '[6]     scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -76,7 +76,7 @@ set scf scf_type df
 set puream true
 banner('ITEM 7')
 energy('scf')
-compare_values(-37.5882728035, get_variable('SCF TOTAL ENERGY'), 6, '[7]  df-scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882728035, variable('SCF TOTAL ENERGY'), 6, '[7]  df-scf spherical        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type df
@@ -85,7 +85,7 @@ set df_basis_guess true
 set puream true
 banner('ITEM 8')
 energy('scf')
-compare_values(-37.5882728035, get_variable('SCF TOTAL ENERGY'), 6, '[8]  df-scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5882728035, variable('SCF TOTAL ENERGY'), 6, '[8]  df-scf spherical castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -96,7 +96,7 @@ set scf scf_type pk
 set puream false
 banner('ITEM 9')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[9]     scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[9]     scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type pk
@@ -105,7 +105,7 @@ set df_basis_guess true
 set puream false
 banner('ITEM 10')
 energy('scf')
-compare_values(-37.5885579065, get_variable('SCF TOTAL ENERGY'), 6, '[10]    scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885579065, variable('SCF TOTAL ENERGY'), 6, '[10]    scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')
@@ -116,7 +116,7 @@ set scf scf_type df
 set puream false
 banner('ITEM 11')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[11] df-scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[11] df-scf cartesian        %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 clean()
 
 set scf scf_type df
@@ -125,7 +125,7 @@ set df_basis_guess true
 set puream false
 banner('ITEM 12')
 energy('scf')
-compare_values(-37.5885589047, get_variable('SCF TOTAL ENERGY'), 6, '[12] df-scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
+compare_values(-37.5885589047, variable('SCF TOTAL ENERGY'), 6, '[12] df-scf cartesian castup %s %s %s %s %s %s' % (get_local_option('SCF', 'SCF_TYPE'), has_local_option_changed('SCF', 'SCF_TYPE'), get_global_option('SCF_TYPE'), has_global_option_changed('SCF_TYPE'), get_option('SCF', 'SCF_TYPE'), has_option_changed('SCF', 'SCF_TYPE')))  #TEST
 set basis_guess false
 set df_basis_guess false
 revoke_local_option_changed('SCF', 'BASIS_GUESS')

--- a/tests/cbs-xtpl-alpha/input.dat
+++ b/tests/cbs-xtpl-alpha/input.dat
@@ -47,18 +47,18 @@ compare_values(scf_123_aug_pcsseg_ref, E, 7, "SCF/aug-pcsseg-[123] with scf_xtpl
 
 E = energy(cbs, scf_wfn='scf', scf_basis='def2-[st]zvpd', scf_scheme=scf_xtpl_helgaker_2,
                corl_wfn='mp2', corl_basis='def2-[st]zvpd', corl_scheme=corl_xtpl_helgaker_2)
-c = get_variable("CBS CORRELATION ENERGY")
+c = variable("CBS CORRELATION ENERGY")
 compare_values(mp2_corl_a_3_0_ref, c, 7, "MP2/def2-[st]zvpd correlation E")                #TEST
 
 E = energy(cbs, scf_wfn='scf', scf_basis='def2-[st]zvpd', scf_scheme=scf_xtpl_helgaker_2,
                corl_wfn='mp2', corl_basis='def2-[st]zvpd', corl_scheme=corl_xtpl_helgaker_2, corl_alpha=2.4)
-c = get_variable("CBS CORRELATION ENERGY")
+c = variable("CBS CORRELATION ENERGY")
 compare_values(mp2_corl_a_2_4_ref, c, 7, "MP2/def2-[st]zvpd correlation E, alpha = 2.4")   #TEST
 
 E = energy(cbs, scf_wfn='scf', scf_basis='cc-pv[dt]z', scf_scheme=scf_xtpl_helgaker_2,
                corl_wfn='mp2', corl_basis='cc-pv[dt]z', corl_scheme=corl_xtpl_helgaker_2, corl_alpha=3.1,
               delta_wfn='ccsd(t)', delta_basis='cc-pv[dt]z', delta_scheme=corl_xtpl_helgaker_2, delta_alpha=2.4)
-c = get_variable("CBS CORRELATION ENERGY")
+c = variable("CBS CORRELATION ENERGY")
 compare_values(corl_delta_a_2_4_ref, c, 7, "MP2 + D:CCSD(T)/cc-[DT] correlation E, alphas = (3.1,2.4)")   #TEST
 
 

--- a/tests/cc-module/input.dat
+++ b/tests/cc-module/input.dat
@@ -69,7 +69,7 @@ def do_check(module, cc_typ, fc):
         dict(qc_module=module, cc_type=cc_typ, freeze_core=fc, basis='cc-pvdz', e_convergence=10, d_convergence=8))
     ret_e = energy('ccsd(t)', molecule=hf)
     for var_name, ref_val in refs[cc_typ][fc].items():
-        compare_values(ref_val, get_variable(var_name), 7, "{}/{} (fc={}) [{}]".format(cc_typ, module, fc,  var_name))
+        compare_values(ref_val, variable(var_name), 7, "{}/{} (fc={}) [{}]".format(cc_typ, module, fc,  var_name))
     compare_values(refs[cc_typ][fc]['CCSD(T) TOTAL ENERGY'],
             ret_e, 7, "{}/{} (fc={}) [{}]".format(cc_typ, module, fc, 'return value'))
     clean_variables()

--- a/tests/cc1/input.dat
+++ b/tests/cc1/input.dat
@@ -18,6 +18,6 @@ refccsd  = -0.20823570806196  #TEST
 reftotal = -76.2311784355056  #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST

--- a/tests/cc10/input.dat
+++ b/tests/cc10/input.dat
@@ -24,6 +24,6 @@ eccsd  =  -0.28134621116616  #TEST
 etotal = -92.47690281733487  #TEST
 
 compare_values(enuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
-compare_values(escf, get_variable("SCF total energy"), 7, "SCF energy")               #TEST
-compare_values(eccsd, get_variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
-compare_values(etotal, get_variable("Current energy"), 7, "Total energy")             #TEST
+compare_values(escf, variable("SCF total energy"), 7, "SCF energy")               #TEST
+compare_values(eccsd, variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
+compare_values(etotal, variable("Current energy"), 7, "Total energy")             #TEST

--- a/tests/cc12/input.dat
+++ b/tests/cc12/input.dat
@@ -18,9 +18,9 @@ set {
 
 energy('eom-ccsd')
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy")                 #TEST
-compare_values(ccsd_0, get_variable("CCSD TOTAL ENERGY"), 6, "CCSD energy")              #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy")                 #TEST
+compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 6, "CCSD energy")              #TEST
 for root in range(1,9):                                                                  #TEST
     ref = eomccsd_ref[root-1]                                                            #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                                 #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root)                                 #TEST
     compare_values(ref, val, 6, "EOM-CCSD root %d" %root)                                #TEST

--- a/tests/cc13/input.dat
+++ b/tests/cc13/input.dat
@@ -26,6 +26,6 @@ set {
 optimize('CCSD')
 
 compare_values(refnuc,   ch2.nuclear_repulsion_energy(),          5, "Nuclear repulsion energy")  #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        6, "SCF energy")                #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 6, "CCSD contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          6, "Total energy")              #TEST
+compare_values(refscf,   variable("SCF total energy"),        6, "SCF energy")                #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 6, "CCSD contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          6, "Total energy")              #TEST

--- a/tests/cc13a/input.dat
+++ b/tests/cc13a/input.dat
@@ -27,6 +27,6 @@ refccsd_t  =  -0.11716018769631   #TEST
 reftotal   = -39.04371227103925   #TEST
 
 compare_values(refnuc,   ch2.nuclear_repulsion_energy(),          5, "Nuclear repulsion energy")  #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        6, "SCF energy")                #TEST
-compare_values(refccsd_t,  get_variable("CCSD(T) correlation energy"), 6, "CCSD(T) contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          6, "Total energy")              #TEST
+compare_values(refscf,   variable("SCF total energy"),        6, "SCF energy")                #TEST
+compare_values(refccsd_t,  variable("CCSD(T) correlation energy"), 6, "CCSD(T) contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          6, "Total energy")              #TEST

--- a/tests/cc14/input.dat
+++ b/tests/cc14/input.dat
@@ -25,6 +25,6 @@ refscf = -38.921394733562281                                                    
 refcor =  -0.120484098351036                                                                    #TEST
 reftot = -39.041878831913316                                                                    #TEST
 compare_values(refnuc, ch2.nuclear_repulsion_energy(),          5, "Nuclear repulsion energy")  #TEST
-compare_values(refscf, get_variable("SCF total energy"),        6, "SCF energy")                #TEST
-compare_values(refcor, get_variable("CCSD correlation energy"), 6, "CCSD contribution")         #TEST
-compare_values(reftot, get_variable("Current energy"),          6, "Total energy")              #TEST
+compare_values(refscf, variable("SCF total energy"),        6, "SCF energy")                #TEST
+compare_values(refcor, variable("CCSD correlation energy"), 6, "CCSD contribution")         #TEST
+compare_values(reftot, variable("Current energy"),          6, "Total energy")              #TEST

--- a/tests/cc15/input.dat
+++ b/tests/cc15/input.dat
@@ -16,6 +16,6 @@ energy("bccd(t)")
 escf = -76.021997876298414 #TEST
 ebccd = -76.228456597086762 #TEST
 ebccd_t = -76.231452929871523 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST

--- a/tests/cc16/input.dat
+++ b/tests/cc16/input.dat
@@ -20,9 +20,9 @@ energy("bccd(t)")
 escf = -38.917378694797030 #TEST
 ebccd = -39.030833895315020 #TEST
 ebccd_t = -39.032691827829460 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
 
 
 # We should obtain the same result as above, but start with different orbitals
@@ -35,6 +35,6 @@ energy("bccd(t)")
 escf = -38.91341670976116 #TEST
 ebccd = -39.030807046983838 #TEST
 ebccd_t = -39.032665163463861 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST

--- a/tests/cc17/input.dat
+++ b/tests/cc17/input.dat
@@ -21,9 +21,9 @@ escf = -38.917378694797                                                        #
 eccsd = -39.03274757226                                                        #TEST
 eeom_ccsd = [-38.6664604477, -38.6032901417, -38.7702711146, -38.6989011688,   #TEST
              -38.7458590086, -38.5424940735, -38.8224374840, -38.6232036004 ]  #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
-compare_values(eccsd, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
 for root in range(1,9):                                                        #TEST
     ref = eeom_ccsd[root-1]                                                    #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
     compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                     #TEST

--- a/tests/cc18/input.dat
+++ b/tests/cc18/input.dat
@@ -20,6 +20,6 @@ refccsd = -0.368843103062227    #TEST
 reftotal = -174.787276104686754 #TEST
 
 compare_values(refnuc, hof.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf, get_variable("SCF total energy"),         9, "SCF energy")               #TEST
-compare_values(refccsd, get_variable("CCSD correlation energy"), 8, "CCSD correlation energy")  #TEST
-compare_values(reftotal, get_variable("Current energy"),         8, "CCSD total energy")        #TEST
+compare_values(refscf, variable("SCF total energy"),         9, "SCF energy")               #TEST
+compare_values(refccsd, variable("CCSD correlation energy"), 8, "CCSD correlation energy")  #TEST
+compare_values(reftotal, variable("Current energy"),         8, "CCSD total energy")        #TEST

--- a/tests/cc2/input.dat
+++ b/tests/cc2/input.dat
@@ -22,6 +22,6 @@ refccsd  = -0.208238532935749  #TEST
 reftotal = -76.2311784833722   #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST

--- a/tests/cc22/input.dat
+++ b/tests/cc22/input.dat
@@ -20,9 +20,9 @@ energy('eom-ccsd')
 escf = -38.904170464925                                                    #TEST
 eccsd = -38.98782404003                                                    #TEST
 eeom_ccsd = [ -38.7169665265, -38.6330680540]                              #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
-compare_values(eccsd, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
 for root in range(1,3):                                                    #TEST
     ref = eeom_ccsd[root-1]                                                #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                   #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root)                   #TEST
     compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                 #TEST

--- a/tests/cc29/input.dat
+++ b/tests/cc29/input.dat
@@ -25,9 +25,9 @@ reflen_355   =   -214.73273  #TEST
 refvel_355   =    384.88786  #TEST
 refmvg_355   =   -644.44746  #TEST
 
-compare_values(reflen_589,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
-compare_values(refvel_589,   get_variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
-compare_values(refmvg_589,   get_variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
-compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
-compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
-compare_values(reflen_355,   get_variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
+compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
+compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST

--- a/tests/cc3/input.dat
+++ b/tests/cc3/input.dat
@@ -22,9 +22,9 @@ refccsd  = -0.208238532935749  #TEST
 reftotal = -76.2311784833722   #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST
 
 ccsd_e, ccsd_wfn = frequencies('ccsd', dertype=1, return_wfn=True)
 fd_freqs_grad = ccsd_wfn.frequencies()

--- a/tests/cc32/input.dat
+++ b/tests/cc32/input.dat
@@ -15,5 +15,5 @@ energy("cc3")
 
 escf = -76.024038511513183  #TEST
 ecc3 = -76.241273893572554  #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ecc3, get_variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc3, variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST

--- a/tests/cc33/input.dat
+++ b/tests/cc33/input.dat
@@ -19,5 +19,5 @@ energy("cc3")
 
 escf = -75.634062420797349 #TEST
 ecc3 = -75.806483036891777 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ecc3, get_variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc3, variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST

--- a/tests/cc35/input.dat
+++ b/tests/cc35/input.dat
@@ -19,5 +19,5 @@ energy("cc3")
 
 escf = -75.629493609435926 #TEST
 ecc3 = -75.806482491739388 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ecc3, get_variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc3, variable("CC3 TOTAL ENERGY"), 7, "CC3 energy") #TEST

--- a/tests/cc38/input.dat
+++ b/tests/cc38/input.dat
@@ -13,4 +13,4 @@ set {
 
 properties('cc2',properties=['polarizability'])
 ref_static_polar = 5.240960398531
-compare_values(ref_static_polar,   get_variable("CC2 DIPOLE POLARIZABILITY @ INF NM"),  3, "CC2 polarizability @ Inf nm") #TEST
+compare_values(ref_static_polar,   variable("CC2 DIPOLE POLARIZABILITY @ INF NM"),  3, "CC2 polarizability @ Inf nm") #TEST

--- a/tests/cc39/input.dat
+++ b/tests/cc39/input.dat
@@ -17,5 +17,5 @@ properties('cc2',properties=['polarizability'])
 refpol_911   =    5.289283300369  #TEST
 refpol_456   =    5.456588276958  #TEST
 
-compare_values(refpol_911,   get_variable("CC2 DIPOLE POLARIZABILITY @ 911NM"),  3, "CC2 polarizability @ 911nm") #TEST
-compare_values(refpol_456,   get_variable("CC2 DIPOLE POLARIZABILITY @ 456NM"),  3, "CC2 polarizability @ 456nm") #TEST
+compare_values(refpol_911,   variable("CC2 DIPOLE POLARIZABILITY @ 911NM"),  3, "CC2 polarizability @ 911nm") #TEST
+compare_values(refpol_456,   variable("CC2 DIPOLE POLARIZABILITY @ 456NM"),  3, "CC2 polarizability @ 456nm") #TEST

--- a/tests/cc4/input.dat
+++ b/tests/cc4/input.dat
@@ -26,14 +26,14 @@ set {
 energy('ccsd(t)')
 
 compare_values(refnuc,   bh.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        9, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
-compare_values(ref_t,    get_variable("(T) correction energy"),   9, "(T) contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          9, "Total energy")             #TEST
-compare_values(0.012982, get_variable("CC T1 DIAGNOSTIC"),         5, "CC T1 Diagnostic")             #TEST
-compare_values(0.025595, get_variable("CC D1 DIAGNOSTIC"),         5, "CC D1 Diagnostic")             #TEST
-compare_values(0.025595, get_variable("CC NEW D1 DIAGNOSTIC"),     5, "CC NEW D1 Diagnostic")             #TEST
-compare_values(0.267312, get_variable("CC D2 DIAGNOSTIC"),         5, "CC D2 Diagnostic")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        9, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
+compare_values(ref_t,    variable("(T) correction energy"),   9, "(T) contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          9, "Total energy")             #TEST
+compare_values(0.012982, variable("CC T1 DIAGNOSTIC"),         5, "CC T1 Diagnostic")             #TEST
+compare_values(0.025595, variable("CC D1 DIAGNOSTIC"),         5, "CC D1 Diagnostic")             #TEST
+compare_values(0.025595, variable("CC NEW D1 DIAGNOSTIC"),     5, "CC NEW D1 Diagnostic")             #TEST
+compare_values(0.267312, variable("CC D2 DIAGNOSTIC"),         5, "CC D2 Diagnostic")             #TEST
 
 #Here's a demonstration of how to print an manipulate the files used by Psi
 psi4_io.print_out()

--- a/tests/cc44/input.dat
+++ b/tests/cc44/input.dat
@@ -27,9 +27,9 @@ scf_0     =   -76.05675776144756                                            #TES
 ccsd_0    =   -76.34161380738567                                            #TEST
 eomccsd_0 = [ -75.961272583411, -75.898190749064 ]                          #TEST
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
-compare_values(ccsd_0, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
+compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
 for root in range(1,3):                                                     #TEST
     ref = eomccsd_0[root-1]                                                 #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                    #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root)                    #TEST
     compare_values(ref, val, 7, "EOM-CCSD root %d" %root)                   #TEST

--- a/tests/cc45/input.dat
+++ b/tests/cc45/input.dat
@@ -19,10 +19,10 @@ cc2_0   =   -76.22253325763003                                                  
 eomcc_0 = [ -75.809233678819, -75.534141615619, -75.826553933384, -75.381447128586,   #TEST
             -75.904202214316, -75.295956806957, -75.729129680049, -75.642857468928 ]  #TEST
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
-compare_values(cc2_0, get_variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
+compare_values(cc2_0, variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
 
 for root in range(1,9):                                  #TEST
     ref = eomcc_0[root-1]                                #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root) #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root) #TEST
     compare_values(ref, val, 6, "EOM-CC2 root %d" %root) #TEST

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -76,15 +76,15 @@ root_refs = {
 
 # check ground state
 for tag,refval in gs_refs.items():
-    compare_values(psi4.get_variable(tag),refval,4, tag)                          #TEST
+    compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
 
 # check eom roots
 for tag,refval in root_refs.items():
-    compare_values(psi4.get_variable(tag),refval,4, tag)                          #TEST
+    compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
 
 
 # Checking that the wfn.Da/Db have been set by ccdensity
 oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST CC")
 for tag,refval in gs_refs.items():
-    oeprop_val = psi4.get_variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
+    oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
     compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST

--- a/tests/cc4a/input.dat
+++ b/tests/cc4a/input.dat
@@ -24,7 +24,7 @@ set {
 energy('ccsd(t)')
 
 compare_values(refnuc,   bh.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        9, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
-compare_values(ref_t,    get_variable("(T) correction energy"),   9, "(T) contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          9, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        9, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
+compare_values(ref_t,    variable("(T) correction energy"),   9, "(T) contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          9, "Total energy")             #TEST

--- a/tests/cc5/input.dat
+++ b/tests/cc5/input.dat
@@ -35,7 +35,7 @@ set {
 energy('ccsd(t)')
 
 compare_values(refnuc,   C4NH4.nuclear_repulsion_energy(),        8, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        8, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 8, "CCSD contribution")        #TEST
-compare_values(ref_t,    get_variable("(T) correction energy"),   8, "(T) contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          8, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        8, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 8, "CCSD contribution")        #TEST
+compare_values(ref_t,    variable("(T) correction energy"),   8, "(T) contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          8, "Total energy")             #TEST

--- a/tests/cc53/input.dat
+++ b/tests/cc53/input.dat
@@ -22,7 +22,7 @@ escf =     -75.930810791060466 #TEST
 eccsd =    -76.164158766102886 #TEST
 eccsd_at = -76.168878167078262 #TEST
 
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(eccsd, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
-compare_values(eccsd_at, get_variable("CCSD(AT) TOTAL ENERGY"), 7, "a-CCSD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
+compare_values(eccsd_at, variable("CCSD(AT) TOTAL ENERGY"), 7, "a-CCSD(T) energy") #TEST
 

--- a/tests/cc54/input.dat
+++ b/tests/cc54/input.dat
@@ -100,13 +100,13 @@ D 2 1.00
 
 ccsd_e, wfn = properties('ccsd',properties=['dipole'],return_wfn=True)
 oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-compare_values(psi4.get_variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-compare_values(psi4.get_variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-compare_values(psi4.get_variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
+compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
+compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
+compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
+compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
 print_variables()

--- a/tests/cc5a/input.dat
+++ b/tests/cc5a/input.dat
@@ -32,7 +32,7 @@ ref_t    =   -0.030675386522182 #TEST
 reftotal = -208.915761026658572 #TEST
 
 compare_values(refnuc,   C4NH4.nuclear_repulsion_energy(),        9, "Nuclear repulsion energy")  #TEST
-compare_values(refscf,   get_variable("SCF total energy"),              9, "SCF energy")                   #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 9, "CCSD contribution")            #TEST
-compare_values(ref_t,    get_variable("(T) correction energy"),   9, "(T) contribution")             #TEST
-compare_values(reftotal, get_variable("Current energy"),          9, "Total energy")                 #TEST
+compare_values(refscf,   variable("SCF total energy"),              9, "SCF energy")                   #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 9, "CCSD contribution")            #TEST
+compare_values(ref_t,    variable("(T) correction energy"),   9, "(T) contribution")             #TEST
+compare_values(reftotal, variable("Current energy"),          9, "Total energy")                 #TEST

--- a/tests/cc6/input.dat
+++ b/tests/cc6/input.dat
@@ -33,7 +33,7 @@ refccsd = -208.885085641759929 #TEST
 ref_t   = -208.915761028789774 #TEST
 
 compare_values(refnuc, C4H4N.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
-compare_values(refscf, get_variable("SCF total energy"), 7, "SCF energy") #TEST
-compare_values(refccsd, get_variable("CCSD total energy"), 7, "CCSD energy") #TEST
-compare_values(ref_t, get_variable("Current energy"), 7, "CCSD(T) energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 7, "SCF energy") #TEST
+compare_values(refccsd, variable("CCSD total energy"), 7, "CCSD energy") #TEST
+compare_values(ref_t, variable("Current energy"), 7, "CCSD(T) energy") #TEST
 

--- a/tests/cc8a/input.dat
+++ b/tests/cc8a/input.dat
@@ -27,7 +27,7 @@ set {
 energy('ccsd(t)')
 
 compare_values(refnuc,   CN.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        9, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
-compare_values(ref_t,    get_variable("(T) correction energy"),   9, "(T) contribution")         #TEST
-compare_values(reftotal, get_variable("Current energy"),          9, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        9, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
+compare_values(ref_t,    variable("(T) correction energy"),   9, "(T) contribution")         #TEST
+compare_values(reftotal, variable("Current energy"),          9, "Total energy")             #TEST

--- a/tests/cc8b/input.dat
+++ b/tests/cc8b/input.dat
@@ -29,6 +29,6 @@ refccsd  =  -0.281342909117434  #TEST
 reftotal = -92.476899474397527  #TEST
 
 compare_values(refnuc,   CN.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        7, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        7, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST

--- a/tests/cc8c/input.dat
+++ b/tests/cc8c/input.dat
@@ -28,6 +28,6 @@ refccsd  =  -0.281346262229454  #TEST
 reftotal = -92.476902827507075  #TEST
 
 compare_values(refnuc,   CN.nuclear_repulsion_energy(),           9, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        7, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        7, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST

--- a/tests/cc9a/input.dat
+++ b/tests/cc9a/input.dat
@@ -31,7 +31,7 @@ e_t    =   -0.014063035624904   #TEST
 etotal =  -92.494542563977362   #TEST
 
 compare_values(enuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
-compare_values(escf, get_variable("SCF total energy"), 9, "SCF energy")               #TEST
-compare_values(eccsd, get_variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
-compare_values(e_t, get_variable("(T) correction energy"), 9, "(T) contribution")         #TEST
-compare_values(etotal, get_variable("Current energy"), 9, "Total energy")             #TEST
+compare_values(escf, variable("SCF total energy"), 9, "SCF energy")               #TEST
+compare_values(eccsd, variable("CCSD correlation energy"), 9, "CCSD contribution")        #TEST
+compare_values(e_t, variable("(T) correction energy"), 9, "(T) contribution")         #TEST
+compare_values(etotal, variable("Current energy"), 9, "Total energy")             #TEST

--- a/tests/cdomp2-1/input.dat
+++ b/tests/cdomp2-1/input.dat
@@ -20,8 +20,8 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "CD-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "CD-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "CD-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "CD-OMP2 Total Energy (a.u.)");               #TEST
 
 

--- a/tests/cdomp2-2/input.dat
+++ b/tests/cdomp2-2/input.dat
@@ -20,7 +20,7 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "CD-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "CD-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "CD-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "CD-OMP2 Total Energy (a.u.)");               #TEST
 

--- a/tests/cepa-module/input.dat
+++ b/tests/cepa-module/input.dat
@@ -42,9 +42,9 @@ def labeler():
 
 def gogo(name, mol, theme):
     retE = energy(name, molecule=mol)
-    compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-    compare_values(cepacorl, get_variable('%s correlation energy' % name), 6, theme)  #TEST
-    compare_values(cepatot, get_variable('%s total energy' % name), 6, theme)  #TEST
+    compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+    compare_values(cepacorl, variable('%s correlation energy' % name), 6, theme)  #TEST
+    compare_values(cepatot, variable('%s total energy' % name), 6, theme)  #TEST
     compare_values(cepatot, retE, 6, theme)  #TEST
     clean_variables()
     clean()

--- a/tests/cepa1/input.dat
+++ b/tests/cepa1/input.dat
@@ -19,7 +19,7 @@ refscf     = -76.02141844515494  #TEST
 refcepa1   = -0.214363572651     #TEST
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")                  #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
-compare_values(refcepa1, get_variable("CEPA(1) CORRELATION ENERGY"), 8, "CEPA(1) correlation energy")  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
+compare_values(refcepa1, variable("CEPA(1) CORRELATION ENERGY"), 8, "CEPA(1) correlation energy")  #TEST
 
 clean()

--- a/tests/cepa2/input.dat
+++ b/tests/cepa2/input.dat
@@ -24,9 +24,9 @@ refDipACPF = 1.94427077135      #TEST
 refQdpACPF = -5.78358853279     #TEST
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")                  #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
-compare_values(refacpf, get_variable("ACPF CORRELATION ENERGY"), 8, "ACPF correlation energy")         #TEST
-compare_values(refDipACPF, get_variable("ACPF DIPOLE Z"), 5, "ACPF Z Component of dipole")             #TEST
-compare_values(refQdpACPF, get_variable("ACPF QUADRUPOLE ZZ"), 5, "ACPF ZZ Component of quadrupole")   #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
+compare_values(refacpf, variable("ACPF CORRELATION ENERGY"), 8, "ACPF correlation energy")         #TEST
+compare_values(refDipACPF, variable("ACPF DIPOLE Z"), 5, "ACPF Z Component of dipole")             #TEST
+compare_values(refQdpACPF, variable("ACPF QUADRUPOLE ZZ"), 5, "ACPF ZZ Component of quadrupole")   #TEST
 
 clean()

--- a/tests/cepa3/input.dat
+++ b/tests/cepa3/input.dat
@@ -19,16 +19,16 @@ set {
 set qc_module fnocc
 energy('cisd')
 
-corr1 = get_variable("CISD CORRELATION ENERGY")
-dipz1 = get_variable("CISD DIPOLE Z")
-qzz1  = get_variable("CISD QUADRUPOLE ZZ")
+corr1 = variable("CISD CORRELATION ENERGY")
+dipz1 = variable("CISD DIPOLE Z")
+qzz1  = variable("CISD QUADRUPOLE ZZ")
 
 set qc_module detci
 properties("cisd")
 
-corr2 = get_variable("CI CORRELATION ENERGY")
-dipz2 = get_variable("CI DIPOLE Z")
-qzz2  = get_variable("CI QUADRUPOLE ZZ")
+corr2 = variable("CI CORRELATION ENERGY")
+dipz2 = variable("CI DIPOLE Z")
+qzz2  = variable("CI QUADRUPOLE ZZ")
 
 print_variables()
 compare_values(corr1,corr2, 9, "DETCI vs coupled-pair CISD correlation energy")   #TEST

--- a/tests/cepa4/input.dat
+++ b/tests/cepa4/input.dat
@@ -17,7 +17,7 @@ set {
 set qc_module fnocc
 energy('lccd')
 
-corr1 = get_variable("LCCD CORRELATION ENERGY")
+corr1 = variable("LCCD CORRELATION ENERGY")
 
 clean()
 
@@ -27,7 +27,7 @@ set dcft_functional cepa0
 set algorithm       twostep
 energy('dcft')
 
-corr2 = get_variable("DCFT LAMBDA ENERGY")
+corr2 = variable("DCFT LAMBDA ENERGY")
 
 compare_values(corr1,corr2, 9, "LCCD vs DCFT/CEPA(0) correlation energy")   #TEST
 

--- a/tests/cfour/kw-1/input.dat
+++ b/tests/cfour/kw-1/input.dat
@@ -15,7 +15,7 @@ set basis 6-31g
 set cfour_CALC_level=CCSD
 
 energy('cfour')
-compare_values(-76.119378156918, get_variable('current energy'), 5, 'Total Energy')
+compare_values(-76.119378156918, variable('current energy'), 5, 'Total Energy')
 compare_strings(True, 'CC_PROGRAM           ICCPRO         VCC' in P4C4_INFO['output'], 'Cfour default VCC')  #TEST
 
 clean()
@@ -25,6 +25,6 @@ set cfour_CALC_level=CCSD
 set cfour_cc_program ecc
 
 energy('cfour')
-compare_values(-76.119378156918, get_variable('current energy'), 5, 'Total Energy')
+compare_values(-76.119378156918, variable('current energy'), 5, 'Total Energy')
 compare_strings(True, 'CC_PROGRAM           ICCPRO         ECC' in P4C4_INFO['output'], 'Cfour overwritten by ECC')  #TEST
 

--- a/tests/cfour/kw-2/input.dat
+++ b/tests/cfour/kw-2/input.dat
@@ -14,7 +14,7 @@ A=104.5
 set basis 6-31g
 
 energy('c4-ccsd')
-compare_values(-76.119378156918, get_variable('current energy'), 5, 'Total Energy')
+compare_values(-76.119378156918, variable('current energy'), 5, 'Total Energy')
 compare_strings(True, 'CC_PROGRAM           ICCPRO         ECC' in P4C4_INFO['output'], 'P4C4 default ECC')  #TEST
 
 clean()
@@ -23,6 +23,6 @@ clean_variables()
 set cfour_cc_program vcc
 
 energy('c4-ccsd')
-compare_values(-76.119378156918, get_variable('current energy'), 5, 'Total Energy')
+compare_values(-76.119378156918, variable('current energy'), 5, 'Total Energy')
 compare_strings(True, 'CC_PROGRAM           ICCPRO         VCC' in P4C4_INFO['output'], 'P4C4 overwritten by VCC')  #TEST
 

--- a/tests/cfour/kw-3/input.dat
+++ b/tests/cfour/kw-3/input.dat
@@ -17,14 +17,14 @@ A=104.5
 set cfour_basis pvdz
 
 energy('c4-mp2')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
 clean()
 clean_variables()
 
 set cfour_basis 6-31g*
 
 energy('c4-mp2')
-compare_values(sph_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* Default Sph')  #TEST
+compare_values(sph_631gs, variable('CURRENT ENERGY'), 6, '6-31G* Default Sph')  #TEST
 clean()
 clean_variables()
 
@@ -32,14 +32,14 @@ set cfour_basis pvdz
 set cfour_spherical false
 
 energy('c4-mp2')
-compare_values(cart_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
+compare_values(cart_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
 clean()
 clean_variables()
 
 set cfour_basis 6-31g*
 
 energy('c4-mp2')
-compare_values(cart_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* forced Cart')  #TEST
+compare_values(cart_631gs, variable('CURRENT ENERGY'), 6, '6-31G* forced Cart')  #TEST
 clean()
 clean_variables()
 

--- a/tests/cfour/kw-4/input.dat
+++ b/tests/cfour/kw-4/input.dat
@@ -17,14 +17,14 @@ A=104.5
 set basis cc-pvdz
 
 energy('c4-mp2')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
 clean()
 clean_variables()
 
 set basis 6-31g*
 
 energy('c4-mp2')
-compare_values(cart_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* Default Cart')  #TEST
+compare_values(cart_631gs, variable('CURRENT ENERGY'), 6, '6-31G* Default Cart')  #TEST
 clean()
 clean_variables()
 
@@ -32,7 +32,7 @@ set basis cc-pvdz
 set puream false
 
 energy('c4-mp2')
-compare_values(cart_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
+compare_values(cart_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
 clean()
 clean_variables()
 
@@ -40,7 +40,7 @@ set basis 6-31g*
 set puream true
 
 energy('c4-mp2')
-compare_values(sph_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* forced Sph')  #TEST
+compare_values(sph_631gs, variable('CURRENT ENERGY'), 6, '6-31G* forced Sph')  #TEST
 clean()
 clean_variables()
 

--- a/tests/cfour/kw-5/input.dat
+++ b/tests/cfour/kw-5/input.dat
@@ -18,7 +18,7 @@ set basis cc-pvdz
 set cfour_spherical true
 
 energy('c4-mp2')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
 clean()
 clean_variables()
 
@@ -26,5 +26,5 @@ set basis 6-31g*
 set cfour_spherical false
 
 energy('c4-mp2')
-compare_values(cart_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* Default Cart')  #TEST
+compare_values(cart_631gs, variable('CURRENT ENERGY'), 6, '6-31G* Default Cart')  #TEST
 

--- a/tests/cfour/kw-6/input.dat
+++ b/tests/cfour/kw-6/input.dat
@@ -19,7 +19,7 @@ set cfour_basis pvdz
 set puream true
 
 energy('c4-mp2')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default Sph')  #TEST
 clean()
 clean_variables()
 
@@ -27,7 +27,7 @@ set cfour_basis 6-31g*
 set puream true
 
 energy('c4-mp2')
-compare_values(sph_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* Default Sph')  #TEST
+compare_values(sph_631gs, variable('CURRENT ENERGY'), 6, '6-31G* Default Sph')  #TEST
 clean()
 clean_variables()
 
@@ -35,7 +35,7 @@ set cfour_basis pvdz
 set puream false
 
 energy('c4-mp2')
-compare_values(cart_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
+compare_values(cart_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ forced Cart')  #TEST
 clean()
 clean_variables()
 
@@ -43,7 +43,7 @@ set cfour_basis 6-31g*
 set puream false
 
 energy('c4-mp2')
-compare_values(cart_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* forced Cart')  #TEST
+compare_values(cart_631gs, variable('CURRENT ENERGY'), 6, '6-31G* forced Cart')  #TEST
 clean()
 clean_variables()
 

--- a/tests/cfour/kw-7/input.dat
+++ b/tests/cfour/kw-7/input.dat
@@ -14,7 +14,7 @@ A=104.5
 set basis cc-pvdz
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  7' in P4C4_INFO['output'], 'SCF_CONV 7 default')  #TEST
 clean()
 clean_variables()
@@ -22,7 +22,7 @@ clean_variables()
 set cfour_scf_conv 6
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  6' in P4C4_INFO['output'], 'SCF_CONV 6 overwritten')  #TEST
 clean()
 clean_variables()
@@ -31,7 +31,7 @@ set cfour_scf_conv 9
 set d_convergence 8
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  9' in P4C4_INFO['output'], 'SCF_CONV 9 cfour kw trumps scf kw')  #TEST
 clean()
 clean_variables()

--- a/tests/cfour/kw-8/input.dat
+++ b/tests/cfour/kw-8/input.dat
@@ -14,7 +14,7 @@ A=104.5
 set basis cc-pvdz
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  7' in P4C4_INFO['output'], 'SCF_CONV 7 default')  #TEST
 clean()
 clean_variables()
@@ -22,7 +22,7 @@ clean_variables()
 set d_convergence 5
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  5' in P4C4_INFO['output'], 'SCF_CONV 5 scf kw overwritten')  #TEST
 clean()
 clean_variables()
@@ -30,7 +30,7 @@ clean_variables()
 set scf d_convergence 5e-7
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  7' in P4C4_INFO['output'], 'P4C4 default SCF_CONV 7')  #TEST
 clean()
 clean_variables()
@@ -39,7 +39,7 @@ set cfour_scf_conv 6
 set d_convergence 8
 
 energy('c4-scf')
-compare_values(-76.026760723833, get_variable('current energy'), 5, 'Total Energy')  #TEST
+compare_values(-76.026760723833, variable('current energy'), 5, 'Total Energy')  #TEST
 compare_strings(True, 'SCF_CONV             ISCFCV          10D-  6' in P4C4_INFO['output'], 'SCF_CONV 6 cfour kw trumps scf kw')  #TEST
 clean()
 clean_variables()

--- a/tests/cfour/mints5-grad/input.dat
+++ b/tests/cfour/mints5-grad/input.dat
@@ -100,8 +100,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[0], get_variable('nuclear repulsion energy'), 3, '[1]  NRE: zmat, external values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[0], variable('nuclear repulsion energy'), 3, '[1]  NRE: zmat, external values')  #TEST
 clean()
 opt_clean()
 
@@ -122,8 +122,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[1], get_variable('nuclear repulsion energy'), 3, '[2]  NRE: zmat, external values, w/dummy')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[1], variable('nuclear repulsion energy'), 3, '[2]  NRE: zmat, external values, w/dummy')  #TEST
 clean()
 opt_clean()
 
@@ -138,8 +138,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[2], get_variable('nuclear repulsion energy'), 3, '[3]  NRE: cartesian, pure')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[2], variable('nuclear repulsion energy'), 3, '[3]  NRE: cartesian, pure')  #TEST
 clean()
 opt_clean()
 
@@ -156,8 +156,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[3], get_variable('nuclear repulsion energy'), 3, '[4]  NRE: cartesian, external values, +/-')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[3], variable('nuclear repulsion energy'), 3, '[4]  NRE: cartesian, external values, +/-')  #TEST
 clean()
 opt_clean()
 
@@ -172,8 +172,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[4], get_variable('nuclear repulsion energy'), 3, '[5]  NRE: cartesian, external values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[4], variable('nuclear repulsion energy'), 3, '[5]  NRE: cartesian, external values')  #TEST
 clean()
 opt_clean()
 
@@ -187,8 +187,8 @@ opt_clean()
 ###}
 ###set reference uhf
 ###opt('c4-scf')
-###print get_variable('nuclear repulsion energy')  #TEST
-###compare_values(nre3_ref[5], get_variable('nuclear repulsion energy'), 3, '[6]  NRE: cartesian, external values')  #TEST
+###print variable('nuclear repulsion energy')  #TEST
+###compare_values(nre3_ref[5], variable('nuclear repulsion energy'), 3, '[6]  NRE: cartesian, external values')  #TEST
 ###clean()
 ###opt_clean()
 ###set reference rhf
@@ -206,8 +206,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[6], get_variable('nuclear repulsion energy'), 3, '[7]  NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[6], variable('nuclear repulsion energy'), 3, '[7]  NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 set basis 6-31g
@@ -224,8 +224,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[7], get_variable('nuclear repulsion energy'), 3, '[8]  NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[7], variable('nuclear repulsion energy'), 3, '[8]  NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -242,8 +242,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[8], get_variable('nuclear repulsion energy'), 3, '[8b]  NRE: zmat, external and internal values, +/-')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[8], variable('nuclear repulsion energy'), 3, '[8b]  NRE: zmat, external and internal values, +/-')  #TEST
 clean()
 opt_clean()
 
@@ -257,8 +257,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[9], get_variable('nuclear repulsion energy'), 3, '[9]  NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[9], variable('nuclear repulsion energy'), 3, '[9]  NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -282,8 +282,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[10], get_variable('nuclear repulsion energy'), 3, '[10] NRE: cartesian, pure, bohr')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[10], variable('nuclear repulsion energy'), 3, '[10] NRE: cartesian, pure, bohr')  #TEST
 clean()
 opt_clean()
 
@@ -303,8 +303,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[11], get_variable('nuclear repulsion energy'), 3, '[11] NRE: cartesian, pure')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[11], variable('nuclear repulsion energy'), 3, '[11] NRE: cartesian, pure')  #TEST
 clean()
 opt_clean()
 
@@ -319,8 +319,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[12], get_variable('nuclear repulsion energy'), 3, '[12] NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[12], variable('nuclear repulsion energy'), 3, '[12] NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -336,8 +336,8 @@ opt_clean()
 ###  H 5 1.0 2 110.0 3 0.0
 ###}
 ###opt('c4-scf')
-###print get_variable('nuclear repulsion energy')  #TEST
-###compare_values(nre3_ref[13], get_variable('nuclear repulsion energy'), 3, '[13] NRE: zmat, internal values, w/dummy')  #TEST
+###print variable('nuclear repulsion energy')  #TEST
+###compare_values(nre3_ref[13], variable('nuclear repulsion energy'), 3, '[13] NRE: zmat, internal values, w/dummy')  #TEST
 ###clean()
 ###opt_clean()
 
@@ -351,8 +351,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[14], get_variable('nuclear repulsion energy'), 3, '[14] NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[14], variable('nuclear repulsion energy'), 3, '[14] NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -369,8 +369,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[15], get_variable('nuclear repulsion energy'), 3, '[15] NRE: cartesian, pure, bohr')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[15], variable('nuclear repulsion energy'), 3, '[15] NRE: cartesian, pure, bohr')  #TEST
 clean()
 opt_clean()
 
@@ -389,8 +389,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[16], get_variable('nuclear repulsion energy'), 3, '[16] NRE: zmat, external & internal values, w/dummy')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[16], variable('nuclear repulsion energy'), 3, '[16] NRE: zmat, external & internal values, w/dummy')  #TEST
 clean()
 opt_clean()
 
@@ -406,8 +406,8 @@ opt_clean()
 #####}
 #####set basis 3-21g
 #####opt('c4-scf')
-#####print get_variable('nuclear repulsion energy')  #TEST
-######compare_values(nre3_ref[17], get_variable('nuclear repulsion energy'), 3, '[17] NRE: zmat, external & internal values')  #TEST
+#####print variable('nuclear repulsion energy')  #TEST
+######compare_values(nre3_ref[17], variable('nuclear repulsion energy'), 3, '[17] NRE: zmat, external & internal values')  #TEST
 #####clean()
 #####opt_clean()
 #####set basis 6-31g
@@ -427,8 +427,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[18], get_variable('nuclear repulsion energy'), 3, '[18] NRE: zmat, external values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[18], variable('nuclear repulsion energy'), 3, '[18] NRE: zmat, external values')  #TEST
 clean()
 opt_clean()
 set guess sad
@@ -445,8 +445,8 @@ set guess sad
 ###  H 5 1.0 2 110.0 3 0.0
 ###}
 ###opt('c4-scf')
-###print get_variable('nuclear repulsion energy')  #TEST
-###compare_values(nre3_ref[19], get_variable('nuclear repulsion energy'), 3, '[19] NRE: zmat, internal values, w/dummy')  #TEST
+###print variable('nuclear repulsion energy')  #TEST
+###compare_values(nre3_ref[19], variable('nuclear repulsion energy'), 3, '[19] NRE: zmat, internal values, w/dummy')  #TEST
 ###clean()
 ###opt_clean()
 
@@ -473,8 +473,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[20], get_variable('nuclear repulsion energy'), 3, '[20] NRE: cartesian, pure')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[20], variable('nuclear repulsion energy'), 3, '[20] NRE: cartesian, pure')  #TEST
 clean()
 opt_clean()
 
@@ -510,8 +510,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[21], get_variable('nuclear repulsion energy'), 3, '[21] NRE: zmat, external and internal values, +/-, w/dummy')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[21], variable('nuclear repulsion energy'), 3, '[21] NRE: zmat, external and internal values, +/-, w/dummy')  #TEST
 clean()
 opt_clean()
 
@@ -532,8 +532,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[22], get_variable('nuclear repulsion energy'), 3, '[22] NRE: zmat, external values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[22], variable('nuclear repulsion energy'), 3, '[22] NRE: zmat, external values')  #TEST
 clean()
 opt_clean()
 
@@ -552,8 +552,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[23], get_variable('nuclear repulsion energy'), 3, '[23] NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[23], variable('nuclear repulsion energy'), 3, '[23] NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -571,8 +571,8 @@ opt_clean()
 ###  D    = 90.0
 ###}
 ###opt('c4-scf')
-###print get_variable('nuclear repulsion energy')  #TEST
-###compare_values(nre3_ref[24], get_variable('nuclear repulsion energy'), 3, '[24] NRE: zmat, external values')  #TEST
+###print variable('nuclear repulsion energy')  #TEST
+###compare_values(nre3_ref[24], variable('nuclear repulsion energy'), 3, '[24] NRE: zmat, external values')  #TEST
 ###clean()
 ###opt_clean()
 
@@ -590,8 +590,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[25], get_variable('nuclear repulsion energy'), 3, '[25] NRE: cartesian, pure')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[25], variable('nuclear repulsion energy'), 3, '[25] NRE: cartesian, pure')  #TEST
 clean()
 opt_clean()
 
@@ -610,8 +610,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[26], get_variable('nuclear repulsion energy'), 3, '[26] NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[26], variable('nuclear repulsion energy'), 3, '[26] NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -632,8 +632,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[27], get_variable('nuclear repulsion energy'), 3, '[27] NRE: zmat, external values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[27], variable('nuclear repulsion energy'), 3, '[27] NRE: zmat, external values')  #TEST
 clean()
 opt_clean()
 
@@ -652,8 +652,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[28], get_variable('nuclear repulsion energy'), 3, '[28] NRE: zmat, internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[28], variable('nuclear repulsion energy'), 3, '[28] NRE: zmat, internal values')  #TEST
 clean()
 opt_clean()
 
@@ -668,8 +668,8 @@ opt_clean()
 ### H 2 1.0 1 90.0 3 -90.0
 ###}
 ###opt('c4-scf')
-###print get_variable('nuclear repulsion energy')  #TEST
-###compare_values(nre3_ref[29], get_variable('nuclear repulsion energy'), 3, '[29] NRE: zmat, internal values, w/dummy')  #TEST
+###print variable('nuclear repulsion energy')  #TEST
+###compare_values(nre3_ref[29], variable('nuclear repulsion energy'), 3, '[29] NRE: zmat, internal values, w/dummy')  #TEST
 ###clean()
 ###opt_clean()
 
@@ -686,8 +686,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[30], get_variable('nuclear repulsion energy'), 3, '[30] NRE: zmat, external and internal values, w/TDA')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[30], variable('nuclear repulsion energy'), 3, '[30] NRE: zmat, external and internal values, w/TDA')  #TEST
 clean()
 opt_clean()
 
@@ -706,8 +706,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[31], get_variable('nuclear repulsion energy'), 3, '[31] NRE: zmat, external and internal values')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[31], variable('nuclear repulsion energy'), 3, '[31] NRE: zmat, external and internal values')  #TEST
 clean()
 opt_clean()
 
@@ -733,8 +733,8 @@ try:
     opt('c4-scf')
 except psi4.ConvergenceError:
     pass
-print(get_variable('nuclear repulsion energy'))  #TEST
-compare_values(nre3_ref[32], get_variable('nuclear repulsion energy'), 3, '[32] NRE: cartesian, external and internal, +/-')  #TEST
+print(variable('nuclear repulsion energy'))  #TEST
+compare_values(nre3_ref[32], variable('nuclear repulsion energy'), 3, '[32] NRE: cartesian, external and internal, +/-')  #TEST
 clean()
 opt_clean()
 

--- a/tests/cfour/mints5/input.dat
+++ b/tests/cfour/mints5/input.dat
@@ -20,7 +20,7 @@ a1 = 110.0
 HOCl.update_geometry()
 nre = HOCl.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[1]  NRE: zmat, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[1]  NRE: zmat, external values')  #TEST
 
 
 molecule NH3  {
@@ -38,7 +38,7 @@ molecule NH3  {
 NH3.update_geometry()
 nre = NH3.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[2]  NRE: zmat, external values, w/dummy')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[2]  NRE: zmat, external values, w/dummy')  #TEST
 
 
 molecule HCCCl  {
@@ -50,7 +50,7 @@ molecule HCCCl  {
 HCCCl.update_geometry()
 nre = HCCCl.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[3]  NRE: cartesian, pure')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[3]  NRE: cartesian, pure')  #TEST
 
 
 molecule C2H2 {
@@ -64,7 +64,7 @@ molecule C2H2 {
 C2H2.update_geometry()
 nre = C2H2.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[4]  NRE: cartesian, external values, +/-')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[4]  NRE: cartesian, external values, +/-')  #TEST
 
 
 molecule N2 {
@@ -76,7 +76,7 @@ molecule N2 {
 N2.update_geometry()
 nre = N2.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[5]  NRE: cartesian, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[5]  NRE: cartesian, external values')  #TEST
 
 
 molecule CN  {
@@ -88,7 +88,7 @@ molecule CN  {
 CN.update_geometry()
 nre = CN.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[6]  NRE: cartesian, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[6]  NRE: cartesian, external values')  #TEST
 
 
 molecule CHFClBr  {
@@ -102,7 +102,7 @@ CHFClBr.update_geometry()
 nre = CHFClBr.nuclear_repulsion_energy()
 set cfour_basis sto-3g
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[7]  NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[7]  NRE: zmat, internal values')  #TEST
 
 
 molecule CH2ClBr  {
@@ -115,7 +115,7 @@ molecule CH2ClBr  {
 CH2ClBr.update_geometry()
 nre = CH2ClBr.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[8]  NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[8]  NRE: zmat, internal values')  #TEST
 
 
 molecule CH2ClBr  {
@@ -129,7 +129,7 @@ molecule CH2ClBr  {
 CH2ClBr.update_geometry()
 nre = CH2ClBr.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[8b]  NRE: zmat, external and internal values, +/-')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[8b]  NRE: zmat, external and internal values, +/-')  #TEST
 
 
 molecule HOCl  {
@@ -140,7 +140,7 @@ molecule HOCl  {
 HOCl.update_geometry()
 nre = HOCl.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[9]  NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[9]  NRE: zmat, internal values')  #TEST
 
 
 molecule C4H4Cl2F2  {
@@ -161,7 +161,7 @@ molecule C4H4Cl2F2  {
 C4H4Cl2F2.update_geometry()
 nre = C4H4Cl2F2.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[10] NRE: cartesian, pure, bohr')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[10] NRE: cartesian, pure, bohr')  #TEST
 
 
 molecule HOOH_dimer  {
@@ -177,7 +177,7 @@ molecule HOOH_dimer  {
 HOOH_dimer.update_geometry()
 nre = HOOH_dimer.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[11] NRE: cartesian, pure')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[11] NRE: cartesian, pure')  #TEST
 
 
 molecule HOOH  {
@@ -189,7 +189,7 @@ molecule HOOH  {
 HOOH.update_geometry()
 nre = HOOH.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[12] NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[12] NRE: zmat, internal values')  #TEST
 
 
 #molecule NOHOHOH  {
@@ -205,7 +205,7 @@ compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[12] NRE: zmat
 #NOHOHOH.update_geometry()
 #nre = NOHOHOH.nuclear_repulsion_energy()
 #energy('cfour')
-#compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[13] NRE: zmat, internal values, w/dummy')  #TEST
+#compare_values(nre, variable('nuclear repulsion energy'), 3, '[13] NRE: zmat, internal values, w/dummy')  #TEST
 
 
 molecule H2O  {
@@ -216,7 +216,7 @@ molecule H2O  {
 H2O.update_geometry()
 nre = H2O.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[14] NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[14] NRE: zmat, internal values')  #TEST
 
 
 molecule CH2F2  {
@@ -230,7 +230,7 @@ molecule CH2F2  {
 CH2F2.update_geometry()
 nre = CH2F2.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[15] NRE: cartesian, pure, bohr')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[15] NRE: cartesian, pure, bohr')  #TEST
 
 
 molecule NH3  {
@@ -246,7 +246,7 @@ molecule NH3  {
 NH3.update_geometry()
 nre = NH3.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[16] NRE: zmat, external & internal values, w/dummy')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[16] NRE: zmat, external & internal values, w/dummy')  #TEST
 
 
 molecule BrF5  {
@@ -261,7 +261,7 @@ molecule BrF5  {
 BrF5.update_geometry()
 nre = BrF5.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[17] NRE: zmat, external & internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[17] NRE: zmat, external & internal values')  #TEST
 
 
 molecule N2H2  {
@@ -276,7 +276,7 @@ molecule N2H2  {
 N2H2.update_geometry()
 nre = N2H2.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[18] NRE: zmat, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[18] NRE: zmat, external values')  #TEST
 
 
 #molecule NOHOHOH  {
@@ -292,7 +292,7 @@ compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[18] NRE: zmat
 #NOHOHOH.update_geometry()
 #nre = NOHOHOH.nuclear_repulsion_energy()
 #energy('cfour')
-#compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[19] NRE: zmat, internal values, w/dummy')  #TEST
+#compare_values(nre, variable('nuclear repulsion energy'), 3, '[19] NRE: zmat, internal values, w/dummy')  #TEST
 
 
 molecule TFCOT {
@@ -316,7 +316,7 @@ molecule TFCOT {
 TFCOT.update_geometry()
 nre = TFCOT.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[20] NRE: cartesian, pure')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[20] NRE: cartesian, pure')  #TEST
 
 
 molecule Li_H2O_4_p  {
@@ -349,7 +349,7 @@ molecule Li_H2O_4_p  {
 Li_H2O_4_p.update_geometry()
 nre = Li_H2O_4_p.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[21] NRE: zmat, external and internal values, +/-, w/dummy')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[21] NRE: zmat, external and internal values, +/-, w/dummy')  #TEST
 
 
 molecule ethylene_cation  {
@@ -367,7 +367,7 @@ molecule ethylene_cation  {
 ethylene_cation.update_geometry()
 nre = ethylene_cation.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[22] NRE: zmat, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[22] NRE: zmat, external values')  #TEST
 
 
 molecule ethane_gauche  {
@@ -383,7 +383,7 @@ molecule ethane_gauche  {
 ethane_gauche.update_geometry()
 nre = ethane_gauche.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[23] NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[23] NRE: zmat, internal values')  #TEST
 
 
 #molecule triplet_ethylene  {
@@ -401,7 +401,7 @@ compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[23] NRE: zmat
 #triplet_ethylene.update_geometry()
 #nre = triplet_ethylene.nuclear_repulsion_energy()
 #energy('cfour')
-#compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[24] NRE: zmat, external values')  #TEST
+#compare_values(nre, variable('nuclear repulsion energy'), 3, '[24] NRE: zmat, external values')  #TEST
 
 
 molecule allene  {
@@ -416,7 +416,7 @@ molecule allene  {
 allene.update_geometry()
 nre = allene.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[25] NRE: cartesian, pure')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[25] NRE: cartesian, pure')  #TEST
 
 
 molecule ethane_staggered  {
@@ -432,7 +432,7 @@ molecule ethane_staggered  {
 ethane_staggered.update_geometry()
 nre = ethane_staggered.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[26] NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[26] NRE: zmat, internal values')  #TEST
 
 
 molecule singlet_ethylene  {
@@ -450,7 +450,7 @@ molecule singlet_ethylene  {
 singlet_ethylene.update_geometry()
 nre = singlet_ethylene.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[27] NRE: zmat, external values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[27] NRE: zmat, external values')  #TEST
 
 
 molecule ethane_eclipsed  {
@@ -466,7 +466,7 @@ molecule ethane_eclipsed  {
 ethane_eclipsed.update_geometry()
 nre = ethane_eclipsed.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[28] NRE: zmat, internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[28] NRE: zmat, internal values')  #TEST
 
 
 #molecule BH4p  {
@@ -481,7 +481,7 @@ compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[28] NRE: zmat
 #BH4p.update_geometry()
 #nre = BH4p.nuclear_repulsion_energy()
 #energy('cfour')
-#compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[29] NRE: zmat, internal values, w/dummy')  #TEST
+#compare_values(nre, variable('nuclear repulsion energy'), 3, '[29] NRE: zmat, internal values, w/dummy')  #TEST
 
 
 molecule CH4  {
@@ -495,7 +495,7 @@ molecule CH4  {
 CH4.update_geometry()
 nre = CH4.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[30] NRE: zmat, external and internal values, w/TDA')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[30] NRE: zmat, external and internal values, w/TDA')  #TEST
 
 
 molecule SF6  {
@@ -511,7 +511,7 @@ molecule SF6  {
 SF6.update_geometry()
 nre = SF6.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[31] NRE: zmat, external and internal values')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[31] NRE: zmat, external and internal values')  #TEST
 
 
 molecule Ih  {
@@ -534,6 +534,6 @@ molecule Ih  {
 Ih.update_geometry()
 nre = Ih.nuclear_repulsion_energy()
 energy('cfour')
-compare_values(nre, get_variable('nuclear repulsion energy'), 3, '[32] NRE: cartesian, external and internal, +/-')  #TEST
+compare_values(nre, variable('nuclear repulsion energy'), 3, '[32] NRE: cartesian, external and internal, +/-')  #TEST
 
 

--- a/tests/cfour/opt-rhf-ccsd_t_-ecc/input.dat
+++ b/tests/cfour/opt-rhf-ccsd_t_-ecc/input.dat
@@ -21,14 +21,14 @@ SCF_CONV=12)
 
 energy('cfour')
 
-compare_values(9.132052626900, get_variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
-compare_values(-76.013878694840, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.217565923762, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.227372475715, get_variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
-compare_values(-76.241251170555, get_variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
-compare_values(-0.003103546371, get_variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
-compare_values(-0.230476022086, get_variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-76.244354716926, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(9.132052626900, variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
+compare_values(-76.013878694840, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.217565923762, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.227372475715, variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
+compare_values(-76.241251170555, variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
+compare_values(-0.003103546371, variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
+compare_values(-0.230476022086, variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-76.244354716926, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -60,12 +60,12 @@ rms_force_g_convergence 6
 
 optimize('cfour')
 
-compare_values(9.132052626900, get_variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
-compare_values(-76.013878694840, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.217565923762, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.227372475715, get_variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
-compare_values(-76.241251170555, get_variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
-compare_values(-0.003103546371, get_variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
-compare_values(-0.230476022086, get_variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-76.244354716926, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(9.132052626900, variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
+compare_values(-76.013878694840, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.217565923762, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.227372475715, variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
+compare_values(-76.241251170555, variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
+compare_values(-0.003103546371, variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
+compare_values(-0.230476022086, variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-76.244354716926, variable('current energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/opt-rhf-ccsd_t_/input.dat
+++ b/tests/cfour/opt-rhf-ccsd_t_/input.dat
@@ -20,14 +20,14 @@ SCF_CONV=12)
 
 energy('cfour')
 
-compare_values(9.132052626900, get_variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
-compare_values(-76.013878694840, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.217565923762, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.227372475715, get_variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
-compare_values(-76.241251170555, get_variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
-compare_values(-0.003103546371, get_variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
-compare_values(-0.230476022086, get_variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-76.244354716926, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(9.132052626900, variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
+compare_values(-76.013878694840, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.217565923762, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.227372475715, variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
+compare_values(-76.241251170555, variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
+compare_values(-0.003103546371, variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
+compare_values(-0.230476022086, variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-76.244354716926, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -58,12 +58,12 @@ rms_force_g_convergence 6
 
 optimize('cfour')
 
-compare_values(9.132052626900, get_variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
-compare_values(-76.013878694840, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.217565923762, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.227372475715, get_variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
-compare_values(-76.241251170555, get_variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
-compare_values(-0.003103546371, get_variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
-compare_values(-0.230476022086, get_variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-76.244354716926, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(9.132052626900, variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
+compare_values(-76.013878694840, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.217565923762, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.227372475715, variable("CCSD CORRELATION ENERGY"), 6, 'CCSD corl')  #TEST
+compare_values(-76.241251170555, variable("CCSD TOTAL ENERGY"), 6, 'CCSD')  #TEST
+compare_values(-0.003103546371, variable('(T) CORRECTION ENERGY'), 6, '(T)')  #TEST
+compare_values(-0.230476022086, variable('current correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-76.244354716926, variable('current energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/opt-rhf-mp2/input.dat
+++ b/tests/cfour/opt-rhf-mp2/input.dat
@@ -18,12 +18,12 @@ SCF_CONV=12)
 
 energy('cfour')
 
-compare_values(9.193817619800, get_variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
-compare_values(-76.057086657615, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.275174751101, get_variable('current correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.332261408717, get_variable('current energy'), 6, 'MP2')  #TEST
-compare_values(-0.066581844960, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS')  #TEST
-compare_values(-0.208592906141, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS')  #TEST
+compare_values(9.193817619800, variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
+compare_values(-76.057086657615, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.275174751101, variable('current correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.332261408717, variable('current energy'), 6, 'MP2')  #TEST
+compare_values(-0.066581844960, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS')  #TEST
+compare_values(-0.208592906141, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS')  #TEST
 
 clean()
 clean_variables()
@@ -51,10 +51,10 @@ rms_force_g_convergence 6
 
 optimize('cfour')
 
-compare_values(9.193817619800, get_variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
-compare_values(-76.057086657615, get_variable('current reference energy'), 6, 'SCF')  #TEST
-compare_values(-0.275174751101, get_variable('current correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.332261408717, get_variable('current energy'), 6, 'MP2')  #TEST
-compare_values(-0.066581844960, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS')  #TEST
-compare_values(-0.208592906141, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS')  #TEST
+compare_values(9.193817619800, variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
+compare_values(-76.057086657615, variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-0.275174751101, variable('current correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.332261408717, variable('current energy'), 6, 'MP2')  #TEST
+compare_values(-0.066581844960, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS')  #TEST
+compare_values(-0.208592906141, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS')  #TEST
 

--- a/tests/cfour/opt-rhf-scf/input.dat
+++ b/tests/cfour/opt-rhf-scf/input.dat
@@ -18,8 +18,8 @@ SCF_CONV=14)
 
 energy('cfour')
 
-compare_values(9.3126203356, get_variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
-compare_values(-75.96133851112, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(9.3126203356, variable('NUCLEAR REPULSION ENERGY'), 6, 'NRE')  #TEST
+compare_values(-75.96133851112, variable('current energy'), 6, 'SCF')  #TEST
 
 
 clean()
@@ -48,6 +48,6 @@ cfour_scf_conv 12
 
 optimize('cfour')
 
-compare_values(9.3126203356, get_variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
-compare_values(-75.96133851112, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(9.3126203356, variable('NUCLEAR REPULSION ENERGY'), 3, 'NRE')  #TEST
+compare_values(-75.96133851112, variable('current energy'), 6, 'SCF')  #TEST
 

--- a/tests/cfour/psi-mp4/input.dat
+++ b/tests/cfour/psi-mp4/input.dat
@@ -26,10 +26,10 @@ print_variables()
 clean()
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
-    #print(store[vari], get_variable(vari))  #TEST
-    #print get_variable(vari)  #TEST
+    #print(store[vari], variable(vari))  #TEST
+    #print variable(vari)  #TEST
 
 molecule h2o {
 O
@@ -49,7 +49,7 @@ print_variables()
 clean()
 
 for vari in test_psivars:  #TEST
-    compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+    compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 
 
 #print '    <<<  UHF  >>>'
@@ -74,7 +74,7 @@ for vari in test_psivars:  #TEST
 #energy('cfour')
 #
 #for vari in test_psivars:
-#    store[vari] = get_variable(vari)
+#    store[vari] = variable(vari)
 #    set_variable(vari, 0.0)
 #
 #molecule nh2 {
@@ -98,7 +98,7 @@ for vari in test_psivars:  #TEST
 #clean()
 #
 #for vari in test_psivars:
-#    compare_values(store[vari], get_variable(vari), 6, vari.upper())
+#    compare_values(store[vari], variable(vari), 6, vari.upper())
 #
 #
 #print '    <<<  ROHF  >>>'
@@ -123,7 +123,7 @@ for vari in test_psivars:  #TEST
 #energy('cfour')
 #
 #for vari in test_psivars:
-#    store[vari] = get_variable(vari)
+#    store[vari] = variable(vari)
 #    set_variable(vari, 0.0)
 #
 #set reference rohf
@@ -133,6 +133,6 @@ for vari in test_psivars:  #TEST
 #clean()
 #
 #for vari in test_psivars:
-#    compare_values(store[vari], get_variable(vari), 6, vari.upper())
+#    compare_values(store[vari], variable(vari), 6, vari.upper())
 ##print store
 #

--- a/tests/cfour/psi-rhf-mp3/input.dat
+++ b/tests/cfour/psi-rhf-mp3/input.dat
@@ -23,10 +23,10 @@ MEMORY=20000000)
 energy('cfour')
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
-    #print(store[vari], get_variable(vari))  #TEST
-    #print get_variable(vari)  #TEST
+    #print(store[vari], variable(vari))  #TEST
+    #print variable(vari)  #TEST
 
 clean()
 clean_variables()
@@ -51,8 +51,8 @@ print(test_psivars)  #TEST
 print_variables()
 for vari in test_psivars:  #TEST
     if vari == 'nuclear repulsion energy':  #TEST
-        compare_values(store[vari], get_variable(vari), 4, vari.upper())  #TEST
+        compare_values(store[vari], variable(vari), 4, vari.upper())  #TEST
     else:  #TEST
-        compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+        compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 
 

--- a/tests/cfour/psi-rhf-scsmp2/input.dat
+++ b/tests/cfour/psi-rhf-scsmp2/input.dat
@@ -25,10 +25,10 @@ print_variables()
 clean()
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
-    #print(store[vari], get_variable(vari))  #TEST
-    #print get_variable(vari)  #TEST
+    #print(store[vari], variable(vari))  #TEST
+    #print variable(vari)  #TEST
 
 molecule h2o {
 O
@@ -48,5 +48,5 @@ energy('mp2')
 print_variables()
 
 for vari in test_psivars:  #TEST
-    compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+    compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 

--- a/tests/cfour/psi-rohf-scsmp2/input.dat
+++ b/tests/cfour/psi-rohf-scsmp2/input.dat
@@ -26,7 +26,7 @@ MEMORY=20000000)
 energy('cfour')
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
 
 molecule {
@@ -48,5 +48,5 @@ print_variables()
 clean()
 
 for vari in test_psivars:  #TEST
-    compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+    compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 

--- a/tests/cfour/psi-uhf-mp3/input.dat
+++ b/tests/cfour/psi-uhf-mp3/input.dat
@@ -26,7 +26,7 @@ MEMORY=20000000)
 energy('cfour')
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
 
 clean()
@@ -53,8 +53,8 @@ print(test_psivars)  #TEST
 print_variables()
 for vari in test_psivars:  #TEST
     if vari == 'nuclear repulsion energy':  #TEST
-        compare_values(store[vari], get_variable(vari), 4, vari.upper())  #TEST
+        compare_values(store[vari], variable(vari), 4, vari.upper())  #TEST
     else:  #TEST
-        compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+        compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 
 

--- a/tests/cfour/psi-uhf-scsmp2/input.dat
+++ b/tests/cfour/psi-uhf-scsmp2/input.dat
@@ -26,7 +26,7 @@ MEMORY=20000000)
 energy('cfour')
 
 for vari in test_psivars:  #TEST
-    store[vari] = get_variable(vari)  #TEST
+    store[vari] = variable(vari)  #TEST
     set_variable(vari, 0.0)  #TEST
 
 molecule nh2 {
@@ -53,5 +53,5 @@ energy('mp2')
 print_variables()
 
 for vari in test_psivars:  #TEST
-    compare_values(store[vari], get_variable(vari), 6, vari.upper())  #TEST
+    compare_values(store[vari], variable(vari), 6, vari.upper())  #TEST
 

--- a/tests/cfour/puream/input.dat
+++ b/tests/cfour/puream/input.dat
@@ -23,7 +23,7 @@ MEMORY=20000000)
 }
 
 energy('cfour')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default (Sph)')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ Default (Sph)')  #TEST
 
 clean()
 clean_variables()
@@ -44,7 +44,7 @@ MEMORY=20000000)
 }
 
 energy('cfour')
-compare_values(sph_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* Default (Sph)')  #TEST
+compare_values(sph_631gs, variable('CURRENT ENERGY'), 6, '6-31G* Default (Sph)')  #TEST
 
 clean()
 clean_variables()
@@ -63,7 +63,7 @@ set cfour_CALC_level=MP2
 set basis 6-31g*
 
 energy('cfour')
-compare_values(cart_631gs, get_variable('CURRENT ENERGY'), 6, '6-31G* P4 Default (Cart)')  #TEST
+compare_values(cart_631gs, variable('CURRENT ENERGY'), 6, '6-31G* P4 Default (Cart)')  #TEST
 
 clean()
 clean_variables()
@@ -72,7 +72,7 @@ cfour {}
 set basis cc-pvdz
 
 energy('cfour')
-compare_values(sph_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ P4 Default (Sph)')  #TEST
+compare_values(sph_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ P4 Default (Sph)')  #TEST
 
 clean()
 clean_variables()
@@ -82,5 +82,5 @@ cfour {}
 set puream false
 
 energy('cfour')
-compare_values(cart_ccpvdz, get_variable('CURRENT ENERGY'), 6, 'cc-pVDZ P4 Forced (Cart)')  #TEST
+compare_values(cart_ccpvdz, variable('CURRENT ENERGY'), 6, 'cc-pVDZ P4 Forced (Cart)')  #TEST
 

--- a/tests/cfour/pywrap-alias/input.dat
+++ b/tests/cfour/pywrap-alias/input.dat
@@ -23,61 +23,61 @@ set mp2 scs on
 
 banner('gold standard')
 energy('sherrill_gold_standard')
-compare_values(-5.66406119, get_variable('CBS TOTAL ENERGY'), 7, "[1]  Au std")
+compare_values(-5.66406119, variable('CBS TOTAL ENERGY'), 7, "[1]  Au std")
 clean()
 
 #banner('scf')
 #energy('SCF')
-#compare_values(-5.551087929000, get_variable('SCF TOTAL ENERGY'), 7, "SCF sp")
+#compare_values(-5.551087929000, variable('SCF TOTAL ENERGY'), 7, "SCF sp")
 #clean()
 
 banner('mp2')
 energy('mp2')
-compare_values(-5.573453229993, get_variable('MP2 TOTAL ENERGY'), 7, "[2]  MP2 sp")
-compare_values(-0.02232850726021, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 7, "      MP2 route check") 
+compare_values(-5.573453229993, variable('MP2 TOTAL ENERGY'), 7, "[2]  MP2 sp")
+compare_values(-0.02232850726021, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 7, "      MP2 route check") 
 # this second check will fail if a request for a mp2 calc gets routed to detci, rather than the mp2 module
 clean()
 
 banner('mp3')
 energy('mp3')
-compare_values(-5.57903326861, get_variable('MP3 TOTAL ENERGY'), 7, '[3]  MP3 occ')
-compare_values(-0.025155295755, get_variable('MP2.5 CORRELATION ENERGY'), 6, '      MP3 route check')
+compare_values(-5.57903326861, variable('MP3 TOTAL ENERGY'), 7, '[3]  MP3 occ')
+compare_values(-0.025155295755, variable('MP2.5 CORRELATION ENERGY'), 6, '      MP3 route check')
 set reference uhf
 set_variable('MP3 TOTAL ENERGY',0.0)
 energy('mp3')
-compare_values(-5.57903326861, get_variable('MP3 TOTAL ENERGY'), 7, '[4]  MP3 detci (energy and route check)')
+compare_values(-5.57903326861, variable('MP3 TOTAL ENERGY'), 7, '[4]  MP3 detci (energy and route check)')
 set reference rhf
 clean()
 
 banner('mp4')
 energy('mp4')
-compare_values(-5.58040727035, get_variable('MP4 TOTAL ENERGY'), 7, '[5]  MP4 fnocc')
+compare_values(-5.58040727035, variable('MP4 TOTAL ENERGY'), 7, '[5]  MP4 fnocc')
 clean()
 
 banner('mp11')
 energy('mp11')
-compare_values(-5.580830858501, get_variable('MP11 TOTAL ENERGY'), 7, "[6]  MP11 sp")
+compare_values(-5.580830858501, variable('MP11 TOTAL ENERGY'), 7, "[6]  MP11 sp")
 clean()
 
 banner('zapt4')
 energy('zapt4')
-compare_values(-5.580407221960, get_variable('ZAPT4 TOTAL ENERGY'), 7, "[7]  ZAPT4 sp")
+compare_values(-5.580407221960, variable('ZAPT4 TOTAL ENERGY'), 7, "[7]  ZAPT4 sp")
 clean()
 
 banner('fci')
 energy('fci')
-compare_values(-5.580830850570, get_variable('FCI TOTAL ENERGY'), 7, "[8]  FCI sp")
+compare_values(-5.580830850570, variable('FCI TOTAL ENERGY'), 7, "[8]  FCI sp")
 clean()
 
 banner('mp2.5')
 energy('mp2.5')
-compare_values(-5.576243225099, get_variable('MP2.5 TOTAL ENERGY'), 7, "[9]  MP2.5 sp")
+compare_values(-5.576243225099, variable('MP2.5 TOTAL ENERGY'), 7, "[9]  MP2.5 sp")
 clean()
 
 banner('cbs()')
 set scf_type pk
 cbs('scf',scf_basis='cc-pvdz')
-compare_values(-5.55609846, get_variable('CBS TOTAL ENERGY'), 7, "[10] cbs()")
+compare_values(-5.55609846, variable('CBS TOTAL ENERGY'), 7, "[10] cbs()")
 clean()
 
 set globals {
@@ -90,7 +90,7 @@ set globals {
 # Try something other than scf
 banner('db()')
 database('scf','S22',subset=[2,8],benchmark='S22A')
-compare_values(0.604937374581, get_variable('S22 DATABASE MEAN ABSOLUTE DEVIATION'), 5, "[11] db()")  #TEST
+compare_values(0.604937374581, variable('S22 DATABASE MEAN ABSOLUTE DEVIATION'), 5, "[11] db()")  #TEST
 clean()
 
 set globals {
@@ -99,17 +99,17 @@ set globals {
 }
 banner('cisd')
 energy('cisd',molecule=He2)
-compare_values(-5.580709674676, get_variable('CISD TOTAL ENERGY'), 7, "[12] CISD sp")
+compare_values(-5.580709674676, variable('CISD TOTAL ENERGY'), 7, "[12] CISD sp")
 clean()
 
 #banner('opt(cbs())')
 #optimize('scf',opt_func=cbs,scf_basis='sto-3g',scf_scheme=highest_1)
-#compare_values(-5.615567415914, get_variable('SCF TOTAL ENERGY'), 6, 'opt(cbs())')
+#compare_values(-5.615567415914, variable('SCF TOTAL ENERGY'), 6, 'opt(cbs())')
 #clean()
 
 banner('opt(arbitraryorder())')
 optimize('mp3')
-compare_values(-5.738452948227, get_variable('MP3 TOTAL ENERGY'), 5, '[13] opt(mp3())')
+compare_values(-5.738452948227, variable('MP3 TOTAL ENERGY'), 5, '[13] opt(mp3())')
 
 #molecule h2o {
 #     O
@@ -120,5 +120,5 @@ compare_values(-5.738452948227, get_variable('MP3 TOTAL ENERGY'), 5, '[13] opt(m
 #set basis sto-3g
 
 #energy('b3lyp-d')
-#compare_values(-75.319769478, get_variable('CURRENT ENERGY'), 7, 'B3LYP-D2 sp')
+#compare_values(-75.319769478, variable('CURRENT ENERGY'), 7, 'B3LYP-D2 sp')
 

--- a/tests/cfour/pywrap-all/input.dat
+++ b/tests/cfour/pywrap-all/input.dat
@@ -34,35 +34,35 @@ set cfour_symmetry false
 
 banner('Test [1] optimize(cbs(energy()))')
 optimize('c4-mp2',func=cbs,corl_basis='cc-pv[dt]z',corl_scheme=corl_xtpl_helgaker_2,delta_wfn='c4-ccsd',delta_basis='3-21g')
-compare_values(ref_OPT_CBS_E_0, get_variable('CBS TOTAL ENERGY'), 5, "[1] Wrapper optimize(cbs(), dertype=0)")  #TEST
+compare_values(ref_OPT_CBS_E_0, variable('CBS TOTAL ENERGY'), 5, "[1] Wrapper optimize(cbs(), dertype=0)")  #TEST
 
 banner('Test [2] database(energy())')
 set basis_guess sto-3g
 set mp2_type conv
 set df_scf_guess false
 db('c4-mp2','RGC10',subset=['HeHe-0.85','HeHe-1.0'],tabulate=['mp2 total energy'])
-compare_values(ref_DB_E, get_variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[2] Wrapper database() incl. castup")  #TEST
+compare_values(ref_DB_E, variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[2] Wrapper database() incl. castup")  #TEST
 revoke_global_option_changed('BASIS_GUESS')
 
 banner('Test [3] database(cbs(energy()))')
 db('c4-mp2','RGC10',func=cbs,subset=['HeHe-0.85','HeHe-1.0'],tabulate=['mp2 total energy','current energy'],corl_basis='cc-pV[DT]Z',corl_scheme=corl_xtpl_helgaker_2,delta_wfn='c4-ccsd(t)',delta_basis='3-21g')
-compare_values(ref_DB_CBS_E, get_variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3] Wrapper database(cbs())")  #TEST
+compare_values(ref_DB_CBS_E, variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3] Wrapper database(cbs())")  #TEST
 
 banner('Test [4] cbs(energy())')
 set mp2_type df
 # for h2 geom after optimization in [1]
 cbs('mp2',corl_basis='cc-pv[dt]z',corl_scheme=corl_xtpl_helgaker_2,delta_wfn='c4-ccsd',delta_basis='3-21g',delta2_wfn='c4-ccsd(t)',delta2_wfn_lesser='c4-ccsd',delta2_basis='3-21g')
-compare_values(ref_CBS_E_postopt, get_variable('CBS TOTAL ENERGY'), 7, "[4] Wrapper cbs()")  #TEST
+compare_values(ref_CBS_E_postopt, variable('CBS TOTAL ENERGY'), 7, "[4] Wrapper cbs()")  #TEST
 set mp2_type conv
 
 banner('Test [5] opt(energy())')
 # TODO switch to mp2 once gradients thoroughly working again
 optimize('c4-mp2',dertype='none')
-compare_values(ref_OPT_E_0, get_variable('CURRENT ENERGY'), 7, "[5] Wrapper optimize(dertype=0)")  #TEST
+compare_values(ref_OPT_E_0, variable('CURRENT ENERGY'), 7, "[5] Wrapper optimize(dertype=0)")  #TEST
 
 banner('Test [6] opt(energy())')
 optimize('c4-scf')
-compare_values(ref_OPT_E_1, get_variable('CURRENT ENERGY'), 7, "[6] Wrapper optimize()")  #TEST
+compare_values(ref_OPT_E_1, variable('CURRENT ENERGY'), 7, "[6] Wrapper optimize()")  #TEST
 
 banner('Test [7] opt(energy())')
 h2.reset_point_group('c1')
@@ -72,12 +72,12 @@ h2.update_geometry()
 # SCF below if we read the previous SCF orbitals.  I seem to have avoided
 # it by upping E_CONVERGENCE to 9 above, we'll see if that holds -CDS
 optimize('c4-mp2')
-compare_values(ref_OPT_E_0, get_variable('CURRENT ENERGY'), 7, "[7] Wrapper optimize()")  #TEST
+compare_values(ref_OPT_E_0, variable('CURRENT ENERGY'), 7, "[7] Wrapper optimize()")  #TEST
 
 banner('Test [8] database(opt(energy()))')
 db('c4-mp2','S22',db_func=optimize,subset=[1],tabulate=['mp2 total energy','current energy'])
-compare_values(ref_DB_OPT_E_S22, get_variable('S22 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 3, "[8] Wrapper database(optimize())")  #TEST
+compare_values(ref_DB_OPT_E_S22, variable('S22 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 3, "[8] Wrapper database(optimize())")  #TEST
 
 banner('Test [9] alias(cbs(energy()))')
 sherrill_gold_standard()
-compare_values(ref_CDS_CBS_E_0, get_variable("CBS TOTAL ENERGY"), 6, '[9] Aliased wrapper calling cbs()')  #TEST
+compare_values(ref_CDS_CBS_E_0, variable("CBS TOTAL ENERGY"), 6, '[9] Aliased wrapper calling cbs()')  #TEST

--- a/tests/cfour/pywrap-basis/input.dat
+++ b/tests/cfour/pywrap-basis/input.dat
@@ -34,5 +34,5 @@ df_basis_sapt {
 }               
 
 energy('c4-scf')
-compare_values(-112.412159937, get_variable('current ENERGY'), 6, """[1] autofrag'd scf: explicit vs. custom haDZ""")  #TEST
+compare_values(-112.412159937, variable('current ENERGY'), 6, """[1] autofrag'd scf: explicit vs. custom haDZ""")  #TEST
 

--- a/tests/cfour/pywrap-cbs1/input.dat
+++ b/tests/cfour/pywrap-cbs1/input.dat
@@ -14,7 +14,7 @@ e_cbs = energy(cbs,
             scf_scheme=scf_xtpl_helgaker_3)
 
 compare_values(-7.4326961561955551, e_cbs, 7, "[1] Li ROHF extrapolated energy")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[1b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[1b]')  #TEST
 clean()
 
 
@@ -36,7 +36,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pV[DT]Z',
             delta_scheme=driver_cbs.corl_xtpl_helgaker_2)
 compare_values(-1.148287763304, e_cbs, 7, "[2] H2 mp2 extrapolated energy with ccsd delta correction")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[2b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[2b]')  #TEST
 clean()
 
 
@@ -53,7 +53,7 @@ e_cbs = energy(cbs,
             corl_scheme=driver_cbs.corl_xtpl_helgaker_2)
 
 compare_values(-2.9033043421572055642, e_cbs, 7, "[3] He ccsd extrapolated energy")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[3b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[3b]')  #TEST
 clean()
 
 # Example with default extrapolation schemes
@@ -64,7 +64,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pVDZ')
 
 compare_values(-2.90394676, e_cbs, 6, '[4] MP5: minimal info')  #TEST
-compare_values(2.0, get_variable('cbs number'), 6, '[4b]')  #TEST
+compare_values(2.0, variable('cbs number'), 6, '[4b]')  #TEST
 clean()
 
 def myownmy_2(functionname, zLO, valueLO, zHI, valueHI, verbose=True, alpha=None):

--- a/tests/cfour/scf4/input.dat
+++ b/tests/cfour/scf4/input.dat
@@ -23,7 +23,7 @@ molecule h2o {
     H 1 R 2 A
 }
 
-print_stdout(" Testing Z-matrix coordinates") #TEST
+print(" Testing Z-matrix coordinates") #TEST
 
 count = 0
 
@@ -47,7 +47,7 @@ for R in Rvals:
 
 count = 0
 
-print_stdout(" Testing polar coordinates") #TEST
+print(" Testing polar coordinates") #TEST
 
 for R in Rvals:
     for A in Avals:

--- a/tests/cfour/sp-rhf-cc3/input.dat
+++ b/tests/cfour/sp-rhf-cc3/input.dat
@@ -20,10 +20,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.283326618243, get_variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
-compare_values(-76.346075078360, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.283326618243, variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
+compare_values(-76.346075078360, variable('cc3 total energy'), 6, 'CC3')  #TEST
 
 clean()
 clean_variables()
@@ -49,10 +49,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.283326618243, get_variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
-compare_values(-76.346075078360, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.283326618243, variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
+compare_values(-76.346075078360, variable('cc3 total energy'), 6, 'CC3')  #TEST
 
 print('        <<< Thorough Psi4 format >>>')
 
@@ -73,10 +73,10 @@ cfour_CC_CONV=12
 
 energy('c4-cc3')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.283326618243, get_variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
-compare_values(-76.346075078360, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.283326618243, variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
+compare_values(-76.346075078360, variable('cc3 total energy'), 6, 'CC3')  #TEST
 
 clean()
 clean_variables()
@@ -102,8 +102,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.283326618243, get_variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
-compare_values(-76.346075078360, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.283326618243, variable('cc3 correlation energy'), 6, 'CC3 corl')  #TEST
+compare_values(-76.346075078360, variable('cc3 total energy'), 6, 'CC3')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd-ao/input.dat
+++ b/tests/cfour/sp-rhf-ccsd-ao/input.dat
@@ -21,10 +21,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.275705491773, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.275705491773, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -51,10 +51,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.275705491773, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.275705491773, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 print('        <<< Thorough Psi4 format >>>')
 
@@ -77,10 +77,10 @@ cfour_cc_program vcc
 
 energy('c4-ccsd')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.275705491773, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.275705491773, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -107,8 +107,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.275705491773, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.275705491773, variable('current correlation energy'), 6, 'Current corl')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd/input.dat
+++ b/tests/cfour/sp-rhf-ccsd/input.dat
@@ -19,10 +19,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
 
 clean()
 clean_variables()
@@ -48,10 +48,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
 
 clean()
 clean_variables()
@@ -77,8 +77,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd_t_-ao-ecc/input.dat
+++ b/tests/cfour/sp-rhf-ccsd_t_-ao-ecc/input.dat
@@ -21,11 +21,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.007263597996, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.007263597996, variable('(t) correction energy'), 6, '(T)')  #TEST
 
 clean()
 clean_variables()
@@ -53,8 +53,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
 
 print('        <<< Thorough Psi4 format >>>')
 
@@ -76,8 +76,8 @@ cfour_CC_CONV=12
 
 energy('c4-ccsd(t)')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
 
 clean()
 clean_variables()
@@ -105,6 +105,6 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd_t_-ao/input.dat
+++ b/tests/cfour/sp-rhf-ccsd_t_-ao/input.dat
@@ -20,10 +20,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -50,10 +50,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -80,8 +80,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd_t_-ecc/input.dat
+++ b/tests/cfour/sp-rhf-ccsd_t_-ecc/input.dat
@@ -20,11 +20,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.2757054917725157, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.2757054917725157, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -51,11 +51,11 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.2757054917725157, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.2757054917725157, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -82,9 +82,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.2757054917725157, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.2757054917725157, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd_t_-fc/input.dat
+++ b/tests/cfour/sp-rhf-ccsd_t_-fc/input.dat
@@ -22,11 +22,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.307900311342, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.250330561135, get_variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
-compare_values(-76.313079021252, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.320175531445, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.307900311342, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.250330561135, variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
+compare_values(-76.313079021252, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.320175531445, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -55,9 +55,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.307900311342, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.250330561135, get_variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
-compare_values(-76.313079021252, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-76.320175531445, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.307900311342, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.250330561135, variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
+compare_values(-76.313079021252, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-76.320175531445, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsd_t_/input.dat
+++ b/tests/cfour/sp-rhf-ccsd_t_/input.dat
@@ -19,12 +19,12 @@
 ###
 ###energy('cfour')
 ###
-###compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-###compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-###compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-###compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-###compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-###compare_values(-0.282969089769, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+###compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+###compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+###compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+###compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+###compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+###compare_values(-0.282969089769, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
 ###
 ###clean()
 ###clean_variables()
@@ -50,12 +50,12 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.282969089769, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.282969089769, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
 
 ### clean()
 ### clean_variables()
@@ -81,10 +81,10 @@ compare_values(-0.282969089769, get_variable('ccsd(t) correlation energy'), 6, '
 ### 
 ### energy('cfour')
 ### 
-### compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-### compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-### compare_values(-76.338453951890, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-### compare_values(-0.275705491773, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-### compare_values(-76.345717549886, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-### compare_values(-0.282969089769, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+### compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+### compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+### compare_values(-76.338453951890, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+### compare_values(-0.275705491773, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+### compare_values(-76.345717549886, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+### compare_values(-0.282969089769, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
 

--- a/tests/cfour/sp-rhf-ccsdt/input.dat
+++ b/tests/cfour/sp-rhf-ccsdt/input.dat
@@ -20,11 +20,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.283033259502, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
-compare_values(-76.345781719619, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
-compare_values(-0.283033259502, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.283033259502, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-76.345781719619, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-0.283033259502, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -50,9 +50,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-76.062748460117, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.283033259502, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
-compare_values(-76.345781719619, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
-compare_values(-0.283033259502, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-76.062748460117, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.283033259502, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-76.345781719619, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-0.283033259502, variable('current correlation energy'), 6, 'Current corl')  #TEST
 

--- a/tests/cfour/sp-rhf-mp2/input.dat
+++ b/tests/cfour/sp-rhf-mp2/input.dat
@@ -18,9 +18,9 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
 clean()
 clean_variables()
@@ -45,9 +45,9 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
 clean()
 clean_variables()
@@ -72,7 +72,7 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.270191667216, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-76.332940127333, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.270191667216, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-76.332940127333, variable('mp2 total energy'), 6, 'MP2')  #TEST
 

--- a/tests/cfour/sp-rhf-scf/input.dat
+++ b/tests/cfour/sp-rhf-scf/input.dat
@@ -18,8 +18,8 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.0627484601, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('current energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -45,8 +45,8 @@ cfour {}  # clear literal block since running sequentially
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.0627484601, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('current energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -74,8 +74,8 @@ set d_convergence 12
 
 energy('c4-scf')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.0627484601, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('current energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -103,8 +103,8 @@ cfour {}  # clear literal block since running sequentially
 
 energy('cfour')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.0627484601, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('current energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -126,6 +126,6 @@ set d_convergence 12
 
 energy('c4-scf')
 
-compare_values(-76.0627484601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-76.0627484601, get_variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-76.0627484601, variable('current energy'), 6, 'SCF')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsd-ao/input.dat
+++ b/tests/cfour/sp-rohf-ccsd-ao/input.dat
@@ -23,18 +23,18 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 
 clean()
 clean_variables()
@@ -64,18 +64,18 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 
 print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
 
@@ -101,18 +101,18 @@ cfour_cc_program vcc
 
 energy('c4-ccsd')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 
 print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
 
@@ -138,16 +138,16 @@ cfour_cc_program vcc
 
 energy('c4-ccsd')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsd/input.dat
+++ b/tests/cfour/sp-rohf-ccsd/input.dat
@@ -21,18 +21,18 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 
 clean()
 clean_variables()
@@ -61,18 +61,18 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 
 clean()
 clean_variables()
@@ -101,16 +101,16 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.1745752, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0432743, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.217849506326, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.802586766392, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.1745752, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0432743, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.217849506326, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.802586766392, variable('current energy'), 6, 'Current')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsd_t_-ao-ecc/input.dat
+++ b/tests/cfour/sp-rohf-ccsd_t_-ao-ecc/input.dat
@@ -24,22 +24,22 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-#compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-#compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.1779580, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0398915, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+#compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+#compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.1779580, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0398915, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -71,21 +71,21 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-#compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-#compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-0.1779580, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0398915, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+#compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+#compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-0.1779580, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0398915, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 # Why CC OS/SS values changing w/ECC?

--- a/tests/cfour/sp-rohf-ccsd_t_-ao/input.dat
+++ b/tests/cfour/sp-rohf-ccsd_t_-ao/input.dat
@@ -24,20 +24,20 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -68,18 +68,18 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsd_t_-fc/input.dat
+++ b/tests/cfour/sp-rohf-ccsd_t_-fc/input.dat
@@ -24,20 +24,20 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002943388250, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.134798097365, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.038374828493, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.176116314109, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.760853573995, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002943388250, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.134798097365, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.038374828493, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.176116314109, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.760853573995, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.777569551624, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.1563275, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.0365048, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.782617433232, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.1928322917376748, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005047881608, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.782617433232, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.777569551624, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.1563275, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.0365048, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.782617433232, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.1928322917376748, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005047881608, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.782617433232, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -66,18 +66,18 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsd_t_/input.dat
+++ b/tests/cfour/sp-rohf-ccsd_t_/input.dat
@@ -22,62 +22,20 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
-
-clean()
-clean_variables()
-cfour {}
-
-print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
-
-molecule {
-0 2
-N
-H 1 R
-H 1 R 2 A
-
-R=1.008
-A=105.0
-}
-
-set {
-cfour_CALC_level =CCSD(T)
-cfour_BASIS=qz2p
-cfour_REFerence=ROHF
-cfour_OCCUPATION [[3,1,1,0],[3,0,1,0]]
-cfour_SCF_CONV=12
-cfour_PRINT=2
-}
-
-energy('cfour')
-
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -106,18 +64,60 @@ cfour_PRINT=2
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
-compare_values(-55.802586766392, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.174575174753, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.043274331574, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807820706828, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.217849506326, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.005233940436, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-compare_values(-55.807820706828, get_variable('current energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
+
+clean()
+clean_variables()
+cfour {}
+
+print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
+
+molecule {
+0 2
+N
+H 1 R
+H 1 R 2 A
+
+R=1.008
+A=105.0
+}
+
+set {
+cfour_CALC_level =CCSD(T)
+cfour_BASIS=qz2p
+cfour_REFerence=ROHF
+cfour_OCCUPATION [[3,1,1,0],[3,0,1,0]]
+cfour_SCF_CONV=12
+cfour_PRINT=2
+}
+
+energy('cfour')
+
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+
+compare_values(-55.802586766392, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.174575174753, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.043274331574, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807820706828, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.217849506326, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.005233940436, variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.807820706828, variable('current energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-rohf-ccsdt/input.dat
+++ b/tests/cfour/sp-rohf-ccsdt/input.dat
@@ -21,14 +21,14 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.223456327195, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
-compare_values(-55.808193587260, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.223456327195, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.808193587260, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
 
 clean()
 clean_variables()
@@ -57,14 +57,14 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.223456327195, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
-compare_values(-55.808193587260, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.223456327195, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.808193587260, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
 
 clean()
 clean_variables()
@@ -93,12 +93,12 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.223456327195, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
-compare_values(-55.808193587260, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.223456327195, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.808193587260, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
 

--- a/tests/cfour/sp-rohf-mp2-sc/input.dat
+++ b/tests/cfour/sp-rohf-mp2-sc/input.dat
@@ -21,12 +21,12 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
 clean()
 clean_variables()
@@ -55,12 +55,12 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
 clean()
 clean_variables()
@@ -89,10 +89,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 

--- a/tests/cfour/sp-rohf-mp2-std/input.dat
+++ b/tests/cfour/sp-rohf-mp2-std/input.dat
@@ -22,19 +22,19 @@ MEMORY=20000000)
 
 energy('cfour')
 #
-#compare_values(, get_variable('energy'), 6, '')  #TEST
-#compare_values(, get_variable('energy'), 6, '')  #TEST
-#compare_values(, get_variable('energy'), 6, '')  #TEST
-#compare_values(, get_variable('energy'), 6, '')  #TEST
-#compare_values(, get_variable('energy'), 6, '')  #TEST
-#compare_values(, get_variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
+#compare_values(, variable('energy'), 6, '')  #TEST
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
 
 # MESSED UP
 

--- a/tests/cfour/sp-rohf-mp4-sc/input.dat
+++ b/tests/cfour/sp-rohf-mp4-sc/input.dat
@@ -20,26 +20,26 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.215858889, get_variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
-compare_values(-55.800596149, get_variable('mp3 total energy'), 6, 'MP3')  #TEST
-#compare_values(-55.807004598386, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-compare_values(-55.806988018769, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-#compare_values(-0.222267338321, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-0.222250758669, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-55.806988018769, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.222250758669, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-#compare_values(-0.217505967817, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-#compare_values(-55.802243227882, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.217489388149, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-compare_values(-55.802226648249, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.004761370505, get_variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.215858889, variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
+compare_values(-55.800596149, variable('mp3 total energy'), 6, 'MP3')  #TEST
+#compare_values(-55.807004598386, variable('mp4 total energy'), 6, 'MP4')  #TEST
+compare_values(-55.806988018769, variable('mp4 total energy'), 6, 'MP4')  #TEST
+#compare_values(-0.222267338321, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-0.222250758669, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-55.806988018769, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.222250758669, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'Current ref')  #TEST
+#compare_values(-0.217505967817, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+#compare_values(-55.802243227882, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.217489388149, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+compare_values(-55.802226648249, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.004761370505, variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
 
 clean()
 clean_variables()
@@ -69,26 +69,26 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.215858889, get_variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
-compare_values(-55.800596149, get_variable('mp3 total energy'), 6, 'MP3')  #TEST
-#compare_values(-55.807004598386, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-compare_values(-55.806988018769, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-#compare_values(-0.222267338321, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-0.222250758669, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-55.806988018769, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.222250758669, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-#compare_values(-0.217505967817, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-#compare_values(-55.802243227882, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.217489388149, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-compare_values(-55.802226648249, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.004761370505, get_variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.215858889, variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
+compare_values(-55.800596149, variable('mp3 total energy'), 6, 'MP3')  #TEST
+#compare_values(-55.807004598386, variable('mp4 total energy'), 6, 'MP4')  #TEST
+compare_values(-55.806988018769, variable('mp4 total energy'), 6, 'MP4')  #TEST
+#compare_values(-0.222267338321, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-0.222250758669, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-55.806988018769, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.222250758669, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'Current ref')  #TEST
+#compare_values(-0.217505967817, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+#compare_values(-55.802243227882, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.217489388149, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+compare_values(-55.802226648249, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.004761370505, variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
 
 clean()
 clean_variables()
@@ -118,26 +118,26 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.002983751786, get_variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
-compare_values(-0.155770420921, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
-compare_values(-0.041785354569, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.200539527276, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.785276787341, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.215858889, get_variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
-compare_values(-55.800596149, get_variable('mp3 total energy'), 6, 'MP3')  #TEST
-#compare_values(-55.807004598386, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-compare_values(-55.806988018769, get_variable('mp4 total energy'), 6, 'MP4')  #TEST
-#compare_values(-0.222267338321, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-0.222250758669, get_variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
-compare_values(-55.806988018769, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.222250758669, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-#compare_values(-0.217505967817, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-#compare_values(-55.802243227882, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.217489388149, get_variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
-compare_values(-55.802226648249, get_variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
-compare_values(-0.004761370505, get_variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.002983751786, variable('mp2 singles energy'), 6, 'MP2 singles')  #TEST
+compare_values(-0.155770420921, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-0.041785354569, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.200539527276, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.785276787341, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.215858889, variable('mp3 correlation energy'), 6, 'MP3 corl')  #TEST
+compare_values(-55.800596149, variable('mp3 total energy'), 6, 'MP3')  #TEST
+#compare_values(-55.807004598386, variable('mp4 total energy'), 6, 'MP4')  #TEST
+compare_values(-55.806988018769, variable('mp4 total energy'), 6, 'MP4')  #TEST
+#compare_values(-0.222267338321, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-0.222250758669, variable('mp4 correlation energy'), 6, 'MP4 corl')  #TEST
+compare_values(-55.806988018769, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.222250758669, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'Current ref')  #TEST
+#compare_values(-0.217505967817, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+#compare_values(-55.802243227882, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.217489388149, variable('mp4(sdq) correlation energy'), 6, 'MP4(SDQ) corl')  #TEST
+compare_values(-55.802226648249, variable('mp4(sdq) total energy'), 6, 'MP4(SDQ)')  #TEST
+compare_values(-0.004761370505, variable('mp4(t) correction energy'), 6, 'MP4(T)')  #TEST
 
 # New run in cfour
 #        S-MBPT(2)       -0.002983751785   -55.587721011671

--- a/tests/cfour/sp-rohf-scf/input.dat
+++ b/tests/cfour/sp-rohf-scf/input.dat
@@ -20,9 +20,9 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -52,9 +52,9 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'SCF')  #TEST
 
 clean()
 clean_variables()
@@ -84,7 +84,7 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5847372601, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current energy'), 6, 'SCF')  #TEST
-compare_values(-55.5847372601, get_variable('current reference energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current energy'), 6, 'SCF')  #TEST
+compare_values(-55.5847372601, variable('current reference energy'), 6, 'SCF')  #TEST
 

--- a/tests/cfour/sp-uhf-cc3/input.dat
+++ b/tests/cfour/sp-uhf-cc3/input.dat
@@ -21,10 +21,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.807963384933, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
-compare_values(-0.218616416146, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.807963384933, variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-0.218616416146, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -55,10 +55,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.807963384933, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
-compare_values(-0.218616416146, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.807963384933, variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-0.218616416146, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -86,10 +86,10 @@ cfour_CC_CONV=12
 
 energy('c4-cc3')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.807963384933, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
-compare_values(-0.218616416146, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.807963384933, variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-0.218616416146, variable('current correlation energy'), 6, 'Current corl')  #TEST
 
 clean()
 clean_variables()
@@ -120,8 +120,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.807963384933, get_variable('cc3 total energy'), 6, 'CC3')  #TEST
-compare_values(-0.218616416146, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.807963384933, variable('cc3 total energy'), 6, 'CC3')  #TEST
+compare_values(-0.218616416146, variable('current correlation energy'), 6, 'Current corl')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsd/input.dat
+++ b/tests/cfour/sp-uhf-ccsd/input.dat
@@ -21,9 +21,9 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
 
 clean()
 clean_variables()
@@ -54,9 +54,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
 
 clean()
 clean_variables()
@@ -87,7 +87,7 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsd_t_-ao-ecc/input.dat
+++ b/tests/cfour/sp-uhf-ccsd_t_-ao-ecc/input.dat
@@ -22,11 +22,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.2132980551718224, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.005166587884, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.2132980551718224, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.005166587884, variable('(t) correction energy'), 6, '(T)')  #TEST
 
 clean()
 clean_variables()
@@ -59,11 +59,11 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.2132980551718224, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.005166587884, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.2132980551718224, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.005166587884, variable('(t) correction energy'), 6, '(T)')  #TEST
 
 clean()
 clean_variables()
@@ -96,9 +96,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.2132980551718224, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.005166587884, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.2132980551718224, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.005166587884, variable('(t) correction energy'), 6, '(T)')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsd_t_-ao/input.dat
+++ b/tests/cfour/sp-uhf-ccsd_t_-ao/input.dat
@@ -22,10 +22,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -56,10 +56,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -90,8 +90,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsd_t_-ecc/input.dat
+++ b/tests/cfour/sp-uhf-ccsd_t_-ecc/input.dat
@@ -22,10 +22,10 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055171822, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055171822, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -57,10 +57,10 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055171822, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055171822, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 
 clean()
 clean_variables()
@@ -92,8 +92,8 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.213298055171822, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.213298055171822, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsd_t_/input.dat
+++ b/tests/cfour/sp-uhf-ccsd_t_/input.dat
@@ -22,64 +22,19 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.173390809645, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.039907245528, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.2184646435, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-0.0051665879, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.173390809645, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.039907245528, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.2184646435, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-0.0051665879, variable('(t) correction energy'), 6, '(T)')  #TEST
 
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-compare_values(-0.2184646435, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.807811611842, get_variable('current energy'), 6, 'Current')  #TEST
-
-clean()
-clean_variables()
-cfour {}
-
-print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
-
-banner('UHF-CCSD(T) energy calculation')
-
-molecule {
-0 2
-N
-H 1 R
-H 1 R 2 A
-
-R=1.008
-A=105.0
-}
-
-set {
-cfour_CALC_level=CCSD(T)
-cfour_BASIS=qz2p
-cfour_MULTiplicity=2
-cfour_REFerence=UHF
-cfour_OCCUPATION= [[3,1 ,1, 0] ,[ 3,0 ,1,0]    ]
-cfour_SCF_CONV=12
-cfour_PRINT=2
-cfour_CC_CONV=12
-}
-
-energy('cfour')
-
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.173390809645, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.039907245528, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.2184646435, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-0.0051665879, get_variable('(t) correction energy'), 6, '(T)')  #TEST
-
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-compare_values(-0.2184646435, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.807811611842, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-0.2184646435, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.807811611842, variable('current energy'), 6, 'Current')  #TEST
 
 clean()
 clean_variables()
@@ -112,17 +67,62 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.802645023958, get_variable('ccsd total energy'), 6, 'CCSD')  #TEST
-compare_values(-0.213298055172, get_variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
-compare_values(-0.173390809645, get_variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
-compare_values(-0.039907245528, get_variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
-compare_values(-55.807811611842, get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
-compare_values(-0.2184646435, get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
-compare_values(-0.0051665879, get_variable('(t) correction energy'), 6, '(T)')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.173390809645, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.039907245528, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.2184646435, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-0.0051665879, variable('(t) correction energy'), 6, '(T)')  #TEST
 
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
-compare_values(-0.2184646435, get_variable('current correlation energy'), 6, 'Current corl')  #TEST
-compare_values(-55.807811611842, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-0.2184646435, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.807811611842, variable('current energy'), 6, 'Current')  #TEST
+
+clean()
+clean_variables()
+cfour {}
+
+print('        <<< Translation of ZMAT to Psi4 format to Cfour >>>')
+
+banner('UHF-CCSD(T) energy calculation')
+
+molecule {
+0 2
+N
+H 1 R
+H 1 R 2 A
+
+R=1.008
+A=105.0
+}
+
+set {
+cfour_CALC_level=CCSD(T)
+cfour_BASIS=qz2p
+cfour_MULTiplicity=2
+cfour_REFerence=UHF
+cfour_OCCUPATION= [[3,1 ,1, 0] ,[ 3,0 ,1,0]    ]
+cfour_SCF_CONV=12
+cfour_PRINT=2
+cfour_CC_CONV=12
+}
+
+energy('cfour')
+
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.802645023958, variable('ccsd total energy'), 6, 'CCSD')  #TEST
+compare_values(-0.213298055172, variable('ccsd correlation energy'), 6, 'CCSD corl')  #TEST
+compare_values(-0.173390809645, variable('ccsd opposite-spin correlation energy'), 6, 'CCSD OS corl')  #TEST
+compare_values(-0.039907245528, variable('ccsd same-spin correlation energy'), 6, 'CCSD SS corl')  #TEST
+compare_values(-55.807811611842, variable('ccsd(t) total energy'), 6, 'CCSD(T)')  #TEST
+compare_values(-0.2184646435, variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')  #TEST
+compare_values(-0.0051665879, variable('(t) correction energy'), 6, '(T)')  #TEST
+
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-0.2184646435, variable('current correlation energy'), 6, 'Current corl')  #TEST
+compare_values(-55.807811611842, variable('current energy'), 6, 'Current')  #TEST
 

--- a/tests/cfour/sp-uhf-ccsdt/input.dat
+++ b/tests/cfour/sp-uhf-ccsdt/input.dat
@@ -21,11 +21,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.808195538134, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
-compare_values(-55.808195538134, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.218848569347, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.808195538134, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.808195538134, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.218848569347, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
 
 clean()
 clean_variables()
@@ -56,11 +56,11 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.808195538134, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
-compare_values(-55.808195538134, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.218848569347, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.808195538134, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.808195538134, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.218848569347, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
 
 clean()
 clean_variables()
@@ -91,9 +91,9 @@ cfour_CC_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-55.808195538134, get_variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
-compare_values(-55.808195538134, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-0.218848569347, get_variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-55.808195538134, variable('ccsdt total energy'), 6, 'CCSDT')  #TEST
+compare_values(-55.808195538134, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.218848569347, variable('ccsdt correlation energy'), 6, 'CCSDT corl')  #TEST
 

--- a/tests/cfour/sp-uhf-mp2/input.dat
+++ b/tests/cfour/sp-uhf-mp2/input.dat
@@ -20,11 +20,11 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.0416164, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.1539141, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.0416164, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.1539141, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
 
 clean()
 clean_variables()
@@ -54,11 +54,11 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.0416164, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.1539141, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.0416164, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.1539141, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
 
 clean()
 clean_variables()
@@ -88,9 +88,9 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.784877360093, get_variable('mp2 total energy'), 6, 'MP2')  #TEST
-compare_values(-0.195530391306, get_variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
-compare_values(-0.0416164, get_variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
-compare_values(-0.1539141, get_variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.784877360093, variable('mp2 total energy'), 6, 'MP2')  #TEST
+compare_values(-0.195530391306, variable('mp2 correlation energy'), 6, 'MP2 corl')  #TEST
+compare_values(-0.0416164, variable('mp2 same-spin correlation energy'), 6, 'MP2 SS corl')  #TEST
+compare_values(-0.1539141, variable('mp2 opposite-spin correlation energy'), 6, 'MP2 OS corl')  #TEST
 

--- a/tests/cfour/sp-uhf-scf/input.dat
+++ b/tests/cfour/sp-uhf-scf/input.dat
@@ -20,9 +20,9 @@ MEMORY=20000000)
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5893469688, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5893469688, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
 
 clean()
 clean_variables()
@@ -52,9 +52,9 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5893469688, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5893469688, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
 
 clean()
 clean_variables()
@@ -84,7 +84,7 @@ cfour_SCF_CONV=12
 
 energy('cfour')
 
-compare_values(-55.5893469688, get_variable('scf total energy'), 6, 'SCF')  #TEST
-compare_values(-55.5893469688, get_variable('current energy'), 6, 'Current')  #TEST
-compare_values(-55.5893469688, get_variable('current reference energy'), 6, 'Current ref')  #TEST
+compare_values(-55.5893469688, variable('scf total energy'), 6, 'SCF')  #TEST
+compare_values(-55.5893469688, variable('current energy'), 6, 'Current')  #TEST
+compare_values(-55.5893469688, variable('current reference energy'), 6, 'Current ref')  #TEST
 

--- a/tests/chemps2/caspt2-n2/input.dat
+++ b/tests/chemps2/caspt2-n2/input.dat
@@ -41,6 +41,6 @@ set dmrg_caspt2_imag          0.0
 
 energy("dmrg-caspt2")
 
-compare_values(-109.15104350802, get_variable("DMRG-SCF ENERGY"), 6, "DMRG-SCF Energy")   #TEST
-compare_values(-109.2680229921, get_variable("CURRENT ENERGY"), 6, "DMRG-CASPT2 Energy")   #TEST
+compare_values(-109.15104350802, variable("DMRG-SCF ENERGY"), 6, "DMRG-SCF Energy")   #TEST
+compare_values(-109.2680229921, variable("CURRENT ENERGY"), 6, "DMRG-CASPT2 Energy")   #TEST
 

--- a/tests/chemps2/caspt2-small/input.dat
+++ b/tests/chemps2/caspt2-small/input.dat
@@ -41,6 +41,6 @@ set dmrg_caspt2_imag          0.0
 
 energy("dmrg-caspt2")
 
-compare_values(-107.2576689206, get_variable("DMRG-SCF ENERGY"), 5, "DMRG-SCF Energy")   #TEST
-compare_values(-107.5036855148, get_variable("CURRENT ENERGY"), 5, "DMRG-CASPT2 Energy")   #TEST
+compare_values(-107.2576689206, variable("DMRG-SCF ENERGY"), 5, "DMRG-SCF Energy")   #TEST
+compare_values(-107.5036855148, variable("CURRENT ENERGY"), 5, "DMRG-CASPT2 Energy")   #TEST
 

--- a/tests/chemps2/ci-h2o/input.dat
+++ b/tests/chemps2/ci-h2o/input.dat
@@ -29,6 +29,6 @@ set dmrg_mps_write            false
 energy("dmrg-ci")
 
 ref_energy = -76.1261102339  #TEST
-compare_values(-76.02141840825, get_variable('SCF TOTAL ENERGY'), 6, 'SCF Energy')  #TEST
-compare_values(ref_energy, get_variable("CURRENT ENERGY"), 6, "DMRG CI Energy")  #TEST
+compare_values(-76.02141840825, variable('SCF TOTAL ENERGY'), 6, 'SCF Energy')  #TEST
+compare_values(ref_energy, variable("CURRENT ENERGY"), 6, "DMRG CI Energy")  #TEST
 

--- a/tests/chemps2/natural-orbital/input.dat
+++ b/tests/chemps2/natural-orbital/input.dat
@@ -38,5 +38,5 @@ set dmrg_local_init         false
 energy("dmrg-scf")
 
 ref_energy = -109.1035023353  #TEST
-compare_values(ref_energy, get_variable("CURRENT ENERGY"), 6, "DMRG Energy")  #TEST
+compare_values(ref_energy, variable("CURRENT ENERGY"), 6, "DMRG Energy")  #TEST
 

--- a/tests/chemps2/scf-n2/input.dat
+++ b/tests/chemps2/scf-n2/input.dat
@@ -37,5 +37,5 @@ set dmrg_local_init        false
 energy("dmrg-scf")
 
 ref_energy = -109.1035023353  #TEST
-compare_values(ref_energy, get_variable("CURRENT ENERGY"), 6, "DMRG Energy")  #TEST
+compare_values(ref_energy, variable("CURRENT ENERGY"), 6, "DMRG Energy")  #TEST
 

--- a/tests/ci-multi/input.dat
+++ b/tests/ci-multi/input.dat
@@ -24,7 +24,7 @@ emp3   = energy('mp3')
 emp4   = energy('mp4')
 
 compare_values(refnuc, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")  #TEST 
-compare_values(refscf, get_variable("SCF total energy"), 8, "SCF energy")  #TEST
+compare_values(refscf, variable("SCF total energy"), 8, "SCF energy")  #TEST
 compare_values(refcisd, ecisd, 6, "CISD energy: DePrince")  #TEST
 compare_values(refcisdt, ecisdt, 6, "CISDT energy: Sherrill")  #TEST
 compare_values(refmp3, emp3, 6, "MP3 energy: Bozkaya")  #TEST
@@ -38,7 +38,7 @@ emp3   = energy('mp3')
 emp4   = energy('mp4')
 
 compare_values(refnuc, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")  #TEST 
-compare_values(refscf, get_variable("SCF total energy"), 8, "SCF energy")  #TEST
+compare_values(refscf, variable("SCF total energy"), 8, "SCF energy")  #TEST
 compare_values(refcisd, ecisd, 6, "CISD energy: Sherrill")  #TEST
 compare_values(refcisdt, ecisdt, 6, "CISDT energy: Sherrill")  #TEST
 compare_values(refmp3, emp3, 6, "MP3 energy: Sherrill")  #TEST

--- a/tests/ci-property/input.dat
+++ b/tests/ci-property/input.dat
@@ -40,61 +40,61 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
 fci_energy = prop('FCI', properties=props)
 
 compare_values(fci_energy, -278.7924561878957, 6, 'FCI Energy')    #TEST
-compare_values(psi4.get_variable('CI DIPOLE Y'), 0.000000000000, 4, "FCI DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CI DIPOLE Z'), 1.908946764853, 4, "FCI DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CI QUADRUPOLE XX'), -22.395945512510, 4, "FCI QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CI QUADRUPOLE YY'), -27.774201286760, 4, "FCI QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CI QUADRUPOLE ZZ'), -29.166055634625, 4, "FCI QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CI QUADRUPOLE YZ'), 0.000000000000, 4, "FCI QUADRUPOLE YZ")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 0 DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 DIPOLE Z'), -0.483503167660, 4, "CI ROOT 0 DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 QUADRUPOLE XX'), -22.419106552690, 4, "CI ROOT 0 QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 QUADRUPOLE YY'), -26.694665553619, 4, "CI ROOT 0 QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 QUADRUPOLE ZZ'), -30.482314878839, 4, "CI ROOT 0 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CI ROOT 0 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 0 QUADRUPOLE YZ")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 DIPOLE Z'), 4.301396697365, 4, "CI ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 QUADRUPOLE XX'), -22.372784472330, 4, "CI ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 QUADRUPOLE YY'), -28.853737019899, 4, "CI ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 QUADRUPOLE ZZ'), -27.849796390412, 4, "CI ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CI ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 1 QUADRUPOLE YZ")    #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 DIPOLE Y')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Y")  #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 DIPOLE Z')), 0.425513677544, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Z")  #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE XX')), 0.016387859082, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE XX")  #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
-compare_values(abs(psi4.get_variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
+compare_values(psi4.variable('CI DIPOLE Y'), 0.000000000000, 4, "FCI DIPOLE Y")    #TEST
+compare_values(psi4.variable('CI DIPOLE Z'), 1.908946764853, 4, "FCI DIPOLE Z")    #TEST
+compare_values(psi4.variable('CI QUADRUPOLE XX'), -22.395945512510, 4, "FCI QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CI QUADRUPOLE YY'), -27.774201286760, 4, "FCI QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CI QUADRUPOLE ZZ'), -29.166055634625, 4, "FCI QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CI QUADRUPOLE YZ'), 0.000000000000, 4, "FCI QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CI ROOT 0 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 0 DIPOLE Y")    #TEST
+compare_values(psi4.variable('CI ROOT 0 DIPOLE Z'), -0.483503167660, 4, "CI ROOT 0 DIPOLE Z")    #TEST
+compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE XX'), -22.419106552690, 4, "CI ROOT 0 QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YY'), -26.694665553619, 4, "CI ROOT 0 QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE ZZ'), -30.482314878839, 4, "CI ROOT 0 QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 0 QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CI ROOT 1 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 1 DIPOLE Y")    #TEST
+compare_values(psi4.variable('CI ROOT 1 DIPOLE Z'), 4.301396697365, 4, "CI ROOT 1 DIPOLE Z")    #TEST
+compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE XX'), -22.372784472330, 4, "CI ROOT 1 QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YY'), -28.853737019899, 4, "CI ROOT 1 QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE ZZ'), -27.849796390412, 4, "CI ROOT 1 QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 1 QUADRUPOLE YZ")    #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Y')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Y")  #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Z')), 0.425513677544, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Z")  #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE XX')), 0.016387859082, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE XX")  #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
+compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
 
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-compare_values(psi4.get_variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
+compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
 
 set DETCI NAT_ORBS true
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-compare_values(psi4.get_variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
+compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
 #name = 'CASSCF'    #TEST
 #prop_list = []    #TEST
 #for dip in ['Y', 'Z']:    #TEST
@@ -103,8 +103,8 @@ compare_values(psi4.get_variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000,
 #    prop_list.append(name + ' QUADRUPOLE ' + quad)    #TEST
 #    #TEST
 #for p in prop_list:    #TEST
-#    val = psi4.get_variable(p)    #TEST
-#    pstring  = "compare_values(psi4.get_variable("    #TEST
+#    val = psi4.variable(p)    #TEST
+#    pstring  = "compare_values(psi4.variable("    #TEST
 #    pstring += "'" + p + "'"    #TEST
 #    pstring += '), %14.12f, 4, "' % val    #TEST
 #    pstring += p    #TEST

--- a/tests/cisd-h2o+-0/input.dat
+++ b/tests/cisd-h2o+-0/input.dat
@@ -22,6 +22,6 @@ set {
 thisenergy = energy('cisd')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     7, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     7, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/cisd-h2o+-1/input.dat
+++ b/tests/cisd-h2o+-1/input.dat
@@ -22,11 +22,11 @@ set {
 thisenergy = energy('cisd')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     7, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     7, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
 
-compare_values(2.68224970371, get_variable("CISD DIPOLE Z"), 3, "CISD Z Dipole")
-compare_values(2.79760370969, get_variable("SCF DIPOLE Z"), 3, "SCF Z Dipole")
+compare_values(2.68224970371, variable("CISD DIPOLE Z"), 3, "CISD Z Dipole")
+compare_values(2.79760370969, variable("SCF DIPOLE Z"), 3, "SCF Z Dipole")
 
 

--- a/tests/cisd-h2o+-2/input.dat
+++ b/tests/cisd-h2o+-2/input.dat
@@ -22,6 +22,6 @@ set {
 thisenergy = energy('cisd')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     7, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     7, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/cisd-h2o-clpse/input.dat
+++ b/tests/cisd-h2o-clpse/input.dat
@@ -27,6 +27,6 @@ thisenergy = energy('cisd')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CISD CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CISD CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/cisd-opt-fd/input.dat
+++ b/tests/cisd-opt-fd/input.dat
@@ -21,6 +21,6 @@ set qc_module detci
 thisenergy = optimize('cisd', dertype = 0)
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(),         4, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),       7, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),       7, "SCF energy") #TEST
 compare_values(refci, thisenergy,                              7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CIsd CORRELATION ENERGY"), 6, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CIsd CORRELATION ENERGY"), 6, "CI correlation energy") #TEST

--- a/tests/cisd-sp-2/input.dat
+++ b/tests/cisd-sp-2/input.dat
@@ -21,6 +21,6 @@ set {
 thisenergy = energy('cisd')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     9, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     9, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CISD CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CISD CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/cisd-sp/input.dat
+++ b/tests/cisd-sp/input.dat
@@ -21,9 +21,9 @@ set {
 thisenergy = energy('cisd')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "[1] Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"), 9, "[1] SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 9, "[1] SCF energy") #TEST
 compare_values(refci, thisenergy, 7, "[1] CISD energy") #TEST
-compare_values(refcorr, get_variable("CISD CORRELATION ENERGY"), 7, "[1] CISD correlation energy") #TEST
+compare_values(refcorr, variable("CISD CORRELATION ENERGY"), 7, "[1] CISD correlation energy") #TEST
 
 clean()
 
@@ -41,6 +41,6 @@ set detci {
 thisenergy = energy('detci')
 
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "[2] Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"), 9, "[2] SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 9, "[2] SCF energy") #TEST
 compare_values(refci, thisenergy, 7, "[2] CISD energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "[2] CISD correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "[2] CISD correlation energy") #TEST

--- a/tests/cookbook/manual-fd-hess-energy/input.dat
+++ b/tests/cookbook/manual-fd-hess-energy/input.dat
@@ -44,7 +44,7 @@ def process_displacement(method, molecule, displacement, n, ndisp, **kwargs):
 
     # Perform the energy calculation
     derivative, wfn = energy(method, return_wfn=True, molecule=molecule, **kwargs)
-    displacement["energy"] = core.get_variable('CURRENT ENERGY')
+    displacement["energy"] = core.variable('CURRENT ENERGY')
 
     # clean may be necessary when changing irreps of displacements
     core.clean()

--- a/tests/cookbook/manual-fd-hess-grad/input.dat
+++ b/tests/cookbook/manual-fd-hess-grad/input.dat
@@ -44,7 +44,7 @@ def process_displacement(method, molecule, displacement, n, ndisp, **kwargs):
 
     # Perform the energy calculation
     derivative, wfn = gradient(method, return_wfn=True, molecule=molecule, **kwargs)
-    displacement["energy"] = core.get_variable('CURRENT ENERGY')
+    displacement["energy"] = core.variable('CURRENT ENERGY')
     displacement["gradient"] = wfn.gradient().np.ravel().tolist()
 
     # clean may be necessary when changing irreps of displacements

--- a/tests/dcft1/input.dat
+++ b/tests/dcft1/input.dat
@@ -35,25 +35,25 @@ set {
 set dcft_functional dc-06
 energy('dcft')
 compare_values(refnuc, he2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");             #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                   #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy");                #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");             #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                   #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy");                #TEST
 
 set dcft_functional dc-12
 energy('dcft')
-compare_values(refdc12scf, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy");     #TEST
-compare_values(refdc12, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy");                #TEST
+compare_values(refdc12scf, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy");     #TEST
+compare_values(refdc12, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy");                #TEST
 
 clean()
 set reference rhf
 
 set dcft_functional odc-06
 energy('dcft')
-compare_values(refodc06scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy");     #TEST
-compare_values(refodc06, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy");                #TEST
+compare_values(refodc06scf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy");     #TEST
+compare_values(refodc06, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy");                #TEST
 
 set dcft_functional odc-12
 energy('dcft')
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST

--- a/tests/dcft2/input.dat
+++ b/tests/dcft2/input.dat
@@ -27,7 +27,7 @@ set dcft_functional dc-06
 energy('dcft')
 
 compare_values(refnuc, he2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");            #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 8, "MP2 Energy");                   #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy");                #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy");     #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");            #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 8, "MP2 Energy");                   #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy");     #TEST

--- a/tests/dcft3/input.dat
+++ b/tests/dcft3/input.dat
@@ -27,12 +27,12 @@ set dcft_functional dc-06
 energy('dcft')
 
 compare_values(refnuc, he2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");            #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 8, "MP2 Energy");                   #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy (two-step)");                #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy (two-step)");     #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");            #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 8, "MP2 Energy");                   #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy (two-step)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy (two-step)");     #TEST
 
 set algorithm simultaneous
 energy('dcft')
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy (simultaneous)");                #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy (simultaneous)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 8, "DC-06 Energy (simultaneous)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 8, "DC-06 SCF Energy (simultaneous)");     #TEST

--- a/tests/dcft4/input.dat
+++ b/tests/dcft4/input.dat
@@ -48,55 +48,55 @@ set {
 set dcft_functional dc-06
 energy('dcft')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=none)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=none)");                #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=none)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=none)");                #TEST
 
 set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (simultaneous, ao_basis=none)"); #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (simultaneous, ao_basis=none)");            #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (simultaneous, ao_basis=none)"); #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (simultaneous, ao_basis=none)");            #TEST
 
 set ao_basis disk
 set algorithm twostep
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=disk)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=disk)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=disk)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=disk)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (simultaneous, ao_basis=disk)"); #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (simultaneous, ao_basis=disk)");            #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (simultaneous, ao_basis=disk)"); #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (simultaneous, ao_basis=disk)");            #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type twostep
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=twostep, ao_basis=none)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=twostep, ao_basis=none)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=twostep, ao_basis=none)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=twostep, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm qc
 set qc_type twostep
 energy('dcft')
 
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=twostep, ao_basis=disk)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=twostep, ao_basis=disk)");                #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (qc, qc_type=twostep, ao_basis=disk)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (qc, qc_type=twostep, ao_basis=disk)");                #TEST
 
 #DC-12
 set dcft_functional dc-12
@@ -104,37 +104,37 @@ set ao_basis none
 set algorithm twostep
 energy('dcft')
 
-compare_values(refdcftscfexact, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=none)");     #TEST
-compare_values(refdcftexact, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=none)");                #TEST
+compare_values(refdcftscfexact, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=none)");     #TEST
+compare_values(refdcftexact, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm twostep
 energy('dcft')
 
-compare_values(refdcftscfexact, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=disk)");     #TEST
-compare_values(refdcftexact, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=disk)");                #TEST
+compare_values(refdcftscfexact, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=disk)");     #TEST
+compare_values(refdcftexact, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refdcftscfexact, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refdcftexact, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refdcftscfexact, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refdcftexact, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refdcftscfexact, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refdcftexact, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refdcftscfexact, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refdcftexact, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refdcftscfexact, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refdcftexact, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refdcftscfexact, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refdcftexact, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
 
 #ODC-06
 set dcft_functional odc-06
@@ -142,31 +142,31 @@ set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refodc06scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc06, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc06scf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc06, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refodc06scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc06, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc06scf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc06, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refodc06scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc06, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc06scf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc06, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type twostep
 energy('dcft')
 
-compare_values(refodc06scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (qc, qc_type=twostep, ao_basis=none)");     #TEST
-compare_values(refodc06, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (qc, qc_type=twostep, ao_basis=none)");                #TEST
+compare_values(refodc06scf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (qc, qc_type=twostep, ao_basis=none)");     #TEST
+compare_values(refodc06, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (qc, qc_type=twostep, ao_basis=none)");                #TEST
 
 #ODC-12
 set dcft_functional odc-12
@@ -174,22 +174,22 @@ set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
 
 #ODC-13
 set dcft_functional odc-13
@@ -197,19 +197,19 @@ set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST

--- a/tests/dcft5/input.dat
+++ b/tests/dcft5/input.dat
@@ -30,10 +30,10 @@ set dcft_functional dc-06
 optimize('dcft')
 
 compare_values(refnuc, O2.nuclear_repulsion_energy(), 5, "Nuclear Repulsion Energy")                       #TEST
-compare_values(refuhf, get_variable("SCF TOTAL ENERGY"), 6, "UHF Energy");                                 #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 6, "MP2 Energy");                                       #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 6, "DC-06 SCF Energy (two-step response)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 6, "DC-06 Energy (two-step response)");                #TEST
+compare_values(refuhf, variable("SCF TOTAL ENERGY"), 6, "UHF Energy");                                 #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 6, "MP2 Energy");                                       #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 6, "DC-06 SCF Energy (two-step response)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 6, "DC-06 Energy (two-step response)");                #TEST
 
 set response_algorithm simultaneous
 O2.R = 1.232
@@ -41,8 +41,8 @@ O2.R = 1.232
 optimize('dcft')
 
 compare_values(refnuc, O2.nuclear_repulsion_energy(), 5, "Nuclear Repulsion Energy")                       #TEST
-compare_values(refuhf, get_variable("SCF TOTAL ENERGY"), 6, "UHF Energy");                                 #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 6, "MP2 Energy");                                       #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 6, "DC-06 SCF Energy (simultaneous response)"); #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 6, "DC-06 Energy (simultaneous response)");            #TEST
+compare_values(refuhf, variable("SCF TOTAL ENERGY"), 6, "UHF Energy");                                 #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 6, "MP2 Energy");                                       #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 6, "DC-06 SCF Energy (simultaneous response)"); #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 6, "DC-06 Energy (simultaneous response)");            #TEST
 

--- a/tests/dcft6/input.dat
+++ b/tests/dcft6/input.dat
@@ -36,18 +36,18 @@ set {
 set dcft_functional dc-06
 energy('dcft')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=none)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=none)");                #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "DC-06 SCF Energy (two-step, ao_basis=none)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "DC-06 Energy (two-step, ao_basis=none)");                #TEST
 
 set dcft_functional dc-12
 energy('dcft')
 
-compare_values(refdcftxscf, get_variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=none)");     #TEST
-compare_values(refdcftx, get_variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=none)");                #TEST
+compare_values(refdcftxscf, variable("DCFT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=none)");     #TEST
+compare_values(refdcftx, variable("DCFT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=none)");                #TEST
 
 set dcft_functional cepa0
 energy('dcft')
 
-compare_values(refdcftcepa, get_variable("DCFT TOTAL ENERGY"), 10, "CEPA0 Energy (two-step, ao_basis=none)");                #TEST
+compare_values(refdcftcepa, variable("DCFT TOTAL ENERGY"), 10, "CEPA0 Energy (two-step, ao_basis=none)");                #TEST

--- a/tests/dcft7/input.dat
+++ b/tests/dcft7/input.dat
@@ -33,14 +33,14 @@ set {
 set dcft_functional odc-06
 energy('dcft')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
-compare_values(refdcftscf, get_variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refdcft, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
+compare_values(refdcftscf, variable("DCFT SCF ENERGY"), 10, "ODC-06 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refdcft, variable("DCFT TOTAL ENERGY"), 10, "ODC-06 Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set dcft_functional odc-12
 energy('dcft')
 
-compare_values(refdcftxscf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refdcftx, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refdcftxscf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refdcftx, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
 

--- a/tests/dcft8/input.dat
+++ b/tests/dcft8/input.dat
@@ -46,31 +46,31 @@ set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
-compare_values(refmp2, get_variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");                                       #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                                             #TEST
 
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=none)");                #TEST
-compare_values(refodc12_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc12_total, get_variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc12_total, variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
-compare_values(refodc12_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc12_total, get_variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc12_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc12_total, variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refodc12scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc12, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
-compare_values(refodc12_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (qc, qc_type=simultaneous, ao_basis=none)");  #TEST
-compare_values(refodc12_total, get_variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12scf, variable("DCFT SCF ENERGY"), 10, "ODC-12 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc12_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-12 Lambda_3 Energy (qc, qc_type=simultaneous, ao_basis=none)");  #TEST
+compare_values(refodc12_total, variable("CURRENT ENERGY"), 10, "ODC-12 Total Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
 
 #ODC-13 (Lambda_3)
 set three_particle perturbative
@@ -79,25 +79,25 @@ set ao_basis none
 set algorithm simultaneous
 energy('dcft')
 
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=none)");                #TEST
-compare_values(refodc13_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc13_total, get_variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc13_total, variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (simultaneous, ao_basis=none)");                #TEST
 
 set ao_basis disk
 set algorithm simultaneous
 energy('dcft')
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=disk)");                #TEST
-compare_values(refodc13_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (simultaneous, ao_basis=disk)");     #TEST
-compare_values(refodc13_total, get_variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (simultaneous, ao_basis=disk)");                #TEST
+compare_values(refodc13_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refodc13_total, variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (simultaneous, ao_basis=disk)");                #TEST
 
 set ao_basis none
 set algorithm qc
 set qc_type simultaneous
 energy('dcft')
 
-compare_values(refodc13scf, get_variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
-compare_values(refodc13, get_variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
-compare_values(refodc13_lambda_3, get_variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (qc, qc_type=simultaneous, ao_basis=none)");  #TEST
-compare_values(refodc13_total, get_variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13scf, variable("DCFT SCF ENERGY"), 10, "ODC-13 SCF Energy (qc, qc_type=simultaneous, ao_basis=none)");     #TEST
+compare_values(refodc13, variable("DCFT TOTAL ENERGY"), 10, "ODC-13 Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST
+compare_values(refodc13_lambda_3, variable("DCFT THREE-PARTICLE ENERGY"), 10, "ODC-13 Lambda_3 Energy (qc, qc_type=simultaneous, ao_basis=none)");  #TEST
+compare_values(refodc13_total, variable("CURRENT ENERGY"), 10, "ODC-13 Total Energy (qc, qc_type=simultaneous, ao_basis=none)");                #TEST

--- a/tests/dcft9/input.dat
+++ b/tests/dcft9/input.dat
@@ -33,24 +33,24 @@ set {
 set reference uhf
 set ao_basis disk
 energy('dcft')
-compare_values(refscf_uhf, get_variable("SCF TOTAL ENERGY"), 10, "UHF Energy");                                       #TEST
-compare_values(refmp2_uhf, get_variable("MP2 TOTAL ENERGY"), 10, "UHF-MP2 Energy");                                             #TEST
-compare_values(refodc12_uhf, get_variable("CURRENT ENERGY"), 10, "UHF-ODC-12 Total Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refscf_uhf, variable("SCF TOTAL ENERGY"), 10, "UHF Energy");                                       #TEST
+compare_values(refmp2_uhf, variable("MP2 TOTAL ENERGY"), 10, "UHF-MP2 Energy");                                             #TEST
+compare_values(refodc12_uhf, variable("CURRENT ENERGY"), 10, "UHF-ODC-12 Total Energy (simultaneous, ao_basis=disk)");     #TEST
 clean()
 
 set reference rhf
 set ao_basis disk
 energy('dcft')
-compare_values(refscf_rhf, get_variable("SCF TOTAL ENERGY"), 10, "RHF Energy");                                       #TEST
-compare_values(refmp2_rhf, get_variable("MP2 TOTAL ENERGY"), 10, "RHF-MP2 Energy");                                             #TEST
-compare_values(refodc12_rhf, get_variable("CURRENT ENERGY"), 10, "RHF-ODC-12 Total Energy (simultaneous, ao_basis=disk)");     #TEST
+compare_values(refscf_rhf, variable("SCF TOTAL ENERGY"), 10, "RHF Energy");                                       #TEST
+compare_values(refmp2_rhf, variable("MP2 TOTAL ENERGY"), 10, "RHF-MP2 Energy");                                             #TEST
+compare_values(refodc12_rhf, variable("CURRENT ENERGY"), 10, "RHF-ODC-12 Total Energy (simultaneous, ao_basis=disk)");     #TEST
 clean()
 
 set reference rhf
 set ao_basis none
 energy('dcft')
-compare_values(refscf_rhf, get_variable("SCF TOTAL ENERGY"), 10, "RHF Energy");                                       #TEST
-compare_values(refmp2_rhf, get_variable("MP2 TOTAL ENERGY"), 10, "RHF-MP2 Energy");                                             #TEST
-compare_values(refodc12_rhf, get_variable("CURRENT ENERGY"), 10, "RHF-ODC-12 Total Energy (simultaneous, ao_basis=none)");     #TEST
+compare_values(refscf_rhf, variable("SCF TOTAL ENERGY"), 10, "RHF Energy");                                       #TEST
+compare_values(refmp2_rhf, variable("MP2 TOTAL ENERGY"), 10, "RHF-MP2 Energy");                                             #TEST
+compare_values(refodc12_rhf, variable("CURRENT ENERGY"), 10, "RHF-ODC-12 Total Energy (simultaneous, ao_basis=none)");     #TEST
 clean()
 

--- a/tests/decontract/input.dat
+++ b/tests/decontract/input.dat
@@ -21,4 +21,4 @@ set {
 
 energy('scf')
 
-compare_values(ref_energy, get_variable("SCF TOTAL ENERGY"), 9, "RHF energy")  #TEST
+compare_values(ref_energy, variable("SCF TOTAL ENERGY"), 9, "RHF energy")  #TEST

--- a/tests/dfcasscf-fzc-sp/input.dat
+++ b/tests/dfcasscf-fzc-sp/input.dat
@@ -17,7 +17,7 @@ set {
 
 casscf_energy, cas_wfn = energy('casscf', return_wfn=True)
 
-compare_values(-76.01725998335047, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.01725998335047, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.07373669020915, casscf_energy, 5, 'FZC CASSCF Energy')  #TEST
 
 cas_orbs = cas_wfn.get_orbitals("ACT")

--- a/tests/dfcasscf-sa-sp/input.dat
+++ b/tests/dfcasscf-sa-sp/input.dat
@@ -27,8 +27,8 @@ set {
 
 casscf_energy = energy('casscf')
 
-compare_values(-153.017422024965640, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
-compare_values(-153.103748057296741, psi4.get_variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
-compare_values(-152.826395504293657, psi4.get_variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
+compare_values(-153.017422024965640, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-153.103748057296741, psi4.variable("CI ROOT 0 TOTAL ENERGY"), 6, 'CASSCF Root 0 Energy')  #TEST
+compare_values(-152.826395504293657, psi4.variable("CI ROOT 1 TOTAL ENERGY"), 6, 'CASSCF Root 1 Energy')  #TEST
 compare_values(-152.965071780795427, casscf_energy, 6, 'CASSCF Energy')  #TEST
 

--- a/tests/dfcasscf-sp/input.dat
+++ b/tests/dfcasscf-sp/input.dat
@@ -17,5 +17,5 @@ set {
 
 
 casscf_energy = energy('casscf')
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017259983350470, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073828605037164, casscf_energy, 6, 'CASSCF Energy')  #TEST

--- a/tests/dfccd1/input.dat
+++ b/tests/dfccd1/input.dat
@@ -22,8 +22,8 @@ set {
 }
 energy('ccd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refcc, get_variable("CCD TOTAL ENERGY"), 6, "DF-CCD Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refcc, variable("CCD TOTAL ENERGY"), 6, "DF-CCD Total Energy (a.u.)");               #TEST
 
 

--- a/tests/dfccdl1/input.dat
+++ b/tests/dfccdl1/input.dat
@@ -22,8 +22,8 @@ set {
 }
 energy('ccd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refcc, get_variable("CCD TOTAL ENERGY"), 6, "DF-CCD Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refcc, variable("CCD TOTAL ENERGY"), 6, "DF-CCD Total Energy (a.u.)");               #TEST
 
 

--- a/tests/dfccsd1/input.dat
+++ b/tests/dfccsd1/input.dat
@@ -24,8 +24,8 @@ set {
 
 energy('ccsd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refcc, get_variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refcc, variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD Total Energy (a.u.)");               #TEST
 
 

--- a/tests/dfccsdat1/input.dat
+++ b/tests/dfccsdat1/input.dat
@@ -21,7 +21,7 @@ set {
 }
 energy('ccsd(at)')
 
-compare_values(refcc, get_variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD");               #TEST
-compare_values(refcc_at, get_variable("CCSD(AT) TOTAL ENERGY"), 6, "DF-CCSD(AT)");               #TEST
+compare_values(refcc, variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD");               #TEST
+compare_values(refcc_at, variable("CCSD(AT) TOTAL ENERGY"), 6, "DF-CCSD(AT)");               #TEST
 
 

--- a/tests/dfccsdl1/input.dat
+++ b/tests/dfccsdl1/input.dat
@@ -24,8 +24,8 @@ set {
 
 energy('ccsd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refcc, get_variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refcc, variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD Total Energy (a.u.)");               #TEST
 
 

--- a/tests/dfccsdt1/input.dat
+++ b/tests/dfccsdt1/input.dat
@@ -23,7 +23,7 @@ set {
 
 energy('ccsd(t)')
 
-compare_values(refcc, get_variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD");               #TEST
-compare_values(refcc_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "DF-CCSD(T)");               #TEST
+compare_values(refcc, variable("CCSD TOTAL ENERGY"), 6, "DF-CCSD");               #TEST
+compare_values(refcc_t, variable("CCSD(T) TOTAL ENERGY"), 6, "DF-CCSD(T)");               #TEST
 
 

--- a/tests/dfep2-1/input.dat
+++ b/tests/dfep2-1/input.dat
@@ -23,7 +23,7 @@ bench_data = [                                      # TEST
         ["EP2 ELECTRON AFFINITY",     0.141289078]] # TEST
 
 for k, v in bench_data:                         # TEST
-    compare_values(v, get_variable(k), 5, k)    # TEST
+    compare_values(v, variable(k), 5, k)    # TEST
     
     # Set variable to zero for future tests
     set_variable(k, 0)                          # TEST
@@ -36,4 +36,4 @@ set EP2_ORBITALS [[5, 6, 7], [1, 2]]
 energy('EP2')
 
 for k, v in bench_data:                         # TEST
-    compare_values(v, get_variable(k), 5, k)    # TEST
+    compare_values(v, variable(k), 5, k)    # TEST

--- a/tests/dfep2-2/input.dat
+++ b/tests/dfep2-2/input.dat
@@ -23,5 +23,5 @@ bench_data = [                                  # TEST
     ["EP2 3B1 ENERGY",            0.14333736]]  # TEST
 
 for k, v in bench_data:                         # TEST
-    compare_values(v, get_variable(k), 4, k)    # TEST
+    compare_values(v, variable(k), 4, k)    # TEST
 

--- a/tests/dfmp2-2/input.dat
+++ b/tests/dfmp2-2/input.dat
@@ -41,7 +41,7 @@ for basisset in basissets:
     ribasis = basisset + "-ri"
     set df_basis_mp2 $ribasis
     edfmp2 = energy('mp2')
-    edfscf = get_variable('SCF TOTAL ENERGY')
+    edfscf = variable('SCF TOTAL ENERGY')
     compare_values(edfscf, refscf[count], 10, basisset + " DF-SCF Energy")            #TEST
     compare_values(edfmp2, refmp2[count], 10, basisset + " DF-MP2 Energy")            #TEST
     count  = count + 1                                                                #TEST

--- a/tests/dfmp2-2/input.dat
+++ b/tests/dfmp2-2/input.dat
@@ -21,15 +21,7 @@ set {
    e_convergence 12
 }
 
-# This is a table that uses just the default parameters
-table = Table(rows=("Basis"), cols=("E(DF-SCF)", "E(DF-MP2)"))
-
-# This is the same table, but with more explicit control of column widths
-longtable = Table(rows=("Basis"), cols=("E(DF-SCF)", "E(DF-MP2)"),
-                  row_label_width=10,
-                  row_label_precision=4,
-                  width=20, precision=12)
-
+table = {}
 basissets = ["cc-pVDZ", "cc-pVTZ"]
 
 count = 0                                                                             #TEST
@@ -45,15 +37,14 @@ for basisset in basissets:
     compare_values(edfscf, refscf[count], 10, basisset + " DF-SCF Energy")            #TEST
     compare_values(edfmp2, refmp2[count], 10, basisset + " DF-MP2 Energy")            #TEST
     count  = count + 1                                                                #TEST
-    # Store the computed values in the tables
+    # Store the computed values for table
     table[basisset]     = [edfscf, edfmp2]
-    longtable[basisset] = [edfscf, edfmp2]
     # We clean out the scratch files here because the dimensions of the basis set have
     # changed, so we want to generate new files
     clean()
 compare_values(refnuc, h2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy") #TEST
 
 print_out("\nSummary of results\n")
-print_out(str(table))
-print_out("\nAnd again, but more precision\n")
-print_out(str(longtable))
+print_out("     Basis           E(DF-SCF)            E(DF-MP2)\n")
+for basisset in table.keys():
+    print_out("{:>10}{:20.12f}{:20.12f}\n".format(basisset, table[basisset][0], table[basisset][1]))

--- a/tests/dfmp2-4/input.dat
+++ b/tests/dfmp2-4/input.dat
@@ -140,5 +140,4 @@ compare_values(conv_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 cor
 compare_values(conv_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
 compare_values(conv_mp2tot, val, 5, 'mp2 return')                                            #TEST
 clean()
-compare_csx()  #TEST
 

--- a/tests/dfmp2-4/input.dat
+++ b/tests/dfmp2-4/input.dat
@@ -30,17 +30,17 @@ set basis cc-pvdz
 
 print('   Testing mp2 (df) ...')
 val = energy('mp2')
-compare_values(df_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
-compare_values(df_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
-compare_values(df_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
-compare_values(df_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
-compare_values(df_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
-compare_values(df_scscorl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')     #TEST
-compare_values(df_scstot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')             #TEST
+compare_values(df_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
+compare_values(df_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
+compare_values(df_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
+compare_values(df_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
+compare_values(df_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(df_scscorl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')     #TEST
+compare_values(df_scstot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')             #TEST
 
-compare_values(df_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
-compare_values(df_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
-compare_values(df_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
+compare_values(df_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
+compare_values(df_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
+compare_values(df_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
 compare_values(df_mp2tot, val, 5, 'mp2 return')                                              #TEST
 clean()
 
@@ -48,17 +48,17 @@ set mp2_type conv
 
 print('   Testing mp2 (conv) ...')
 val = energy('mp2')
-compare_values(conv_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
-compare_values(conv_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
-compare_values(conv_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
-compare_values(conv_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
-compare_values(conv_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
-compare_values(conv_scscorl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')   #TEST
-compare_values(conv_scstot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')           #TEST
+compare_values(conv_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
+compare_values(conv_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
+compare_values(conv_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
+compare_values(conv_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
+compare_values(conv_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
+compare_values(conv_scscorl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')   #TEST
+compare_values(conv_scstot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')           #TEST
 
-compare_values(conv_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
-compare_values(conv_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
-compare_values(conv_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(conv_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
+compare_values(conv_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
+compare_values(conv_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
 compare_values(conv_mp2tot, val, 5, 'mp2 return')                                            #TEST
 clean()
 
@@ -69,17 +69,17 @@ set mp2_type df
 
 print('   Testing explicit scs mp2 (df) ...')
 val = energy('mp2')
-compare_values(df_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
-compare_values(df_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
-compare_values(df_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
-compare_values(df_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
-compare_values(df_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
-compare_values(df_scscorl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')     #TEST
-compare_values(df_scstot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')             #TEST
+compare_values(df_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
+compare_values(df_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
+compare_values(df_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
+compare_values(df_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
+compare_values(df_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(df_scscorl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')     #TEST
+compare_values(df_scstot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')             #TEST
 
-compare_values(df_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
-compare_values(df_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
-compare_values(df_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
+compare_values(df_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
+compare_values(df_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
+compare_values(df_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
 compare_values(df_mp2tot, val, 5, 'mp2 return')                                              #TEST
 clean()
 
@@ -87,17 +87,17 @@ set mp2_type conv
 
 print('   Testing explicit mp2 (conv) ...')
 val = energy('mp2')
-compare_values(conv_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
-compare_values(conv_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
-compare_values(conv_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
-compare_values(conv_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
-compare_values(conv_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
-compare_values(conv_scscorl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')   #TEST
-compare_values(conv_scstot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')           #TEST
+compare_values(conv_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
+compare_values(conv_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
+compare_values(conv_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
+compare_values(conv_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
+compare_values(conv_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
+compare_values(conv_scscorl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')   #TEST
+compare_values(conv_scstot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')           #TEST
 
-compare_values(conv_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
-compare_values(conv_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
-compare_values(conv_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(conv_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
+compare_values(conv_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
+compare_values(conv_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
 compare_values(conv_mp2tot, val, 5, 'mp2 return')                                            #TEST
 clean()
 
@@ -109,17 +109,17 @@ set mp2_type df
 
 print('   Testing user-def scs mp2 (df) ...')
 val = energy('mp2')
-compare_values(df_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
-compare_values(df_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
-compare_values(df_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
-compare_values(df_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
-compare_values(df_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
-compare_values(df_5050corl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')    #TEST
-compare_values(df_5050tot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')            #TEST
+compare_values(df_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                       #TEST
+compare_values(df_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')      #TEST
+compare_values(df_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os')  #TEST
+compare_values(df_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')            #TEST
+compare_values(df_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(df_5050corl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')    #TEST
+compare_values(df_5050tot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')            #TEST
 
-compare_values(df_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
-compare_values(df_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
-compare_values(df_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
+compare_values(df_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')               #TEST
+compare_values(df_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')        #TEST
+compare_values(df_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                      #TEST
 compare_values(df_mp2tot, val, 5, 'mp2 return')                                              #TEST
 clean()
 
@@ -127,17 +127,17 @@ set mp2_type conv
 
 print('   Testing user-def scs mp2 (conv) ...')
 val = energy('mp2')
-compare_values(conv_ref, get_variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
-compare_values(conv_mp2ss, get_variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
-compare_values(conv_mp2os, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
-compare_values(conv_mp2corl, get_variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
-compare_values(conv_mp2tot, get_variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
-compare_values(conv_5050corl, get_variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')  #TEST
-compare_values(conv_5050tot, get_variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')          #TEST
+compare_values(conv_ref, variable('SCF TOTAL ENERGY'), 5, 'mp2 ref')                     #TEST
+compare_values(conv_mp2ss, variable('MP2 SAME-SPIN CORRELATION ENERGY'), 5, 'mp2 ss')    #TEST
+compare_values(conv_mp2os, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 5, 'mp2 os') #TEST
+compare_values(conv_mp2corl, variable('MP2 CORRELATION ENERGY'), 5, 'mp2 corl')          #TEST
+compare_values(conv_mp2tot, variable('MP2 TOTAL ENERGY'), 5, 'mp2 tot')                  #TEST
+compare_values(conv_5050corl, variable('SCS-MP2 CORRELATION ENERGY'), 5, 'mp2 scscorl')  #TEST
+compare_values(conv_5050tot, variable('SCS-MP2 TOTAL ENERGY'), 5, 'mp2 scstot')          #TEST
 
-compare_values(conv_ref, get_variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
-compare_values(conv_mp2corl, get_variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
-compare_values(conv_mp2tot, get_variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
+compare_values(conv_ref, variable('CURRENT REFERENCE ENERGY'), 5, 'mp2 ref')             #TEST
+compare_values(conv_mp2corl, variable('CURRENT CORRELATION ENERGY'), 5, 'mp2 corl')      #TEST
+compare_values(conv_mp2tot, variable('CURRENT ENERGY'), 5, 'mp2 tot')                    #TEST
 compare_values(conv_mp2tot, val, 5, 'mp2 return')                                            #TEST
 clean()
 compare_csx()  #TEST

--- a/tests/dfomp2-1/input.dat
+++ b/tests/dfomp2-1/input.dat
@@ -22,8 +22,8 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
 
 

--- a/tests/dfomp2-2/input.dat
+++ b/tests/dfomp2-2/input.dat
@@ -22,7 +22,7 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
 

--- a/tests/dfomp2-3/input.dat
+++ b/tests/dfomp2-3/input.dat
@@ -21,7 +21,7 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
 

--- a/tests/dfomp2-4/input.dat
+++ b/tests/dfomp2-4/input.dat
@@ -21,7 +21,7 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "DF-OMP2 Total Energy (a.u.)");               #TEST
 

--- a/tests/dfomp2p5-1/input.dat
+++ b/tests/dfomp2p5-1/input.dat
@@ -22,8 +22,8 @@ set {
 }
 energy('omp2.5')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
-compare_values(refomp3, get_variable("OMP2.5 TOTAL ENERGY"), 6, "DF-OMP2.5 Total Energy");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
+compare_values(refomp3, variable("OMP2.5 TOTAL ENERGY"), 6, "DF-OMP2.5 Total Energy");               #TEST
 
 

--- a/tests/dfomp2p5-2/input.dat
+++ b/tests/dfomp2p5-2/input.dat
@@ -23,8 +23,8 @@ set {
 }
 energy('omp2.5')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
-compare_values(refomp3, get_variable("OMP2.5 TOTAL ENERGY"), 6, "DF-OMP2.5 Total Energy");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
+compare_values(refomp3, variable("OMP2.5 TOTAL ENERGY"), 6, "DF-OMP2.5 Total Energy");               #TEST
 
 

--- a/tests/dfomp3-1/input.dat
+++ b/tests/dfomp3-1/input.dat
@@ -22,8 +22,8 @@ set {
 }
 energy('omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
-compare_values(refomp3, get_variable("OMP3 TOTAL ENERGY"), 6, "DF-OMP3 Total Energy");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
+compare_values(refomp3, variable("OMP3 TOTAL ENERGY"), 6, "DF-OMP3 Total Energy");               #TEST
 
 

--- a/tests/dfomp3-2/input.dat
+++ b/tests/dfomp3-2/input.dat
@@ -23,8 +23,8 @@ set {
 }
 energy('omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
-compare_values(refomp3, get_variable("OMP3 TOTAL ENERGY"), 6, "DF-OMP3 Total Energy");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "DF-HF Energy");                        #TEST
+compare_values(refomp3, variable("OMP3 TOTAL ENERGY"), 6, "DF-OMP3 Total Energy");               #TEST
 
 

--- a/tests/dfrasscf-sp/input.dat
+++ b/tests/dfrasscf-sp/input.dat
@@ -24,5 +24,5 @@ molecule mol {
 
 rasscf_energy = energy('RASSCF')
 
-compare_values(-76.017259983350470, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017259983350470, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 compare_values(-76.073028564767768, rasscf_energy, 6, 'RASSCF Energy')  #TEST

--- a/tests/dfscf-bz2/input.dat
+++ b/tests/dfscf-bz2/input.dat
@@ -53,4 +53,4 @@ set {
 thisenergy = energy('scf')
 
 compare_values(refnuc, bz2.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")       #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     6, "SCF energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     6, "SCF energy") #TEST

--- a/tests/dft-custom-dhdf/input.dat
+++ b/tests/dft-custom-dhdf/input.dat
@@ -40,39 +40,39 @@ set scf_type direct
 # ======= Ne tests =======
 activate(ne)
 edhdf = energy('b2plyp')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 compare_values(-128.82658637, e_dft, 6, 'Ne: B2PLYP_DFT')   #TEST
 compare_values(-0.084559253, e_mp2, 6,  'Ne: B2PLYP_PT2')   #TEST
 compare_values(-128.911145626722, edhdf, 6,  'Ne: B2PLYP')   #TEST
 clean()
 
 edhdf = energy('b2gpplyp')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 compare_values(-128.78793537, e_dft, 6, 'Ne: B2GPPLYP_DFT')   #TEST
 compare_values(-0.109088934, e_mp2, 6,  'Ne: B2GPPLYP_PT2')   #TEST
 compare_values(-128.897024329309, edhdf, 6,  'Ne: B2GPPLYP')   #TEST
 clean()
 
 #edhdf = energy('core-dsd-blyp')
-#e_dft=get_variable('SCF TOTAL ENERGY')
-#e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+#e_dft=variable('SCF TOTAL ENERGY')
+#e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 #compare_values(, e_dft, 6, 'Ne: DSD-BLYP_DFT')   #TEST
 #compare_values(, e_mp2, 7,  'Ne: DSD-BLYP_PT2')   #TEST 
 #compare_values(, edhdf, 6,  'Ne: DSD-BLYP')   #TEST
 #clean()
 
 edhdf = energy('ptpss')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 compare_values(-128.809366, e_dft, 6, 'Ne: PTPSS_DFT')   #TEST
 compare_values(-0.086404, e_mp2, 4,  'Ne: PTPSS_PT2')   #TEST error=1e-5 OK?
 compare_values(-128.895770, edhdf, 4,  'Ne: PTPSS')   #TEST only 4 decimals because of PT2
 
 edhdf = energy('pwpb95')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 compare_values(-128.85817666, e_dft, 5, 'Ne: PWPB95_DFT')   #TEST 
 compare_values(-0.062529936, e_mp2, 5,  'Ne: PWPB95_PT2')   #TEST
 compare_values(-128.920706595202, edhdf, 5,  'Ne: PWPB95')   #TEST
@@ -80,8 +80,8 @@ clean()
 
 set freeze_core true 
 edhdf = energy('dsd-blyp')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 # new fctl definition, ref in ref_outputs/orca_rev_dsdblyp.out 
 compare_values(-128.74250101, e_dft, 6, 'Ne: DSD-BLYP_DFT')   #TEST
 compare_values(-0.140004832412, e_mp2, 7,  'Ne: DSD-BLYP_PT2')   #TEST 
@@ -93,8 +93,8 @@ compare_values(-128.882505842412, edhdf, 6,  'Ne: DSD-BLYP')   #TEST
 clean()
 
 edhdf = energy('pbe0-dh')
-e_dft=get_variable('SCF TOTAL ENERGY')
-e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+e_dft=variable('SCF TOTAL ENERGY')
+e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 compare_values(-128.81862850, e_dft, 4, 'Ne: PBE0-DH DFT')   #TEST 
 compare_values(-0.037540749, e_mp2, 5,  'Ne: PBE0-DH PT2')   #TEST
 compare_values(-128.856169249025, edhdf, 4,  'Ne: PBE0-DH')   #TEST
@@ -169,7 +169,7 @@ compare_values(-3.3187, e_dhdft * 627.509, 2, "DSD-PBEP86: Ammonia")  #TEST
 #clean()
 
 #edhdf = energy('pwpb95')
-#e_dft=get_variable('SCF TOTAL ENERGY')
-#e_mp2=get_variable('DOUBLE-HYBRID CORRECTION ENERGY')
+#e_dft=variable('SCF TOTAL ENERGY')
+#e_mp2=variable('DOUBLE-HYBRID CORRECTION ENERGY')
 #compare_values(-76.34572003, e_dft, 5, 'wat: PWPB95_DFT')   #TEST 
 #clean()

--- a/tests/dft-psivar/input.dat
+++ b/tests/dft-psivar/input.dat
@@ -44,7 +44,6 @@ compare_values(ref_hf_1e, variable("One-Electron Energy"),   6, "HF: 1e")  #TEST
 compare_values(ref_hf_2e, variable("Two-Electron Energy"),   6, "HF: 2e")  #TEST
 compare_values(ref_nn + ref_hf_1e + ref_hf_2e, variable("hf Total Energy"), 6, "HF: total HF")  #TEST
 compare_values(ref_nn + ref_hf_1e + ref_hf_2e, variable("SCF Total Energy"), 6, "HF: total SCF")  #TEST
-compare_csx()  #TEST
 clean()
 
 energy('b3lyp')
@@ -55,7 +54,6 @@ compare_values(ref_b3lyp_xc, variable("DFT XC Energy"),       6, "DFT: XC")  #TE
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Functional Total Energy"), 6, "DFT: total FNCL")  #TEST
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("SCF Total Energy"), 6, "DFT: total SCF")  #TEST
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Total Energy"), 6, "DFT: total DFT")  #TEST
-compare_csx()  #TEST
 clean()
 
 energy('b3lyp-d')
@@ -67,7 +65,6 @@ compare_values(ref_b3lyp_d, variable("dispersion correction Energy"), 6, "DFT-D:
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Functional Total Energy"), 6, "DFT-D: total FNCL")  #TEST
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, variable("SCF Total Energy"), 6, "DFT-D: total SCF")  #TEST
 compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, variable("DFT Total Energy"), 6, "DFT-D: total DFT")  #TEST
-compare_csx()  #TEST
 clean()
 
 energy('b2plyp')
@@ -79,15 +76,7 @@ compare_values(ref_b2plyp_dh, variable("DOUBLE-hybrid correction Energy"), 6, "D
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("DFT Functional Total Energy"), 6, "DH-DFT: total FNCL")  #TEST
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("SCF Total Energy"), 6, "DH-DFT: total SCF")  #TEST
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_dh, variable("DFT Total Energy"), 6, "DH-DFT: total DFT")  #TEST
-compare_csx()  #TEST
 clean()
-
-# this will trigger if -D psivar from b3lyp-d shows up here after b2plyp  #TEST
-if 'csx4psi' in sys.modules.keys():  #TEST
-    if get_global_option('WRITE_CSX'):  #TEST
-        enedict = csx2endict()  #TEST
-        if 'DISPERSION CORRECTION ENERGY' in enedict.keys():  #TEST
-            compare_values(enedict['DISPERSION CORRECTION ENERGY'], 0.0, 4, '-D psivar cleaned')  #TEST
 
 energy('b2plyp-d')
 compare_values(ref_nn, variable("Nuclear Repulsion Energy"),               6, "DH-DFT-D: NN")  #TEST
@@ -99,5 +88,4 @@ compare_values(ref_b2plyp_dh, variable("double-hybrid correction Energy"), 6, "D
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("DFT Functional Total Energy"), 6, "DH-DFT-D: total FNCL")  #TEST
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d, variable("SCF Total Energy"), 6, "DH-DFT-D: total SCF")  #TEST
 compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d + ref_b2plyp_dh, variable("DFT Total Energy"), 6, "DH-DFT-D: total DFT")  #TEST
-compare_csx()  #TEST
 

--- a/tests/dft-psivar/input.dat
+++ b/tests/dft-psivar/input.dat
@@ -39,46 +39,46 @@ ref_b2plyp_dh = -0.046404359527       #TEST
 
 
 energy('scf')
-compare_values(ref_nn, get_variable("Nuclear Repulsion Energy"), 6, "HF: NN")  #TEST
-compare_values(ref_hf_1e, get_variable("One-Electron Energy"),   6, "HF: 1e")  #TEST
-compare_values(ref_hf_2e, get_variable("Two-Electron Energy"),   6, "HF: 2e")  #TEST
-compare_values(ref_nn + ref_hf_1e + ref_hf_2e, get_variable("hf Total Energy"), 6, "HF: total HF")  #TEST
-compare_values(ref_nn + ref_hf_1e + ref_hf_2e, get_variable("SCF Total Energy"), 6, "HF: total SCF")  #TEST
+compare_values(ref_nn, variable("Nuclear Repulsion Energy"), 6, "HF: NN")  #TEST
+compare_values(ref_hf_1e, variable("One-Electron Energy"),   6, "HF: 1e")  #TEST
+compare_values(ref_hf_2e, variable("Two-Electron Energy"),   6, "HF: 2e")  #TEST
+compare_values(ref_nn + ref_hf_1e + ref_hf_2e, variable("hf Total Energy"), 6, "HF: total HF")  #TEST
+compare_values(ref_nn + ref_hf_1e + ref_hf_2e, variable("SCF Total Energy"), 6, "HF: total SCF")  #TEST
 compare_csx()  #TEST
 clean()
 
 energy('b3lyp')
-compare_values(ref_nn, get_variable("Nuclear Repulsion Energy"),  6, "DFT: NN")  #TEST
-compare_values(ref_b3lyp_1e, get_variable("One-Electron Energy"), 6, "DFT: 1e")  #TEST
-compare_values(ref_b3lyp_2e, get_variable("Two-Electron Energy"), 6, "DFT: 2e")  #TEST
-compare_values(ref_b3lyp_xc, get_variable("DFT XC Energy"),       6, "DFT: XC")  #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, get_variable("DFT Functional Total Energy"), 6, "DFT: total FNCL")  #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, get_variable("SCF Total Energy"), 6, "DFT: total SCF")  #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, get_variable("DFT Total Energy"), 6, "DFT: total DFT")  #TEST
+compare_values(ref_nn, variable("Nuclear Repulsion Energy"),  6, "DFT: NN")  #TEST
+compare_values(ref_b3lyp_1e, variable("One-Electron Energy"), 6, "DFT: 1e")  #TEST
+compare_values(ref_b3lyp_2e, variable("Two-Electron Energy"), 6, "DFT: 2e")  #TEST
+compare_values(ref_b3lyp_xc, variable("DFT XC Energy"),       6, "DFT: XC")  #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Functional Total Energy"), 6, "DFT: total FNCL")  #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("SCF Total Energy"), 6, "DFT: total SCF")  #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Total Energy"), 6, "DFT: total DFT")  #TEST
 compare_csx()  #TEST
 clean()
 
 energy('b3lyp-d')
-compare_values(ref_nn, get_variable("Nuclear Repulsion Energy"),          6, "DFT-D: NN")  #TEST
-compare_values(ref_b3lyp_1e, get_variable("One-Electron Energy"),         6, "DFT-D: 1e")  #TEST
-compare_values(ref_b3lyp_2e, get_variable("Two-Electron Energy"),         6, "DFT-D: 2e")  #TEST
-compare_values(ref_b3lyp_xc, get_variable("DFT XC Energy"),               6, "DFT-D: XC")  #TEST
-compare_values(ref_b3lyp_d, get_variable("dispersion correction Energy"), 6, "DFT-D: D")   #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, get_variable("DFT Functional Total Energy"), 6, "DFT-D: total FNCL")  #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, get_variable("SCF Total Energy"), 6, "DFT-D: total SCF")  #TEST
-compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, get_variable("DFT Total Energy"), 6, "DFT-D: total DFT")  #TEST
+compare_values(ref_nn, variable("Nuclear Repulsion Energy"),          6, "DFT-D: NN")  #TEST
+compare_values(ref_b3lyp_1e, variable("One-Electron Energy"),         6, "DFT-D: 1e")  #TEST
+compare_values(ref_b3lyp_2e, variable("Two-Electron Energy"),         6, "DFT-D: 2e")  #TEST
+compare_values(ref_b3lyp_xc, variable("DFT XC Energy"),               6, "DFT-D: XC")  #TEST
+compare_values(ref_b3lyp_d, variable("dispersion correction Energy"), 6, "DFT-D: D")   #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc, variable("DFT Functional Total Energy"), 6, "DFT-D: total FNCL")  #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, variable("SCF Total Energy"), 6, "DFT-D: total SCF")  #TEST
+compare_values(ref_nn + ref_b3lyp_1e + ref_b3lyp_2e + ref_b3lyp_xc + ref_b3lyp_d, variable("DFT Total Energy"), 6, "DFT-D: total DFT")  #TEST
 compare_csx()  #TEST
 clean()
 
 energy('b2plyp')
-compare_values(ref_nn, get_variable("Nuclear Repulsion Energy"),               6, "DH-DFT: NN")  #TEST
-compare_values(ref_b2plyp_1e, get_variable("One-Electron Energy"),             6, "DH-DFT: 1e")  #TEST
-compare_values(ref_b2plyp_2e, get_variable("Two-Electron Energy"),             6, "DH-DFT: 2e")  #TEST
-compare_values(ref_b2plyp_xc, get_variable("DFT XC Energy"),                   6, "DH-DFT: XC")  #TEST
-compare_values(ref_b2plyp_dh, get_variable("DOUBLE-hybrid correction Energy"), 6, "DH-DFT: DH")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, get_variable("DFT Functional Total Energy"), 6, "DH-DFT: total FNCL")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, get_variable("SCF Total Energy"), 6, "DH-DFT: total SCF")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_dh, get_variable("DFT Total Energy"), 6, "DH-DFT: total DFT")  #TEST
+compare_values(ref_nn, variable("Nuclear Repulsion Energy"),               6, "DH-DFT: NN")  #TEST
+compare_values(ref_b2plyp_1e, variable("One-Electron Energy"),             6, "DH-DFT: 1e")  #TEST
+compare_values(ref_b2plyp_2e, variable("Two-Electron Energy"),             6, "DH-DFT: 2e")  #TEST
+compare_values(ref_b2plyp_xc, variable("DFT XC Energy"),                   6, "DH-DFT: XC")  #TEST
+compare_values(ref_b2plyp_dh, variable("DOUBLE-hybrid correction Energy"), 6, "DH-DFT: DH")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("DFT Functional Total Energy"), 6, "DH-DFT: total FNCL")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("SCF Total Energy"), 6, "DH-DFT: total SCF")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_dh, variable("DFT Total Energy"), 6, "DH-DFT: total DFT")  #TEST
 compare_csx()  #TEST
 clean()
 
@@ -90,14 +90,14 @@ if 'csx4psi' in sys.modules.keys():  #TEST
             compare_values(enedict['DISPERSION CORRECTION ENERGY'], 0.0, 4, '-D psivar cleaned')  #TEST
 
 energy('b2plyp-d')
-compare_values(ref_nn, get_variable("Nuclear Repulsion Energy"),               6, "DH-DFT-D: NN")  #TEST
-compare_values(ref_b2plyp_1e, get_variable("One-Electron Energy"),             6, "DH-DFT-D: 1e")  #TEST
-compare_values(ref_b2plyp_2e, get_variable("Two-Electron Energy"),             6, "DH-DFT-D: 2e")  #TEST
-compare_values(ref_b2plyp_xc, get_variable("DFT XC Energy"),                   6, "DH-DFT-D: XC")  #TEST
-compare_values(ref_b2plyp_d, get_variable("dispersion correction Energy"),     6, "DH-DFT-D: D")   #TEST
-compare_values(ref_b2plyp_dh, get_variable("double-hybrid correction Energy"), 6, "DH-DFT-D: DH")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, get_variable("DFT Functional Total Energy"), 6, "DH-DFT-D: total FNCL")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d, get_variable("SCF Total Energy"), 6, "DH-DFT-D: total SCF")  #TEST
-compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d + ref_b2plyp_dh, get_variable("DFT Total Energy"), 6, "DH-DFT-D: total DFT")  #TEST
+compare_values(ref_nn, variable("Nuclear Repulsion Energy"),               6, "DH-DFT-D: NN")  #TEST
+compare_values(ref_b2plyp_1e, variable("One-Electron Energy"),             6, "DH-DFT-D: 1e")  #TEST
+compare_values(ref_b2plyp_2e, variable("Two-Electron Energy"),             6, "DH-DFT-D: 2e")  #TEST
+compare_values(ref_b2plyp_xc, variable("DFT XC Energy"),                   6, "DH-DFT-D: XC")  #TEST
+compare_values(ref_b2plyp_d, variable("dispersion correction Energy"),     6, "DH-DFT-D: D")   #TEST
+compare_values(ref_b2plyp_dh, variable("double-hybrid correction Energy"), 6, "DH-DFT-D: DH")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc, variable("DFT Functional Total Energy"), 6, "DH-DFT-D: total FNCL")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d, variable("SCF Total Energy"), 6, "DH-DFT-D: total SCF")  #TEST
+compare_values(ref_nn + ref_b2plyp_1e + ref_b2plyp_2e + ref_b2plyp_xc + ref_b2plyp_d + ref_b2plyp_dh, variable("DFT Total Energy"), 6, "DH-DFT-D: total DFT")  #TEST
 compare_csx()  #TEST
 

--- a/tests/dft-reference/input.dat
+++ b/tests/dft-reference/input.dat
@@ -15,5 +15,5 @@ reference rks
 }
 
 mp2_dft = energy("MP2", dft_functional="PBE0") #TEST
-compare_values(-76.3005012762123869, get_variable("SCF TOTAL ENERGY"), 6, "PBE0 Reference")  #TEST
+compare_values(-76.3005012762123869, variable("SCF TOTAL ENERGY"), 6, "PBE0 Reference")  #TEST
 compare_values(-76.4870829006874402, mp2_dft, 6, "MP2 with PBE0 orbitals")  #TEST

--- a/tests/dft-smoke/input.dat
+++ b/tests/dft-smoke/input.dat
@@ -75,14 +75,14 @@ pbed2 = {
 
 ret = energy('scf', dft_functional=pbed2)
 compare_values(test_dict['PBE'] + test_dict_dash['E']['075'], ret, 5, 'PBE-D2 Energy, dft_functional=dict(s6=native)')
-compare_values(test_dict_dash['E']['075'], get_variable('PBE-D2 dispersion correction energy'), 5, 'PBE-D2 Energy, dft_functional=dict(s6=native)')
+compare_values(test_dict_dash['E']['075'], variable('PBE-D2 dispersion correction energy'), 5, 'PBE-D2 Energy, dft_functional=dict(s6=native)')
 clean()
 
 import numpy as np
 pbed2['dispersion']['params']['s6'] = 1.0
 ret = energy('scf', dft_functional=pbed2)
 compare_values(test_dict['PBE'] + test_dict_dash['E']['100'], ret, 5, 'PBE-D2 Energy, dft_functional=dict(s6=1.0)')
-compare_values(test_dict_dash['E']['100'], get_variable('tpss-d2 dispersion correction energy'), 5, 'PBE-D2 Energy, dft_functional=dict(s6=1.0)')
+compare_values(test_dict_dash['E']['100'], variable('tpss-d2 dispersion correction energy'), 5, 'PBE-D2 Energy, dft_functional=dict(s6=1.0)')
 clean()
 
 set dft_dispersion_parameters [1.0]

--- a/tests/dft-vv10/input.dat
+++ b/tests/dft-vv10/input.dat
@@ -30,58 +30,58 @@ set D_CONVERGENCE 1.e-10
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
-    compare_values(v, psi4.get_variable(k), 9, k) # TEST
+    compare_values(v, psi4.variable(k), 9, k) # TEST
 
 set reference uks
 scf_e, scf_wfn = energy("VV10", return_wfn=True)
 
 for k, v in bench.items():                        # TEST
-    compare_values(v, psi4.get_variable(k), 9, k) # TEST
-scf_nl=psi4.get_variable('scf TOTAL ENERGY')
+    compare_values(v, psi4.variable(k), 9, k) # TEST
+scf_nl=psi4.variable('scf TOTAL ENERGY')
 
 # dft-nl tests:
 
 set reference rks
 scf_e, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(Enl_blypnl_b40, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
-scf_nl=psi4.get_variable('scf TOTAL ENERGY')
+compare_values(Enl_blypnl_b40, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP-NL dashtest') # TEST
+scf_nl=psi4.variable('scf TOTAL ENERGY')
 
 # tuple modified b
 set nl_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(Enl_blypnl_b50, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
+compare_values(Enl_blypnl_b50, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b ') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
 
 #tuple modified b and C
 set nl_dispersion_parameters [5.0, 0.1]
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(Enl_blypnl_b50_c01, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
+compare_values(Enl_blypnl_b50_c01, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP-NL tuple b and C ') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
 
 #modified b and C
 set DFT_VV10_B  5.0
 set DFT_VV10_C  0.1
 scf_e, scf_wfn = energy("blyp-nl", return_wfn=True)
-compare_values(Enl_blypnl_b50_c01, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
+compare_values(Enl_blypnl_b50_c01, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP-NL custom b and C ') # TEST
 revoke_global_option_changed('DFT_VV10_C') 
 revoke_global_option_changed('DFT_VV10_B') 
 
 # add VV10 without dashparam. Here scf_nl is saved
 set DFT_VV10_B  4.0
 scf_nl, scf_wfn = energy("BLYP", return_wfn=True)
-compare_values(Enl_blypnl_b40, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
+compare_values(Enl_blypnl_b40, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP + custom VV10 ENERGY') # TEST
 revoke_global_option_changed('DFT_VV10_B') 
 
 #modify libxc func containing vv10
 set nl_dispersion_parameters [5.0]
 scf_e, scf_wfn = energy("wb97m-v", return_wfn=True)
-compare_values(Enl_wb97mv_b50, psi4.get_variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
+compare_values(Enl_wb97mv_b50, psi4.variable('DFT VV10 ENERGY') , 6, 'wB97M-V tuple b') # TEST
 revoke_global_option_changed('nl_dispersion_parameters')
 
 # POST-SCF VV10 correction
 set DFT_VV10_POSTSCF true
 post_nl, scf_wfn = energy("BLYP-NL", return_wfn=True)
-compare_values(Enl_blypnl_post, psi4.get_variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
+compare_values(Enl_blypnl_post, psi4.variable('DFT VV10 ENERGY') , 6, 'BLYP-NL postscf 1') # TEST
 
 # check if result is sensible and total scf is ok
 compare_values(scf_nl, post_nl, 6, 'BLYP-NL postscf 2') # TEST

--- a/tests/dftd3/energy/input.dat
+++ b/tests/dftd3/energy/input.dat
@@ -22,7 +22,7 @@ H   0.000000   0.000000   0.627352
 H   0.000000   0.000000   3.963929
 }
 
-print_stdout('  -D correction from Py-side')                      #TEST
+print('  -D correction from Py-side')                      #TEST
 eneyne.update_geometry()
 E, G = eneyne.run_dftd3('b3lyp', 'd2')
 compare_values(ref_d2[0], E, 7, 'Ethene-Ethyne -D2')              #TEST
@@ -68,7 +68,7 @@ set dft_spherical_points 110
 #set scf print 3  # will print dftd3 program output to psi4 output file
 
 
-print_stdout('  -D correction from C-side')                                                                         #TEST
+print('  -D correction from C-side')                                                                         #TEST
 activate(mA)
 energy('b3lyp-d2', engine='libdisp')
 compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')  #TEST
@@ -88,7 +88,7 @@ compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -
 energy('wb97x-d')
 compare_values(-0.000834247063, variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')            #TEST
 
-print_stdout('  non-default -D correction from C-side')                                                                 #TEST
+print('  non-default -D correction from C-side')                                                                 #TEST
 activate(mB)
 set dft_dispersion_parameters [0.75]
 energy('b3lyp-d', engine='libdisp')
@@ -117,7 +117,7 @@ set dft_dispersion_parameters [1.0]
 energy('wb97x-d')
 compare_values(-0.000834247063, variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')                #TEST
 
-print_stdout('  non-default -D correction from Py-side')                                                         #TEST
+print('  non-default -D correction from Py-side')                                                         #TEST
 eneyne.update_geometry()
 eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
 compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')              #TEST
@@ -153,7 +153,7 @@ compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethe
 eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
 compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')      #TEST
 
-print_stdout('  cast-up, -D correction from C-side')                                                         #TEST
+print('  cast-up, -D correction from C-side')                                                         #TEST
 set basis_guess sto-3g
 energy('b3lyp-d3bj')
 compare_values(ref_d3bj[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST

--- a/tests/dftd3/energy/input.dat
+++ b/tests/dftd3/energy/input.dat
@@ -71,91 +71,91 @@ set dft_spherical_points 110
 print_stdout('  -D correction from C-side')                                                                         #TEST
 activate(mA)
 energy('b3lyp-d2', engine='libdisp')
-compare_values(ref_d2[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')  #TEST
+compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')  #TEST
 energy('b3lyp-d2', engine='dftd3')
-compare_values(ref_d2[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')       #TEST
+compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')       #TEST
 energy('b3lyp-d3zero')
-compare_values(ref_d3zero[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+compare_values(ref_d3zero[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
 energy('b3lyp-d3bj')
-compare_values(ref_d3bj[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
+compare_values(ref_d3bj[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
 
 energy('b3lyp-d2')
-compare_values(ref_d2[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')                    #TEST
+compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')                    #TEST
 energy('b3lyp-d3')
-compare_values(ref_d3zero[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')                #TEST
+compare_values(ref_d3zero[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')                #TEST
 energy('b3lyp-d')
-compare_values(ref_d2[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')                     #TEST
+compare_values(ref_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')                     #TEST
 energy('wb97x-d')
-compare_values(-0.000834247063, get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')            #TEST
+compare_values(-0.000834247063, variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')            #TEST
 
 print_stdout('  non-default -D correction from C-side')                                                                 #TEST
 activate(mB)
 set dft_dispersion_parameters [0.75]
 energy('b3lyp-d', engine='libdisp')
-compare_values(ref_pbe_d2[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')  #TEST
+compare_values(ref_pbe_d2[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')  #TEST
 set dft_dispersion_parameters [0.75, 20.0]
 energy('b3lyp-d2', engine='dftd3')
-compare_values(ref_pbe_d2[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')       #TEST
+compare_values(ref_pbe_d2[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')       #TEST
 set dft_dispersion_parameters [1.0,  0.722, 1.217, 14.0]
 energy('b3lyp-d3zero')
-compare_values(ref_pbe_d3zero[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+compare_values(ref_pbe_d3zero[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
 set dft_dispersion_parameters [1.000, 0.7875, 0.4289, 4.4407]
 energy('b3lyp-d3(bj)')
-compare_values(ref_pbe_d3bj[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
+compare_values(ref_pbe_d3bj[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
 
 set dft_dispersion_parameters [0.75]
 energy('b3lyp-d2')
-compare_values(ref_pbe_d2[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')                    #TEST
+compare_values(ref_pbe_d2[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')                    #TEST
 set dft_dispersion_parameters [1.0,  0.722, 1.217, 14.0]
 energy('b3lyp-d3')
-compare_values(ref_pbe_d3zero[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')                #TEST
+compare_values(ref_pbe_d3zero[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')                #TEST
 set dft_dispersion_parameters [0.75]
 energy('b3lyp-d')
-compare_values(ref_pbe_d2[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')                     #TEST
+compare_values(ref_pbe_d2[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')                     #TEST
 activate(mA)
 set dft_dispersion_parameters [1.0]
 energy('wb97x-d')
-compare_values(-0.000834247063, get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')                #TEST
+compare_values(-0.000834247063, variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')                #TEST
 
 print_stdout('  non-default -D correction from Py-side')                                                         #TEST
 eneyne.update_geometry()
 eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-compare_values(ref_pbe_d2[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')              #TEST
+compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')              #TEST
 mA = eneyne.extract_subsets(1)
 mA.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-compare_values(ref_pbe_d2[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2')                     #TEST
+compare_values(ref_pbe_d2[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2')                     #TEST
 mB = eneyne.extract_subsets(2)
 mB.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-compare_values(ref_pbe_d2[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D2')                     #TEST
+compare_values(ref_pbe_d2[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D2')                     #TEST
 
 eneyne.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-compare_values(ref_pbe_d3zero[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (zero)')   #TEST
+compare_values(ref_pbe_d3zero[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (zero)')   #TEST
 mA = eneyne.extract_subsets(1)
 mA.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-compare_values(ref_pbe_d3zero[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (zero)')          #TEST
+compare_values(ref_pbe_d3zero[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (zero)')          #TEST
 mB = eneyne.extract_subsets(2)
 mB.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-compare_values(ref_pbe_d3zero[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (zero)')          #TEST
+compare_values(ref_pbe_d3zero[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (zero)')          #TEST
 
 eneyne.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-compare_values(ref_pbe_d3bj[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (bj)')       #TEST
+compare_values(ref_pbe_d3bj[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (bj)')       #TEST
 mA = eneyne.extract_subsets(1)
 mA.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-compare_values(ref_pbe_d3bj[1], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (bj)')              #TEST
+compare_values(ref_pbe_d3bj[1], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (bj)')              #TEST
 mB = eneyne.extract_subsets(2)
 mB.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-compare_values(ref_pbe_d3bj[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (bj)')              #TEST
+compare_values(ref_pbe_d3bj[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (bj)')              #TEST
 
 eneyne.run_dftd3('b3lyp', 'd3', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-compare_values(ref_pbe_d3zero[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (alias)')  #TEST
+compare_values(ref_pbe_d3zero[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (alias)')  #TEST
 eneyne.run_dftd3('b3lyp', 'd', {'s6': 0.75})
-compare_values(ref_pbe_d2[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D (alias)')       #TEST
+compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D (alias)')       #TEST
 eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-compare_values(ref_pbe_d2[0], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')      #TEST
+compare_values(ref_pbe_d2[0], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')      #TEST
 
 print_stdout('  cast-up, -D correction from C-side')                                                         #TEST
 set basis_guess sto-3g
 energy('b3lyp-d3bj')
-compare_values(ref_d3bj[2], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
+compare_values(ref_d3bj[2], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')      #TEST
 
 

--- a/tests/dftd3/psithon2/input.dat
+++ b/tests/dftd3/psithon2/input.dat
@@ -13,7 +13,7 @@ molecule h2o {
 set basis cc-pVDZ
 energy('scf')
 
-compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'Built-in energy')  #TEST
+compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'Built-in energy')  #TEST
 clean()
 
 refS22AmadSAPT0 = 2.105857433479                                                            #TEST
@@ -67,14 +67,14 @@ set myplugin1 {
 
 energy('myplugin1')
 
-compare_values(-74.9455096208439784, get_variable('CURRENT ENERGY'), 6, 'PSIPATH plugin')
+compare_values(-74.9455096208439784, variable('CURRENT ENERGY'), 6, 'PSIPATH plugin')
 clean()
 
 ###########################
 set basis mysto3g
 set df_basis_scf myccpvdzri
 energy('scf')
-compare_values(-74.9455096190513927, get_variable('CURRENT ENERGY'), 6, 'PSIPATH orbital and jk basis sets')
+compare_values(-74.9455096190513927, variable('CURRENT ENERGY'), 6, 'PSIPATH orbital and jk basis sets')
 clean()
 
 ###########################
@@ -111,7 +111,7 @@ set basis cc-pVDZ
 set df_basis_scf cc-pVDZ-JKFIT
 energy('scf')
 
-compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'Built-in energy again')  #TEST
+compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'Built-in energy again')  #TEST
 clean()
 
 

--- a/tests/dftd3/psithon2/psiaux1/myplugin1/inputalt.dat
+++ b/tests/dftd3/psithon2/psiaux1/myplugin1/inputalt.dat
@@ -24,5 +24,5 @@ set myplugin1 {
 energy('myplugin1')
 
 myplugin1.exampleFN()
-compare_values(-74.9455096208439784, get_variable('CURRENT ENERGY'), 6, 'plug1')
+compare_values(-74.9455096208439784, variable('CURRENT ENERGY'), 6, 'plug1')
 

--- a/tests/dftd3/version/input.dat
+++ b/tests/dftd3/version/input.dat
@@ -83,7 +83,7 @@ mBuncp.update_geometry()
 mAcp.update_geometry()
 mBcp.update_geometry()
 
-print_stdout('  Part I: -D correction from Py-side')  #TEST
+print('  Part I: -D correction from Py-side')  #TEST
 fctl = 'b3lyp'
 der = 0
 hasD3M = True
@@ -96,7 +96,7 @@ try:
         E = mBcp.run_dftd3(fctl, dlvl, dertype=der)
         compare_values(refs[dlvl]['m'], E, 7, 'monoB(CP) ' + dlvl)  #TEST
 except qcdb.Dftd3Error as e:
-    print_stdout("""dftd3 version cannot compute some -D variants. some future tests will not be run""")
+    print("""dftd3 version cannot compute some -D variants. some future tests will not be run""")
     hasD3M = False
 
 #hasD3M = False  # temporary until fctl released into superfunctionals list
@@ -112,7 +112,7 @@ set dft_radial_points 50  # use really bad grid for speed since all we want is t
 set dft_spherical_points 110
 #set scf print 3  # will print dftd3 program output to psi4 output file
 
-print_stdout('  Part II: -D correction from C-side')  #TEST
+print('  Part II: -D correction from C-side')  #TEST
 energy('b3lyp-d2', molecule=eeee)
 compare_values(refs['d2']['d'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
 # single test below fails for mysterious dft reasons
@@ -173,7 +173,7 @@ qmBuncp.update_geometry()
 qmAcp.update_geometry()
 qmBcp.update_geometry()
 
-print_stdout('  Part III: -D correction from Py-side on Py-mol')  #TEST
+print('  Part III: -D correction from Py-side on Py-mol')  #TEST
 levels = ['d2', 'd3zero', 'd3bj']
 if hasD3M:
     levels.extend(['d3mzero', 'd3mbj'])
@@ -188,7 +188,7 @@ for dlvl in levels:
 
 # <<<  Part 4  >>>
 
-print_stdout('  Part IV: -D correction from C-side, all functionals')  #TEST
+print('  Part IV: -D correction from C-side, all functionals')  #TEST
 if hasD3M:
     for fl in ['blyp', 'b3lyp', 'b2plyp', 'bp86', 'pbe', 'pbe0', 'b97', 'wpbe']:
         energy(fl + '-d3mbj', molecule=mBuncp)

--- a/tests/dftd3/version/input.dat
+++ b/tests/dftd3/version/input.dat
@@ -114,32 +114,32 @@ set dft_spherical_points 110
 
 print_stdout('  Part II: -D correction from C-side')  #TEST
 energy('b3lyp-d2', molecule=eeee)
-compare_values(refs['d2']['d'], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
+compare_values(refs['d2']['d'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
 # single test below fails for mysterious dft reasons
-compare_values(refs['dft']['d'] + refs['d2']['d'], get_variable('DFT TOTAL ENERGY'), 5, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
-#compare_values(refs['dft']['d'] + refs['d2']['d'], get_variable('B3LYP-D2 TOTAL ENERGY'), 5, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
+compare_values(refs['dft']['d'] + refs['d2']['d'], variable('DFT TOTAL ENERGY'), 5, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
+#compare_values(refs['dft']['d'] + refs['d2']['d'], variable('B3LYP-D2 TOTAL ENERGY'), 5, 'Ethene dimer -D2 (calling dftd3 -old)')  #TEST
 
 energy('b3lyp-d3', molecule=mAuncp)
-compare_values(refs['d3zero']['m'], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
-compare_values(refs['d3zero']['m'], get_variable('B3LYP-D3 DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
-compare_values(refs['dft']['muncp'] + refs['d3zero']['m'], get_variable('DFT TOTAL ENERGY'), 5, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
-#compare_values(refs['dft']['muncp'] + refs['d3zero']['m'], get_variable('B3LYP-D2 TOTAL ENERGY'), 5, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+compare_values(refs['d3zero']['m'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+compare_values(refs['d3zero']['m'], variable('B3LYP-D3 DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+compare_values(refs['dft']['muncp'] + refs['d3zero']['m'], variable('DFT TOTAL ENERGY'), 5, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
+#compare_values(refs['dft']['muncp'] + refs['d3zero']['m'], variable('B3LYP-D2 TOTAL ENERGY'), 5, 'Ethene -D3 (calling dftd3 -zero)')  #TEST
 
 energy('b3lyp-d3bj', molecule=mAcp)
-compare_values(refs['d3bj']['m'], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
-compare_values(refs['dft']['mcp'] + refs['d3bj']['m'], get_variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
-#compare_values(refs['dft']['mcp'] + refs['d3bj']['m'], get_variable('B3LYP-D3(BJ) TOTAL ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
+compare_values(refs['d3bj']['m'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
+compare_values(refs['dft']['mcp'] + refs['d3bj']['m'], variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
+#compare_values(refs['dft']['mcp'] + refs['d3bj']['m'], variable('B3LYP-D3(BJ) TOTAL ENERGY'), 7, 'Ethene -D3(BJ) (calling dftd3 -bj)')  #TEST
 
 if hasD3M:
     energy('b3lyp-d3m', molecule=mBuncp)
-    compare_values(refs['d3mzero']['m'], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
-    compare_values(refs['dft']['muncp'] + refs['d3mzero']['m'], get_variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
-    #compare_values(refs['dft']['muncp'] + refs['d3mzero']['m'], get_variable('B3LYP-D3M TOTAL ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
+    compare_values(refs['d3mzero']['m'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
+    compare_values(refs['dft']['muncp'] + refs['d3mzero']['m'], variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
+    #compare_values(refs['dft']['muncp'] + refs['d3mzero']['m'], variable('B3LYP-D3M TOTAL ENERGY'), 7, 'Ethene -D3M (calling dftd3 -zerom)')  #TEST
     
     energy('b3lyp-d3mbj', molecule=mBcp)
-    compare_values(refs['d3mbj']['m'], get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
-    compare_values(refs['dft']['mcp'] + refs['d3mbj']['m'], get_variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
-    #compare_values(refs['dft']['mcp'] + refs['d3mbj']['m'], get_variable('B3LYP-D3M(BJ) TOTAL ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
+    compare_values(refs['d3mbj']['m'], variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
+    compare_values(refs['dft']['mcp'] + refs['d3mbj']['m'], variable('DFT TOTAL ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
+    #compare_values(refs['dft']['mcp'] + refs['d3mbj']['m'], variable('B3LYP-D3M(BJ) TOTAL ENERGY'), 7, 'Ethene -D3M(BJ) (calling dftd3 -bjm)')  #TEST
 
 
 # <<<  Part 3  >>>
@@ -192,7 +192,7 @@ print_stdout('  Part IV: -D correction from C-side, all functionals')  #TEST
 if hasD3M:
     for fl in ['blyp', 'b3lyp', 'b2plyp', 'bp86', 'pbe', 'pbe0', 'b97', 'wpbe']:
         energy(fl + '-d3mbj', molecule=mBuncp)
-        compare_values(refs2['dft'][fl] + refs2['dash'][fl + '-d3mbj'], get_variable('CURRENT ENERGY'), 5, fl + '-d3mbj')  #TEST
+        compare_values(refs2['dft'][fl] + refs2['dash'][fl + '-d3mbj'], variable('CURRENT ENERGY'), 5, fl + '-d3mbj')  #TEST
         energy(fl + '-d3mzero', molecule=mBuncp)
-        compare_values(refs2['dft'][fl] + refs2['dash'][fl + '-d3mzero'], get_variable('CURRENT ENERGY'), 5, fl + '-d3m')  #TEST
+        compare_values(refs2['dft'][fl] + refs2['dash'][fl + '-d3mzero'], variable('CURRENT ENERGY'), 5, fl + '-d3m')  #TEST
 

--- a/tests/erd/mp2-module/input.dat
+++ b/tests/erd/mp2-module/input.dat
@@ -44,27 +44,27 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf conv: 3 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module fnocc
 eugene = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 compare_values(mp2tot, eugene, 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rhf conv: 3 detci')  #TEST
 clean_variables()
 clean()
@@ -80,18 +80,18 @@ set mp2_type df
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
 print_variables()
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 rob = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, rob, 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -106,9 +106,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -124,9 +124,9 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf conv: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -142,18 +142,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -168,9 +168,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -186,18 +186,18 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
 #compare_values(mp2tot, ugur, 6, 'mp2 rohf conv: 2 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf conv: 2 detci')  #TEST
 clean_variables()
 clean()
@@ -212,18 +212,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -238,9 +238,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -271,9 +271,9 @@ set freeze_core true
 #set qc_module occ
 #theme = 'mp2 grad rhf conv fc: 1 occ*'
 #retG = gradient('mp2', molecule=hf)
-#compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+#compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 #compare_matrices(mp2totg, retG, 6, theme)  #TEST
 #clean_variables()
 #clean()
@@ -291,9 +291,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad rhf conv nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -316,9 +316,9 @@ set freeze_core true
 ### set qc_module occ
 ### theme = 'mp2 grad rhf df fc: 2 occ'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -326,9 +326,9 @@ set freeze_core true
 ### set qc_module dfmp2
 ### theme = 'mp2 grad rhf df fc: 2 dfmp2*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -346,9 +346,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad rhf df nfc: 2 occ'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -356,9 +356,9 @@ set freeze_core false
 ### set qc_module dfmp2
 ### theme = 'mp2 grad rhf df nfc: 2 dfmp2*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -385,9 +385,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad uhf conv nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -412,9 +412,9 @@ set freeze_core true
 ### set qc_module occ
 ### theme = 'mp2 grad uhf df fc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -434,9 +434,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad uhf df nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -477,9 +477,9 @@ set points 5
 
 retG = gradient('mp2', molecule=bh_h2p)
 theme = 'mp2 grad rohf df nfc: findif'
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()

--- a/tests/erd/scf5/input.dat
+++ b/tests/erd/scf5/input.dat
@@ -2,7 +2,7 @@
 
 set integral_package ERD
 
-print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
+print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
 
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
@@ -31,7 +31,7 @@ molecule triplet_o2 {
 singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
-print_stdout('   -Nuclear Repulsion:') #TEST
+print('   -Nuclear Repulsion:') #TEST
 compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
 compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
@@ -42,7 +42,7 @@ set {
     print 2
 }
 
-print_stdout('    -Singlet RHF:') #TEST
+print('    -Singlet RHF:') #TEST
 set scf reference rhf
 
 set scf_type pk
@@ -61,7 +61,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
 
-print_stdout('    -Singlet UHF:') #TEST
+print('    -Singlet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -80,7 +80,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
 
-print_stdout('    -Singlet CUHF:') #TEST
+print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk
@@ -107,7 +107,7 @@ set {
     print 2
 }
 
-print_stdout('    -Triplet UHF:') #TEST
+print('    -Triplet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -128,7 +128,7 @@ compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet ROHF:') #TEST
+print('    -Triplet ROHF:') #TEST
 set scf reference rohf
 
 set scf_type pk
@@ -152,7 +152,7 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet CUHF:') #TEST
+print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk

--- a/tests/extern1/input.dat
+++ b/tests/extern1/input.dat
@@ -33,9 +33,9 @@ set {
 }
 
 fd_grad = gradient('scf', molecule=water, dertype=0)
-fd_ener = psi4.get_variable('CURRENT ENERGY')
+fd_ener = psi4.variable('CURRENT ENERGY')
 an_grad = gradient('scf', molecule=water)
-an_ener = psi4.get_variable('CURRENT ENERGY')
+an_ener = psi4.variable('CURRENT ENERGY')
 
 compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
 compare_values(-76.0194112285529968, fd_ener, 6, 'Finite difference energy')  #TEST

--- a/tests/extern2/input.dat
+++ b/tests/extern2/input.dat
@@ -25,9 +25,9 @@ set {
 }
 
 fd_grad = gradient('mp2', molecule=water, dertype=0)
-fd_ener = psi4.get_variable('CURRENT ENERGY')
+fd_ener = psi4.variable('CURRENT ENERGY')
 an_grad = gradient('mp2', molecule=water)
-an_ener = psi4.get_variable('CURRENT ENERGY')
+an_ener = psi4.variable('CURRENT ENERGY')
 
 compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
 compare_values(-76.2080976129895618, fd_ener, 6, 'Finite difference energy')  #TEST

--- a/tests/fci-coverage/input.dat
+++ b/tests/fci-coverage/input.dat
@@ -18,7 +18,7 @@ set {
 
 scf_energy, scf_wfn = energy("SCF", return_wfn=True)
 #compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-#compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+#compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 
 # Test major methods
 set DIAG_METHOD SEM

--- a/tests/fci-dipole/input.dat
+++ b/tests/fci-dipole/input.dat
@@ -24,9 +24,9 @@ thisenergy = prop('fci')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")                  #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
 compare_values(refci, thisenergy,                      7, "CI energy")                                 #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy")             #TEST
-compare_values(refDipHF, get_variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
-compare_values(refDipCI, get_variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
-compare_values(refQdpCI, get_variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy")             #TEST
+compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
+compare_values(refDipCI, variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
+compare_values(refQdpCI, variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST

--- a/tests/fci-h2o-2/input.dat
+++ b/tests/fci-h2o-2/input.dat
@@ -21,6 +21,6 @@ thisenergy = energy('fci')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/fci-h2o-fzcv/input.dat
+++ b/tests/fci-h2o-fzcv/input.dat
@@ -22,6 +22,6 @@ thisenergy = energy('fci')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/fci-h2o/input.dat
+++ b/tests/fci-h2o/input.dat
@@ -20,6 +20,6 @@ thisenergy = energy('fci')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/fci-tdm-2/input.dat
+++ b/tests/fci-tdm-2/input.dat
@@ -35,12 +35,12 @@ set detci e_convergence 8
 thisenergy = prop('fci', properties=['DIPOLE', 'QUADRUPOLE', 'TRANSITION_DIPOLE', 'TRANSITION_QUADRUPOLE'])
 
 compare_values(refnuc, bh_h2p.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")       #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST
 compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #TEST
-compare_values(refci2,   get_variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
-compare_values(refcorr1, get_variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
-compare_values(refcorr2, get_variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-compare_values(refDipHF, get_variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1, get_variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2, get_variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(abs(refTDM), abs(get_variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
+compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
+compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
+compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
+compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST

--- a/tests/fci-tdm/input.dat
+++ b/tests/fci-tdm/input.dat
@@ -31,12 +31,12 @@ set {
 thisenergy = prop('fci', properties=['DIPOLE', 'QUADRUPOLE', 'TRANSITION_DIPOLE', 'TRANSITION_QUADRUPOLE'])
 
 compare_values(refnuc, he2p.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")       #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST
 compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #TEST
-compare_values(refci2,   get_variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
-compare_values(refcorr1, get_variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
-compare_values(refcorr2, get_variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-compare_values(refDipHF, get_variable("SCF DIPOLE Z"), 5, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1, get_variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2, get_variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(abs(refTDM), abs(get_variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
+compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
+compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
+compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
+compare_values(refDipHF, variable("SCF DIPOLE Z"), 5, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST

--- a/tests/fnocc1/input.dat
+++ b/tests/fnocc1/input.dat
@@ -18,8 +18,8 @@ refscf    = -76.02141844515494 #TEST
 refqcisd  =  -0.214455072238 #TEST
 refqcisdt =  -0.217610678343 #TEST
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy") #TEST
-compare_values(refqcisd, get_variable("QCISD CORRELATION ENERGY"), 8, "QCISD correlation energy") #TEST
-compare_values(refqcisdt, get_variable("QCISD(T) CORRELATION ENERGY"), 8, "QCISD(T) correlation energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy") #TEST
+compare_values(refqcisd, variable("QCISD CORRELATION ENERGY"), 8, "QCISD correlation energy") #TEST
+compare_values(refqcisdt, variable("QCISD(T) CORRELATION ENERGY"), 8, "QCISD(T) correlation energy") #TEST
 
 clean()

--- a/tests/fnocc2/input.dat
+++ b/tests/fnocc2/input.dat
@@ -15,7 +15,7 @@ energy('g2')
 refg2    = -76.332048079709 #TEST
 refgibbs = -76.349644857811 #TEST
 
-compare_values(refg2, get_variable("G2 TOTAL ENERGY"), 8, "G2 energy (0 K)") #TEST 
-compare_values(refgibbs, get_variable("G2 FREE ENERGY"), 8, "G2 free energy (298 K)") #TEST 
+compare_values(refg2, variable("G2 TOTAL ENERGY"), 8, "G2 energy (0 K)") #TEST
+compare_values(refgibbs, variable("G2 FREE ENERGY"), 8, "G2 free energy (298 K)") #TEST
 
 clean()

--- a/tests/fnocc3/input.dat
+++ b/tests/fnocc3/input.dat
@@ -18,7 +18,7 @@ energy('qcisd(t)')
 refqcisd  = -76.267121113654 #TEST
 refqcisdt = -76.272102955182 #TEST
 
-compare_values(refqcisd, get_variable("QCISD TOTAL ENERGY"), 9, "FNO-QCISD total energy") #TEST 
-compare_values(refqcisdt, get_variable("QCISD(T) TOTAL ENERGY"), 9, "FNO-QCISD(T) total energy") #TEST 
+compare_values(refqcisd, variable("QCISD TOTAL ENERGY"), 9, "FNO-QCISD total energy") #TEST
+compare_values(refqcisdt, variable("QCISD(T) TOTAL ENERGY"), 9, "FNO-QCISD(T) total energy") #TEST
 
 clean()

--- a/tests/fnocc4/input.dat
+++ b/tests/fnocc4/input.dat
@@ -20,14 +20,14 @@ set {
   cc_type cd
 }
 energy('ccsd(t)')
-edfccsd  = get_variable("CCSD CORRELATION ENERGY")
-edfccsdt = get_variable("CCSD(T) CORRELATION ENERGY")
+edfccsd  = variable("CCSD CORRELATION ENERGY")
+edfccsdt = variable("CCSD(T) CORRELATION ENERGY")
 
 refscf   = -76.03568944758564 #TEST
 refccsd  = -0.230820828839    #TEST
 refccsdt = -0.236177474967    #TEST
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF energy")  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF energy")  #TEST
 compare_values(refccsd, edfccsd, 8, "DF-CCSD correlation energy")          #TEST 
 compare_values(refccsdt, edfccsdt, 8, "DF-CCSD(T) correlation energy")     #TEST 
 
@@ -42,10 +42,10 @@ set fnocc {
     r_convergence 1e1
 }
 energy('ccsd')
-emp2    = get_variable("MP2 CORRELATION ENERGY")
+emp2    = variable("MP2 CORRELATION ENERGY")
 clean()
 energy('mp2')
-emp2_2  = get_variable("MP2 CORRELATION ENERGY")
+emp2_2  = variable("MP2 CORRELATION ENERGY")
 compare_values(emp2, emp2_2, 8, "MP2 correlation energy (DFMP2 vs. DFCC)")     #TEST 
 
 clean()

--- a/tests/freq-isotope1/input.dat
+++ b/tests/freq-isotope1/input.dat
@@ -61,11 +61,11 @@ dto.set_mass(1, 2.014101779)
 dto.set_mass(2, 3.01604927)
 
 e, wfn = freq('hf', molecule=h2o, return_wfn=True)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'H2O E0')  #TEST
-compare_values(0.024367, get_variable('ZPVE'), 4, 'H2O ZPVE')  #TEST
-compare_values(0.027199, get_variable('thermal energy correction'), 4, 'H2O dE')  #TEST
-compare_values(0.028143, get_variable('enthalpy correction'), 4, 'H2O dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'H2O E0')  #TEST
+compare_values(0.024367, variable('ZPVE'), 4, 'H2O ZPVE')  #TEST
+compare_values(0.027199, variable('thermal energy correction'), 4, 'H2O dE')  #TEST
+compare_values(0.028143, variable('enthalpy correction'), 4, 'H2O dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(45.283, entropy, 2, 'H2O S')  # molpro  #TEST
 
 clean()
@@ -73,11 +73,11 @@ clean()
 set t 400.0
 
 vibanal_wfn(wfn)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'H2O E0 @400K')  #TEST
-compare_values(0.024367, get_variable('ZPVE'), 4, 'H2O ZPVE @400K')  #TEST
-compare_values(0.028170, get_variable('thermal energy correction'), 4, 'H2O dE @400K')  #TEST
-compare_values(0.029436, get_variable('enthalpy correction'), 4, 'H2O dH @400K')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'H2O E0 @400K')  #TEST
+compare_values(0.024367, variable('ZPVE'), 4, 'H2O ZPVE @400K')  #TEST
+compare_values(0.028170, variable('thermal energy correction'), 4, 'H2O dE @400K')  #TEST
+compare_values(0.029436, variable('enthalpy correction'), 4, 'H2O dH @400K')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.603, entropy, 1, 'H2O S @400K')  #TEST
 
 clean()
@@ -85,21 +85,21 @@ clean()
 set t 298.15
 
 freq('hf', molecule=d2o)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'D2O E0')  #TEST
-compare_values(0.017731, get_variable('ZPVE'), 4, 'D2O ZPVE')  #TEST
-compare_values(0.020566, get_variable('thermal energy correction'), 4, 'D2O dE')  #TEST
-compare_values(0.021510, get_variable('enthalpy correction'), 4, 'D2O dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'D2O E0')  #TEST
+compare_values(0.017731, variable('ZPVE'), 4, 'D2O ZPVE')  #TEST
+compare_values(0.020566, variable('thermal energy correction'), 4, 'D2O dE')  #TEST
+compare_values(0.021510, variable('enthalpy correction'), 4, 'D2O dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.525, entropy, 2, 'D2O S')  # molpro  #TEST
 
 clean()
 
 e, wfn = freq('hf', molecule=hdo, return_wfn=True)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'HDO E0')  #TEST
-compare_values(0.021103, get_variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
-compare_values(0.023935, get_variable('thermal energy correction'), 4, 'HDO dE')  #TEST
-compare_values(0.024878, get_variable('enthalpy correction'), 4, 'HDO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'HDO E0')  #TEST
+compare_values(0.021103, variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
+compare_values(0.023935, variable('thermal energy correction'), 4, 'HDO dE')  #TEST
+compare_values(0.024878, variable('enthalpy correction'), 4, 'HDO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.828, entropy, 2, 'HDO S')  # molpro sym=cs #TEST
 
 # For a symmetry-lowering isotopic substitution like HDO, psi4 recomputes
@@ -111,11 +111,11 @@ compare_values(47.828, entropy, 2, 'HDO S')  # molpro sym=cs #TEST
 set rotational_symmetry_number 2
 
 vibanal_wfn(wfn)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'HDO E0')  #TEST
-compare_values(0.021103, get_variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
-compare_values(0.023935, get_variable('thermal energy correction'), 4, 'HDO dE')  #TEST
-compare_values(0.024878, get_variable('enthalpy correction'), 4, 'HDO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'HDO E0')  #TEST
+compare_values(0.021103, variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
+compare_values(0.023935, variable('thermal energy correction'), 4, 'HDO dE')  #TEST
+compare_values(0.024878, variable('enthalpy correction'), 4, 'HDO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(46.450, entropy, 2, 'HDO S')  # molpro default #TEST
 
 clean()
@@ -126,10 +126,10 @@ clean()
 psi4.revoke_global_option_changed('rotational_symmetry_number')
 
 freq('hf', molecule=dto)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'DTO E0')  #TEST
-compare_values(0.016317, get_variable('ZPVE'), 4, 'DTO ZPVE')  #TEST
-compare_values(0.019154, get_variable('thermal energy correction'), 4, 'DTO dE')  #TEST
-compare_values(0.020098, get_variable('enthalpy correction'), 4, 'DTO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'DTO E0')  #TEST
+compare_values(0.016317, variable('ZPVE'), 4, 'DTO ZPVE')  #TEST
+compare_values(0.019154, variable('thermal energy correction'), 4, 'DTO dE')  #TEST
+compare_values(0.020098, variable('enthalpy correction'), 4, 'DTO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(49.603, entropy, 2, 'DTO S')  # molpro sym=cs #TEST
 

--- a/tests/freq-isotope2/input.dat
+++ b/tests/freq-isotope2/input.dat
@@ -30,42 +30,42 @@ dto.set_mass(2, 3.01604927)
 
 e, wfn = freq('hf', molecule=h2o, return_wfn=True)
 compare_strings('c2v', h2o.schoenflies_symbol(), 'H2O C2v')  #TEST
-compare_values(-74.96590119, get_variable('current energy'), 6, 'H2O E0')  #TEST
-compare_values(0.024367, get_variable('ZPVE'), 4, 'H2O ZPVE')  #TEST
-compare_values(0.027199, get_variable('thermal energy correction'), 4, 'H2O dE')  #TEST
-compare_values(0.028143, get_variable('enthalpy correction'), 4, 'H2O dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'H2O E0')  #TEST
+compare_values(0.024367, variable('ZPVE'), 4, 'H2O ZPVE')  #TEST
+compare_values(0.027199, variable('thermal energy correction'), 4, 'H2O dE')  #TEST
+compare_values(0.028143, variable('enthalpy correction'), 4, 'H2O dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(45.283, entropy, 2, 'H2O S')  # molpro  #TEST
 
 set t 400.0
 
 vibanal_wfn(wfn)
 compare_strings('c2v', h2o.schoenflies_symbol(), 'H2O C2v')  #TEST
-compare_values(-74.96590119, get_variable('current energy'), 6, 'H2O E0 @400K')  #TEST
-compare_values(0.024367, get_variable('ZPVE'), 4, 'H2O ZPVE @400K')  #TEST
-compare_values(0.028170, get_variable('thermal energy correction'), 4, 'H2O dE @400K')  #TEST
-compare_values(0.029436, get_variable('enthalpy correction'), 4, 'H2O dH @400K')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'H2O E0 @400K')  #TEST
+compare_values(0.024367, variable('ZPVE'), 4, 'H2O ZPVE @400K')  #TEST
+compare_values(0.028170, variable('thermal energy correction'), 4, 'H2O dE @400K')  #TEST
+compare_values(0.029436, variable('enthalpy correction'), 4, 'H2O dH @400K')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.603, entropy, 1, 'H2O S @400K')  #TEST
 
 set t 298.15
 
 vibanal_wfn(wfn, molecule=d2o)
 compare_strings('c2v', d2o.schoenflies_symbol(), 'D2O C2v')  #TEST
-compare_values(-74.96590119, get_variable('current energy'), 6, 'D2O E0')  #TEST
-compare_values(0.017731, get_variable('ZPVE'), 4, 'D2O ZPVE')  #TEST
-compare_values(0.020566, get_variable('thermal energy correction'), 4, 'D2O dE')  #TEST
-compare_values(0.021510, get_variable('enthalpy correction'), 4, 'D2O dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'D2O E0')  #TEST
+compare_values(0.017731, variable('ZPVE'), 4, 'D2O ZPVE')  #TEST
+compare_values(0.020566, variable('thermal energy correction'), 4, 'D2O dE')  #TEST
+compare_values(0.021510, variable('enthalpy correction'), 4, 'D2O dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.525, entropy, 2, 'D2O S')  # molpro  #TEST
 
 vibanal_wfn(wfn, molecule=hdo)
 compare_strings('cs', hdo.schoenflies_symbol(), 'HDO Cs')  #TEST
-compare_values(-74.96590119, get_variable('current energy'), 6, 'HDO E0')  #TEST
-compare_values(0.021103, get_variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
-compare_values(0.023935, get_variable('thermal energy correction'), 4, 'HDO dE')  #TEST
-compare_values(0.024878, get_variable('enthalpy correction'), 4, 'HDO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'HDO E0')  #TEST
+compare_values(0.021103, variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
+compare_values(0.023935, variable('thermal energy correction'), 4, 'HDO dE')  #TEST
+compare_values(0.024878, variable('enthalpy correction'), 4, 'HDO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(47.828, entropy, 2, 'HDO S')  # molpro sym=cs #TEST
 
 # For a symmetry-lowering isotopic substitution like HDO, psi4 recomputes
@@ -77,11 +77,11 @@ compare_values(47.828, entropy, 2, 'HDO S')  # molpro sym=cs #TEST
 set rotational_symmetry_number 2
 
 vibanal_wfn(wfn, molecule=hdo)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'HDO E0')  #TEST
-compare_values(0.021103, get_variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
-compare_values(0.023935, get_variable('thermal energy correction'), 4, 'HDO dE')  #TEST
-compare_values(0.024878, get_variable('enthalpy correction'), 4, 'HDO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'HDO E0')  #TEST
+compare_values(0.021103, variable('ZPVE'), 4, 'HDO ZPVE')  #TEST
+compare_values(0.023935, variable('thermal energy correction'), 4, 'HDO dE')  #TEST
+compare_values(0.024878, variable('enthalpy correction'), 4, 'HDO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(46.450, entropy, 2, 'HDO S')  # molpro default #TEST
 
 # Could just reset the symmetry number to 1 since that's the correct
@@ -91,11 +91,11 @@ psi4.revoke_global_option_changed('rotational_symmetry_number')
 
 set hessian_write on
 vibanal_wfn(wfn, molecule=dto)
-compare_values(-74.96590119, get_variable('current energy'), 6, 'DTO E0')  #TEST
-compare_values(0.016317, get_variable('ZPVE'), 4, 'DTO ZPVE')  #TEST
-compare_values(0.019154, get_variable('thermal energy correction'), 4, 'DTO dE')  #TEST
-compare_values(0.020098, get_variable('enthalpy correction'), 4, 'DTO dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')
+compare_values(-74.96590119, variable('current energy'), 6, 'DTO E0')  #TEST
+compare_values(0.016317, variable('ZPVE'), 4, 'DTO ZPVE')  #TEST
+compare_values(0.019154, variable('thermal energy correction'), 4, 'DTO dE')  #TEST
+compare_values(0.020098, variable('enthalpy correction'), 4, 'DTO dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')
 compare_values(49.603, entropy, 2, 'DTO S')  # molpro sym=cs #TEST
 
 # A. print all the vib-related info from original `e, wfn = freq()` call

--- a/tests/fsapt-allterms/input.dat
+++ b/tests/fsapt-allterms/input.dat
@@ -62,11 +62,11 @@ Eref = {  #TEST
 
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/fsapt-diff1/input.dat
+++ b/tests/fsapt-diff1/input.dat
@@ -60,11 +60,11 @@ Eref = {  #TEST
 
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/fsapt-terms/input.dat
+++ b/tests/fsapt-terms/input.dat
@@ -44,11 +44,11 @@ Eref = {  #TEST
 
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/fsapt1/input.dat
+++ b/tests/fsapt1/input.dat
@@ -60,11 +60,11 @@ Eref = {  #TEST
 
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/fsapt2/input.dat
+++ b/tests/fsapt2/input.dat
@@ -39,11 +39,11 @@ Eref = {  #TEST
 
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/gcp/pbeh3c/input.dat
+++ b/tests/gcp/pbeh3c/input.dat
@@ -103,65 +103,65 @@ compare_values(0.001995109, E, 5, 'S22-16 pbeh-3c gcp')  #TEST
 
 
 E = energy('pbeh3c', molecule=s2di)
-D = get_variable('DISPERSION CORRECTION ENERGY')
+D = variable('DISPERSION CORRECTION ENERGY')
 compare_values(-152.5317809, E - D, 3, 'S22-2 pbeh-3c df-scf')  #TEST
 E = energy('pbeh3c/def2-msvp', molecule=s2ma)
-D = get_variable('DISPERSION CORRECTION ENERGY')
+D = variable('DISPERSION CORRECTION ENERGY')
 compare_values(-76.25917393, E - D, 3, 'S22-2 pbeh-3c df-scf')  #TEST
 E = energy('pbeh3c/def2-msvp', molecule=s2mb)
-D = get_variable('DISPERSION CORRECTION ENERGY')
+D = variable('DISPERSION CORRECTION ENERGY')
 compare_values(-76.25916677, E - D, 3, 'S22-2 pbeh-3c df-scf')  #TEST
 
 ###E = energy('pbeh3c/def2-msvp', molecule=s4di)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-339.1053347, E - D, 3, 'S22-4 pbeh-3c df-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s4ma)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-169.5357145, E - D, 3, 'S22-4 pbeh-3c df-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s4mb)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-169.5357145, E - D, 3, 'S22-4 pbeh-3c df-scf')  #TEST
 
 ###E = energy('pbeh3c/def2-msvp', molecule=s16di)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-155.5555081, E - D, 3, 'S22-16 pbeh-3c df-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s16ma)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-78.40891313, E - D, 3, 'S22-16 pbeh-3c df-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s16mb)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-77.1436109,  E - D, 3, 'S22-16 pbeh-3c df-scf')  #TEST
 
 set scf_type pk
 
 ###E = energy('pbeh3c/def2-msvp', molecule=s2di)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-152.5315952, E - D, 5, 'S22-2 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s2ma)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-76.25907424, E - D, 4, 'S22-2 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s2mb)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-76.25906757, E - D, 4, 'S22-2 pbeh-3c cv-scf')  #TEST
 
 ###E = energy('pbeh3c/def2-msvp', molecule=s4di)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-339.1049866, E - D, 5, 'S22-4 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s4ma)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-169.5355168, E - D, 5, 'S22-4 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s4mb)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-169.5355168, E - D, 5, 'S22-4 pbeh-3c cv-scf')  #TEST
 
 ###E = energy('pbeh3c/def2-msvp', molecule=s16di)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-155.5553632, E - D, 5, 'S22-16 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s16ma)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-78.40881566, E - D, 5, 'S22-16 pbeh-3c cv-scf')  #TEST
 ###E = energy('pbeh3c/def2-msvp', molecule=s16mb)
-###D = get_variable('DISPERSION CORRECTION ENERGY')
+###D = variable('DISPERSION CORRECTION ENERGY')
 ###compare_values(-77.14356134, E - D, 4, 'S22-16 pbeh-3c cv-scf')  #TEST
 
 set scf_type df

--- a/tests/gdma/gdma1/input.dat
+++ b/tests/gdma/gdma1/input.dat
@@ -43,8 +43,8 @@ set {
 energy, wfn = energy('scf', return_wfn=True)
 
 gdma(wfn)
-dmavals = get_array_variable("DMA DISTRIBUTED MULTIPOLES")
-totvals = get_array_variable("DMA TOTAL MULTIPOLES")
+dmavals = variable("DMA DISTRIBUTED MULTIPOLES")
+totvals = variable("DMA TOTAL MULTIPOLES")
 compare_values(ref_energy, energy, 8, "SCF Energy")                                                 #TEST
 compare_matrices(dmavals, ref_dma_mat, 6, "DMA Distributed Multipoles")                             #TEST
 compare_matrices(totvals, ref_tot_mat, 6, "DMA Total Multipoles")                                   #TEST

--- a/tests/gibbs/input.dat
+++ b/tests/gibbs/input.dat
@@ -18,7 +18,7 @@ set {
 
 optimize('scf')
 frequencies('scf')
-compare_values( N2_321G_RHF_G, get_variable('GIBBS FREE ENERGY'), 6, "N2 Gibbs Free Energy") #TEST
+compare_values( N2_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "N2 Gibbs Free Energy") #TEST
 
 #
 
@@ -36,7 +36,7 @@ set {
 
 optimize('scf')
 frequencies('scf')
-compare_values( H2O_321G_RHF_G, get_variable('GIBBS FREE ENERGY'), 6, "H2O Gibbs Free Energy") #TEST
+compare_values( H2O_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "H2O Gibbs Free Energy") #TEST
 
 #
 
@@ -54,7 +54,7 @@ set {
 
 optimize('scf')
 frequencies('scf')
-compare_values( NH3_321G_RHF_G, get_variable('GIBBS FREE ENERGY'), 6, "NH3 Gibbs Free Energy") #TEST
+compare_values( NH3_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "NH3 Gibbs Free Energy") #TEST
 
 #
 
@@ -74,5 +74,5 @@ set {
 
 optimize('scf')
 frequencies('scf')
-compare_values( CH4_321G_RHF_G, get_variable('GIBBS FREE ENERGY'), 6, "CH4 Gibbs Free Energy") #TEST
+compare_values( CH4_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "CH4 Gibbs Free Energy") #TEST
 

--- a/tests/isapt1/input.dat
+++ b/tests/isapt1/input.dat
@@ -107,11 +107,11 @@ Eref = {  #TEST
     
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : psi4.variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : psi4.variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : psi4.variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : psi4.variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : psi4.variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/isapt2/input.dat
+++ b/tests/isapt2/input.dat
@@ -63,11 +63,11 @@ Eref = {  #TEST
     
 Epsi = {  #TEST
     'Enuc'  : mol.nuclear_repulsion_energy(),           #TEST
-    'Eelst' : psi4.get_variable("SAPT ELST ENERGY"),    #TEST
-    'Eexch' : psi4.get_variable("SAPT EXCH ENERGY"),    #TEST    
-    'Eind'  : psi4.get_variable("SAPT IND ENERGY"),     #TEST   
-    'Edisp' : psi4.get_variable("SAPT DISP ENERGY"),    #TEST   
-    'Etot'  : psi4.get_variable("SAPT0 TOTAL ENERGY"),  #TEST   
+    'Eelst' : psi4.variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch' : psi4.variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'  : psi4.variable("SAPT IND ENERGY"),     #TEST
+    'Edisp' : psi4.variable("SAPT DISP ENERGY"),    #TEST
+    'Etot'  : psi4.variable("SAPT0 TOTAL ENERGY"),  #TEST
     }  #TEST
 
 for key in keys:  #TEST

--- a/tests/libefp/efp-grad/input.dat
+++ b/tests/libefp/efp-grad/input.dat
@@ -73,7 +73,7 @@ set efp dertype first
 
 energy('efp')
 compare_values(0.0, efp_spec.nuclear_repulsion_energy(), 6, "NRE")  #TEST
-compare_values(-0.0066095987170644, get_variable('CURRENT ENERGY'), 5, 'EFP Total')  #TEST
+compare_values(-0.0066095987170644, variable('CURRENT ENERGY'), 5, 'EFP Total')  #TEST
 
 torq = get_array_variable("EFP TORQUE")  # replaces get_efp_torque()
 compare_matrices(refEFP, torq, 6, "libefp printed gradients, vs. psi4 read-from-libefp gradients") #TEST

--- a/tests/libefp/qchem-efp-sp/input.dat
+++ b/tests/libefp/qchem-efp-sp/input.dat
@@ -11,11 +11,11 @@ energy('efp')
 
 # values copied from q-chem output file  #TEST
 compare_values( 0.0, bz2.nuclear_repulsion_energy(), 6, 'NRE')  #TEST
-compare_values(-0.006945881265, get_variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST
-compare_values( 0.046915489574, get_variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST
-compare_values(-0.000675030191, get_variable('efp ind energy'), 6, 'EFP-EFP Ind')  #TEST
-compare_values(-0.021092526180, get_variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST
-compare_values( 0.018202051938, get_variable('current energy'), 6, 'EFP-EFP Total')  #TEST
+compare_values(-0.006945881265, variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST
+compare_values( 0.046915489574, variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST
+compare_values(-0.000675030191, variable('efp ind energy'), 6, 'EFP-EFP Ind')  #TEST
+compare_values(-0.021092526180, variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST
+compare_values( 0.018202051938, variable('current energy'), 6, 'EFP-EFP Total')  #TEST
 
 molecule h2 {
 H 0. 0. 0.

--- a/tests/libefp/qchem-qmefp-puream-sp/input.dat
+++ b/tests/libefp/qchem-qmefp-puream-sp/input.dat
@@ -50,13 +50,13 @@ print_variables()
 
 print('      basis 6-31G*')
 compare_values(qc_nre, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')  #TEST
-compare_values(qc_elst + qc_qelst, get_variable('EFP ELST ENERGY'), 6, 'Tot Elst')  #TEST
-compare_values(qc_disp, get_variable('EFP DISP ENERGY'), 6, 'efp Disp')  #TEST
-compare_values(qc_exch, get_variable('EFP EXCH ENERGY'), 6, 'efp Exch')  #TEST
-compare_values(qc_efpcor, get_variable('EFP ELST ENERGY') + get_variable('EFP EXCH ENERGY') + get_variable('EFP DISP ENERGY'), 6, 'Corr EFP')  #TEST
-compare_values(qc_indc_631, get_variable('EFP IND ENERGY'), 6, 'Tot Indc')  #TEST
-compare_values(qc_efptot_631, get_variable('EFP TOTAL ENERGY'), 6, 'Tot EFP')  #TEST
-compare_values(qc_scftot_631, get_variable('SCF TOTAL ENERGY'), 6, 'Tot SCF')  #TEST
+compare_values(qc_elst + qc_qelst, variable('EFP ELST ENERGY'), 6, 'Tot Elst')  #TEST
+compare_values(qc_disp, variable('EFP DISP ENERGY'), 6, 'efp Disp')  #TEST
+compare_values(qc_exch, variable('EFP EXCH ENERGY'), 6, 'efp Exch')  #TEST
+compare_values(qc_efpcor, variable('EFP ELST ENERGY') + variable('EFP EXCH ENERGY') + variable('EFP DISP ENERGY'), 6, 'Corr EFP')  #TEST
+compare_values(qc_indc_631, variable('EFP IND ENERGY'), 6, 'Tot Indc')  #TEST
+compare_values(qc_efptot_631, variable('EFP TOTAL ENERGY'), 6, 'Tot EFP')  #TEST
+compare_values(qc_scftot_631, variable('SCF TOTAL ENERGY'), 6, 'Tot SCF')  #TEST
 
 clean()
 
@@ -70,11 +70,11 @@ print_variables()
 
 print('      basis cc-pVDZ')
 compare_values(qc_nre, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')  #TEST
-compare_values(qc_elst + qc_qelst, get_variable('EFP ELST ENERGY'), 6, 'Tot Elst')  #TEST
-compare_values(qc_disp, get_variable('EFP DISP ENERGY'), 6, 'efp Disp')  #TEST
-compare_values(qc_exch, get_variable('EFP EXCH ENERGY'), 6, 'efp Exch')  #TEST
-compare_values(qc_efpcor, get_variable('EFP ELST ENERGY') + get_variable('EFP EXCH ENERGY') + get_variable('EFP DISP ENERGY'), 6, 'Corr EFP')  #TEST
-compare_values(qc_indc_dz, get_variable('EFP IND ENERGY'), 6, 'Tot Indc')  #TEST
-compare_values(qc_efptot_dz, get_variable('EFP TOTAL ENERGY'), 6, 'Tot EFP')  #TEST
-compare_values(qc_scftot_dz, get_variable('SCF TOTAL ENERGY'), 6, 'Tot SCF')  #TEST
+compare_values(qc_elst + qc_qelst, variable('EFP ELST ENERGY'), 6, 'Tot Elst')  #TEST
+compare_values(qc_disp, variable('EFP DISP ENERGY'), 6, 'efp Disp')  #TEST
+compare_values(qc_exch, variable('EFP EXCH ENERGY'), 6, 'efp Exch')  #TEST
+compare_values(qc_efpcor, variable('EFP ELST ENERGY') + variable('EFP EXCH ENERGY') + variable('EFP DISP ENERGY'), 6, 'Corr EFP')  #TEST
+compare_values(qc_indc_dz, variable('EFP IND ENERGY'), 6, 'Tot Indc')  #TEST
+compare_values(qc_efptot_dz, variable('EFP TOTAL ENERGY'), 6, 'Tot EFP')  #TEST
+compare_values(qc_scftot_dz, variable('SCF TOTAL ENERGY'), 6, 'Tot SCF')  #TEST
 

--- a/tests/libefp/qchem-qmefp-sp/input.dat
+++ b/tests/libefp/qchem-qmefp-sp/input.dat
@@ -25,12 +25,12 @@ set df_scf_guess false
 
 energy('efp')
 compare_values( 9.1793879214, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')  #TEST
-compare_values(-0.0004901368, get_variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST  # from q-chem
-compare_values(-0.0003168768, get_variable('efp ind energy'), 6, 'EFP-EFP Indc')  #TEST
-compare_values(-0.0021985285, get_variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST  # from q-chem
-compare_values( 0.0056859871, get_variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST  # from q-chem
-compare_values( 0.0026804450, get_variable('efp total energy'), 6, 'EFP-EFP Totl')  #TEST
-compare_values( 0.0026804450, get_variable('current energy'), 6, 'Current')  #TEST
+compare_values(-0.0004901368, variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST  # from q-chem
+compare_values(-0.0003168768, variable('efp ind energy'), 6, 'EFP-EFP Indc')  #TEST
+compare_values(-0.0021985285, variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST  # from q-chem
+compare_values( 0.0056859871, variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST  # from q-chem
+compare_values( 0.0026804450, variable('efp total energy'), 6, 'EFP-EFP Totl')  #TEST
+compare_values( 0.0026804450, variable('current energy'), 6, 'Current')  #TEST
 print_variables()
 
 clean()
@@ -42,13 +42,13 @@ set d_convergence 12
 energy('scf')
 
 compare_values( 9.1793879214, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')  #TEST
-#compare_values(-0.0004901368, get_variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST  # from q-chem
-#compare_values( 0.2592625628, get_variable(''), 6, 'QM-EFP Elst')  #TEST  # from q-chem
-compare_values( 0.2622598847, get_variable('efp total energy') - get_variable('efp ind energy'), 6, 'EFP corr to SCF')  #TEST  # from q-chem
-compare_values(-0.0117694790, get_variable('efp ind energy'), 6, 'QM-EFP Indc')  #TEST  # from q-chem
-compare_values(-0.0021985285, get_variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST  # from q-chem
-compare_values( 0.0056859871, get_variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST  # from q-chem
-compare_values( 0.2504904057, get_variable('efp total energy'), 6, 'EFP-EFP Totl')  #TEST  # from q-chem
-compare_values(-76.0139362744, get_variable('scf total energy'), 6, 'SCF')  #TEST  # from q-chem
+#compare_values(-0.0004901368, variable('efp elst energy'), 6, 'EFP-EFP Elst')  #TEST  # from q-chem
+#compare_values( 0.2592625628, variable(''), 6, 'QM-EFP Elst')  #TEST  # from q-chem
+compare_values( 0.2622598847, variable('efp total energy') - variable('efp ind energy'), 6, 'EFP corr to SCF')  #TEST  # from q-chem
+compare_values(-0.0117694790, variable('efp ind energy'), 6, 'QM-EFP Indc')  #TEST  # from q-chem
+compare_values(-0.0021985285, variable('efp disp energy'), 6, 'EFP-EFP Disp')  #TEST  # from q-chem
+compare_values( 0.0056859871, variable('efp exch energy'), 6, 'EFP-EFP Exch')  #TEST  # from q-chem
+compare_values( 0.2504904057, variable('efp total energy'), 6, 'EFP-EFP Totl')  #TEST  # from q-chem
+compare_values(-76.0139362744, variable('scf total energy'), 6, 'SCF')  #TEST  # from q-chem
 print_variables()
 

--- a/tests/min-input/input.dat
+++ b/tests/min-input/input.dat
@@ -44,11 +44,11 @@ for method in Earray:
    water.fix_orientation(True)
    water.update_geometry()
 
-   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY')))
+   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY')))
    if method == 'CISD':  # fnocc finds insufficent room for excitation
         psi4.set_global_option('QC_MODULE', 'DETCI')
    ans = energy(method)
-   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY'), ans))
+   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY'), ans))
 
 #-------------------------------------------------------------------------------------------
 clean()
@@ -63,9 +63,9 @@ for method in Earray:
    water.fix_orientation(True)
    water.update_geometry()
 
-   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY')))
+   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY')))
    ans = energy(method)
-   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY'), ans))
+   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY'), ans))
 
 set reference rhf
 #-------------------------------------------------------------------------------------------
@@ -90,9 +90,9 @@ for method in Earray:
    water.fix_orientation(True)
    water.update_geometry()
 
-   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY')))
+   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY')))
    ans = energy(method)
-   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY'), ans))
+   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY'), ans))
 
 #-------------------------------------------------------------------------------------------
 
@@ -131,7 +131,7 @@ Earray = [
   ]
 
 for method in Earray:
-   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY')))
+   print_out('%s\t%s\t%s\t%s\n' % ('SYMMTOL BEFORE: ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY')))
    ans = energy(method)
-   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY'), ans))
+   print_out('%s\t%s\t%s\t%s\t%s\n' % ('SYMMTOL AFTER:  ', method, water.schoenflies_symbol(), variable('CURRENT ENERGY'), ans))
 

--- a/tests/mints3/input.dat
+++ b/tests/mints3/input.dat
@@ -1,5 +1,5 @@
 #! Test individual integral objects for correctness.
-print_stdout(' Case Study Test of Integrals')
+print(' Case Study Test of Integrals')
 
 molecule h2o {
   o@15.99491461956
@@ -37,7 +37,7 @@ RefX.load(input_directory + "Lx-STO-3G.dat")                         #TEST
 RefY.load(input_directory + "Ly-STO-3G.dat")                         #TEST
 RefZ.load(input_directory + "Lz-STO-3G.dat")                         #TEST
 
-print_stdout("   -H2O STO-3G Angular Momentum Integrals:")           #TEST
+print("   -H2O STO-3G Angular Momentum Integrals:")           #TEST
 compare_matrices(RefX, Li[0], 12, "SO Lx")                           #TEST
 compare_matrices(RefY, Li[1], 12, "SO Ly")                           #TEST
 compare_matrices(RefZ, Li[2], 12, "SO Lz")                           #TEST
@@ -64,7 +64,7 @@ RefX.load(input_directory + "Lx-6-311Gss.dat")                       #TEST
 RefY.load(input_directory + "Ly-6-311Gss.dat")                       #TEST
 RefZ.load(input_directory + "Lz-6-311Gss.dat")                       #TEST
 
-print_stdout("   -H2O 6-311G** Angular Momentum Integrals:")         #TEST
+print("   -H2O 6-311G** Angular Momentum Integrals:")         #TEST
 compare_matrices(RefX, Li[0], 12, "SO Lx")                           #TEST
 compare_matrices(RefY, Li[1], 12, "SO Ly")                           #TEST
 compare_matrices(RefZ, Li[2], 12, "SO Lz")                           #TEST
@@ -91,7 +91,7 @@ RefX.load(input_directory + "Lx-cc-pVTZ.dat")                        #TEST
 RefY.load(input_directory + "Ly-cc-pVTZ.dat")                        #TEST
 RefZ.load(input_directory + "Lz-cc-pVTZ.dat")                        #TEST
 
-print_stdout("   -H2O cc-pVTZ Angular Momentum Integrals:")          #TEST
+print("   -H2O cc-pVTZ Angular Momentum Integrals:")          #TEST
 compare_matrices(RefX, Li[0], 12, "SO Lx")                           #TEST
 compare_matrices(RefY, Li[1], 12, "SO Ly")                           #TEST
 compare_matrices(RefZ, Li[2], 12, "SO Lz")                           #TEST
@@ -122,7 +122,7 @@ RefX.load(input_directory + "Px-STO-3G.dat")                         #TEST
 RefY.load(input_directory + "Py-STO-3G.dat")                         #TEST
 RefZ.load(input_directory + "Pz-STO-3G.dat")                         #TEST
 
-print_stdout("   -H2O STO-3G Nabla Integrals:")                      #TEST
+print("   -H2O STO-3G Nabla Integrals:")                      #TEST
 compare_matrices(RefX, Pi[0], 12, "SO Px")                           #TEST
 compare_matrices(RefY, Pi[1], 12, "SO Py")                           #TEST
 compare_matrices(RefZ, Pi[2], 12, "SO Pz")                           #TEST
@@ -149,7 +149,7 @@ RefX.load(input_directory + "Px-6-311Gss.dat")                       #TEST
 RefY.load(input_directory + "Py-6-311Gss.dat")                       #TEST
 RefZ.load(input_directory + "Pz-6-311Gss.dat")                       #TEST
 
-print_stdout("   -H2O 6-311G** Nabla Integrals:")                    #TEST
+print("   -H2O 6-311G** Nabla Integrals:")                    #TEST
 compare_matrices(RefX, Pi[0], 12, "SO Px")                           #TEST
 compare_matrices(RefY, Pi[1], 12, "SO Py")                           #TEST
 compare_matrices(RefZ, Pi[2], 12, "SO Pz")                           #TEST
@@ -176,7 +176,7 @@ RefX.load(input_directory + "Px-cc-pVTZ.dat")                        #TEST
 RefY.load(input_directory + "Py-cc-pVTZ.dat")                        #TEST
 RefZ.load(input_directory + "Pz-cc-pVTZ.dat")                        #TEST
 
-print_stdout("   -H2O cc-pVTZ Nabla Integrals:")                     #TEST
+print("   -H2O cc-pVTZ Nabla Integrals:")                     #TEST
 compare_matrices(RefX, Pi[0], 12, "SO Px")                           #TEST
 compare_matrices(RefY, Pi[1], 12, "SO Py")                           #TEST
 compare_matrices(RefZ, Pi[2], 12, "SO Pz")                           #TEST

--- a/tests/mp2-module/input.dat
+++ b/tests/mp2-module/input.dat
@@ -43,27 +43,27 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf conv: 3 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module fnocc
 eugene = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 compare_values(mp2tot, eugene, 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rhf conv: 3 detci')  #TEST
 clean_variables()
 clean()
@@ -79,23 +79,23 @@ set mp2_type df
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
 print_variables()
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 rob, robwfn = energy('mp2', molecule=hf, return_wfn=True)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, rob, 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 # test dfmp2 wfn, too
-compare_values(scftot, robwfn.get_variable('SCF TOTAL ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
-compare_values(mp2corl, robwfn.get_variable('MP2 CORRELATION ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
-compare_values(mp2tot, robwfn.get_variable('MP2 TOTAL ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
+compare_values(scftot, robwfn.variable('SCF TOTAL ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
+compare_values(mp2corl, robwfn.variable('MP2 CORRELATION ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
+compare_values(mp2tot, robwfn.variable('MP2 TOTAL ENERGY'), 6, 'mp2 rhf df: 2 dfmp2* wfn')  #TEST
 clean_variables()
 clean()
 
@@ -109,9 +109,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -127,9 +127,9 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf conv: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -145,18 +145,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -171,9 +171,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -189,18 +189,18 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
 #compare_values(mp2tot, ugur, 6, 'mp2 rohf conv: 2 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf conv: 2 detci')  #TEST
 clean_variables()
 clean()
@@ -215,18 +215,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -241,9 +241,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -274,9 +274,9 @@ set freeze_core true
 #set qc_module occ
 #theme = 'mp2 grad rhf conv fc: 1 occ*'
 #retG = gradient('mp2', molecule=hf)
-#compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+#compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 #compare_matrices(mp2totg, retG, 6, theme)  #TEST
 #clean_variables()
 #clean()
@@ -294,9 +294,9 @@ set freeze_core false
 set qc_module occ
 theme = 'mp2 grad rhf conv nfc: 1 occ*'
 retG = gradient('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -319,9 +319,9 @@ set freeze_core true
 set qc_module occ
 theme = 'mp2 grad rhf df fc: 2 occ'
 retG = gradient('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -329,9 +329,9 @@ clean()
 set qc_module dfmp2
 theme = 'mp2 grad rhf df fc: 2 dfmp2*'
 retG = gradient('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -349,9 +349,9 @@ set freeze_core false
 set qc_module occ
 theme = 'mp2 grad rhf df nfc: 2 occ'
 retG = gradient('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -359,9 +359,9 @@ clean()
 set qc_module dfmp2
 theme = 'mp2 grad rhf df nfc: 2 dfmp2*'
 retG = gradient('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -388,9 +388,9 @@ set freeze_core false
 set qc_module occ
 theme = 'mp2 grad uhf conv nfc: 1 occ*'
 retG = gradient('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -415,9 +415,9 @@ set freeze_core true
 set qc_module occ
 theme = 'mp2 grad uhf df fc: 1 occ*'
 retG = gradient('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -437,9 +437,9 @@ set freeze_core false
 set qc_module occ
 theme = 'mp2 grad uhf df nfc: 1 occ*'
 retG = gradient('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()
@@ -480,9 +480,9 @@ set points 5
 
 retG = gradient('mp2', molecule=bh_h2p)
 theme = 'mp2 grad rohf df nfc: findif'
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -22,13 +22,13 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
          'MULTIPOLE(3)', 'NO_OCCUPATIONS']
 
 mp2_e, mp2_wfn = prop('MP2', properties = props, return_wfn=True)
-compare_values(psi4.get_variable('CURRENT ENERGY'), -184.1840201594929454, 6, "MP2 Energy") #TEST
-compare_values(psi4.get_variable('MP2 DIPOLE X'), 0.000000000000, 4, "MP2 DIPOLE X") #TEST
-compare_values(psi4.get_variable('MP2 DIPOLE Y'), 0.000000000000, 4, "MP2 DIPOLE Y") #TEST
-compare_values(psi4.get_variable('MP2 DIPOLE Z'), 0.234000203994, 4, "MP2 DIPOLE Z") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE XX'), -14.731131601691, 4, "MP2 QUADRUPOLE XX") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE YY'), -14.731131601691, 4, "MP2 QUADRUPOLE YY") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE ZZ'), -19.287283345539, 4, "MP2 QUADRUPOLE ZZ") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE XY'), 0.000000000000, 4, "MP2 QUADRUPOLE XY") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE XZ'), 0.000000000000, 4, "MP2 QUADRUPOLE XZ") #TEST
-compare_values(psi4.get_variable('MP2 QUADRUPOLE YZ'), 0.000000000000, 4, "MP2 QUADRUPOLE YZ") #TEST
+compare_values(psi4.variable('CURRENT ENERGY'), -184.1840201594929454, 6, "MP2 Energy") #TEST
+compare_values(psi4.variable('MP2 DIPOLE X'), 0.000000000000, 4, "MP2 DIPOLE X") #TEST
+compare_values(psi4.variable('MP2 DIPOLE Y'), 0.000000000000, 4, "MP2 DIPOLE Y") #TEST
+compare_values(psi4.variable('MP2 DIPOLE Z'), 0.234000203994, 4, "MP2 DIPOLE Z") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE XX'), -14.731131601691, 4, "MP2 QUADRUPOLE XX") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE YY'), -14.731131601691, 4, "MP2 QUADRUPOLE YY") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE ZZ'), -19.287283345539, 4, "MP2 QUADRUPOLE ZZ") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE XY'), 0.000000000000, 4, "MP2 QUADRUPOLE XY") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE XZ'), 0.000000000000, 4, "MP2 QUADRUPOLE XZ") #TEST
+compare_values(psi4.variable('MP2 QUADRUPOLE YZ'), 0.000000000000, 4, "MP2 QUADRUPOLE YZ") #TEST

--- a/tests/mpn-bh/input.dat
+++ b/tests/mpn-bh/input.dat
@@ -21,9 +21,9 @@ set {
 thisenergy = energy('mp10')
 
 compare_values(refnuc, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci_10, thisenergy,                      8, "MP(10) energy") #TEST
-compare_values(refcorr_10, get_variable("CURRENT CORRELATION ENERGY"), 8, "MP(10) correlation energy") #TEST
+compare_values(refcorr_10, variable("CURRENT CORRELATION ENERGY"), 8, "MP(10) correlation energy") #TEST
 
 clean()
 
@@ -43,6 +43,6 @@ set basis aug-cc-pVDZ
 thisenergy = energy('mp19')
 
 compare_values(refnuc, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci_19, thisenergy,                      8, "MP(19) energy") #TEST
-compare_values(refcorr_19, get_variable("CURRENT CORRELATION ENERGY"), 8, "MP(19) correlation energy") #TEST
+compare_values(refcorr_19, variable("CURRENT CORRELATION ENERGY"), 8, "MP(19) correlation energy") #TEST

--- a/tests/mrcc/ccsd_t_/input.dat
+++ b/tests/mrcc/ccsd_t_/input.dat
@@ -13,6 +13,6 @@ set {
 
 optimize('mrccsd(t)')
 
-compare_values(9.115333820319844, get_variable("NUCLEAR REPULSION ENERGY"), 4, 'nre')  #TEST
-compare_values(-76.2413050123293, get_variable('CCSD(T) TOTAL ENERGY'), 6, 'ccsd(t)')  #TEST
+compare_values(9.115333820319844, variable("NUCLEAR REPULSION ENERGY"), 4, 'nre')  #TEST
+compare_values(-76.2413050123293, variable('CCSD(T) TOTAL ENERGY'), 6, 'ccsd(t)')  #TEST
 

--- a/tests/mrcc/ccsdt/input.dat
+++ b/tests/mrcc/ccsdt/input.dat
@@ -14,9 +14,9 @@ set {
 
 energy('mrccsdt')
 
-compare_values(  8.801465529972, get_variable("NUCLEAR REPULSION ENERGY"), 6, 'NRE')  #TEST
-compare_values(-76.021418445155, get_variable("SCF TOTAL ENERGY"), 6, 'SCF')  #TEST
-compare_values( -0.204692406830, get_variable("MP2 CORRELATION ENERGY") , 6, 'MP2 correlation')  #TEST
-compare_values( -0.217715210258, get_variable("CCSDT CORRELATION ENERGY"), 6, 'CCSDT correlation')  #TEST
-compare_values(-76.239133655413, get_variable("CURRENT ENERGY"), 6, 'CCSDT')  #TEST
+compare_values(  8.801465529972, variable("NUCLEAR REPULSION ENERGY"), 6, 'NRE')  #TEST
+compare_values(-76.021418445155, variable("SCF TOTAL ENERGY"), 6, 'SCF')  #TEST
+compare_values( -0.204692406830, variable("MP2 CORRELATION ENERGY") , 6, 'MP2 correlation')  #TEST
+compare_values( -0.217715210258, variable("CCSDT CORRELATION ENERGY"), 6, 'CCSDT correlation')  #TEST
+compare_values(-76.239133655413, variable("CURRENT ENERGY"), 6, 'CCSDT')  #TEST
 

--- a/tests/mrcc/ccsdt_q_/input.dat
+++ b/tests/mrcc/ccsdt_q_/input.dat
@@ -16,7 +16,7 @@ set {
 
 energy('mrccsdt(q)')
 
-compare_values(-76.226110861653, get_variable('MP2 TOTAL ENERGY'), 6, 'mp2')  #TEST
-compare_values(-76.239620872765, get_variable('CCSDT[Q] TOTAL ENERGY'), 6, 'ccsdt[q]')  #TEST
-compare_values(-76.239672099230, get_variable('CCSDT(Q) TOTAL ENERGY'), 6, 'ccsdt(q)')  #TEST
+compare_values(-76.226110861653, variable('MP2 TOTAL ENERGY'), 6, 'mp2')  #TEST
+compare_values(-76.239620872765, variable('CCSDT[Q] TOTAL ENERGY'), 6, 'ccsdt[q]')  #TEST
+compare_values(-76.239672099230, variable('CCSDT(Q) TOTAL ENERGY'), 6, 'ccsdt(q)')  #TEST
 

--- a/tests/mrcc/optfreq/input.dat
+++ b/tests/mrcc/optfreq/input.dat
@@ -14,8 +14,8 @@ set {
 optimize('mrccsdt')
 E, wfn = frequencies('mrccsdt', return_wfn=True)
 
-compare_values(-76.228662489627, get_variable('MP2 TOTAL ENERGY'), 6, 'mp2')  #TEST
-compare_values(-76.241470028327, get_variable('CCSDT TOTAL ENERGY'), 6, 'ccsdt')  #TEST
+compare_values(-76.228662489627, variable('MP2 TOTAL ENERGY'), 6, 'mp2')  #TEST
+compare_values(-76.241470028327, variable('CCSDT TOTAL ENERGY'), 6, 'ccsdt')  #TEST
 
 ref_freq = psi4.Vector(3)  #TEST
 ref_freq.set(0, 0, 1689.9409)  #TEST

--- a/tests/mrcc/rohf_ccsdt_q_/input.dat
+++ b/tests/mrcc/rohf_ccsdt_q_/input.dat
@@ -29,6 +29,6 @@ H -2.6301702073  0.6086421759  0.0000000000
 
 energy('mrccsdt(q)')
 
-compare_values(-225.566203961615, get_variable("CCSDT TOTAL ENERGY"), 6, 'ccsdt') #TEST
-compare_values(-225.566377483810, get_variable("CCSDT(Q)/A TOTAL ENERGY"), 6, 'ccsdt(q)/a') #TEST
-compare_values(-225.566381521567, get_variable("CCSDT(Q)/B TOTAL ENERGY"), 6, 'ccsdt(q)/b') #TEST
+compare_values(-225.566203961615, variable("CCSDT TOTAL ENERGY"), 6, 'ccsdt') #TEST
+compare_values(-225.566377483810, variable("CCSDT(Q)/A TOTAL ENERGY"), 6, 'ccsdt(q)/a') #TEST
+compare_values(-225.566381521567, variable("CCSDT(Q)/B TOTAL ENERGY"), 6, 'ccsdt(q)/b') #TEST

--- a/tests/nbody-cp-gradient/input.dat
+++ b/tests/nbody-cp-gradient/input.dat
@@ -32,11 +32,11 @@ energy_dict, gradient_dict = {}, {} #TEST
 for i in cp_scheme: #TEST
     mol = water_trimer.extract_subsets(eval(i)[0], list(set(eval(i)[1]) - set(eval(i)[0]))) #TEST
     gradient_dict[i], wfn_mol = gradient('SCF/STO-3G', molecule=mol, return_wfn=True) #TEST
-    energy_dict[i] = core.get_variable('CURRENT ENERGY') #TEST
+    energy_dict[i] = core.variable('CURRENT ENERGY') #TEST
     core.clean() #TEST
 
     compare_values(energy_dict[i], wfn.variables()[i], 8, 'Energy of %s' %i) #TEST
-    compare_arrays(gradient_dict[i], wfn.arrays()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
+    compare_arrays(gradient_dict[i], wfn.variables()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
 
 energy, gradient = 0, np.zeros((9, 3)) #TEST
 for i in cp_scheme: #TEST
@@ -51,4 +51,4 @@ for i in range(3): #TEST
 for i in cp_scheme: #TEST
     gradient += cp_scheme[i] * np.array(gradient_dict[i]) #TEST
     
-compare_arrays(gradient, wfn.arrays()['GRADIENT 2'], 8, 'CP-Corrected Gradient') #TEST
+compare_arrays(gradient, wfn.variables()['GRADIENT 2'], 8, 'CP-Corrected Gradient') #TEST

--- a/tests/nbody-freq/input.dat
+++ b/tests/nbody-freq/input.dat
@@ -24,9 +24,9 @@ set geom_maxiter 100
 optimize('hf', molecule=h2o_trimer, bsse_type='nocp', max_nbody=2, return_total_data=True)
 e, wfn = freq('hf', molecule=h2o_trimer, return_wfn=True, bsse_type='nocp', max_nbody=2, return_total_data=True)
 compare_values(85.1205563211, h2o_trimer.nuclear_repulsion_energy(), 3, "H2O_TRIMER Nuclear repulsion energy")  #TEST
-compare_values(-224.91766723, get_variable('current energy'), 6, 'H2O_TRIMER E0')  #TEST
-compare_values(0.083771, get_variable('ZPVE'), 4, 'H2O_TRIMER ZPVE')  #TEST
-compare_values(0.091146, get_variable('thermal energy correction'), 4, 'H2O_TRIMER dE')  #TEST
-compare_values(0.092090, get_variable('enthalpy correction'), 4, 'H2O_TRIMER dH')  #TEST
-entropy = 1000 * psi_hartree2kcalmol * (get_variable('enthalpy correction') - get_variable('gibbs free energy correction')) / get_global_option('t')  #TEST
+compare_values(-224.91766723, variable('current energy'), 6, 'H2O_TRIMER E0')  #TEST
+compare_values(0.083771, variable('ZPVE'), 4, 'H2O_TRIMER ZPVE')  #TEST
+compare_values(0.091146, variable('thermal energy correction'), 4, 'H2O_TRIMER dE')  #TEST
+compare_values(0.092090, variable('enthalpy correction'), 4, 'H2O_TRIMER dH')  #TEST
+entropy = 1000 * psi_hartree2kcalmol * (variable('enthalpy correction') - variable('gibbs free energy correction')) / get_global_option('t')  #TEST
 compare_values(78.894, entropy, 2, 'H2O_TRIMER S')  #TEST

--- a/tests/nbody-he-cluster/input.dat
+++ b/tests/nbody-he-cluster/input.dat
@@ -24,6 +24,6 @@ energy('MP2/aug-cc-pV[D,T]Z', molecule=he_trimer, bsse_type=['cp', 'nocp', 'vmfc
 for bsse_type in ['CP', 'NOCP', 'VMFC']:                                          #TEST
     for n in [2, 3]:                                                              #TEST
         var_key = bsse_type + ('-CORRECTED %d-BODY INTERACTION ENERGY' % n)       #TEST
-        computed_value = psi4.get_variable(var_key)                               #TEST
+        computed_value = psi4.variable(var_key)                               #TEST
         compare_values(comparison_dict[bsse_type][n], computed_value, 8, var_key) #TEST
 

--- a/tests/nbody-intermediates/input.dat
+++ b/tests/nbody-intermediates/input.dat
@@ -37,6 +37,6 @@ energy('SCF/cc-pvdz', molecule=noble_trimer, bsse_type=['cp', 'nocp', 'vmfc'])
 
 for compl in comparison_dict.keys():
     var_key = 'N-BODY %s TOTAL ENERGY' % compl                                #TEST
-    computed_value = psi4.get_variable(var_key)                               #TEST
+    computed_value = psi4.variable(var_key)                               #TEST
     compare_values(comparison_dict[compl], computed_value, 8, var_key)        #TEST
 

--- a/tests/nbody-multi-level/input.dat
+++ b/tests/nbody-multi-level/input.dat
@@ -24,7 +24,7 @@ e, wfn = energy('', molecule=h2o_trimer, bsse_type=['nocp', 'cp', 'vmfc'], retur
 clean()
 comparison_dict = {'nocp': -225.019408434635, 'cp': -225.000173661598, 'vmfc': -224.998744381484} #TEST
 for b, v in comparison_dict.items():                                                              #TEST
-    compare_values(v, wfn.get_variable('2'+b), 6, b + '-corrected multi-level energy')            #TEST
+    compare_values(v, wfn.variable('2'+b), 6, b + '-corrected multi-level energy')            #TEST
 
 # Compute 1-body contribution with ccsd(t) and estimate all higher order contributions with scf
 levels = {1: 'mp2/sto-3g', 'supersystem': 'scf/sto-3g'}
@@ -32,7 +32,7 @@ e, wfn = energy('', molecule=h2o_trimer, bsse_type='nocp', return_total_data=Tru
 clean()
 comparison_dict = {'1': -224.998373505116, '3': -225.023509855159}                                #TEST
 for n, v in comparison_dict.items():                                                              #TEST  
-    compare_values(v, wfn.get_variable(n+'nocp'), 6, 'Supersystem multi-level energy')            #TEST
+    compare_values(v, wfn.variable(n+'nocp'), 6, 'Supersystem multi-level energy')            #TEST
 
 # Compute electrostatically embedded  many-body expansion energy.with Mulliken charges
 e, wfn = energy('scf/sto-3g', molecule=h2o_trimer, bsse_type='vmfc', return_total_data=True, return_wfn=True,
@@ -40,7 +40,7 @@ e, wfn = energy('scf/sto-3g', molecule=h2o_trimer, bsse_type='vmfc', return_tota
 clean()
 comparison_dict = {'1': -224.911009557547, '2': -224.912828186182}                                #TEST
 for n, v in comparison_dict.items():                                                              #TEST
-    compare_values(v, wfn.get_variable(n), 6, 'Electrostatically embedded many-body expansion')   #TEST
+    compare_values(v, wfn.variable(n), 6, 'Electrostatically embedded many-body expansion')   #TEST
 
 # Compute electrostatically embedded  many-body expansion energy.with TIP3P charges
 tip3p_charges = [-0.834, 0.417, 0.417]
@@ -50,4 +50,4 @@ e, wfn = energy('scf/sto-3g', molecule=h2o_trimer, bsse_type='vmfc', return_tota
 clean()
 comparison_dict = {'1': -224.940138148882, '2': -224.943882712817}                                #TEST
 for n, v in comparison_dict.items():                                                              #TEST
-    compare_values(v, wfn.get_variable(n), 6, 'Electrostatically embedded many-body expansion')   #TEST
+    compare_values(v, wfn.variable(n), 6, 'Electrostatically embedded many-body expansion')   #TEST

--- a/tests/nbody-nocp-gradient/input.dat
+++ b/tests/nbody-nocp-gradient/input.dat
@@ -31,11 +31,11 @@ energy_dict, gradient_dict = {}, {} #TEST
 for i in nocp_scheme: #TEST
     mol = water_trimer.extract_subsets(eval(i)[0], list(set(eval(i)[1]) - set(eval(i)[0]))) #TEST
     gradient_dict[i], wfn_mol = gradient('SCF/STO-3G', molecule=mol, return_wfn=True) #TEST
-    energy_dict[i] = core.get_variable('CURRENT ENERGY') #TEST
+    energy_dict[i] = core.variable('CURRENT ENERGY') #TEST
     core.clean() #TEST
 
     compare_values(energy_dict[i], wfn.variables()[i], 8, 'Energy of %s' %i) #TEST
-    compare_arrays(gradient_dict[i], wfn.arrays()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
+    compare_arrays(gradient_dict[i], wfn.variables()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
 
 energy, gradient = 0, np.zeros((9, 3)) #TEST
 for i in nocp_scheme: #TEST
@@ -52,4 +52,4 @@ for key in nocp_scheme: #TEST
     index = [i*3, i*3 + 1, i*3 + 2, j*3, j*3 + 1, j*3 + 2] #TEST
     gradient[index, :] += nocp_scheme[key] * np.array(gradient_dict[key]) #TEST
     
-compare_arrays(gradient, wfn.arrays()['GRADIENT 2'], 8, 'NoCP-Corrected Gradient') #TEST
+compare_arrays(gradient, wfn.variables()['GRADIENT 2'], 8, 'NoCP-Corrected Gradient') #TEST

--- a/tests/nbody-vmfc-gradient/input.dat
+++ b/tests/nbody-vmfc-gradient/input.dat
@@ -33,11 +33,11 @@ energy_dict, gradient_dict = {}, {} #TEST
 for i in vmfc_scheme: #TEST
     mol = water_trimer.extract_subsets(eval(i)[0], list(set(eval(i)[1]) - set(eval(i)[0]))) #TEST
     gradient_dict[i], wfn_mol = gradient('SCF/STO-3G', molecule=mol, return_wfn=True) #TEST
-    energy_dict[i] = core.get_variable('CURRENT ENERGY') #TEST
+    energy_dict[i] = core.variable('CURRENT ENERGY') #TEST
     core.clean() #TEST
 
     compare_values(energy_dict[i], wfn.variables()[i], 8, 'Energy of %s' %i) #TEST
-    compare_arrays(gradient_dict[i], wfn.arrays()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
+    compare_arrays(gradient_dict[i], wfn.variables()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
 
 energy, gradient = 0, np.zeros((9, 3)) #TEST
 
@@ -55,4 +55,4 @@ for key in vmfc_scheme: #TEST
     index = [i*3, i*3 + 1, i*3 + 2, j*3, j*3 + 1, j*3 + 2] #TEST
     gradient[index, :] += vmfc_scheme[key] * np.array(gradient_dict[key]) #TEST
  
-compare_arrays(gradient, wfn.arrays()['GRADIENT 2'], 8, 'VMFC-Corrected Gradient') #TEST
+compare_arrays(gradient, wfn.variables()['GRADIENT 2'], 8, 'VMFC-Corrected Gradient') #TEST

--- a/tests/ocepa1/input.dat
+++ b/tests/ocepa1/input.dat
@@ -16,7 +16,7 @@ set {
 }
 energy('olccd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
-compare_values(refocepa, get_variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
+compare_values(refocepa, variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");               #TEST
 

--- a/tests/ocepa2/input.dat
+++ b/tests/ocepa2/input.dat
@@ -17,6 +17,6 @@ set {
 }
 energy('olccd', dft_functional='b3lyp')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refocepa, get_variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refocepa, variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");                   #TEST

--- a/tests/ocepa3/input.dat
+++ b/tests/ocepa3/input.dat
@@ -17,6 +17,6 @@ set {
 }
 energy('olccd')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refocepa, get_variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refocepa, variable("OLCCD TOTAL ENERGY"), 6, "OCEPA(0) Total Energy (a.u.)");                   #TEST

--- a/tests/omp2-1/input.dat
+++ b/tests/omp2-1/input.dat
@@ -20,9 +20,9 @@ set {
 
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");               #TEST
-compare_values(refscsomp2, get_variable("SCS-OMP2 TOTAL ENERGY"), 6, "SCS-OMP2 Total Energy (a.u.)");    #TEST
-compare_values(refsosomp2, get_variable("SOS-OMP2 TOTAL ENERGY"), 6, "SOS-OMP2 Total Energy (a.u.)");    #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");               #TEST
+compare_values(refscsomp2, variable("SCS-OMP2 TOTAL ENERGY"), 6, "SCS-OMP2 Total Energy (a.u.)");    #TEST
+compare_values(refsosomp2, variable("SOS-OMP2 TOTAL ENERGY"), 6, "SOS-OMP2 Total Energy (a.u.)");    #TEST
 

--- a/tests/omp2-2/input.dat
+++ b/tests/omp2-2/input.dat
@@ -18,6 +18,6 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");                   #TEST

--- a/tests/omp2-3/input.dat
+++ b/tests/omp2-3/input.dat
@@ -18,6 +18,6 @@ set {
 }
 energy('omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refomp2, get_variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refomp2, variable("OMP2 TOTAL ENERGY"), 6, "OMP2 Total Energy (a.u.)");                   #TEST

--- a/tests/omp2-4/input.dat
+++ b/tests/omp2-4/input.dat
@@ -17,7 +17,7 @@ set {
 
 thisenergy = optimize('scs-omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
 compare_values(refscsomp2, thisenergy, 6, "SCS-OMP2 Total Energy (a.u.)");                #TEST
 

--- a/tests/omp2-5/input.dat
+++ b/tests/omp2-5/input.dat
@@ -17,7 +17,7 @@ set {
 
 thisenergy = optimize('sos-omp2')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
 compare_values(refsosomp2, thisenergy, 6, "SOS-OMP2 Total Energy (a.u.)");                #TEST
 

--- a/tests/omp2p5-1/input.dat
+++ b/tests/omp2p5-1/input.dat
@@ -18,7 +18,7 @@ set {
 
 energy('omp2.5')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
-compare_values(refmp3, get_variable("MP2.5 TOTAL ENERGY"), 6, "MP2.5 Total Energy (a.u.)");               #TEST
-compare_values(refomp3, get_variable("OMP2.5 TOTAL ENERGY"), 6, "OMP2.5 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
+compare_values(refmp3, variable("MP2.5 TOTAL ENERGY"), 6, "MP2.5 Total Energy (a.u.)");               #TEST
+compare_values(refomp3, variable("OMP2.5 TOTAL ENERGY"), 6, "OMP2.5 Total Energy (a.u.)");               #TEST

--- a/tests/omp2p5-2/input.dat
+++ b/tests/omp2p5-2/input.dat
@@ -18,7 +18,7 @@ set {
 
 energy('omp2.5')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
-compare_values(refmp3, get_variable("MP2.5 TOTAL ENERGY"), 6, "MP2.5 Total Energy (a.u.)");               #TEST
-compare_values(refomp3, get_variable("OMP2.5 TOTAL ENERGY"), 6, "OMP2.5 Total Energy (a.u.)");               #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
+compare_values(refmp3, variable("MP2.5 TOTAL ENERGY"), 6, "MP2.5 Total Energy (a.u.)");               #TEST
+compare_values(refomp3, variable("OMP2.5 TOTAL ENERGY"), 6, "OMP2.5 Total Energy (a.u.)");               #TEST

--- a/tests/omp3-1/input.dat
+++ b/tests/omp3-1/input.dat
@@ -19,9 +19,9 @@ set {
 
 energy('omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
-compare_values(refomp3, get_variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");               #TEST
-compare_values(refscsomp3, get_variable("SCS-OMP3 TOTAL ENERGY"), 6, "SCS-OMP3 Total Energy (a.u.)");    #TEST
-compare_values(refsosomp3, get_variable("SOS-OMP3 TOTAL ENERGY"), 6, "SOS-OMP3 Total Energy (a.u.)");    #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)");  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");                        #TEST
+compare_values(refomp3, variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");               #TEST
+compare_values(refscsomp3, variable("SCS-OMP3 TOTAL ENERGY"), 6, "SCS-OMP3 Total Energy (a.u.)");    #TEST
+compare_values(refsosomp3, variable("SOS-OMP3 TOTAL ENERGY"), 6, "SOS-OMP3 Total Energy (a.u.)");    #TEST
 

--- a/tests/omp3-2/input.dat
+++ b/tests/omp3-2/input.dat
@@ -16,6 +16,6 @@ set {
 }
 energy('omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refomp3, get_variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refomp3, variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");                   #TEST

--- a/tests/omp3-3/input.dat
+++ b/tests/omp3-3/input.dat
@@ -16,6 +16,6 @@ set {
 }
 energy('omp3', dft_functional='b3lyp')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
-compare_values(refomp3, get_variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");                   #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refomp3, variable("OMP3 TOTAL ENERGY"), 6, "OMP3 Total Energy (a.u.)");                   #TEST

--- a/tests/omp3-4/input.dat
+++ b/tests/omp3-4/input.dat
@@ -17,7 +17,7 @@ set {
 
 thisenergy = optimize('scs-omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
 compare_values(refscsomp3, thisenergy, 6, "SCS-OMP3 Total Energy (a.u.)");                #TEST
 

--- a/tests/omp3-5/input.dat
+++ b/tests/omp3-5/input.dat
@@ -17,7 +17,7 @@ set {
 
 thisenergy = optimize('sos-omp3')
 
-compare_values(refnuc, get_variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 5, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 6, "SCF Energy (a.u.)");             #TEST
 compare_values(refsosomp3, thisenergy, 6, "SOS-OMP3 Total Energy (a.u.)");                #TEST
 

--- a/tests/opt-lindep-change/input.dat
+++ b/tests/opt-lindep-change/input.dat
@@ -25,7 +25,7 @@ except ConvergenceError:
 # comparison aginst ref might change if optimizer changes; 
 # if that happens just compare fewer digits or update the refenergy. 
 # The key question is just whether or not the computation fails.
-compare_values(refenergy, get_variable("DFT TOTAL ENERGY"), 2, "Reference energy") #TEST
+compare_values(refenergy, variable("DFT TOTAL ENERGY"), 2, "Reference energy") #TEST
 
 # clean up scratch since optimization ended abruptly
 psi4_io.set_specific_retention(1, False)

--- a/tests/pasture-ccsorttransqt2/bccd_driver/input.dat
+++ b/tests/pasture-ccsorttransqt2/bccd_driver/input.dat
@@ -21,8 +21,8 @@ energy("bccd(t)")
 escf = -38.917378694797030 #TEST
 ebccd = -39.030833895315020 #TEST
 ebccd_t = -39.032691827829460 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
 
 

--- a/tests/pasture-ccsorttransqt2/ccenergy_driver/input.dat
+++ b/tests/pasture-ccsorttransqt2/ccenergy_driver/input.dat
@@ -19,6 +19,6 @@ refccsd  = -0.20823570806196  #TEST
 reftotal = -76.2311784355056  #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST

--- a/tests/pcmsolver/ccsd-pte/input.dat
+++ b/tests/pcmsolver/ccsd-pte/input.dat
@@ -45,7 +45,7 @@ pcm =
 
 energy_pte, wfn = energy('ccsd', return_wfn=True)
 compare_values(Mg.nuclear_repulsion_energy(), nucenergy, 10, "Nuclear repulsion energy (PCM, total algorithm)") # TEST
-compare_values(scf_totalenergy, get_variable("SCF Total energy"), 10, "SCF Total energy (PCM, total algorithm)") # TEST
-compare_values(scf_polenergy, wfn.reference_wavefunction().get_variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
+compare_values(scf_totalenergy, variable("SCF Total energy"), 10, "SCF Total energy (PCM, total algorithm)") # TEST
+compare_values(scf_polenergy, wfn.reference_wavefunction().variable("PCM POLARIZATION ENERGY"), 8, "SCF Polarization energy (PCM, total algorithm)") #TEST
 compare_values(pte_totalenergy, energy_pte, 10, "CCSD Total energy (PCM PTE algorithm)") #TEST
-compare_values(pte_correnergy, get_variable("CURRENT CORRELATION ENERGY"), 10, "CCSD Correlation energy (PCM PTE algorithm)") # TEST
+compare_values(pte_correnergy, variable("CURRENT CORRELATION ENERGY"), 10, "CCSD Correlation energy (PCM PTE algorithm)") # TEST

--- a/tests/pcmsolver/dft/input.dat
+++ b/tests/pcmsolver/dft/input.dat
@@ -42,13 +42,13 @@ print('RKS-PCM B3LYP, total algorithm')
 energy_scf1 = energy('b3lyp')
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(totalenergy, energy_scf1, 9, "Total energy (PCM, total algorithm)") #TEST
-compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('RKS-PCM B3LYP, separate algorithm')
 energy_scf2 = energy('b3lyp')
 compare_values(totalenergy, energy_scf2, 9, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UKS on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -56,4 +56,4 @@ set reference uks
 print('UKS-PCM B3LYP, total algorithm')
 energy_scf3 = energy('b3lyp')
 compare_values(totalenergy, energy_scf3, 9, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST

--- a/tests/pcmsolver/dipole/input.dat
+++ b/tests/pcmsolver/dipole/input.dat
@@ -69,7 +69,7 @@ for m in ['HF', 'B3LYP']:
     set perturb_h false
     e, wfn = energy(m, return_wfn=True)
     oeprop(wfn, 'MULTIPOLES(1)')
-    analytic = get_variable('SCF DIPOLE Z')
+    analytic = variable('SCF DIPOLE Z')
 
     compare_values(ref_3pt[m], dm_z_3point, 8, 'Z dipole moment, using 3-point stencil %s' % m) # TEST
     compare_values(ref_5pt[m], dm_z_5point, 8, 'Z dipole moment, using 5-point stencil %s' % m) # TEST

--- a/tests/pcmsolver/scf/input.dat
+++ b/tests/pcmsolver/scf/input.dat
@@ -47,13 +47,13 @@ print('PK-RHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('PK-RHF-PCM, separate algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -61,7 +61,7 @@ set reference uhf
 print('PK-UHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Check SCF_TYPE OUT_OF_CORE
 set reference rhf
@@ -70,13 +70,13 @@ print('OUT_OF_CORE-RHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('OUT_OF_CORE-RHF-PCM, separate algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -84,7 +84,7 @@ set reference uhf
 print('OUT_OF_CORE-UHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Check SCF_TYPE DIRECT
 set reference rhf
@@ -93,13 +93,13 @@ print('DIRECT-RHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('DIRECT-RHF-PCM, separate algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -107,7 +107,7 @@ set reference uhf
 print('DIRECT-UHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Check SCF_TYPE DF
 set reference rhf
@@ -116,13 +116,13 @@ print('DF-RHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(df_totalenergy, energy_scf, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(df_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(df_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('DF-RHF-PCM, separate algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(df_totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(df_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(df_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -130,7 +130,7 @@ set reference uhf
 print('DF-UHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(df_totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(df_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(df_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Check SCF_TYPE CD
 set reference rhf
@@ -139,13 +139,13 @@ print('CD-RHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
 compare_values(cd_totalenergy, energy_scf, 10, "Total energy (PCM, total algorithm)") #TEST
-compare_values(cd_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+compare_values(cd_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
 set pcm_scf_type separate
 print('CD-RHF-PCM, separate algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(cd_totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(cd_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(cd_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
 set pcm_scf_type total
@@ -153,5 +153,5 @@ set reference uhf
 print('CD-UHF-PCM, total algorithm')
 energy_scf, wfn = energy('scf', return_wfn=True)
 compare_values(cd_totalenergy, energy_scf, 10, "Total energy (PCM, separate algorithm)") #TEST
-compare_values(cd_polenergy, wfn.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+compare_values(cd_polenergy, wfn.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 

--- a/tests/props1/input.dat
+++ b/tests/props1/input.dat
@@ -39,7 +39,7 @@ set perturb_h false
 # Compute the analytic dipoles, for comparison
 e,wfn = energy('scf', return_wfn=True)
 oeprop(wfn, "MULTIPOLES(1)")
-analytic = get_variable("DIPOLE Z")
+analytic = variable("DIPOLE Z")
 
 # Tabulate the results of the energy computation
 for val in range(len(lambdas)):

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -71,9 +71,9 @@ for R in Rvals:
     compare_values(refENuc[count], dimer.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    compare_values(refDipY[count], get_variable("SCF DIPOLE Y"),                                     #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], get_variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
+    compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()
@@ -90,9 +90,9 @@ for R in Rvals:
     compare_values(refENuc[count], monoB.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    compare_values(refDipY[count], get_variable("SCF DIPOLE Y"),                                     #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], get_variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
+    compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()

--- a/tests/props3/input.dat
+++ b/tests/props3/input.dat
@@ -55,11 +55,11 @@ scf_e, scf_wfn = energy('scf', return_wfn=True)
 oeprop(scf_wfn, "MULTIPOLES(7)", "ESP_AT_NUCLEI")
 
 for mpole,val in reversed(sorted(refs.items())):        #TEST
-    compare_values(val, get_variable(mpole),  4, mpole) #TEST
+    compare_values(val, variable(mpole),  4, mpole) #TEST
 
 for n in range(1,13):                                   #TEST
     st = "ESP AT CENTER %d" % n                         #TEST
-    compare_values(esps[n-1], get_variable(st),  4, st) #TEST
+    compare_values(esps[n-1], variable(st),  4, st) #TEST
     
 clean()
 

--- a/tests/psimrcc-ccsd_t-1/input.dat
+++ b/tests/psimrcc-ccsd_t-1/input.dat
@@ -40,5 +40,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, ch2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkccsd_t, get_variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkccsd_t, variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST

--- a/tests/psimrcc-ccsd_t-2/input.dat
+++ b/tests/psimrcc-ccsd_t-2/input.dat
@@ -41,5 +41,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, ch2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkccsd_t, get_variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkccsd_t, variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST

--- a/tests/psimrcc-ccsd_t-3/input.dat
+++ b/tests/psimrcc-ccsd_t-3/input.dat
@@ -41,5 +41,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, ch2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkccsd_t, get_variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkccsd_t, variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST

--- a/tests/psimrcc-ccsd_t-4/input.dat
+++ b/tests/psimrcc-ccsd_t-4/input.dat
@@ -42,5 +42,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, ch2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkccsd_t, get_variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkccsd_t, variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST

--- a/tests/psimrcc-pt2/input.dat
+++ b/tests/psimrcc-pt2/input.dat
@@ -39,5 +39,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, ch2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkpt2, get_variable("CURRENT ENERGY") , 8, "Mk-MRPT2 energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkpt2, variable("CURRENT ENERGY") , 8, "Mk-MRPT2 energy")            #TEST

--- a/tests/psimrcc-sp1/input.dat
+++ b/tests/psimrcc-sp1/input.dat
@@ -39,5 +39,5 @@ set psimrcc {
 
 energy('psimrcc')
 compare_values(refnuc, o2.nuclear_repulsion_energy()     , 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST 
-compare_values(refmkccsd, get_variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST 
+compare_values(refscf, variable("SCF TOTAL ENERGY")  , 9, "SCF energy")               #TEST
+compare_values(refmkccsd, variable("CURRENT ENERGY") , 8, "MkCCSD energy")            #TEST

--- a/tests/psithon2/input.dat
+++ b/tests/psithon2/input.dat
@@ -13,7 +13,7 @@ molecule h2o {
 set basis cc-pVDZ
 energy('scf')
 
-compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'Built-in energy')  #TEST
+compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'Built-in energy')  #TEST
 clean()
 
 refS22AmadSAPT0 = 2.105857433479                                                            #TEST
@@ -67,14 +67,14 @@ set myplugin1 {
 
 energy('myplugin1')
 
-compare_values(-74.9455096208439784, get_variable('CURRENT ENERGY'), 6, 'PSIPATH plugin')  #TEST
+compare_values(-74.9455096208439784, variable('CURRENT ENERGY'), 6, 'PSIPATH plugin')  #TEST
 clean()
 
 ###########################
 set basis mysto3g
 set df_basis_scf myccpvdzri
 energy('scf')
-compare_values(-74.9455096190513927, get_variable('CURRENT ENERGY'), 6, 'PSIPATH orbital and jk basis sets')  #TEST
+compare_values(-74.9455096190513927, variable('CURRENT ENERGY'), 6, 'PSIPATH orbital and jk basis sets')  #TEST
 clean()
 
 ###########################
@@ -89,7 +89,7 @@ set basis cc-pVDZ
 set df_basis_scf cc-pVDZ-JKFIT
 energy('scf')
 
-compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'Built-in energy again')  #TEST
+compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'Built-in energy again')  #TEST
 clean()
 
 

--- a/tests/psithon2/psiaux1/myplugin1/inputalt.dat
+++ b/tests/psithon2/psiaux1/myplugin1/inputalt.dat
@@ -24,5 +24,5 @@ set myplugin1 {
 energy('myplugin1')
 
 myplugin1.exampleFN()
-compare_values(-74.9455096208439784, get_variable('CURRENT ENERGY'), 6, 'plug1')
+compare_values(-74.9455096208439784, variable('CURRENT ENERGY'), 6, 'plug1')
 

--- a/tests/pytest/test_addons.py
+++ b/tests/pytest/test_addons.py
@@ -86,8 +86,8 @@ def test_gdma():
     energy, wfn = psi4.energy('scf', return_wfn=True)
 
     psi4.gdma(wfn)
-    dmavals = psi4.core.get_array_variable("DMA DISTRIBUTED MULTIPOLES")
-    totvals = psi4.core.get_array_variable("DMA TOTAL MULTIPOLES")
+    dmavals = psi4.core.variable("DMA DISTRIBUTED MULTIPOLES")
+    totvals = psi4.core.variable("DMA TOTAL MULTIPOLES")
     assert psi4.compare_values(ref_energy, energy, 8, "SCF Energy")
     assert psi4.compare_matrices(dmavals, ref_dma_mat, 6, "DMA Distributed Multipoles")
     assert psi4.compare_matrices(totvals, ref_tot_mat, 6, "DMA Total Multipoles")
@@ -111,11 +111,11 @@ def test_mrcc():
 
     psi4.energy('mrccsdt')
 
-    assert psi4.compare_values(  8.801465529972, psi4.get_variable("NUCLEAR REPULSION ENERGY"), 6, 'NRE')
-    assert psi4.compare_values(-76.021418445155, psi4.get_variable("SCF TOTAL ENERGY"), 6, 'SCF')
-    assert psi4.compare_values( -0.204692406830, psi4.get_variable("MP2 CORRELATION ENERGY") , 6, 'MP2 correlation')
-    assert psi4.compare_values( -0.217715210258, psi4.get_variable("CCSDT CORRELATION ENERGY"), 6, 'CCSDT correlation')
-    assert psi4.compare_values(-76.239133655413, psi4.get_variable("CURRENT ENERGY"), 6, 'CCSDT')
+    assert psi4.compare_values(  8.801465529972, psi4.variable("NUCLEAR REPULSION ENERGY"), 6, 'NRE')
+    assert psi4.compare_values(-76.021418445155, psi4.variable("SCF TOTAL ENERGY"), 6, 'SCF')
+    assert psi4.compare_values( -0.204692406830, psi4.variable("MP2 CORRELATION ENERGY") , 6, 'MP2 correlation')
+    assert psi4.compare_values( -0.217715210258, psi4.variable("CCSDT CORRELATION ENERGY"), 6, 'CCSDT correlation')
+    assert psi4.compare_values(-76.239133655413, psi4.variable("CURRENT ENERGY"), 6, 'CCSDT')
 
 
 @pytest.mark.smoke
@@ -163,7 +163,7 @@ def test_chemps2():
     psi4.energy("dmrg-scf")
 
     ref_energy = -109.1035023353
-    assert psi4.compare_values(ref_energy, psi4.get_variable("CURRENT ENERGY"), 6, "DMRG Energy")
+    assert psi4.compare_values(ref_energy, psi4.variable("CURRENT ENERGY"), 6, "DMRG Energy")
 
 
 @pytest.mark.smoke
@@ -243,87 +243,87 @@ def test_dftd3():
     psi4.print_stdout('  -D correction from C-side')
     psi4.activate(mA)
     #psi4.energy('b3lyp-d2', engine='libdisp')
-    #assert psi4.compare_values(ref_d2[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')
+    #assert psi4.compare_values(ref_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')
     #psi4.energy('b3lyp-d2')
-    #assert psi4.compare_values(ref_d2[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')
+    #assert psi4.compare_values(ref_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')
     #psi4.energy('b3lyp-d3zero')
-    #assert psi4.compare_values(ref_d3zero[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')
+    #assert psi4.compare_values(ref_d3zero[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')
     psi4.energy('b3lyp-d3bj')
-    assert psi4.compare_values(ref_d3bj[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')
+    assert psi4.compare_values(ref_d3bj[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')
 
     psi4.energy('b3lyp-d2', engine='libdisp')
-    assert psi4.compare_values(ref_d2[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')
+    assert psi4.compare_values(ref_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')
     #psi4.energy('b3lyp-d3')
-    #assert psi4.compare_values(ref_d3zero[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')
+    #assert psi4.compare_values(ref_d3zero[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')
     #psi4.energy('b3lyp-d')
-    #assert psi4.compare_values(ref_d2[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')
+    #assert psi4.compare_values(ref_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')
     psi4.energy('wb97x-d')
-    assert psi4.compare_values(-0.000834247063, psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
+    assert psi4.compare_values(-0.000834247063, psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
 
     psi4.print_stdout('  non-default -D correction from C-side')
     psi4.activate(mB)
     #psi4.set_options({'dft_dispersion_parameters': [0.75]})
     #psi4.energy('b3lyp-d2', engine='libdisp')
-    #assert psi4.compare_values(ref_pbe_d2[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')
+    #assert psi4.compare_values(ref_pbe_d2[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')
     #psi4.set_options({'dft_dispersion_parameters': [0.75, 20.0]})
     #psi4.energy('b3lyp-d2')
-    #assert psi4.compare_values(ref_pbe_d2[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')
+    #assert psi4.compare_values(ref_pbe_d2[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling dftd3 -old)')
     #psi4.set_options({'dft_dispersion_parameters': [1.0,  0.722, 1.217, 14.0]})
     #psi4.energy('b3lyp-d3zero')
-    #assert psi4.compare_values(ref_pbe_d3zero[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')
+    #assert psi4.compare_values(ref_pbe_d3zero[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -zero)')
     psi4.set_options({'dft_dispersion_parameters': [1.000, 0.7875, 0.4289, 4.4407]})
     psi4.energy('b3lyp-d3bj')
-    assert psi4.compare_values(ref_pbe_d3bj[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')
+    assert psi4.compare_values(ref_pbe_d3bj[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (calling dftd3 -bj)')
 
     psi4.set_options({'dft_dispersion_parameters': [0.75]})
     psi4.energy('b3lyp-d2', engine='dftd3')
-    assert psi4.compare_values(ref_pbe_d2[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')
+    assert psi4.compare_values(ref_pbe_d2[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (alias)')
     psi4.set_options({'dft_dispersion_parameters': [1.0,  0.722, 1.217, 14.0]})
     psi4.energy('b3lyp-d3')
-    assert psi4.compare_values(ref_pbe_d3zero[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')
+    assert psi4.compare_values(ref_pbe_d3zero[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (alias)')
     psi4.set_options({'dft_dispersion_parameters': [0.75]})
     psi4.energy('b3lyp-d')
-    assert psi4.compare_values(ref_pbe_d2[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')
+    assert psi4.compare_values(ref_pbe_d2[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D (alias)')
     psi4.activate(mA)
     psi4.set_options({'dft_dispersion_parameters': [1.0]})
     psi4.energy('wb97x-d')
-    assert psi4.compare_values(-0.000834247063, psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
+    assert psi4.compare_values(-0.000834247063, psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
 
     psi4.print_stdout('  non-default -D correction from Py-side')
     eneyne.update_geometry()
     eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-    assert psi4.compare_values(ref_pbe_d2[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')
+    assert psi4.compare_values(ref_pbe_d2[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')
     mA = eneyne.extract_subsets(1)
     mA.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-    assert psi4.compare_values(ref_pbe_d2[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2')
+    assert psi4.compare_values(ref_pbe_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2')
     mB = eneyne.extract_subsets(2)
     mB.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-    assert psi4.compare_values(ref_pbe_d2[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D2')
+    assert psi4.compare_values(ref_pbe_d2[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D2')
 
     eneyne.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-    assert psi4.compare_values(ref_pbe_d3zero[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (zero)')
+    assert psi4.compare_values(ref_pbe_d3zero[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (zero)')
     mA = eneyne.extract_subsets(1)
     mA.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-    assert psi4.compare_values(ref_pbe_d3zero[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (zero)')
+    assert psi4.compare_values(ref_pbe_d3zero[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (zero)')
     mB = eneyne.extract_subsets(2)
     mB.run_dftd3('b3lyp', 'd3zero', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
-    assert psi4.compare_values(ref_pbe_d3zero[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (zero)')
+    assert psi4.compare_values(ref_pbe_d3zero[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (zero)')
 
     eneyne.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-    assert psi4.compare_values(ref_pbe_d3bj[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (bj)')
+    assert psi4.compare_values(ref_pbe_d3bj[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (bj)')
     mA = eneyne.extract_subsets(1)
     mA.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-    assert psi4.compare_values(ref_pbe_d3bj[1], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (bj)')
+    assert psi4.compare_values(ref_pbe_d3bj[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D3 (bj)')
     mB = eneyne.extract_subsets(2)
     mB.run_dftd3('b3lyp', 'd3bj', {'s6': 1.000, 's8':  0.7875, 'a1':  0.4289, 'a2': 4.4407})
-    assert psi4.compare_values(ref_pbe_d3bj[2], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (bj)')
+    assert psi4.compare_values(ref_pbe_d3bj[2], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethyne -D3 (bj)')
     eneyne.run_dftd3('b3lyp', 'd3', {'s6': 1.0,  's8': 0.722, 'sr6': 1.217, 'alpha6': 14.0})
 
-    assert psi4.compare_values(ref_pbe_d3zero[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (alias)')
+    assert psi4.compare_values(ref_pbe_d3zero[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D3 (alias)')
     eneyne.run_dftd3('b3lyp', 'd', {'s6': 0.75})
-    assert psi4.compare_values(ref_pbe_d2[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D (alias)')
+    assert psi4.compare_values(ref_pbe_d2[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D (alias)')
     eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
-    assert psi4.compare_values(ref_pbe_d2[0], psi4.get_variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')
+    assert psi4.compare_values(ref_pbe_d2[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2 (alias)')
 
 
 @pytest.mark.smoke
@@ -358,12 +358,12 @@ def test_libefp():
 
     psi4.energy('efp')
     assert psi4.compare_values( 9.1793879214, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')
-    assert psi4.compare_values(-0.0004901368, psi4.get_variable('efp elst energy'), 6, 'EFP-EFP Elst')  # from q-chem
-    assert psi4.compare_values(-0.0003168768, psi4.get_variable('efp ind energy'), 6, 'EFP-EFP Indc')
-    assert psi4.compare_values(-0.0021985285, psi4.get_variable('efp disp energy'), 6, 'EFP-EFP Disp')  # from q-chem
-    assert psi4.compare_values( 0.0056859871, psi4.get_variable('efp exch energy'), 6, 'EFP-EFP Exch')  # from q-chem
-    assert psi4.compare_values( 0.0026804450, psi4.get_variable('efp total energy'), 6, 'EFP-EFP Totl')
-    assert psi4.compare_values( 0.0026804450, psi4.get_variable('current energy'), 6, 'Current')
+    assert psi4.compare_values(-0.0004901368, psi4.variable('efp elst energy'), 6, 'EFP-EFP Elst')  # from q-chem
+    assert psi4.compare_values(-0.0003168768, psi4.variable('efp ind energy'), 6, 'EFP-EFP Indc')
+    assert psi4.compare_values(-0.0021985285, psi4.variable('efp disp energy'), 6, 'EFP-EFP Disp')  # from q-chem
+    assert psi4.compare_values( 0.0056859871, psi4.variable('efp exch energy'), 6, 'EFP-EFP Exch')  # from q-chem
+    assert psi4.compare_values( 0.0026804450, psi4.variable('efp total energy'), 6, 'EFP-EFP Totl')
+    assert psi4.compare_values( 0.0026804450, psi4.variable('current energy'), 6, 'Current')
     psi4.core.print_variables()
 
     psi4.core.clean()
@@ -376,12 +376,12 @@ def test_libefp():
     psi4.energy('scf')
 
     assert psi4.compare_values( 9.1793879214, qmefp.nuclear_repulsion_energy(), 6, 'QM NRE')
-    assert psi4.compare_values( 0.2622598847, psi4.get_variable('efp total energy') - psi4.get_variable('efp ind energy'), 6, 'EFP corr to SCF')  # from q-chem
-    assert psi4.compare_values(-0.0117694790, psi4.get_variable('efp ind energy'), 6, 'QM-EFP Indc')  # from q-chem
-    assert psi4.compare_values(-0.0021985285, psi4.get_variable('efp disp energy'), 6, 'EFP-EFP Disp')  # from q-chem
-    assert psi4.compare_values( 0.0056859871, psi4.get_variable('efp exch energy'), 6, 'EFP-EFP Exch')  # from q-chem
-    assert psi4.compare_values( 0.2504904057, psi4.get_variable('efp total energy'), 6, 'EFP-EFP Totl')  # from q-chem
-    assert psi4.compare_values(-76.0139362744, psi4.get_variable('scf total energy'), 6, 'SCF')  # from q-chem
+    assert psi4.compare_values( 0.2622598847, psi4.variable('efp total energy') - psi4.variable('efp ind energy'), 6, 'EFP corr to SCF')  # from q-chem
+    assert psi4.compare_values(-0.0117694790, psi4.variable('efp ind energy'), 6, 'QM-EFP Indc')  # from q-chem
+    assert psi4.compare_values(-0.0021985285, psi4.variable('efp disp energy'), 6, 'EFP-EFP Disp')  # from q-chem
+    assert psi4.compare_values( 0.0056859871, psi4.variable('efp exch energy'), 6, 'EFP-EFP Exch')  # from q-chem
+    assert psi4.compare_values( 0.2504904057, psi4.variable('efp total energy'), 6, 'EFP-EFP Totl')  # from q-chem
+    assert psi4.compare_values(-76.0139362744, psi4.variable('scf total energy'), 6, 'SCF')  # from q-chem
     psi4.core.print_variables()
 
 
@@ -433,26 +433,26 @@ def test_pcmsolver():
     energy_scf1, wfn1 = psi4.energy('scf', return_wfn=True)
     assert psi4.compare_values(nucenergy, NH3.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy (PCM, total algorithm)") #TEST
     assert psi4.compare_values(totalenergy, energy_scf1, 10, "Total energy (PCM, total algorithm)") #TEST
-    assert psi4.compare_values(polenergy, wfn1.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
+    assert psi4.compare_values(polenergy, wfn1.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, total algorithm)") #TEST
 
     psi4.set_options({'pcm_scf_type': 'separate'})
     print('RHF-PCM, separate algorithm')
     energy_scf2 = psi4.energy('scf')
     assert psi4.compare_values(totalenergy, energy_scf2, 10, "Total energy (PCM, separate algorithm)")
-    assert psi4.compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
+    assert psi4.compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
 
     # Now force use of UHF on NH3 to check sanity of the algorithm with PCM
     psi4.set_options({'pcm_scf_type': 'total', 'reference': 'uhf'})
     print('UHF-PCM, total algorithm')
     energy_scf3 = psi4.energy('scf')
     assert psi4.compare_values(totalenergy, energy_scf3, 10, "Total energy (PCM, separate algorithm)")
-    assert psi4.compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
+    assert psi4.compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")
 
     psi4.set_options({'pcm_scf_type': 'total', 'reference': 'rohf'})
     print('ROHF-PCM, total algorithm')
     energy_scf4 = psi4.energy('scf')
     assert psi4.compare_values(totalenergy, energy_scf4, 10, "Total energy (PCM, separate algorithm)") #TEST
-    assert psi4.compare_values(polenergy, psi4.get_variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
+    assert psi4.compare_values(polenergy, psi4.variable("PCM POLARIZATION ENERGY"), 6, "Polarization energy (PCM, separate algorithm)")  #TEST
 
 
 def _test_scf5():
@@ -705,12 +705,12 @@ def test_cfour():
 
     psi4.energy('cfour')
 
-    assert psi4.compare_values(-76.062748460117, psi4.get_variable('scf total energy'), 6, 'SCF')
-    assert psi4.compare_values(-76.332940127333, psi4.get_variable('mp2 total energy'), 6, 'MP2')
-    assert psi4.compare_values(-76.338453951890, psi4.get_variable('ccsd total energy'), 6, 'CCSD')
-    assert psi4.compare_values(-0.275705491773, psi4.get_variable('ccsd correlation energy'), 6, 'CCSD corl')
-    assert psi4.compare_values(-76.345717549886, psi4.get_variable('ccsd(t) total energy'), 6, 'CCSD(T)')
-    assert psi4.compare_values(-0.282969089769, psi4.get_variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')
+    assert psi4.compare_values(-76.062748460117, psi4.variable('scf total energy'), 6, 'SCF')
+    assert psi4.compare_values(-76.332940127333, psi4.variable('mp2 total energy'), 6, 'MP2')
+    assert psi4.compare_values(-76.338453951890, psi4.variable('ccsd total energy'), 6, 'CCSD')
+    assert psi4.compare_values(-0.275705491773, psi4.variable('ccsd correlation energy'), 6, 'CCSD corl')
+    assert psi4.compare_values(-76.345717549886, psi4.variable('ccsd(t) total energy'), 6, 'CCSD(T)')
+    assert psi4.compare_values(-0.282969089769, psi4.variable('ccsd(t) correlation energy'), 6, 'CCSD(T) corl')
 
 
 @pytest.mark.smoke
@@ -762,8 +762,8 @@ def test_v2rdm_casscf():
 
     psi4.energy('v2rdm-casscf', molecule=n2)
 
-    assert psi4.compare_values(refscf, psi4.get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
-    assert psi4.compare_values(refv2rdm, psi4.get_variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy")
+    assert psi4.compare_values(refscf, psi4.variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
+    assert psi4.compare_values(refv2rdm, psi4.variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy")
 
 
 @pytest.mark.smoke
@@ -912,8 +912,8 @@ def disabled_test_forte():
     assert psi4.compare_values(refscf, scf,10,"SCF Energy")
 
     psi4.energy('forte')
-    assert psi4.compare_values(refaci, psi4.get_variable("ACI ENERGY"),10,"ACI energy")
-    assert psi4.compare_values(refacipt2, psi4.get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+    assert psi4.compare_values(refaci, psi4.variable("ACI ENERGY"),10,"ACI energy")
+    assert psi4.compare_values(refacipt2, psi4.variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 
 
 @pytest.mark.smoke
@@ -930,7 +930,7 @@ def test_snsmp2():
 
     e = psi4.energy('sns-mp2')
 
-    assert psi4.compare_values(0.00176708227, psi4.get_variable('SNS-MP2 TOTAL ENERGY'), 5, "SNS-MP2 IE [Eh]")
+    assert psi4.compare_values(0.00176708227, psi4.variable('SNS-MP2 TOTAL ENERGY'), 5, "SNS-MP2 IE [Eh]")
 
 
 @pytest.mark.smoke

--- a/tests/pytest/test_addons.py
+++ b/tests/pytest/test_addons.py
@@ -194,7 +194,7 @@ def test_dftd3():
     H   0.000000   0.000000   3.963929
     """)
 
-    psi4.print_stdout('  -D correction from Py-side')
+    print('  -D correction from Py-side')
     eneyne.update_geometry()
     E, G = eneyne.run_dftd3('b3lyp', 'd2')
     assert psi4.compare_values(ref_d2[0], E, 7, 'Ethene-Ethyne -D2')
@@ -240,7 +240,7 @@ def test_dftd3():
                       #'scf print': 3,  # will print dftd3 program output to psi4 output file
                     })
 
-    psi4.print_stdout('  -D correction from C-side')
+    print('  -D correction from C-side')
     psi4.activate(mA)
     #psi4.energy('b3lyp-d2', engine='libdisp')
     #assert psi4.compare_values(ref_d2[1], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene -D2 (calling psi4 Disp class)')
@@ -260,7 +260,7 @@ def test_dftd3():
     psi4.energy('wb97x-d')
     assert psi4.compare_values(-0.000834247063, psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
 
-    psi4.print_stdout('  non-default -D correction from C-side')
+    print('  non-default -D correction from C-side')
     psi4.activate(mB)
     #psi4.set_options({'dft_dispersion_parameters': [0.75]})
     #psi4.energy('b3lyp-d2', engine='libdisp')
@@ -289,7 +289,7 @@ def test_dftd3():
     psi4.energy('wb97x-d')
     assert psi4.compare_values(-0.000834247063, psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene wb97x-d (chg)')
 
-    psi4.print_stdout('  non-default -D correction from Py-side')
+    print('  non-default -D correction from Py-side')
     eneyne.update_geometry()
     eneyne.run_dftd3('b3lyp', 'd2', {'s6': 0.75})
     assert psi4.compare_values(ref_pbe_d2[0], psi4.variable('DISPERSION CORRECTION ENERGY'), 7, 'Ethene-Ethyne -D2')
@@ -459,8 +459,8 @@ def _test_scf5():
     """scf5"""
     #! Test of all different algorithms and reference types for SCF, on singlet and triplet O2, using the cc-pVTZ basis set and using ERD integrals.
 
-    psi4.print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2')
-    psi4.print_stdout('    -Integral package: {}'.format(psi4.core.get_global_option('integral_package')))
+    print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2')
+    print('    -Integral package: {}'.format(psi4.core.get_global_option('integral_package')))
 
     #Ensure that the checkpoint file is always nuked
     psi4.core.IOManager.shared_object().set_specific_retention(32,False)
@@ -489,7 +489,7 @@ def _test_scf5():
     singlet_o2.update_geometry()
     triplet_o2.update_geometry()
 
-    psi4.print_stdout('    -Nuclear Repulsion:')
+    print('    -Nuclear Repulsion:')
     assert psi4.compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")
     assert psi4.compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")
 

--- a/tests/pytest/test_psi4.py
+++ b/tests/pytest/test_psi4.py
@@ -16,7 +16,7 @@ def test_psi4_basic():
     psi4.set_options({'basis': "cc-pVDZ"})
     psi4.energy('scf')
 
-    assert psi4.compare_values(-76.0266327341067125, psi4.get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')
+    assert psi4.compare_values(-76.0266327341067125, psi4.variable('SCF TOTAL ENERGY'), 6, 'SCF energy')
 
 
 @pytest.mark.smoke
@@ -41,9 +41,9 @@ def test_psi4_cc():
     reftotal = -76.2311784355056
 
     assert psi4.compare_values(refnuc,   h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")
-    assert psi4.compare_values(refscf,   psi4.get_variable("SCF total energy"), 5, "SCF energy")
-    assert psi4.compare_values(refccsd,  psi4.get_variable("CCSD correlation energy"), 4, "CCSD contribution")
-    assert psi4.compare_values(reftotal, psi4.get_variable("Current energy"), 7, "Total energy")
+    assert psi4.compare_values(refscf,   psi4.variable("SCF total energy"), 5, "SCF energy")
+    assert psi4.compare_values(refccsd,  psi4.variable("CCSD correlation energy"), 4, "CCSD contribution")
+    assert psi4.compare_values(reftotal, psi4.variable("Current energy"), 7, "Total energy")
 
 
 @pytest.mark.smoke
@@ -164,11 +164,11 @@ def test_psi4_sapt():
 
     psi4.energy('sapt0', molecule=ethene_ethyne)
 
-    Eelst = psi4.get_variable("SAPT ELST ENERGY")
-    Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-    Eind  = psi4.get_variable("SAPT IND ENERGY")
-    Edisp = psi4.get_variable("SAPT DISP ENERGY")
-    ET    = psi4.get_variable("SAPT0 TOTAL ENERGY")
+    Eelst = psi4.variable("SAPT ELST ENERGY")
+    Eexch = psi4.variable("SAPT EXCH ENERGY")
+    Eind  = psi4.variable("SAPT IND ENERGY")
+    Edisp = psi4.variable("SAPT DISP ENERGY")
+    ET    = psi4.variable("SAPT0 TOTAL ENERGY")
 
     assert psi4.compare_values(Eref[0], ethene_ethyne.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy")
     assert psi4.compare_values(Eref[1], Eelst, 6, "SAPT0 Eelst")
@@ -218,26 +218,26 @@ def test_psi4_scfproperty():
 
     psi4.properties('scf', properties=props)
 
-    assert psi4.compare_values(psi4.get_variable("CURRENT ENERGY"), -38.91591819679808, 6, "SCF energy")
-    assert psi4.compare_values(psi4.get_variable('SCF DIPOLE X'), 0.000000000000, 4, "SCF DIPOLE X")
-    assert psi4.compare_values(psi4.get_variable('SCF DIPOLE Y'), 0.000000000000, 4, "SCF DIPOLE Y")
-    assert psi4.compare_values(psi4.get_variable('SCF DIPOLE Z'), 0.572697798348, 4, "SCF DIPOLE Z")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE XX'), -7.664066833060, 4, "SCF QUADRUPOLE XX")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE YY'), -6.097755074075, 4, "SCF QUADRUPOLE YY")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE ZZ'), -7.074596012050, 4, "SCF QUADRUPOLE ZZ")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE XY'), 0.000000000000, 4, "SCF QUADRUPOLE XY")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE XZ'), 0.000000000000, 4, "SCF QUADRUPOLE XZ")
-    assert psi4.compare_values(psi4.get_variable('SCF QUADRUPOLE YZ'), 0.000000000000, 4, "SCF QUADRUPOLE YZ")
+    assert psi4.compare_values(psi4.variable("CURRENT ENERGY"), -38.91591819679808, 6, "SCF energy")
+    assert psi4.compare_values(psi4.variable('SCF DIPOLE X'), 0.000000000000, 4, "SCF DIPOLE X")
+    assert psi4.compare_values(psi4.variable('SCF DIPOLE Y'), 0.000000000000, 4, "SCF DIPOLE Y")
+    assert psi4.compare_values(psi4.variable('SCF DIPOLE Z'), 0.572697798348, 4, "SCF DIPOLE Z")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XX'), -7.664066833060, 4, "SCF QUADRUPOLE XX")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE YY'), -6.097755074075, 4, "SCF QUADRUPOLE YY")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE ZZ'), -7.074596012050, 4, "SCF QUADRUPOLE ZZ")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XY'), 0.000000000000, 4, "SCF QUADRUPOLE XY")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XZ'), 0.000000000000, 4, "SCF QUADRUPOLE XZ")
+    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE YZ'), 0.000000000000, 4, "SCF QUADRUPOLE YZ")
 
     psi4.properties('B3LYP', properties=props)
 
-    assert psi4.compare_values(psi4.get_variable('CURRENT ENERGY'), -39.14134740550916, 6, "B3LYP energy")
-    assert psi4.compare_values(psi4.get_variable('B3LYP DIPOLE X'), 0.000000000000, 4, "B3LYP DIPOLE X")
-    assert psi4.compare_values(psi4.get_variable('B3LYP DIPOLE Y'), -0.000000000000, 4, "B3LYP DIPOLE Y")
-    assert psi4.compare_values(psi4.get_variable('B3LYP DIPOLE Z'), 0.641741521158, 4, "B3LYP DIPOLE Z")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE XX'), -7.616483183211, 4, "B3LYP QUADRUPOLE XX")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE YY'), -6.005896804551, 4, "B3LYP QUADRUPOLE YY")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE ZZ'), -7.021817489904, 4, "B3LYP QUADRUPOLE ZZ")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE XY'), 0.000000000000, 4, "B3LYP QUADRUPOLE XY")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE XZ'), 0.000000000000, 4, "B3LYP QUADRUPOLE XZ")
-    assert psi4.compare_values(psi4.get_variable('B3LYP QUADRUPOLE YZ'), -0.000000000000, 4, "B3LYP QUADRUPOLE YZ")
+    assert psi4.compare_values(psi4.variable('CURRENT ENERGY'), -39.14134740550916, 6, "B3LYP energy")
+    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE X'), 0.000000000000, 4, "B3LYP DIPOLE X")
+    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE Y'), -0.000000000000, 4, "B3LYP DIPOLE Y")
+    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE Z'), 0.641741521158, 4, "B3LYP DIPOLE Z")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XX'), -7.616483183211, 4, "B3LYP QUADRUPOLE XX")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE YY'), -6.005896804551, 4, "B3LYP QUADRUPOLE YY")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE ZZ'), -7.021817489904, 4, "B3LYP QUADRUPOLE ZZ")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XY'), 0.000000000000, 4, "B3LYP QUADRUPOLE XY")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XZ'), 0.000000000000, 4, "B3LYP QUADRUPOLE XZ")
+    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE YZ'), -0.000000000000, 4, "B3LYP QUADRUPOLE YZ")

--- a/tests/python/cc54/input.py
+++ b/tests/python/cc54/input.py
@@ -101,13 +101,13 @@ D 2 1.00
 
 ccsd_e, wfn = psi4.properties('ccsd',properties=['dipole'],return_wfn=True)
 psi4.oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-psi4.compare_values(psi4.get_variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-psi4.compare_values(psi4.get_variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
+psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
 psi4.core.print_variables()

--- a/tests/python/vibanalysis/input.py
+++ b/tests/python/vibanalysis/input.py
@@ -743,7 +743,7 @@ def test_psi4_hessian(ref_geom_str, ref_vibonly, geom_str, tol, comparison_label
     
     psi4.core.clean()
     E, pwfn = psi4.frequency('hf', return_wfn=True, molecule=apmol, dertype=dertype)
-    print(psi4.get_variable('CURRENT ENERGY'))
+    print(psi4.variable('CURRENT ENERGY'))
 
     #sphess = qcdb.vib.hessian_symmetrize(np.asarray(pwfn.hessian()), aqmol)
     #print('Symmetrization non-catastrophic:', np.allclose(np.asarray(phess), sphess, atol=1.0e-1))
@@ -862,7 +862,7 @@ ch4_thermo_mol = psi4.geometry("""
 psi4.core.clean()
 psi4.optimize('hf/3-21g', molecule=ch4_thermo_mol)
 E, thermo_wfn = psi4.freq('hf/3-21g', return_wfn=True, molecule=ch4_thermo_mol, dertype=1)
-print(psi4.get_variable('CURRENT ENERGY'))
+print(psi4.variable('CURRENT ENERGY'))
 
 thermo_vibinfo = psi4.driver.vibanal_wfn(thermo_wfn)
 

--- a/tests/pywrap-alias/input.dat
+++ b/tests/pywrap-alias/input.dat
@@ -23,61 +23,61 @@ set occ do_scs on
 
 banner('gold standard')
 energy(sherrill_gold_standard)
-compare_values(-5.66406119, get_variable('CBS TOTAL ENERGY'), 7, "[1]  Au std")  #TEST
+compare_values(-5.66406119, variable('CBS TOTAL ENERGY'), 7, "[1]  Au std")  #TEST
 clean()
 
 #banner('scf')
 #energy('SCF')
-#compare_values(-5.551087929000, get_variable('SCF TOTAL ENERGY'), 7, "SCF sp")  #TEST
+#compare_values(-5.551087929000, variable('SCF TOTAL ENERGY'), 7, "SCF sp")  #TEST
 #clean()
 
 banner('mp2')
 energy('mp2')
-compare_values(-5.573453229993, get_variable('MP2 TOTAL ENERGY'), 7, "[2]  MP2 sp")  #TEST
-compare_values(-0.02232850726021, get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 7, "      MP2 route check")  #TEST
+compare_values(-5.573453229993, variable('MP2 TOTAL ENERGY'), 7, "[2]  MP2 sp")  #TEST
+compare_values(-0.02232850726021, variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'), 7, "      MP2 route check")  #TEST
 # this second check will fail if a request for a mp2 calc gets routed to detci, rather than the mp2 module
 clean()
 
 banner('mp3')
 energy('mp3')
-compare_values(-5.57903326861, get_variable('MP3 TOTAL ENERGY'), 7, '[3]  MP3 occ')  #TEST
-compare_values(-0.025155295755, get_variable('MP2.5 CORRELATION ENERGY'), 6, '      MP3 route check')  #TEST
+compare_values(-5.57903326861, variable('MP3 TOTAL ENERGY'), 7, '[3]  MP3 occ')  #TEST
+compare_values(-0.025155295755, variable('MP2.5 CORRELATION ENERGY'), 6, '      MP3 route check')  #TEST
 set reference uhf
 set_variable('MP3 TOTAL ENERGY',0.0)
 energy('mp3')
-compare_values(-5.57903326861, get_variable('MP3 TOTAL ENERGY'), 7, '[4]  MP3 detci (energy and route check)')  #TEST
+compare_values(-5.57903326861, variable('MP3 TOTAL ENERGY'), 7, '[4]  MP3 detci (energy and route check)')  #TEST
 set reference rhf
 clean()
 
 banner('mp4')
 energy('mp4')
-compare_values(-5.58040727035, get_variable('MP4 TOTAL ENERGY'), 7, '[5]  MP4 fnocc')  #TEST
+compare_values(-5.58040727035, variable('MP4 TOTAL ENERGY'), 7, '[5]  MP4 fnocc')  #TEST
 clean()
 
 banner('mp11')
 energy('mp11')
-compare_values(-5.580830858501, get_variable('MP11 TOTAL ENERGY'), 7, "[6]  MP11 sp")  #TEST
+compare_values(-5.580830858501, variable('MP11 TOTAL ENERGY'), 7, "[6]  MP11 sp")  #TEST
 clean()
 
 banner('zapt4')
 energy('zapt4')
-compare_values(-5.580407221960, get_variable('ZAPT4 TOTAL ENERGY'), 7, "[7]  ZAPT4 sp")  #TEST
+compare_values(-5.580407221960, variable('ZAPT4 TOTAL ENERGY'), 7, "[7]  ZAPT4 sp")  #TEST
 clean()
 
 banner('fci')
 energy('fci')
-compare_values(-5.580830850570, get_variable('FCI TOTAL ENERGY'), 7, "[8]  FCI sp")  #TEST
+compare_values(-5.580830850570, variable('FCI TOTAL ENERGY'), 7, "[8]  FCI sp")  #TEST
 clean()
 
 banner('mp2.5')
 energy('mp2.5')
-compare_values(-5.576243225099, get_variable('MP2.5 TOTAL ENERGY'), 7, "[9]  MP2.5 sp")  #TEST
+compare_values(-5.576243225099, variable('MP2.5 TOTAL ENERGY'), 7, "[9]  MP2.5 sp")  #TEST
 clean()
 
 banner('cbs()')
 set scf_type pk
 energy(cbs, scf_type='scf', scf_basis='cc-pvdz')
-compare_values(-5.55609846, get_variable('CBS TOTAL ENERGY'), 7, "[10] cbs()")  #TEST
+compare_values(-5.55609846, variable('CBS TOTAL ENERGY'), 7, "[10] cbs()")  #TEST
 clean()
 
 set {
@@ -90,7 +90,7 @@ set {
 # Try something other than scf
 banner('db()')
 database('scf','S22',subset=[2,8],benchmark='S22A')
-compare_values(0.604937374581, get_variable('S22 DATABASE MEAN ABSOLUTE DEVIATION'), 5, "[11] db()")  #TEST
+compare_values(0.604937374581, variable('S22 DATABASE MEAN ABSOLUTE DEVIATION'), 5, "[11] db()")  #TEST
 clean()
 
 set {
@@ -99,18 +99,18 @@ set {
 }
 banner('cisd')
 energy('cisd',molecule=He2)
-compare_values(-5.580709674676, get_variable('CISD TOTAL ENERGY'), 7, "[12] CISD sp")  #TEST
+compare_values(-5.580709674676, variable('CISD TOTAL ENERGY'), 7, "[12] CISD sp")  #TEST
 clean()
 
 #banner('opt(cbs())')
 #optimize('scf',opt_func=cbs,scf_basis='sto-3g',scf_scheme=highest_1)
-#compare_values(-5.615567415914, get_variable('SCF TOTAL ENERGY'), 6, 'opt(cbs())')  #TEST
+#compare_values(-5.615567415914, variable('SCF TOTAL ENERGY'), 6, 'opt(cbs())')  #TEST
 #clean()
 
 #banner('opt(arbitraryorder())')
 #optimize('mp3')
-#compare_values(-5.738452948227, get_variable('MP3 TOTAL ENERGY'), 5, '[13] opt(mp3())')  #TEST
-#compare_values(-5.738452948227, get_variable('CURRENT ENERGY'), 5, '[13b] opt(mp3())')  #TEST
+#compare_values(-5.738452948227, variable('MP3 TOTAL ENERGY'), 5, '[13] opt(mp3())')  #TEST
+#compare_values(-5.738452948227, variable('CURRENT ENERGY'), 5, '[13b] opt(mp3())')  #TEST
 
 #molecule h2o {
 #     O
@@ -121,5 +121,5 @@ clean()
 #set basis sto-3g
 
 #energy('b3lyp-d')
-#compare_values(-75.319769478, get_variable('CURRENT ENERGY'), 7, 'B3LYP-D2 sp')  #TEST
+#compare_values(-75.319769478, variable('CURRENT ENERGY'), 7, 'B3LYP-D2 sp')  #TEST
 

--- a/tests/pywrap-all/input.dat
+++ b/tests/pywrap-all/input.dat
@@ -35,7 +35,7 @@ set {
 
 banner('Test [1] optimize(cbs(energy()))')
 E, wfn = optimize(cbs, corl_wfn='mp2', corl_basis='cc-pv[dt]z', delta_wfn='ccsd', delta_basis='3-21g', return_wfn=True, dertype=0)
-compare_values(ref_OPT_CBS_E_0, get_variable('CBS TOTAL ENERGY'), 5, "[1b] Wrapper optimize(cbs(), dertype=0)")  #TEST
+compare_values(ref_OPT_CBS_E_0, variable('CBS TOTAL ENERGY'), 5, "[1b] Wrapper optimize(cbs(), dertype=0)")  #TEST
 compare_values(0.0, wfn.gradient().rms(), 3, '[1a] rms gradient')  #TEST
 wfn.gradient().print_out()
 
@@ -44,29 +44,29 @@ set basis_guess sto-3g
 set mp2_type conv
 set df_scf_guess false
 db('mp2','RGC10',subset=['HeHe-0.85','HeHe-1.0'],tabulate=['mp2 total energy'])
-compare_values(ref_DB_E, get_variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[2] Wrapper database() incl. castup")  #TEST
+compare_values(ref_DB_E, variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[2] Wrapper database() incl. castup")  #TEST
 revoke_global_option_changed('BASIS_GUESS')
 
 banner('Test [3] database(cbs(energy()))')
 db(cbs, 'RGC10', corl_wfn='mp2', subset=['HeHe-0.85','HeHe-1.0'],tabulate=['cbs total energy','current energy'],corl_basis='cc-pV[DT]Z',corl_scheme=corl_xtpl_helgaker_2,delta_wfn='ccsd(t)',delta_basis='3-21g')
-compare_values(ref_DB_CBS_E, get_variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3] Wrapper database(cbs())")  #TEST
+compare_values(ref_DB_CBS_E, variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3] Wrapper database(cbs())")  #TEST
 db('mp2/cc-pV[DT]Z + d:ccsd(t)/3-21g', 'RGC10', subset=['HeHe-0.85','HeHe-1.0'],tabulate=['current correlation energy','current energy'])
-compare_values(ref_DB_CBS_E, get_variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3b] Wrapper database(cbs())")  #TEST
+compare_values(ref_DB_CBS_E, variable('RGC10 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 5, "[3b] Wrapper database(cbs())")  #TEST
 
 
 banner('Test [4] cbs(energy())')
 # for h2 geom after optimization in [1]
 energy(cbs, corl_wfn='mp2',corl_basis='cc-pv[dt]z',corl_scheme=corl_xtpl_helgaker_2,delta_wfn='ccsd',delta_basis='3-21g',delta2_wfn='ccsd(t)',delta2_wfn_lesser='ccsd',delta2_basis='3-21g')
-compare_values(ref_CBS_E_postopt, get_variable('CBS TOTAL ENERGY'), 7, "[4] Wrapper cbs()")  #TEST
+compare_values(ref_CBS_E_postopt, variable('CBS TOTAL ENERGY'), 7, "[4] Wrapper cbs()")  #TEST
 
 banner('Test [5] opt(energy())')
 # TODO switch to mp2 once gradients thoroughly working again
 optimize('mp2',dertype='none')
-compare_values(ref_OPT_E_0, get_variable('CURRENT ENERGY'), 7, "[5] Wrapper optimize(dertype=0)")  #TEST
+compare_values(ref_OPT_E_0, variable('CURRENT ENERGY'), 7, "[5] Wrapper optimize(dertype=0)")  #TEST
 
 banner('Test [6] opt(energy())')
 optimize('scf')
-compare_values(ref_OPT_E_1, get_variable('CURRENT ENERGY'), 7, "[6] Wrapper optimize()")  #TEST
+compare_values(ref_OPT_E_1, variable('CURRENT ENERGY'), 7, "[6] Wrapper optimize()")  #TEST
 
 banner('Test [7] opt(energy())')
 h2.reset_point_group('c1')
@@ -76,12 +76,12 @@ h2.update_geometry()
 # SCF below if we read the previous SCF orbitals.  I seem to have avoided
 # it by upping E_CONVERGENCE to 9 above, we'll see if that holds -CDS
 optimize('mp2')
-compare_values(ref_OPT_E_0, get_variable('CURRENT ENERGY'), 7, "[7] Wrapper optimize()")  #TEST
+compare_values(ref_OPT_E_0, variable('CURRENT ENERGY'), 7, "[7] Wrapper optimize()")  #TEST
 
 banner('Test [8] database(opt(energy()))')
 db('mp2','S22',db_func=optimize,subset=[1],tabulate=['mp2 total energy','current energy'])
-compare_values(ref_DB_OPT_E_S22, get_variable('S22 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 3, "[8] Wrapper database(optimize())")  #TEST
+compare_values(ref_DB_OPT_E_S22, variable('S22 DATABASE ROOT-MEAN-SQUARE DEVIATION'), 3, "[8] Wrapper database(optimize())")  #TEST
 
 banner('Test [9] alias(cbs(energy()))')
 energy(sherrill_gold_standard)
-compare_values(ref_CDS_CBS_E_0, get_variable("CBS TOTAL ENERGY"), 6, '[9] Aliased wrapper calling cbs()')  #TEST
+compare_values(ref_CDS_CBS_E_0, variable("CBS TOTAL ENERGY"), 6, '[9] Aliased wrapper calling cbs()')  #TEST

--- a/tests/pywrap-basis/input.dat
+++ b/tests/pywrap-basis/input.dat
@@ -36,7 +36,7 @@ df_basis_sapt {
 set scf_type df
 
 energy('sapt0')
-compare_values(-0.004628759506, get_variable('SAPT TOTAL ENERGY'), 6, """[1] autofrag'd sapt: explicit vs. custom haDZ""")  #TEST
+compare_values(-0.004628759506, variable('SAPT TOTAL ENERGY'), 6, """[1] autofrag'd sapt: explicit vs. custom haDZ""")  #TEST
 clean()
 
 

--- a/tests/pywrap-cbs1/input.dat
+++ b/tests/pywrap-cbs1/input.dat
@@ -16,7 +16,7 @@ e_cbs = energy(cbs,
             scf_scheme=scf_xtpl_helgaker_3)
 
 compare_values(-7.4326961561955551, e_cbs, 7, "[1] Li ROHF extrapolated energy")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[1b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[1b]')  #TEST
 clean()
 
 
@@ -43,7 +43,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pV[DT]Z',
             delta_scheme=driver_cbs.corl_xtpl_helgaker_2)
 compare_values(-1.148287763304, e_cbs, 7, "[2] H2 mp2 extrapolated energy with ccsd delta correction")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[2b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[2b]')  #TEST
 clean()
 
 
@@ -65,7 +65,7 @@ e_cbs = energy(cbs,
             corl_scheme=driver_cbs.corl_xtpl_helgaker_2)
 
 compare_values(-2.9033043421572055642, e_cbs, 7, "[3] He ccsd extrapolated energy")  #TEST
-compare_values(3.0, get_variable('cbs number'), 6, '[3b]')  #TEST
+compare_values(3.0, variable('cbs number'), 6, '[3b]')  #TEST
 clean()
 
 # Example with default extrapolation schemes
@@ -76,7 +76,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pVDZ')
 
 compare_values(-2.90394676, e_cbs, 6, '[4] MP5: minimal info')  #TEST
-compare_values(2.0, get_variable('cbs number'), 6, '[4b]')  #TEST
+compare_values(2.0, variable('cbs number'), 6, '[4b]')  #TEST
 clean()
 
 

--- a/tests/pywrap-checkrun-convcrit/input.dat
+++ b/tests/pywrap-checkrun-convcrit/input.dat
@@ -42,13 +42,13 @@ for convcrit in convmat:
     
     print('')  #TEST
     energy('scf')
-    compare_values(e_dfscf, get_variable('CURRENT ENERGY'), convcrit[3], '  scf sp %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
+    compare_values(e_dfscf, variable('CURRENT ENERGY'), convcrit[3], '  scf sp %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
     clean()
 
     energy('cisd')
-    compare_values(e_pkscf, get_variable('CURRENT REFERENCE ENERGY'), convcrit[4], 'cisd scf %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
+    compare_values(e_pkscf, variable('CURRENT REFERENCE ENERGY'), convcrit[4], 'cisd scf %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
     clean()
-    compare_values(e_cisd, get_variable('CURRENT CORRELATION ENERGY'), convcrit[5], ' cisd sp %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
+    compare_values(e_cisd, variable('CURRENT CORRELATION ENERGY'), convcrit[5], ' cisd sp %d %d %d to %d %d %d' % (convcrit[0], convcrit[1], convcrit[2], convcrit[3], convcrit[4], convcrit[5]))  #TEST
     
     revoke_global_option_changed('E_CONVERGENCE')
     revoke_local_option_changed('SCF', 'E_CONVERGENCE')

--- a/tests/pywrap-checkrun-rhf/input.dat
+++ b/tests/pywrap-checkrun-rhf/input.dat
@@ -48,7 +48,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -113,7 +113,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -145,7 +145,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 compare_values(0.0, 0.0, 3, 'Nothing segfaulted')  #TEST

--- a/tests/pywrap-checkrun-rohf/input.dat
+++ b/tests/pywrap-checkrun-rohf/input.dat
@@ -48,7 +48,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -111,7 +111,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 compare_values(0.0, 0.0, 3, 'Nothing segfaulted')  #TEST

--- a/tests/pywrap-checkrun-uhf/input.dat
+++ b/tests/pywrap-checkrun-uhf/input.dat
@@ -48,7 +48,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ for method in Earray:
    banner('Testing %s' % (method)) 
    G, wfn = gradient(method, return_wfn=True)
    ans = wfn.energy()
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -111,7 +111,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 #-------------------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ for method in Earray:
 
    banner('Testing %s' % (method)) 
    ans = energy(method)
-   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), get_variable('CURRENT ENERGY') - ans, ans))
+   print('%16s\t%s\t%s\t%s' % (method, water.schoenflies_symbol(), variable('CURRENT ENERGY') - ans, ans))
    clean()
 
 compare_values(0.0, 0.0, 3, 'Nothing segfaulted')  #TEST

--- a/tests/pywrap-freq-e-sowreap/input.dat
+++ b/tests/pywrap-freq-e-sowreap/input.dat
@@ -28,11 +28,11 @@ ref_eq_e = -74.9659011923  #TEST
 
 fd_freqs = get_frequencies()  #TEST
 #compare_vectors(anal_freqs, fd_freqs, 1, 'Frequencies')  #TEST
-#compare_values(ref_zpve, get_variable('ZPVE'), 4, 'ZPVE')  #TEST
-#compare_values(ref_eq_e, get_variable('current energy'), 6, 'SP energy')  #TEST
+#compare_values(ref_zpve, variable('ZPVE'), 4, 'ZPVE')  #TEST
+#compare_values(ref_eq_e, variable('current energy'), 6, 'SP energy')  #TEST
 #compare_values(ref_eq_nre, get_active_molecule().nuclear_repulsion_energy(), 6, 'SP NRE')  #TEST
 #compare_values(ref_eq_nre, h2o.nuclear_repulsion_energy(), 6, 'SP NRE')  #TEST
-#compare_values(ref_eq_nre, get_variable('nuclear repulsion energy'), 6, 'SP NRE')  #TEST
+#compare_values(ref_eq_nre, variable('nuclear repulsion energy'), 6, 'SP NRE')  #TEST
 
 #print_variables()
 

--- a/tests/pywrap-freq-g-sowreap/input.dat
+++ b/tests/pywrap-freq-g-sowreap/input.dat
@@ -29,11 +29,11 @@ ref_eq_e = -74.9659011923  #TEST
 
 fd_freqs = get_frequencies()  #TEST
 #compare_vectors(anal_freqs, fd_freqs, 1, 'Frequencies')  #TEST
-#compare_values(ref_zpve, get_variable('ZPVE'), 4, 'ZPVE')  #TEST
-#compare_values(ref_eq_e, get_variable('current energy'), 6, 'SP energy')  #TEST
+#compare_values(ref_zpve, variable('ZPVE'), 4, 'ZPVE')  #TEST
+#compare_values(ref_eq_e, variable('current energy'), 6, 'SP energy')  #TEST
 #compare_values(ref_eq_nre, get_active_molecule().nuclear_repulsion_energy(), 6, 'SP NRE')  #TEST
 #compare_values(ref_eq_nre, h2o.nuclear_repulsion_energy(), 6, 'SP NRE')  #TEST
-#compare_values(ref_eq_nre, get_variable('nuclear repulsion energy'), 6, 'SP NRE')  #TEST
+#compare_values(ref_eq_nre, variable('nuclear repulsion energy'), 6, 'SP NRE')  #TEST
 
 #print_variables()
 

--- a/tests/rasci-c2-active/input.dat
+++ b/tests/rasci-c2-active/input.dat
@@ -25,9 +25,9 @@ set {
 thisenergy = energy('detci')
 
 compare_values(refnuc, c2.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     9, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     9, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
 
 clean()
 revoke_global_option_changed("ACTIVE")
@@ -48,7 +48,7 @@ set {
 thisenergy = energy('detci')
 
 compare_values(refnuc, c2.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     9, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     9, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
 

--- a/tests/rasci-h2o/input.dat
+++ b/tests/rasci-h2o/input.dat
@@ -24,6 +24,6 @@ thisenergy = energy('detci')
 
 # 7 digits on CI seems ok, but we may need to back it down to 6 later #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     8, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/rasci-ne/input.dat
+++ b/tests/rasci-ne/input.dat
@@ -39,9 +39,9 @@ set detci {
 thisenergy, this_wfn = energy('detci', return_wfn=True)
 
 compare_values(refnuc, ne.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("SCF total energy"),     9, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     9, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
 
 ## Now, run the RASCI
 refnuc   =    0.0000000000    #TEST
@@ -82,6 +82,6 @@ set detci {
 thisenergy = energy('detci', ref_wfn=this_wfn)
 
 compare_values(refnuc, ne.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
-compare_values(refscf, get_variable("current REFerence energy"),     9, "SCF energy") #TEST
+compare_values(refscf, variable("current REFerence energy"),     9, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "CI energy") #TEST
-compare_values(refcorr, get_variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
+compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy") #TEST

--- a/tests/rasscf-sp/input.dat
+++ b/tests/rasscf-sp/input.dat
@@ -21,7 +21,7 @@ molecule mol {
 }
 
 scf_e, scf_wfn = psi4.energy("SCF", return_wfn=True)
-compare_values(-76.017259983350, psi4.get_variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
+compare_values(-76.017259983350, psi4.variable("SCF TOTAL ENERGY"), 6, "SCF Energy")  #TEST
 
 set icore 1
 rasscf_energy, rasscf_wfn = energy('RASSCF', ref_wfn=scf_wfn, return_wfn=True)

--- a/tests/sapt-compare/input.dat
+++ b/tests/sapt-compare/input.dat
@@ -30,13 +30,13 @@ set {
 }
 
 energy('sapt0', molecule=dimer)
-sapt0_vars = psi4.core.get_variables() #TEST
+sapt0_vars = psi4.core.variables() #TEST
 
 energy('fisapt0', molecule=dimer)
-fisapt0_vars = psi4.core.get_variables() #TEST
+fisapt0_vars = psi4.core.variables() #TEST
 
 energy('sapt(dft)', molecule=dimer)
-sapt_dft_vars = psi4.core.get_variables() #TEST
+sapt_dft_vars = psi4.core.variables() #TEST
 
 for k in ["SAPT ELST ENERGY", "SAPT EXCH ENERGY", "SAPT IND ENERGY"]: #TEST
     compare_values(Eref[k], sapt_dft_vars[k], 5, "SAPT(DFT) " + k) #TEST

--- a/tests/sapt-dft-api/input.dat
+++ b/tests/sapt-dft-api/input.dat
@@ -38,4 +38,4 @@ wfnD = core.Wavefunction.build(sapt_dimer)
 data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
 
 for k, v in Eref.items():                                  #TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k) #TEST

--- a/tests/sapt-dft-lrc/input.dat
+++ b/tests/sapt-dft-lrc/input.dat
@@ -38,4 +38,4 @@ wfnD = core.Wavefunction.build(sapt_dimer)
 data = procrouting.sapt.sapt_dft(wfnD, wfnA, wfnB)
 
 for k, v in Eref.items():                                  #TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k) #TEST

--- a/tests/sapt-dft1/input.dat
+++ b/tests/sapt-dft1/input.dat
@@ -24,4 +24,4 @@ set {
 energy('sapt(dft)', molecule=dimer)
 
 for k, v in Eref.items():                                  #TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k) #TEST

--- a/tests/sapt-dft2/input.dat
+++ b/tests/sapt-dft2/input.dat
@@ -30,5 +30,5 @@ set {
 energy('sapt(dft)', molecule=dimer)
 
 for k, v in Eref.items():                                  #TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) #TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k) #TEST
 

--- a/tests/sapt-exch-ind-inf/input.dat
+++ b/tests/sapt-exch-ind-inf/input.dat
@@ -31,4 +31,4 @@ set SAPT_DFT_FUNCTIONAL HF
 energy('sapt(dft)', molecule=dimer)
 
 for k, v in Eref.items():                                  # TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k) # TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k) # TEST

--- a/tests/sapt-sf1/input.dat
+++ b/tests/sapt-sf1/input.dat
@@ -32,4 +32,4 @@ compare_dict = { #TEST
 energy("SF-SAPT")
 
 for k, v in compare_dict.items():  #TEST
-    compare_values(v / 1000.0, psi4.get_variable(k), 6, k)  #TEST
+    compare_values(v / 1000.0, psi4.variable(k), 6, k)  #TEST

--- a/tests/sapt1/input.dat
+++ b/tests/sapt1/input.dat
@@ -39,11 +39,11 @@ set {
 
 energy('sapt0', molecule=ethene_ethyne)
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT0 TOTAL ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT0 TOTAL ENERGY")
 
 compare_values(Eref[0], ethene_ethyne.nuclear_repulsion_energy(), 9, "Nuclear Repulsion Energy") #TEST
 compare_values(Eref[1], Eelst, 6, "SAPT0 Eelst")                                                 #TEST

--- a/tests/sapt2/input.dat
+++ b/tests/sapt2/input.dat
@@ -48,11 +48,11 @@ set sapt {
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT0 TOTAL ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT0 TOTAL ENERGY")
 
 Eref = [ -0.00156580384,  #TEST
           0.00393298774,  #TEST

--- a/tests/sapt3/input.dat
+++ b/tests/sapt3/input.dat
@@ -46,4 +46,4 @@ ref_dict = { #TEST
 
 
 for key, ref in ref_dict.items():  #TEST
-    compare_values(ref, psi4.get_variable(key), 6, key)  #TEST
+    compare_values(ref, psi4.variable(key), 6, key)  #TEST

--- a/tests/sapt4/input.dat
+++ b/tests/sapt4/input.dat
@@ -39,15 +39,15 @@ set sapt {
 
 energy('sapt2+(3)')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ESAPT0 = psi4.get_variable("SAPT0 TOTAL ENERGY")
-ESAPT2 = psi4.get_variable("SAPT2 TOTAL ENERGY")
-ESAPT2p = psi4.get_variable("SAPT2+ TOTAL ENERGY")
-ESAPT2pp3 = psi4.get_variable("SAPT2+(3) TOTAL ENERGY")
-ESAPT = psi4.get_variable("SAPT TOTAL ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ESAPT0 = psi4.variable("SAPT0 TOTAL ENERGY")
+ESAPT2 = psi4.variable("SAPT2 TOTAL ENERGY")
+ESAPT2p = psi4.variable("SAPT2+ TOTAL ENERGY")
+ESAPT2pp3 = psi4.variable("SAPT2+(3) TOTAL ENERGY")
+ESAPT = psi4.variable("SAPT TOTAL ENERGY")
 
 Eref = [ -0.04076062059,   #TEST
           0.04625663134,   #TEST

--- a/tests/sapt5/input.dat
+++ b/tests/sapt5/input.dat
@@ -28,7 +28,7 @@ set {
 
 energy('sapt0-ct')
 
-ECT = psi4.get_variable("SAPT CT ENERGY")
+ECT = psi4.variable("SAPT CT ENERGY")
 
 Eref = [ -0.0006483 ]   #TEST
 

--- a/tests/sapt6/input.dat
+++ b/tests/sapt6/input.dat
@@ -370,11 +370,11 @@ for codelist in [codes[0], codes[2], codes[6], codes[14]]:
     for subcode in codelist:
         for term in ['ELST ENERGY', 'EXCH ENERGY', 'IND ENERGY', 'DISP ENERGY', 'TOTAL ENERGY']:
             pv = ' '.join([subcode, term])
-            compare_values(refs[alpha][subcode][term], h2kc * get_variable(pv), digits, pv)  #TEST
+            compare_values(refs[alpha][subcode][term], h2kc * variable(pv), digits, pv)  #TEST
             if subcode == method:
                 gpv = ' '.join(['SAPT', term])
-                compare_values(refs[alpha][subcode][term], h2kc * get_variable(gpv), digits, gpv)  #TEST
-    compare_values(refs[alpha][method]['TOTAL ENERGY'], h2kc * get_variable('CURRENT ENERGY'), digits, 'CURRENT ENERGY')  #TEST
+                compare_values(refs[alpha][subcode][term], h2kc * variable(gpv), digits, gpv)  #TEST
+    compare_values(refs[alpha][method]['TOTAL ENERGY'], h2kc * variable('CURRENT ENERGY'), digits, 'CURRENT ENERGY')  #TEST
 
     clean()
     clean_variables()
@@ -392,11 +392,11 @@ for codelist in [codes[1], codes[3], codes[9]]:
             continue
         for term in ['ELST ENERGY', 'EXCH ENERGY', 'IND ENERGY', 'DISP ENERGY', 'TOTAL ENERGY']:
             pv = ' '.join([subcode, term])
-            compare_values(refs[alpha][subcode][term], h2kc * get_variable(pv), digits, pv)  #TEST
+            compare_values(refs[alpha][subcode][term], h2kc * variable(pv), digits, pv)  #TEST
             if subcode == method:
                 gpv = ' '.join(['SAPT', term])
-                compare_values(refs[alpha][subcode][term], h2kc * get_variable(gpv), digits, gpv)  #TEST
-    compare_values(refs[alpha][method]['TOTAL ENERGY'], h2kc * get_variable('CURRENT ENERGY'), digits, 'CURRENT ENERGY')  #TEST
+                compare_values(refs[alpha][subcode][term], h2kc * variable(gpv), digits, gpv)  #TEST
+    compare_values(refs[alpha][method]['TOTAL ENERGY'], h2kc * variable('CURRENT ENERGY'), digits, 'CURRENT ENERGY')  #TEST
 
     clean()
     clean_variables()

--- a/tests/sapt7/input.dat
+++ b/tests/sapt7/input.dat
@@ -33,11 +33,11 @@ stability_analysis follow
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT ENERGY")
 
 Eref = [ -0.00415587718,  #TEST
           0.00206359843,  #TEST
@@ -61,11 +61,11 @@ stability_analysis follow
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT ENERGY")
 
 Eref = [ -0.00601846895,  #TEST
           0.00212658317,  #TEST

--- a/tests/sapt8/input.dat
+++ b/tests/sapt8/input.dat
@@ -29,11 +29,11 @@ df_basis_sapt aug-cc-pVDZ-ri
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT ENERGY")
 
 Eref = [ -0.00005818602,  #TEST
           0.00019907113,  #TEST
@@ -56,11 +56,11 @@ scf_type direct
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")
-Eind  = psi4.get_variable("SAPT IND ENERGY")
-Edisp = psi4.get_variable("SAPT DISP ENERGY")
-ET    = psi4.get_variable("SAPT ENERGY")
+Eelst = psi4.variable("SAPT ELST ENERGY")
+Eexch = psi4.variable("SAPT EXCH ENERGY")
+Eind  = psi4.variable("SAPT IND ENERGY")
+Edisp = psi4.variable("SAPT DISP ENERGY")
+ET    = psi4.variable("SAPT ENERGY")
 
 Eref = [ -0.00012024341,  #TEST
           0.00018948726,  #TEST

--- a/tests/scf-bz2/input.dat
+++ b/tests/scf-bz2/input.dat
@@ -54,4 +54,4 @@ set {
 thisenergy = energy('scf')
 
 compare_values(refnuc, bz2.nuclear_repulsion_energy(), 5, "Nuclear repulsion energy")       #TEST 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy") #TEST

--- a/tests/scf-guess-read1/input.dat
+++ b/tests/scf-guess-read1/input.dat
@@ -12,7 +12,7 @@ set scf d_convergence 6
 set basis cc-pVDZ
 energy('scf')
 
-compare_values(-76.02663273485877, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+compare_values(-76.02663273485877, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
 
 clean()
 
@@ -22,4 +22,4 @@ set scf reference uhf
 set scf guess read
 energy('scf')
 
-compare_values(-75.63211086688469, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+compare_values(-75.63211086688469, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST

--- a/tests/scf-guess-read2/input.dat
+++ b/tests/scf-guess-read2/input.dat
@@ -14,8 +14,8 @@ energy('scf')
 set guess read
 energy('scf')
 
-compare_values(-149.54395801861, get_variable('SCF TOTAL ENERGY'), 6, 'RHF SCF energy')  #TEST
-compare_values(1, get_variable('SCF ITERATIONS'), 6, 'RHF Iterations')  #TEST
+compare_values(-149.54395801861, variable('SCF TOTAL ENERGY'), 6, 'RHF SCF energy')  #TEST
+compare_values(1, variable('SCF ITERATIONS'), 6, 'RHF Iterations')  #TEST
 
 # ROHF
 oxygen.set_multiplicity(3)
@@ -27,8 +27,8 @@ energy('scf')
 set guess read
 energy('scf')
 
-compare_values(1, get_variable('SCF ITERATIONS'), 6, 'ROHF Iterations')  #TEST
-compare_values(-149.60909083608954, get_variable('SCF TOTAL ENERGY'), 6, 'ROHF SCF energy')  #TEST
+compare_values(1, variable('SCF ITERATIONS'), 6, 'ROHF Iterations')  #TEST
+compare_values(-149.60909083608954, variable('SCF TOTAL ENERGY'), 6, 'ROHF SCF energy')  #TEST
 
 # UHF
 set reference uhf
@@ -38,8 +38,8 @@ energy('scf')
 set guess read
 energy('scf')
 
-compare_values(1, get_variable('SCF ITERATIONS'), 6, 'UHF Iterations')  #TEST
-compare_values(-149.6286212486728004, get_variable('SCF TOTAL ENERGY'), 6, 'UHF SCF energy')  #TEST
+compare_values(1, variable('SCF ITERATIONS'), 6, 'UHF Iterations')  #TEST
+compare_values(-149.6286212486728004, variable('SCF TOTAL ENERGY'), 6, 'UHF SCF energy')  #TEST
 
 # Double check that SAD basis sets work #TEST
 molecule helium {                       #TEST
@@ -48,4 +48,4 @@ molecule helium {                       #TEST
 }                                       #TEST
 
 energy("SCF")                           #TEST
-compare_values(-2.8551883987270719, get_variable('SCF TOTAL ENERGY'), 6, 'UHF SCF energy')  #TEST
+compare_values(-2.8551883987270719, variable('SCF TOTAL ENERGY'), 6, 'UHF SCF energy')  #TEST

--- a/tests/scf-property/input.dat
+++ b/tests/scf-property/input.dat
@@ -30,26 +30,26 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
 
 properties('scf', properties=props)
 
-compare_values(psi4.get_variable("CURRENT ENERGY"), -38.91591819679808, 6, "SCF energy")         #TEST
-compare_values(psi4.get_variable('SCF DIPOLE X'), 0.000000000000, 4, "SCF DIPOLE X")    #TEST
-compare_values(psi4.get_variable('SCF DIPOLE Y'), 0.000000000000, 4, "SCF DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('SCF DIPOLE Z'), 0.572697798348, 4, "SCF DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE XX'), -7.664066833060, 4, "SCF QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE YY'), -6.097755074075, 4, "SCF QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE ZZ'), -7.074596012050, 4, "SCF QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE XY'), 0.000000000000, 4, "SCF QUADRUPOLE XY")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE XZ'), 0.000000000000, 4, "SCF QUADRUPOLE XZ")    #TEST
-compare_values(psi4.get_variable('SCF QUADRUPOLE YZ'), 0.000000000000, 4, "SCF QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable("CURRENT ENERGY"), -38.91591819679808, 6, "SCF energy")         #TEST
+compare_values(psi4.variable('SCF DIPOLE X'), 0.000000000000, 4, "SCF DIPOLE X")    #TEST
+compare_values(psi4.variable('SCF DIPOLE Y'), 0.000000000000, 4, "SCF DIPOLE Y")    #TEST
+compare_values(psi4.variable('SCF DIPOLE Z'), 0.572697798348, 4, "SCF DIPOLE Z")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE XX'), -7.664066833060, 4, "SCF QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE YY'), -6.097755074075, 4, "SCF QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE ZZ'), -7.074596012050, 4, "SCF QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE XY'), 0.000000000000, 4, "SCF QUADRUPOLE XY")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE XZ'), 0.000000000000, 4, "SCF QUADRUPOLE XZ")    #TEST
+compare_values(psi4.variable('SCF QUADRUPOLE YZ'), 0.000000000000, 4, "SCF QUADRUPOLE YZ")    #TEST
 
 properties('B3LYP', properties=props)
 
-compare_values(psi4.get_variable('CURRENT ENERGY'), -39.14134740550916, 6, "B3LYP energy")    #TEST
-compare_values(psi4.get_variable('B3LYP DIPOLE X'), 0.000000000000, 4, "B3LYP DIPOLE X")    #TEST
-compare_values(psi4.get_variable('B3LYP DIPOLE Y'), -0.000000000000, 4, "B3LYP DIPOLE Y")    #TEST
-compare_values(psi4.get_variable('B3LYP DIPOLE Z'), 0.641741521158, 4, "B3LYP DIPOLE Z")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE XX'), -7.616483183211, 4, "B3LYP QUADRUPOLE XX")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE YY'), -6.005896804551, 4, "B3LYP QUADRUPOLE YY")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE ZZ'), -7.021817489904, 4, "B3LYP QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE XY'), 0.000000000000, 4, "B3LYP QUADRUPOLE XY")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE XZ'), 0.000000000000, 4, "B3LYP QUADRUPOLE XZ")    #TEST
-compare_values(psi4.get_variable('B3LYP QUADRUPOLE YZ'), -0.000000000000, 4, "B3LYP QUADRUPOLE YZ")    #TEST
+compare_values(psi4.variable('CURRENT ENERGY'), -39.14134740550916, 6, "B3LYP energy")    #TEST
+compare_values(psi4.variable('B3LYP DIPOLE X'), 0.000000000000, 4, "B3LYP DIPOLE X")    #TEST
+compare_values(psi4.variable('B3LYP DIPOLE Y'), -0.000000000000, 4, "B3LYP DIPOLE Y")    #TEST
+compare_values(psi4.variable('B3LYP DIPOLE Z'), 0.641741521158, 4, "B3LYP DIPOLE Z")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE XX'), -7.616483183211, 4, "B3LYP QUADRUPOLE XX")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE YY'), -6.005896804551, 4, "B3LYP QUADRUPOLE YY")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE ZZ'), -7.021817489904, 4, "B3LYP QUADRUPOLE ZZ")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE XY'), 0.000000000000, 4, "B3LYP QUADRUPOLE XY")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE XZ'), 0.000000000000, 4, "B3LYP QUADRUPOLE XZ")    #TEST
+compare_values(psi4.variable('B3LYP QUADRUPOLE YZ'), -0.000000000000, 4, "B3LYP QUADRUPOLE YZ")    #TEST

--- a/tests/scf-response1/input.dat
+++ b/tests/scf-response1/input.dat
@@ -62,4 +62,4 @@ bench_vals = {                                  #TEST
     "TRACELESS QUADRUPOLE POLARIZABILITY ZZZZ" :   33.02770}   #TEST
 
 for k, v in bench_vals.items():                   #TEST
-    compare_values(get_variable(k), v, 3, k)      #TEST
+    compare_values(variable(k), v, 3, k)      #TEST

--- a/tests/scf-upcast-custom-basis/input.dat
+++ b/tests/scf-upcast-custom-basis/input.dat
@@ -19,7 +19,7 @@ core.IO.set_default_namespace("low")
 set basis low
 energy('hf')
 
-compare_values(-74.9634059, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+compare_values(-74.9634059, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
 
 
 core.IO.set_default_namespace('high')
@@ -29,4 +29,4 @@ set basis high
 energy('hf')
 
 
-compare_values(-76.02663273485877, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+compare_values(-76.02663273485877, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST

--- a/tests/scf11-freq-from-energies/input.dat
+++ b/tests/scf11-freq-from-energies/input.dat
@@ -1,5 +1,5 @@
 #! Test frequencies by finite differences of energies for planar C4NH4 TS
-print_stdout(' Frequencies by finite differences of energies for planar C4NH4 TS') #TEST
+print(' Frequencies by finite differences of energies for planar C4NH4 TS') #TEST
 
 molecule c4nh4 {
 -1 1

--- a/tests/scf4/input.dat
+++ b/tests/scf4/input.dat
@@ -21,7 +21,7 @@ molecule h2o {
     H 1 R 2 A
 }
 
-print_stdout(" Testing Z-matrix coordinates") #TEST
+print(" Testing Z-matrix coordinates") #TEST
 
 count = 0
 
@@ -46,7 +46,7 @@ for R in Rvals:
 
 count = 0
 
-print_stdout(" Testing polar coordinates") #TEST
+print(" Testing polar coordinates") #TEST
 
 for R in Rvals:
     for A in Avals:

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -1,6 +1,6 @@
 #! Test of all different algorithms and reference types for SCF, on singlet and triplet O2, using the cc-pVTZ basis set.
 
-print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
+print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
 
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
@@ -29,7 +29,7 @@ molecule triplet_o2 {
 singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
-print_stdout('   -Nuclear Repulsion:') #TEST
+print('   -Nuclear Repulsion:') #TEST
 compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
 compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
@@ -40,7 +40,7 @@ set {
     print 2
 }
 
-print_stdout('    -Singlet RHF:') #TEST
+print('    -Singlet RHF:') #TEST
 set scf reference rhf
 
 set scf_type pk
@@ -59,7 +59,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
 
-print_stdout('    -Singlet UHF:') #TEST
+print('    -Singlet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -78,7 +78,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
 
-print_stdout('    -Singlet CUHF:') #TEST
+print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk
@@ -105,7 +105,7 @@ set {
     print 2
 }
 
-print_stdout('    -Triplet UHF:') #TEST
+print('    -Triplet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -126,7 +126,7 @@ compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet ROHF:') #TEST
+print('    -Triplet ROHF:') #TEST
 set scf reference rohf
 
 set scf_type pk
@@ -150,7 +150,7 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet CUHF:') #TEST
+print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk

--- a/tests/simint/mp2-module/input.dat
+++ b/tests/simint/mp2-module/input.dat
@@ -44,27 +44,27 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf conv: 3 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module fnocc
 eugene = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 compare_values(mp2tot, eugene, 6, 'mp2 rhf conv: 3 fnocc')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf conv: 3 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rhf conv: 3 detci')  #TEST
 clean_variables()
 clean()
@@ -80,18 +80,18 @@ set mp2_type df
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
 print_variables()
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 rob = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, rob, 6, 'mp2 rhf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -106,9 +106,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=hf)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -124,9 +124,9 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf conv: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf conv: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -142,18 +142,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 uhf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -168,9 +168,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 uhf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 uhf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -186,18 +186,18 @@ set mp2_type conv
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 occ*')  #TEST
 #compare_values(mp2tot, ugur, 6, 'mp2 rohf conv: 2 occ*')  #TEST
 clean_variables()
 clean()
 
 set qc_module detci
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf conv: 2 detci')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf conv: 2 detci')  #TEST
 clean_variables()
 clean()
@@ -212,18 +212,18 @@ set mp2_type df
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 occ')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf df: 2 occ')  #TEST
 clean_variables()
 clean()
 
 set qc_module dfmp2
 david = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 compare_values(mp2tot, david, 6, 'mp2 rohf df: 2 dfmp2*')  #TEST
 clean_variables()
 clean()
@@ -238,9 +238,9 @@ set mp2_type cd
 
 set qc_module occ
 ugur = energy('mp2', molecule=bh_h2p)
-compare_values(scftot, get_variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(scftot, variable('hf total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, 'mp2 rohf cd: 1 occ*')  #TEST
 compare_values(mp2tot, ugur, 6, 'mp2 rohf cd: 1 occ*')  #TEST
 clean_variables()
 clean()
@@ -271,9 +271,9 @@ set freeze_core true
 #set qc_module occ
 #theme = 'mp2 grad rhf conv fc: 1 occ*'
 #retG = gradient('mp2', molecule=hf)
-#compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-#compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-#compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+#compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+#compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+#compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 #compare_matrices(mp2totg, retG, 6, theme)  #TEST
 #clean_variables()
 #clean()
@@ -291,9 +291,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad rhf conv nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -316,9 +316,9 @@ set freeze_core true
 ### set qc_module occ
 ### theme = 'mp2 grad rhf df fc: 2 occ'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -326,9 +326,9 @@ set freeze_core true
 ### set qc_module dfmp2
 ### theme = 'mp2 grad rhf df fc: 2 dfmp2*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -346,9 +346,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad rhf df nfc: 2 occ'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -356,9 +356,9 @@ set freeze_core false
 ### set qc_module dfmp2
 ### theme = 'mp2 grad rhf df nfc: 2 dfmp2*'
 ### retG = gradient('mp2', molecule=hf)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -385,9 +385,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad uhf conv nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -412,9 +412,9 @@ set freeze_core true
 ### set qc_module occ
 ### theme = 'mp2 grad uhf df fc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -434,9 +434,9 @@ set freeze_core false
 ### set qc_module occ
 ### theme = 'mp2 grad uhf df nfc: 1 occ*'
 ### retG = gradient('mp2', molecule=bh_h2p)
-### compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-### compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-### compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+### compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+### compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+### compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 ### compare_matrices(mp2totg, retG, 6, theme)  #TEST
 ### clean_variables()
 ### clean()
@@ -477,9 +477,9 @@ set points 5
 
 retG = gradient('mp2', molecule=bh_h2p)
 theme = 'mp2 grad rohf df nfc: findif'
-compare_values(scftot, get_variable('hf total energy'), 6, theme)  #TEST
-compare_values(mp2corl, get_variable('mp2 correlation energy'), 6, theme)  #TEST
-compare_values(mp2tot, get_variable('mp2 total energy'), 6, theme)  #TEST
+compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
+compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
+compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
 compare_matrices(mp2totg, retG, 6, theme)  #TEST
 clean_variables()
 clean()

--- a/tests/simint/scf5/input.dat
+++ b/tests/simint/scf5/input.dat
@@ -2,7 +2,7 @@
 
 set integral_package SIMINT
 
-print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
+print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
 
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
@@ -31,7 +31,7 @@ molecule triplet_o2 {
 singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
-print_stdout('   -Nuclear Repulsion:') #TEST
+print('   -Nuclear Repulsion:') #TEST
 compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
 compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
@@ -42,7 +42,7 @@ set {
     print 2
 }
 
-print_stdout('    -Singlet RHF:') #TEST
+print('    -Singlet RHF:') #TEST
 set scf reference rhf
 
 set scf_type pk
@@ -61,7 +61,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
 
-print_stdout('    -Singlet UHF:') #TEST
+print('    -Singlet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -80,7 +80,7 @@ set scf_type df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
 
-print_stdout('    -Singlet CUHF:') #TEST
+print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk
@@ -107,7 +107,7 @@ set {
     print 2
 }
 
-print_stdout('    -Triplet UHF:') #TEST
+print('    -Triplet UHF:') #TEST
 set scf reference uhf
 
 set scf_type pk
@@ -128,7 +128,7 @@ compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet ROHF:') #TEST
+print('    -Triplet ROHF:') #TEST
 set scf reference rohf
 
 set scf_type pk
@@ -152,7 +152,7 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet CUHF:') #TEST
+print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
 
 set scf_type pk

--- a/tests/snsmp2/cc-cc/input.dat
+++ b/tests/snsmp2/cc-cc/input.dat
@@ -29,13 +29,13 @@ no_reorient
 
 energy('sns-mp2')
 
-#compare_values( 2.57199e-02, get_variable('DF-HF/desavqz-psi-rev1 Density Matrix Overlap'),            6, "ovlhf")  #TEST
-#compare_values(-1.07132e-03, get_variable('DF-HF/desavqz-psi-rev1 Electrostatic Interaction Energy'),  6, "eshf")   #TEST
-#compare_values( 2.55943e-03, get_variable('DF-HF/desavqz-psi-rev1 Heitler-London Energy'),             6, "hl")  #TEST
-#compare_values( 2.82251e-02, get_variable('DF-MP2/desavqz-psi-rev1 Density Matrix Overlap'),           6, "ovlmp")  #TEST
-#compare_values(-1.22020e-03, get_variable('DF-MP2/desavqz-psi-rev1 Electrostatic Interaction Energy'), 6, "esmp")   #TEST
-#compare_values( 2.25913e-03, get_variable('DF-HF/desavqz-psi-rev1 CP Interaction Energy'),             5, "inthf")  #TEST
-#compare_values(-2.14025e-03, get_variable('DF-MP2/desavqz-psi-rev1 CP Interaction Energy'),            5, "intmp")  #TEST
-compare_values(-0.00213376589, get_variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
+#compare_values( 2.57199e-02, variable('DF-HF/desavqz-psi-rev1 Density Matrix Overlap'),            6, "ovlhf")  #TEST
+#compare_values(-1.07132e-03, variable('DF-HF/desavqz-psi-rev1 Electrostatic Interaction Energy'),  6, "eshf")   #TEST
+#compare_values( 2.55943e-03, variable('DF-HF/desavqz-psi-rev1 Heitler-London Energy'),             6, "hl")  #TEST
+#compare_values( 2.82251e-02, variable('DF-MP2/desavqz-psi-rev1 Density Matrix Overlap'),           6, "ovlmp")  #TEST
+#compare_values(-1.22020e-03, variable('DF-MP2/desavqz-psi-rev1 Electrostatic Interaction Energy'), 6, "esmp")   #TEST
+#compare_values( 2.25913e-03, variable('DF-HF/desavqz-psi-rev1 CP Interaction Energy'),             5, "inthf")  #TEST
+#compare_values(-2.14025e-03, variable('DF-MP2/desavqz-psi-rev1 CP Interaction Energy'),            5, "intmp")  #TEST
+compare_values(-0.00213376589, variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
 
 

--- a/tests/snsmp2/cf-o/input.dat
+++ b/tests/snsmp2/cf-o/input.dat
@@ -20,12 +20,12 @@ symmetry c1
 
 energy('sns-mp2')
 
-#compare_values( 0.02957596, get_variable('DF-HF/desavqz Density Matrix Overlap'),            6, "ovlhf")  #TEST
-#compare_values(-0.00863467, get_variable('DF-HF/desavqz Electrostatic Interaction Energy'),  6, "eshf")  #TEST
-#compare_values(-0.00143114, get_variable('DF-HF/desavqz Heitler-London Energy'),             6, "hl")  #TEST
-#compare_values( 0.03455406, get_variable('DF-MP2/desavqz Density Matrix Overlap'),           6, "ovlmp")  #TEST
-#compare_values(-0.00841727, get_variable('DF-MP2/desavqz Electrostatic Interaction Energy'), 6, "esmp")  #TEST
-#compare_values(-0.00348609, get_variable('DF-HF/desavqz CP Interaction Energy'),             5, "inthf")  #TEST
-#compare_values(-0.00597490, get_variable('DF-MP2/desavqz CP Interaction Energy'),            5, "intmp")  #TEST
-compare_values( -0.00618314810, get_variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
+#compare_values( 0.02957596, variable('DF-HF/desavqz Density Matrix Overlap'),            6, "ovlhf")  #TEST
+#compare_values(-0.00863467, variable('DF-HF/desavqz Electrostatic Interaction Energy'),  6, "eshf")  #TEST
+#compare_values(-0.00143114, variable('DF-HF/desavqz Heitler-London Energy'),             6, "hl")  #TEST
+#compare_values( 0.03455406, variable('DF-MP2/desavqz Density Matrix Overlap'),           6, "ovlmp")  #TEST
+#compare_values(-0.00841727, variable('DF-MP2/desavqz Electrostatic Interaction Energy'), 6, "esmp")  #TEST
+#compare_values(-0.00348609, variable('DF-HF/desavqz CP Interaction Energy'),             5, "inthf")  #TEST
+#compare_values(-0.00597490, variable('DF-MP2/desavqz CP Interaction Energy'),            5, "intmp")  #TEST
+compare_values( -0.00618314810, variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
 

--- a/tests/snsmp2/he-he/input.dat
+++ b/tests/snsmp2/he-he/input.dat
@@ -9,5 +9,5 @@ He 2 0 0
 
 energy('sns-mp2')
 
-compare_values(  0.00176708227, get_variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
+compare_values(  0.00176708227, variable('SNS-MP2 TOTAL ENERGY'),                         5, "SNS-MP2 IE [Eh]")  #TEST
 

--- a/tests/stability1/input.dat
+++ b/tests/stability1/input.dat
@@ -41,7 +41,7 @@ set = {
 
 thisenergy = energy('scf')
 
-stab = get_array_variable("SCF STABILITY EIGENVALUES")
+stab = variable("SCF STABILITY EIGENVALUES")
 
 compare_values(nucenergy, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
 compare_values(refenergy, thisenergy, 9, "Reference energy")                            #TEST
@@ -76,7 +76,7 @@ set = {
 
 thisenergy = energy('scf')
 
-stab = get_array_variable("SCF STABILITY EIGENVALUES")
+stab = variable("SCF STABILITY EIGENVALUES")
 
 compare_values(nucenergy, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
 compare_values(refenergy, thisenergy, 9, "Reference energy")                            #TEST
@@ -86,7 +86,7 @@ set scf_type pk
 
 thisenergy = energy('scf')
 
-stab = get_array_variable("SCF STABILITY EIGENVALUES")
+stab = variable("SCF STABILITY EIGENVALUES")
 
 compare_values(nucenergy, bh.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
 compare_values(refenergy, thisenergy, 9, "Reference energy")                            #TEST

--- a/tests/stability2/input.dat
+++ b/tests/stability2/input.dat
@@ -42,7 +42,7 @@ set = {
 
 thisenergy = energy('scf')
 
-stab = get_array_variable("SCF STABILITY EIGENVALUES")
+stab = variable("SCF STABILITY EIGENVALUES")
 
 compare_values(nucenergy, cn.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
 compare_values(refenergy, thisenergy, 9, "Reference energy")                            #TEST

--- a/tests/tu1-h2o-energy/input.dat
+++ b/tests/tu1-h2o-energy/input.dat
@@ -12,8 +12,7 @@ molecule h2o {
 set basis cc-pVDZ
 energy('scf')
 
-
-compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
+compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
 compare_csx()  #TEST
 
 

--- a/tests/tu1-h2o-energy/input.dat
+++ b/tests/tu1-h2o-energy/input.dat
@@ -13,7 +13,3 @@ set basis cc-pVDZ
 energy('scf')
 
 compare_values(-76.0266327341067125, variable('SCF TOTAL ENERGY'), 6, 'SCF energy')  #TEST
-compare_csx()  #TEST
-
-
-

--- a/tests/tu2-ch2-energy/input.dat
+++ b/tests/tu2-ch2-energy/input.dat
@@ -14,4 +14,4 @@ set basis 6-31G**
 set reference uhf
 energy ('scf')
 
-compare_values(-38.9253346245799605, get_variable('scf total energy'), 6, 'SCF energy')  #TEST
+compare_values(-38.9253346245799605, variable('scf total energy'), 6, 'SCF energy')  #TEST

--- a/tests/tu3-h2o-opt/input.dat
+++ b/tests/tu3-h2o-opt/input.dat
@@ -13,4 +13,4 @@ set basis cc-pVDZ
 optimize('scf')
 
 compare_values(nucenergy, h2o.nuclear_repulsion_energy(), 3, "Nuclear repulsion energy")    #TEST
-compare_values(refenergy, get_variable("CURRENT ENERGY"), 4, "Reference energy") #TEST
+compare_values(refenergy, variable("CURRENT ENERGY"), 4, "Reference energy") #TEST

--- a/tests/tu5-sapt/input.dat
+++ b/tests/tu5-sapt/input.dat
@@ -26,11 +26,11 @@ set {
 
 energy('sapt0')
 
-Eelst = psi4.get_variable("SAPT ELST ENERGY")   #TEST
-Eexch = psi4.get_variable("SAPT EXCH ENERGY")   #TEST
-Eind  = psi4.get_variable("SAPT IND ENERGY")    #TEST
-Edisp = psi4.get_variable("SAPT DISP ENERGY")   #TEST
-ET    = psi4.get_variable("SAPT0 TOTAL ENERGY")  #TEST
+Eelst = psi4.variable("SAPT ELST ENERGY")   #TEST
+Eexch = psi4.variable("SAPT EXCH ENERGY")   #TEST
+Eind  = psi4.variable("SAPT IND ENERGY")    #TEST
+Edisp = psi4.variable("SAPT DISP ENERGY")   #TEST
+ET    = psi4.variable("SAPT0 TOTAL ENERGY")  #TEST
 
 Eref = [ 85.1890645313,  -0.003378388762,  0.003704416103,  #TEST
          -0.000889316601,  -0.001672292164, -0.002235581423 ] #TEST

--- a/tests/v2rdm_casscf/v2rdm1/input.dat
+++ b/tests/v2rdm_casscf/v2rdm1/input.dat
@@ -45,6 +45,6 @@ refv2rdm = -103.086205379481   # TEST
 
 energy('v2rdm-casscf', molecule=n2)
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy") # TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy") # TEST
 

--- a/tests/v2rdm_casscf/v2rdm2/input.dat
+++ b/tests/v2rdm_casscf/v2rdm2/input.dat
@@ -35,6 +35,6 @@ refv2rdm = -109.094404909477   # TEST
 
 energy('v2rdm-casscf')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy") # TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 5, "v2RDM-CASSCF total energy") # TEST
 

--- a/tests/v2rdm_casscf/v2rdm5/input.dat
+++ b/tests/v2rdm_casscf/v2rdm5/input.dat
@@ -35,6 +35,6 @@ refv2rdm = -109.091487394061   # TEST
 
 energy('v2rdm-casscf')
 
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy") # TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy") # TEST
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy") # TEST
 

--- a/tests/v2rdm_casscf/v2rdm6/input.dat
+++ b/tests/v2rdm_casscf/v2rdm6/input.dat
@@ -38,6 +38,6 @@ refscf   = -108.95016246035139    #TEST
 refv2rdm = -109.095505119442      #TEST
 
 compare_values(refnuc,   n2.nuclear_repulsion_energy(),  3, "Nuclear repulsion energy")   #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 4, "SCF total energy")           #TEST
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")  #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 4, "SCF total energy")           #TEST
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")  #TEST
 

--- a/tests/x2c1/input.dat
+++ b/tests/x2c1/input.dat
@@ -70,11 +70,11 @@ D   1   1.00
 }
 
 ccsd_nr_energy = energy('ccsd')
-scf_nr_energy = psi4.get_variable("HF TOTAL ENERGY")
+scf_nr_energy = psi4.variable("HF TOTAL ENERGY")
 set relativistic x2c
 set basis_relativistic adecon  # shouldn't need to specify
 ccsd_rel_energy = energy('ccsd')
-scf_rel_energy = psi4.get_variable("HF TOTAL ENERGY")
+scf_rel_energy = psi4.variable("HF TOTAL ENERGY")
 
 compare_values(ref_nuc_energy, h2o.nuclear_repulsion_energy(), 8, "Nuclear repulsion energy") #TEST
 compare_values(scf_ref_nr_energy, scf_nr_energy, 8, "Non-relativistic SCF energy")            #TEST

--- a/tests/zaptn-nh2/input.dat
+++ b/tests/zaptn-nh2/input.dat
@@ -26,6 +26,6 @@ thisenergy = energy('zapt25')
 
 compare_values(refnuc, nh2.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST 
 # Seems to be hard to match PSI3 for ROHF energies to more than 7 digits #TEST
-compare_values(refscf, get_variable("SCF total energy"),     7, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),     7, "SCF energy") #TEST
 compare_values(refci, thisenergy,                      7, "ZAPT(25) energy") #TEST
-compare_values(refcorr, get_variable("CURRENT CORRELATION ENERGY"), 7, "ZAPT(25) correlation energy") #TEST
+compare_values(refcorr, variable("CURRENT CORRELATION ENERGY"), 7, "ZAPT(25) correlation energy") #TEST


### PR DESCRIPTION
## Description
This should follow directly after #1393 (for the moment, includes it) because otherwise users will get all the deprecation warnings not only from their own input files but from the driver itself. Think of how many times `get_variable` is called, and you'll see the magnitude.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] updates syntax py-side and c-side and example-side so that if all the deprecated functions went away (obviously, this is how I tested it), Psi4 would still work nicely

## Notes
- snsmp2 raises a warning b/c it's using the `get_variable`. but that's the purpose of deprecation warnings -- to allow downstream to exist with multiple versions of upstream.
- I'll still need to investigate whether the "culprit line" is right, given our psithon/psiapi and namespace promotion complications

## Checklist
- [ ] ~Tests added for any new features~
- [x] full test suite, less a few addons

## Status
- [x] Ready for review **look only at "update driver for PsiPEP002" commit. Previous are #1393 and following is just the tests**
- [x] Ready for merge
