### PR TITLE
Check for explicitly defined dispersion corrections first.

### DIFF
--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -121,11 +121,19 @@ for functional_name in dict_functionals:
     for alias in functional_aliases:
         functionals[alias] = dict_functionals[functional_name]
 
-    # if the parent functional is already dispersion corrected, skip to next
+    # if the parent functional is already dispersion corrected:
     if "dispersion" in dict_functionals[functional_name]:
         disp = dict_functionals[functional_name]['dispersion']
-        dashcoeff_supplement[disp['type']]['definitions'][functional_name] = disp
-        # this is to "bless" dft/*_functionals dispersion definitions
+        for formal in functional_aliases:
+            # "bless" the original functional dft/*_functionals dispersion definition including aliases
+            dashcoeff_supplement[disp['type']]['definitions'][formal] = disp
+            # generate dispersion aliases for every functional alias
+            for nominal_dispersion_level, resolved_dispersion_level in _dispersion_aliases.items():
+                if resolved_dispersion_level.lower() == disp["type"]:
+                    alias = formal.replace(disp["type"], nominal_dispersion_level.lower())
+                    if alias not in functionals:
+                        dashcoeff_supplement[disp['type']]['definitions'][formal] = disp
+                        functionals[alias] = dict_functionals[functional_name]
         continue
 
     # else loop through dispersion types in dashparams (also considering aliases)
@@ -137,8 +145,8 @@ for functional_name in dict_functionals:
             formal = functional_name + "-" + resolved_dispersion_level
             for alias in functional_aliases:
                 alias += "-" + nominal_dispersion_level.lower()
-                if formal != alias:
-                    functionals[alias] = copy.deepcopy(dict_functionals[formal])
+                if alias not in functionals:
+                    functionals[alias] = dict_functionals[formal]
         # if not, build it from dashparam logic if possible
         else:
             for dispersion_functional in intf_dftd3.dashcoeff[resolved_dispersion_level]['definitions']:
@@ -376,7 +384,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
         if "citation" not in d_params:
             d_params["citation"] = False
         if "nlc" in d_params:
-            sup.set_vv10_b(-1.0) 
+            sup.set_vv10_b(-1.0)
             sup.set_do_vv10(d_params["nlc"])
         if d_params["type"] == 'nl':
             sup.set_vv10_b(d_params["params"]["b"])

--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -129,7 +129,7 @@ for functional_name in dict_functionals:
             dashcoeff_supplement[disp['type']]['definitions'][formal] = disp
             # generate dispersion aliases for every functional alias
             for nominal_dispersion_level, resolved_dispersion_level in _dispersion_aliases.items():
-                if resolved_dispersion_level.lower() == disp["type"]:
+                if resolved_dispersion_level == disp["type"]:
                     alias = formal.replace(disp["type"], nominal_dispersion_level.lower())
                     if alias not in functionals:
                         dashcoeff_supplement[disp['type']]['definitions'][formal] = disp

--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -131,18 +131,28 @@ for functional_name in dict_functionals:
     # else loop through dispersion types in dashparams (also considering aliases)
     #   and build dispersion corrected version (applies also for aliases)
     for nominal_dispersion_level, resolved_dispersion_level in _dispersion_aliases.items():
-        for dispersion_functional in intf_dftd3.dashcoeff[resolved_dispersion_level]['definitions']:
-            if dispersion_functional.lower() in functional_aliases:
-                func = copy.deepcopy(dict_functionals[functional_name])
-                func["name"] += "-" + resolved_dispersion_level
-                func["dispersion"] = copy.deepcopy(intf_dftd3.dashcoeff[resolved_dispersion_level]['definitions'][dispersion_functional])
-                func["dispersion"]["type"] = resolved_dispersion_level
+        # first check whether there is a pre-defined dispersion corrected functional
+        # of the same resolved_dispersion_level type
+        if functional_name + "-" + resolved_dispersion_level in dict_functionals:
+            formal = functional_name + "-" + resolved_dispersion_level
+            for alias in functional_aliases:
+                alias += "-" + nominal_dispersion_level.lower()
+                if formal != alias:
+                    functionals[alias] = copy.deepcopy(dict_functionals[formal])
+        # if not, build it from dashparam logic if possible
+        else:
+            for dispersion_functional in intf_dftd3.dashcoeff[resolved_dispersion_level]['definitions']:
+                if dispersion_functional.lower() in functional_aliases:
+                    func = copy.deepcopy(dict_functionals[functional_name])
+                    func["name"] += "-" + resolved_dispersion_level
+                    func["dispersion"] = copy.deepcopy(intf_dftd3.dashcoeff[resolved_dispersion_level]['definitions'][dispersion_functional])
+                    func["dispersion"]["type"] = resolved_dispersion_level
 
-                # this ensures that M06-2X-D3, M06-2X-D3ZERO, M062X-D3 or M062X-D3ZERO
-                #   all point to the same method (M06-2X-D3ZERO)
-                for alias in functional_aliases:
-                    alias += "-" + nominal_dispersion_level.lower()
-                    functionals[alias] = func
+                    # this ensures that M06-2X-D3, M06-2X-D3ZERO, M062X-D3 or M062X-D3ZERO
+                    #   all point to the same method (M06-2X-D3ZERO)
+                    for alias in functional_aliases:
+                        alias += "-" + nominal_dispersion_level.lower()
+                        functionals[alias] = func
 
 
 def check_consistency(func_dictionary):

