### PR TITLE
Improve the default path on Winodws

### DIFF
--- a/psi4/src/psi4/libpsio/filemanager.cc
+++ b/psi4/src/psi4/libpsio/filemanager.cc
@@ -48,7 +48,12 @@ namespace psi {
 PSIOManager::PSIOManager() {
     pid_ = psio_getpid();
 #ifdef _MSC_VER
-    set_default_path("C:\\");
+    if (const char* path = std::getenv("TEMP"))
+        set_default_path(path);
+    else if (const char* path = std::getenv("TMP"))
+        set_default_path(path);
+    else
+        set_default_path("C:");
 #else
     set_default_path("/tmp");
 #endif


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

Make *Psi4* to work without setting `PSI_SCRATCH`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Set the default path to `TEMP` or `TMP` value

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
