### PR TITLE
dft: "B97" conceded to Grimme

### DIFF
--- a/psi4/driver/procrouting/dft/libxc_functionals.py
+++ b/psi4/driver/procrouting/dft/libxc_functionals.py
@@ -73,7 +73,7 @@ funcs.append({"name": "B3P86"          , "xc_functionals": {"HYB_GGA_XC_B3P86"  
 funcs.append({"name": "O3LYP"          , "xc_functionals": {"HYB_GGA_XC_O3LYP"          : {}}})
 funcs.append({"name": "mPW1K"          , "xc_functionals": {"HYB_GGA_XC_mPW1K"          : {}}})
 funcs.append({"name": "PBE0"           , "xc_functionals": {"HYB_GGA_XC_PBEH"           : {}}, "alias": ["PBEH"]})
-funcs.append({"name": "B97"            , "xc_functionals": {"HYB_GGA_XC_B97"            : {}}, "alias": ["B97-0"]})
+funcs.append({"name": "B97-0"          , "xc_functionals": {"HYB_GGA_XC_B97"            : {}}})
 funcs.append({"name": "B97-1"          , "xc_functionals": {"HYB_GGA_XC_B97_1"          : {}}})
 funcs.append({"name": "B97-2"          , "xc_functionals": {"HYB_GGA_XC_B97_2"          : {}}})
 funcs.append({"name": "X3LYP"          , "xc_functionals": {"HYB_GGA_XC_X3LYP"          : {}}})


### PR DESCRIPTION
## Description
So the reason there haven't been conda packages for a while is `dft1-alt` is non-deterministically broken on py35. Further investigation shows that the `energy('b97-d')` call was sometimes Grimme GGA for XC and sometimes Becke hybrid but always Grimme dispersion (unordered dicts, remember). Probably introduced by #1151 when I stopped listing `b97-d` as an XC of its own and special casing the processing. The proposed sol'n -- conceding "B97" to Grimme and calling the original hyb "B97-0" -- isn't great or historically sound. But I think it's workable.

## Checklist
- [x] a ctest command in py35 that failed 2/6 runs before failed 0/6 runs after

## Status
- [x] Ready for review
- [x] Ready for merge
