### PR TITLE
Fix bug that prevents setting a local string/int option from the py-side if module != current_module

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -614,10 +614,14 @@ bool py_psi_set_global_option_double(std::string const& key, double value) {
 bool py_psi_set_local_option_array(std::string const& module, std::string const& key, const py::list& values,
                                    DataType* entry = nullptr) {
     std::string nonconst_key = to_upper(key);
+
     // Assign a new head entry on the first time around only
     if (entry == nullptr) {
         // We just do a cheesy "get" to make sure keyword is valid.  This get will throw if not.
+        std::string module_temp = Process::environment.options.get_current_module();
+        Process::environment.options.set_current_module(module);
         Data& data = Process::environment.options[nonconst_key];
+        Process::environment.options.set_current_module(module_temp);
         // This "if" statement is really just here to make sure the compiler doesn't optimize out the get, above.
         if (data.type() == "array") Process::environment.options.set_array(module, nonconst_key);
     }
@@ -700,7 +704,10 @@ bool py_psi_set_global_option_array_wrapper(std::string const& key, py::list val
 
 void py_psi_set_local_option_python(const std::string& key, py::object& obj) {
     std::string nonconst_key = to_upper(key);
+    std::string module_temp = Process::environment.options.get_current_module();
+    Process::environment.options.set_current_module(module);
     Data& data = Process::environment.options[nonconst_key];
+    Process::environment.options.set_current_module(module_temp);
 
     if (data.type() == "python")
         dynamic_cast<PythonDataType*>(data.get())->assign(obj);

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -704,10 +704,7 @@ bool py_psi_set_global_option_array_wrapper(std::string const& key, py::list val
 
 void py_psi_set_local_option_python(const std::string& key, py::object& obj) {
     std::string nonconst_key = to_upper(key);
-    std::string module_temp = Process::environment.options.get_current_module();
-    Process::environment.options.set_current_module(module);
     Data& data = Process::environment.options[nonconst_key];
-    Process::environment.options.set_current_module(module_temp);
 
     if (data.type() == "python")
         dynamic_cast<PythonDataType*>(data.get())->assign(obj);

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -521,7 +521,11 @@ Options& py_psi_get_options() { return Process::environment.options; }
 
 bool py_psi_set_local_option_string(std::string const& module, std::string const& key, std::string const& value) {
     std::string nonconst_key = to_upper(key);
+
+    std::string module_temp = Process::environment.options.get_current_module();
+    Process::environment.options.set_current_module(module);
     Data& data = Process::environment.options[nonconst_key];
+    Process::environment.options.set_current_module(module_temp);
 
     if (data.type() == "string") {
         Process::environment.options.set_str(module, nonconst_key, value);
@@ -540,7 +544,11 @@ bool py_psi_set_local_option_string(std::string const& module, std::string const
 
 bool py_psi_set_local_option_int(std::string const& module, std::string const& key, int value) {
     std::string nonconst_key = to_upper(key);
+
+    std::string module_temp = Process::environment.options.get_current_module();
+    Process::environment.options.set_current_module(module);
     Data& data = Process::environment.options[nonconst_key];
+    Process::environment.options.set_current_module(module_temp);
 
     if (data.type() == "double") {
         double val = (specifies_convergence(nonconst_key)) ? pow(10.0, -value) : double(value);


### PR DESCRIPTION
## Description
Small bug fix that prevents adding local options to a module. This error shows only for `string` and `int` type options, but I potentially also in `array` and `python` data types. This PR addresses all four cases.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix option reading bug

## Questions
- In the following part of the code one can potentially encounter the same problem. This can be fixed by adding `module` to the list of parameters passed to this function. Any reason why there is no `std::string module` in the parameter list? Adding it would also make this function consistent with other `set_local_x` functions.
https://github.com/psi4/psi4/blob/396b4c51d6902301baeed41386c49ccb9099a30b/psi4/src/core.cc#L705-L707

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge