### PR TITLE
Symmetry-Breaking Findif, and Reference First

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -141,6 +141,7 @@ def _process_displacement(derivfunc, method, molecule, displacement, n, ndisp, *
           A string specifying the method to be used for the computation.
        molecule: psi4.core.molecule or qcdb.molecule
           The molecule for the computation. All processing is handled internally.
+          molecule must not be modified!
        displacement : dict
           A dictionary containing the necessary information for the displacement.
           See driver_findif/_geom_generator.py docstring for details.

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1160,6 +1160,7 @@ void export_mints(py::module& m) {
         .def(py::init<const std::string&>())
         .def("symbol", &PointGroup::symbol, "Returns Schoenflies symbol for point group")
         .def("order", &PointGroup::order, "Return the order of the point group")
+        .def("bits", &PointGroup::bits, "Return the bit representation of the point group")
         .def("char_table", &PointGroup::char_table, "Return the CharacterTable of the point group");
     // def("origin", &PointGroup::origin).
     //            def("set_symbol", &PointGroup::set_symbol);
@@ -1328,9 +1329,11 @@ void export_mints(py::module& m) {
              "Returns first derivative of nuclear repulsion energy as a matrix (natom, 3)")
         .def("nuclear_repulsion_energy_deriv2", &Molecule::nuclear_repulsion_energy_deriv2,
              "Returns second derivative of nuclear repulsion energy as a matrix (natom X 3, natom X 3)")
-        .def("find_point_group", &Molecule::find_point_group,
+        .def("find_point_group", &Molecule::find_point_group, py::arg("tolerance") = DEFAULT_SYM_TOL,
              "Finds computational molecular point group, user can override this with the symmetry "
              "keyword")
+        .def("find_highest_point_group", &Molecule::find_highest_point_group, py::arg("tolerance") = DEFAULT_SYM_TOL,
+             "Finds highest possible computational molecular point group")
         .def("reset_point_group", &Molecule::reset_point_group, "Overrides symmetry from outside the molecule string")
         .def("set_point_group", &Molecule::set_point_group,
              "Sets the molecular point group to the point group object arg0")

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -1947,7 +1947,8 @@ std::shared_ptr<PointGroup> Molecule::find_point_group(double tol) const {
         int end = user.length() - 1;
 
         bool user_specified_direction = false;
-        // Did the user provide directionality? If they did, the last letter would be x, y, or z
+        // Did the user provide directionality? If they did, the last letter (not character) would be x, y, or z
+        end -= (user[end] == ')');
         if (user[end] == 'X' || user[end] == 'x' || user[end] == 'Y' || user[end] == 'y' || user[end] == 'Z' ||
             user[end] == 'z') {
             // Directionality given, assume the user is smart enough to know what they're doing.

--- a/tests/fd-freq-energy/input.dat
+++ b/tests/fd-freq-energy/input.dat
@@ -39,6 +39,7 @@ clean()
 
 # Frequencies by 3-pt formula in C2v.
 molecule h2o {
+  symmetry c2v
   O
   H 1 0.9894093
   H 1 0.9894093 2 100.02688

--- a/tests/fd-freq-energy/input.dat
+++ b/tests/fd-freq-energy/input.dat
@@ -45,6 +45,7 @@ molecule h2o {
   H 1 0.9894093 2 100.02688
 }
 
+set DOCC [3, 0, 1, 1]
 set { points 3 }
 
 scf_e, scf_wfn = frequencies('scf', dertype=0, return_wfn=True)


### PR DESCRIPTION
## Description
Fixes #1052 at long, long last: when the user explicitly declares a symmetry, findif is now smart enough to put displacements in the proper subgroup.

As part of the fix, control over molecule cloning for finite difference has passed to `_process_displacement`. It seemed easier (and more appropriate) than adding code to make a new clone in each for loop. The clone would be necessary so that each displacement can have its own symmetry.

Since I was touching that part of the code anyways, I have reorganized so that the reference is guaranteed to be the first displacement. This has the advantage that if orbital reading is enabled, the following displacements will be able to read from the reference, as intended.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixes #1052
- [x] Exposes more C functions to Python
- [x] Move the reference geometry first for ease of orbital reads

## Checklist
- [x] Tests modified to account for bug fix
- [x] All findif tests passing

## Status
- [x] Ready for review
- [x] Ready for merge
