### PR TITLE
Unpin MKL for Windows builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,7 @@ jobs:
           conda install --channel conda-forge ^
                         cmake ^
                         deepdiff ^
-                        intel-openmp=2018.0.3 ^
-                        mkl-devel=2018.0.3 ^
+                        mkl-devel ^
                         mpmath ^
                         networkx ^
                         ninja ^


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

Some time ago (#1240), MKL version had to be pinned for Windows builds. Now it is fixed and the latest version could be used.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Unpin MKL version

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