--- a/psi4/driver/procrouting/dft/dh_functionals.py
+++ b/psi4/driver/procrouting/dft/dh_functionals.py
@@ -110,7 +110,6 @@ funcs.append({
 
 funcs.append({
     "name": "DSD-BLYP-D3BJ",
-    "alias": ["DSD-BLYP-D3(BJ)"],
     "x_functionals": {
         "GGA_X_B88": {
             "alpha": 0.29
@@ -275,7 +274,6 @@ funcs.append({
 
 funcs.append({
     "name": "DSD-PBEP86-D3BJ",
-    "alias": ["DSD-PBEP86-D3(BJ)"],
     "x_functionals": {
         "GGA_X_PBE": {
             "alpha": 0.31
@@ -431,7 +429,6 @@ funcs.append({
 
 funcs.append({
     "name": "DSD-PBEPBE-D3BJ",
-    "alias": ["DSD-PBEPBE-D3(BJ)"],
     "x_functionals": {
         "GGA_X_PBE": {
             "alpha": 0.32
@@ -707,7 +704,6 @@ funcs.append({
 
 funcs.append({
     "name": "DSD-PBEB95-D3BJ",
-    "alias": ["DSD-PBEB95-D3(BJ)"],
     "x_functionals": {
         "GGA_X_PBE": {
             "alpha": 0.34

--- a/psi4/driver/procrouting/dft/gga_functionals.py
+++ b/psi4/driver/procrouting/dft/gga_functionals.py
@@ -223,7 +223,6 @@ funcs.append({
 
 funcs.append({
     "name": "B97-D2",
-    "alias": ["B97-D"],
     "xc_functionals": {
         "GGA_XC_B97_D": {}
     },
@@ -238,8 +237,7 @@ funcs.append({
 })
 
 funcs.append({
-    "name": "B97-D3",
-    "alias": ["B97-D3ZERO"],
+    "name": "B97-D3ZERO",
     "xc_functionals": {
         "GGA_XC_B97_D": {}
     },
@@ -257,7 +255,6 @@ funcs.append({
 
 funcs.append({
     "name": "B97-D3BJ",
-    "alias": ["B97-D3(BJ)"],
     "xc_functionals": {
         "GGA_XC_B97_D": {}
     },
@@ -273,8 +270,7 @@ funcs.append({
 })
 
 funcs.append({
-    "name": "B97-D3M",
-    "alias": ["B97-D3MZERO"],
+    "name": "B97-D3MZERO",
     "xc_functionals": {
         "GGA_XC_B97_D": {}
     },
@@ -291,7 +287,6 @@ funcs.append({
 
 funcs.append({
     "name": "B97-D3MBJ",
-    "alias": ["B97-D3M(BJ)"],
     "xc_functionals": {
         "GGA_XC_B97_D": {}
     },

--- a/psi4/driver/procrouting/dft/hyb_functionals.py
+++ b/psi4/driver/procrouting/dft/hyb_functionals.py
@@ -562,7 +562,6 @@ funcs.append({
 
 funcs.append({
     "name": "wB97M-D3BJ",
-    "alias": ["wB97M-D3(BJ)"],
     "xc_functionals": {
         "HYB_MGGA_XC_WB97M_V": {}
     },
@@ -584,7 +583,6 @@ funcs.append({
 
 funcs.append({
     "name": "wB97X-D3BJ",
-    "alias": ["wB97X-D3(BJ)"],
     "xc_functionals": {
         "HYB_GGA_XC_WB97X_V": {}
     },

--- a/psi4/driver/procrouting/dft/mgga_functionals.py
+++ b/psi4/driver/procrouting/dft/mgga_functionals.py
@@ -187,7 +187,6 @@ funcs.append({
 
 funcs.append({
     "name": "B97M-D3BJ",
-    "alias": ["B97M-D3(BJ)"],
     "xc_functionals": {
         "MGGA_XC_B97M_V": {}
     },


### PR DESCRIPTION
## Description
Resolves #1404. This makes `dsd-blyp-d3(bj)` pull data from `dsd-blyp-d3bj`, as opposed to `dsd-blyp` + `dashparam["d3bj"]["dsd-blyp"]`. Currently affected functionals are:

```
created b97-0-d2 from b97-d2
created b97-0-d from b97-d2
created b97-d from b97-d2
created b97-0-d3bj from b97-d3bj
created b97-0-d3(bj) from b97-d3bj
created b97-d3(bj) from b97-d3bj
created b97-0-d3mbj from b97-d3mbj
created b97-0-d3m(bj) from b97-d3mbj
created b97-d3m(bj) from b97-d3mbj
created dsd-blyp-d from dsd-blyp-d2
created dsd-blyp-d3(bj) from dsd-blyp-d3bj
created dsdpbep86-d2 from dsd-pbep86-d2
created dsdpbep86-d from dsd-pbep86-d2
created dsd-pbep86-d from dsd-pbep86-d2
created dsdpbep86-d3bj from dsd-pbep86-d3bj
created dsdpbep86-d3(bj) from dsd-pbep86-d3bj
created dsd-pbep86-d3(bj) from dsd-pbep86-d3bj
created dsdpbep86-nl from dsd-pbep86-nl
created dsdpbepbe-d2 from dsd-pbepbe-d2
created dsdpbepbe-d from dsd-pbepbe-d2
created dsd-pbepbe-d from dsd-pbepbe-d2
created dsdpbepbe-d3bj from dsd-pbepbe-d3bj
created dsdpbepbe-d3(bj) from dsd-pbepbe-d3bj
created dsd-pbepbe-d3(bj) from dsd-pbepbe-d3bj
created dsdpbepbe-nl from dsd-pbepbe-nl
created dsd-pbeb95-d from dsd-pbeb95-d2
created dsd-pbeb95-d3(bj) from dsd-pbeb95-d3bj
```

The `B97-0` and `B97-D2` mess will have to wait until #1403 is merged.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [X] When a functional has a defined dispersion version, aliases are copied from that, as opposed to the `dashparam` data.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
