### PR TITLE
Fix path handling and psithon2 test on Windows

### DIFF
--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -229,13 +229,13 @@ def database(name, db_name, **kwargs):
     kwargs.pop('molecule', None)
 
     # Paths to search for database files: here + PSIPATH + library + PYTHONPATH
-    dbPaths = []
-    dbPaths.append(os.getcwd())
-    dbPaths.extend(os.environ.get('PSIPATH', '').split(os.path.pathsep))
-    dbPaths.append(os.path.join(core.get_datadir(), 'databases'))
-    dbPaths.append(os.path.dirname(__file__))
-    dbPaths = list(map(os.path.abspath, dbPaths))
-    sys.path = dbPaths + sys.path
+    db_paths = []
+    db_paths.append(os.getcwd())
+    db_paths.extend(os.environ.get('PSIPATH', '').split(os.path.pathsep))
+    db_paths.append(os.path.join(core.get_datadir(), 'databases'))
+    db_paths.append(os.path.dirname(__file__))
+    db_paths = list(map(os.path.abspath, db_paths))
+    sys.path[1:1] = db_paths
     # TODO this should be modernized a la interface_cfour
 
     # Define path and load module for requested database

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -229,16 +229,13 @@ def database(name, db_name, **kwargs):
     kwargs.pop('molecule', None)
 
     # Paths to search for database files: here + PSIPATH + library + PYTHONPATH
-    psidatadir = core.get_datadir()
-    #nolongerpredictable psidatadir = __file__ + '/../..' if psidatadir is None else psidatadir
-    libraryPath = ':' + os.path.abspath(psidatadir) + '/databases'
-    driver_loc = os.path.dirname(os.path.abspath(__file__))
-    dbPath = os.path.abspath('.') + \
-        ':' + ':'.join([os.path.abspath(x) for x in os.environ.get('PSIPATH', '').split(':')]) + \
-        libraryPath + \
-        ':' + driver_loc  # so the databases can "import qcdb"
-
-    sys.path = [sys.path[0]] + dbPath.split(':') + sys.path[1:]
+    dbPaths = []
+    dbPaths.append(os.getcwd())
+    dbPaths.extend(os.environ.get('PSIPATH', '').split(os.path.pathsep))
+    dbPaths.append(os.path.join(core.get_datadir(), 'databases'))
+    dbPaths.append(os.path.dirname(__file__))
+    dbPaths = list(map(os.path.abspath, dbPaths))
+    sys.path = dbPaths + sys.path
     # TODO this should be modernized a la interface_cfour
 
     # Define path and load module for requested database

--- a/tests/psithon2/input.dat
+++ b/tests/psithon2/input.dat
@@ -1,7 +1,7 @@
 #! Accesses basis sets, databases, plugins, and executables in non-install locations
 
 import os
