### PR TITLE
reset options state from dictionary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #    - NumPy (also runtime; avoidable at buildtime if gau2grid pre-built; e.g., `conda install numpy`)
 #    - deepdiff (runtime only; e.g., `conda install deepdiff -c conda-forge`)
 #    - networkx (runtime only; e.g., `conda install networkx`)
+#    - pint (runtime only; e.g., `conda install pint -c conda-forge`)
 
 #  These three "###  Options  ###" sections contain useful CMake variables for build configuration.
 
@@ -53,7 +54,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 #    - PYTHON_INCLUDE_DIR "Path to the python include files (e.g., /path/to/include/python2.7)"
 #    - SPHINX_ROOT "Root directory for Sphinx: 'bin/sphinx-build' (or similar) should be in this dir."
 #
-#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gau2grid, gdma, Libint, PCMSolver, pybind11, pylibefp, simint, Libxc
+#    For any ${AddOn} of: ambit, CheMPS2, dkh, libefp, erd, gau2grid, gdma, Libint, PCMSolver, pybind11, pylibefp,
+#                         qcelemental, simint, Libxc
 #    - CMAKE_PREFIX_PATH "Set to list of root directories to look for externally built add-ons and dependencies
 #      (e.g., /path/to/install-libint;/path/to/install-gdma where exists /path/to/install-libint/lib/libderiv.a)"
 #    - ${AddOn}_DIR "Set to directory containing ${AddOn}Config.cmake file to facilitate detection of external build"

--- a/doc/sphinxman/source/add_tests.rst
+++ b/doc/sphinxman/source/add_tests.rst
@@ -77,3 +77,12 @@ Of those small modifications, first, note the special comment at the top (starti
 The reference values are assigned to variables for later use. The compare_values function (along with several relatives in :source:`psi4/driver/p4util/util.py` for comparing strings, matrices, etc.) checks that the computed values match these reference values to suitable precision. This function prints an error message and signals that the test failed to the make system, if the values don't match. Any lines of the input associated with the validation process should be flagged with #TEST at the end of each line, so that they can be removed when copying from the tests to the samples directory.
 
 Finally, add the directory name to the list of tests in :source:`tests/CMakeLists.txt`.
+
+In preparing the test case, turn energy, density, amplitude, and
+geometry convergence criteria to very tight levels, and use these
+results for reference energies, reference geometries, reference cube
+files, *etc.*. Then, either remove or relax the convergence settings,
+if these are not a vital part of the test. In choosing the number of
+digits for :py:class:`compare_values` and other compare_* functions,
+select a number looser than the convergence set in the test or the
+default convergence for the calculation type (energy, gradient, *etc.*).

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -184,18 +184,16 @@ Libint, and even C++ compilers on Linux and Mac) can be
 satisfied through conda. The links below give examples of how to configure
 that software for |PSIfour| and any notes and warnings pertaining to it.
 
-* :ref:`C++ and C Compilers <cmake:cxx>` (C++11 compliant)
+* :ref:`C++ and C Compilers <cmake:cxx>` (C++14 compliant)
 
 * :ref:`Optimized BLAS and LAPACK libraries <cmake:lapack>` (preferably NOT one supplied by a standard
   Linux distribution)
 
 * :ref:`Python interpreter and headers <cmake:python>` (3.5, 3.6, or 3.7) https://www.python.org/
 
-* CMake (3.3+) http://www.cmake.org/download/
+* CMake (3.8+) http://www.cmake.org/download/
 
 * NumPy (needed at runtime *and* buildtime) http://www.numpy.org/
-
-* mpmath (only needed if you build gau2grid to angular momentum >16) http://mpmath.org/
 
 * System utilities: GNU make, GNU install, POSIX threads (Pthreads) library
 
@@ -210,6 +208,8 @@ build system will automatically download and build.
 
 * pybind11 |w---w| `[what is this?] <https://pybind11.readthedocs.io/en/master/>`_ `[min version] <https://github.com/psi4/psi4/blob/master/external/upstream/pybind11/CMakeLists.txt#L1>`_
 
+* QCElemental |w---w| `[what is this?] <https://qcelemental.readthedocs.io/en/latest/>`_
+
 Additionally, there are runtime-only dependencies:
 
 * NumPy http://www.numpy.org/
@@ -217,6 +217,8 @@ Additionally, there are runtime-only dependencies:
 * networkx https://github.com/networkx/networkx
 
 * deepdiff https://github.com/seperman/deepdiff
+
+* pint https://pint.readthedocs.io/en/latest/
 
 
 .. _`faq:addondepend`:
@@ -1299,7 +1301,7 @@ B. Build with specific Python
 
   .. code-block:: bash
 
-    >>> cmake -DPYTHON_EXECUTABLE=/path/to/interp/python2.7
+    >>> cmake -DPYTHON_EXECUTABLE=/path/to/interp/python3.6
 
 C. Build with full Python specification to root directory ``${PFXC}``
 

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -166,19 +166,6 @@ PsiReturnType mrcc_generate_input(SharedWavefunction, Options&, const py::dict&)
 PsiReturnType mrcc_load_ccdensities(SharedWavefunction, Options&, const py::dict&);
 }  // namespace mrcc
 
-// Finite difference functions
-namespace findif {
-std::vector<SharedMatrix> fd_geoms_1_0(std::shared_ptr<Molecule>, Options&);
-std::vector<SharedMatrix> fd_geoms_freq_0(std::shared_ptr<Molecule>, Options&, int irrep);
-std::vector<SharedMatrix> fd_geoms_freq_1(std::shared_ptr<Molecule>, Options&, int irrep);
-std::vector<SharedMatrix> atomic_displacements(std::shared_ptr<Molecule>, Options&);
-
-SharedMatrix fd_1_0(std::shared_ptr<Molecule>, Options&, const py::list&);
-SharedMatrix fd_freq_0(std::shared_ptr<Molecule>, Options&, const py::list&, int irrep);
-SharedMatrix fd_freq_1(std::shared_ptr<Molecule>, Options&, const py::list&, int irrep);
-void displace_atom(SharedMatrix geom, const int atom, const int coord, const int sign, const double disp_size);
-}  // namespace findif
-
 // CC functions
 namespace cctransort {
 PsiReturnType cctransort(SharedWavefunction, Options&);


### PR DESCRIPTION
## Description
add function to reset options state from dictionary

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] all the non-optking misc. from #1335 
- [x] if you call `run_json` from within the same `import psi4` instance (as opposed to `subprocess` of `psi4 --json`), your options are all cleared by the call. Even if you just call something else that does the psi4 json call (like pyoptking), this happens. This is a little function that lets you continue **for global options only**.

```
# collect options
all_options = p4util.prepare_options_for_modules(changedOnly=True, commandsInsteadDict=False)

# destroys options
optking_json_dict = optking.run_json_dict(optking_schema)

# restore options
 p4util.reset_pe_options(all_options)
```

## Checklist
- [ ] Tests added for any new features
- [x] it worked a month ago.

## Status
- [x] Ready for review
- [x] Ready for merge
