### PR TITLE
Remove a few libmints exports

### DIFF
--- a/psi4/src/psi4/libmints/ecpint.h
+++ b/psi4/src/psi4/libmints/ecpint.h
@@ -87,7 +87,7 @@ struct ShellPairData {
  * This should not usually be created directly, it is instead owned by an ECPIntegral object,
  * so that integrals can be performed over multiple ECP centers without duplicating work.
  */
-class PSI_API AngularIntegral {
+class AngularIntegral {
    private:
     /// Maximum angular momentum of orbital basis and ECP basis, respectively
     int LB, LE;
@@ -190,7 +190,7 @@ class PSI_API AngularIntegral {
  * This should not be used directly, and is owned by ECPIntegral.
  * It provides the interface to the adaptive quadrature algorithms used to calculate the type 1 and 2 radial integrals.
  */
-class PSI_API RadialIntegral {
+class RadialIntegral {
    private:
     /// The larger integration grid for type 1 integrals, and for when the smaller grid fails for type 2 integrals
     GCQuadrature bigGrid;

--- a/psi4/src/psi4/libmints/potentialint.h
+++ b/psi4/src/psi4/libmints/potentialint.h
@@ -194,7 +194,7 @@ void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor) {
     }  // End loop over shell 1
 }
 
-class PSI_API PrintIntegralsFunctor {
+class PrintIntegralsFunctor {
    public:
     /**
      * A functor, to be used with PCMPotentialInt, that just prints the integrals out for debugging
@@ -204,7 +204,7 @@ class PSI_API PrintIntegralsFunctor {
     }
 };
 
-class PSI_API ContractOverDensityFunctor {
+class ContractOverDensityFunctor {
     /**
      * A functor, to be used with PCMPotentialInt, that just contracts potential integrals and the
      * density matrix, over the basis function indices, giving the charge expectation value.
@@ -221,7 +221,7 @@ class PSI_API ContractOverDensityFunctor {
     void operator()(int bf1, int bf2, int center, double integral) { charges_[center] += pD_[bf1][bf2] * integral; }
 };
 
-class PSI_API ContractOverChargesFunctor {
+class ContractOverChargesFunctor {
     /**
      * A functor, to be used with PCMPotentialInt, that just contracts potential integrals over charges,
      * leaving a contribution to the Fock matrix


### PR DESCRIPTION
## Description
I found a few classes that shouldn't be exported.  From ecpint.h, `AngularIntegral` and `RadialIntegral` are only used internally and are implementation dependent.  In potentialint.h, the functors reside fully in the header and thus don't need to be "exported".

## Status
- [x] Ready for review
- [x] Ready for merge
