### PR TITLE
Fix invalid memory access in psi::cceom::get_moinfo

### DIFF
--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -92,11 +92,9 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     moinfo.irr_labs_lowercase = (char **)malloc(sizeof(char *) * nirreps);
     for (i = 0; i < nirreps; i++) {
-        moinfo.irr_labs_lowercase[i] = (char *)malloc(4 * sizeof(char));
-        moinfo.irr_labs_lowercase[i][0] = std::tolower(moinfo.irr_labs[i][0]);
-        moinfo.irr_labs_lowercase[i][1] = std::tolower(moinfo.irr_labs[i][1]);
-        moinfo.irr_labs_lowercase[i][2] = std::tolower(moinfo.irr_labs[i][2]);
-        moinfo.irr_labs_lowercase[i][3] = '\0';
+        moinfo.irr_labs_lowercase[i] = ::strdup(moinfo.irr_labs[i].c_str());
+        for (j = 0; j < ::strlen(moinfo.irr_labs_lowercase[i]); ++j)
+            moinfo.irr_labs_lowercase[i][j] = std::tolower(moinfo.irr_labs_lowercase[i][j]);
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params.ref), sizeof(int));


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

The problem was reported in #1255

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Fix invalid memory access in `psi::cceom::get_moinfo`
- [ ] Fix `cc46` and `cc47` tests on Windows

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