-os.environ['PSIPATH'] = 'psiaux1:psiaux2'
+os.environ['PSIPATH'] = os.path.pathsep.join(['psiaux1', 'psiaux2'])
 
 ###########################
 molecule h2o {


### PR DESCRIPTION
## Description

This is part of Psi4 porting to Windows (#933).

`psithon2` test fails on Windows:
```
2018-12-05T15:52:01.1057243Z 8/9 Test #307: psithon2 .........................***Failed   24.86 sec
2018-12-05T15:52:01.1057730Z 	Built-in energy...................................................PASSED
2018-12-05T15:52:01.1059103Z 	PSIPATH database..................................................PASSED
2018-12-05T15:52:01.1059291Z 	Built-in database.................................................PASSED
2018-12-05T15:52:01.1059763Z 	PSIPATH plugin....................................................PASSED
2018-12-05T15:52:01.1059834Z 
2018-12-05T15:52:01.1060236Z QcdbException BasisSetNotFound: BasisSet::construct: Unable to find a basis set for atom 1 for key BASIS among:
2018-12-05T15:52:01.1060376Z   Shell Entries: ['O']
2018-12-05T15:52:01.1060874Z   Basis Sets: [('MYSTO3G', 'MYSTO3G', None)]
2018-12-05T15:52:01.1061043Z   File Path: D:\a\1\b\build\tests\psithon2, D:\a\1\b\build\tests\psithon2\psiaux1:psiaux2, D:\a\1\b\build\stage\share\psi4\basis
2018-12-05T15:52:01.1061446Z   Input Blocks: 
2018-12-05T15:52:01.1061509Z 
2018-12-05T15:52:01.1061540Z 
2018-12-05T15:52:01.1061649Z 
2018-12-05T15:52:01.1061699Z Traceback (most recent call last):
2018-12-05T15:52:01.1062102Z   File "D:/a/1/b/build/stage/bin/psi4", line 272, in <module>
2018-12-05T15:52:01.1062185Z     exec(content)
2018-12-05T15:52:01.1062629Z   File "<string>", line 68, in <module>
2018-12-05T15:52:01.1062767Z   File "D:\a\1\b\build\stage\lib\psi4\driver\driver.py", line 545, in energy
2018-12-05T15:52:01.1063166Z     wfn = procedures['energy'][lowername](lowername, molecule=molecule, **kwargs)
2018-12-05T15:52:01.1063257Z   File "D:\a\1\b\build\stage\lib\psi4\driver\procrouting\proc.py", line 2022, in run_scf
2018-12-05T15:52:01.1063640Z     scf_wfn = scf_helper(name, post_scf=False, **kwargs)
2018-12-05T15:52:01.1063739Z   File "D:\a\1\b\build\stage\lib\psi4\driver\procrouting\proc.py", line 1281, in scf_helper
2018-12-05T15:52:01.1064223Z     base_wfn = core.Wavefunction.build(scf_molecule, core.get_global_option('BASIS'))
2018-12-05T15:52:01.1064321Z   File "D:\a\1\b\build\stage\lib\psi4\driver\p4util\python_helpers.py", line 116, in pybuild_wavefunction
2018-12-05T15:52:01.1064724Z     basis = core.BasisSet.build(mol, "ORBITAL", basis)
2018-12-05T15:52:01.1064814Z   File "D:\a\1\b\build\stage\lib\psi4\driver\p4util\python_helpers.py", line 78, in pybuild_basis
2018-12-05T15:52:01.1065478Z     return_atomlist=return_atomlist)
2018-12-05T15:52:01.1065645Z   File "D:\a\1\b\build\stage\lib\psi4\driver\qcdb\libmintsbasisset.py", line 684, in pyconstruct
2018-12-05T15:52:01.1065754Z     verbose=verbose)
2018-12-05T15:52:01.1065810Z   File "D:\a\1\b\build\stage\lib\psi4\driver\qcdb\libmintsbasisset.py", line 902, in construct
2018-12-05T15:52:01.1065961Z     (at + 1, key, text2))
2018-12-05T15:52:01.1066510Z 
2018-12-05T15:52:01.1066674Z BasisSetNotFound: BasisSet::construct: Unable to find a basis set for atom 1 for key BASIS among:
2018-12-05T15:52:01.1067070Z   Shell Entries: ['O']
2018-12-05T15:52:01.1067208Z   Basis Sets: [('MYSTO3G', 'MYSTO3G', None)]
2018-12-05T15:52:01.1067274Z   File Path: D:\a\1\b\build\tests\psithon2, D:\a\1\b\build\tests\psithon2\psiaux1:psiaux2, D:\a\1\b\build\stage\share\psi4\basis
2018-12-05T15:52:01.1067365Z   Input Blocks: 
2018-12-05T15:52:01.1067711Z 
2018-12-05T15:52:01.1067830Z Exit Status: infile ( 1 ); autotest ( None ); sowreap ( None ); overall ( 1 )
2018-12-05T15:52:01.1067917Z 
```

The result of the fix will be visible when #1399 is merged.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix path handling in `psi4.driver.wrapper_dababase.dabatabe`
- [x] Fix `psithon2` test

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
