### PR TITLE
Add opt-full-hess-every test only when MAX_AM_ERI is high enough

### DIFF
--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -216,7 +216,7 @@ TwoBodyAOInt* IntegralFactory::erd_eri(int deriv, bool use_shell_pairs) {
 #ifdef USING_erd
     if (deriv == 0 && integral_package == "ERD") return new ERDERI(this, deriv, use_shell_pairs);
 #endif
-    if (deriv > 0) outfile->Printf("ERI derivative integrals only available using Libint");
+    if (deriv > 0 && integral_package != "LIBINT") outfile->Printf("ERI derivative integrals only available using Libint");
     if (integral_package == "SIMINT" || integral_package == "ERD")
         outfile->Printf("Chosen integral package " + integral_package +
                         " unavailable.\nRecompile with the appropriate option set.\nFalling back to Libint");
@@ -231,7 +231,7 @@ TwoBodyAOInt* IntegralFactory::eri(int deriv, bool use_shell_pairs) {
 #ifdef USING_erd
     if (deriv == 0 && integral_package == "ERD") return new ERDERI(this, deriv, use_shell_pairs);
 #endif
-    if (deriv > 0) outfile->Printf("ERI derivative integrals only available using Libint");
+    if (deriv > 0 && integral_package != "LIBINT") outfile->Printf("ERI derivative integrals only available using Libint");
     if (integral_package == "SIMINT" || integral_package == "ERD")
         outfile->Printf("Chosen integral package " + integral_package +
                         " unavailable.\nRecompile with the appropriate option set.\nFalling back to Libint");

--- a/tests/opt-full-hess-every/CMakeLists.txt
+++ b/tests/opt-full-hess-every/CMakeLists.txt
@@ -1,3 +1,5 @@
 include(TestingMacros)
 
-add_regression_test(opt-full-hess-every "psi;quicktests;opt")
+if(MAX_AM_ERI GREATER_EQUAL 6)
+    add_regression_test(opt-full-hess-every "psi;quicktests;opt")
+endif()


### PR DESCRIPTION
## Description
The default `MAX_AM_ERI` isn't high enough to perform this test.  Add it only when it is configured high enough.

## Status
- [x] Ready for review
- [x] Ready for merge
