### PR TITLE
Fix a memory error in psi::MOInfo::read_mo_spaces

### DIFF
--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -254,9 +254,9 @@ void MOInfo::read_mo_spaces() {
         intvec fvir_ref;
         //        intvec actv_docc_ref;
 
-        focc_ref = convert_int_array_to_vector(nirreps, ref_wfn.frzcpi());
-        docc_ref = convert_int_array_to_vector(nirreps, ref_wfn.doccpi());
-        actv_ref = convert_int_array_to_vector(nirreps, ref_wfn.soccpi());
+        focc_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.frzcpi());
+        docc_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.doccpi());
+        actv_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.soccpi());
         fvir_ref.assign(nirreps_ref, 0);
         //        actv_docc_ref.assign(nirreps_ref,0);
 


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

The problem was already reported in #1255

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix a memory error in `psi::MOInfo::read_mo_spaces`
- [x] Fix `psimrcc-fd-freq2` test on Windows

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
