### PR TITLE
Fix a bug in load_plugin

### DIFF
--- a/psi4/src/psi4/libplugin/load_plugin.cc
+++ b/psi4/src/psi4/libplugin/load_plugin.cc
@@ -66,7 +66,7 @@ plugin_info plugin_load(std::string &plugin_pathname) {
     // Modify info.name converting things that are allowed
     // filename characters to allowed C++ function names.
     // Replace all '-' with '_'
-    std::transform(info.name.begin(), info.name.end(), info.name.begin(), [](char c) { return c == '_' ? '-' : c; });
+    std::transform(info.name.begin(), info.name.end(), info.name.begin(), [](char c) { return c == '-' ? '_' : c; });
 
     info.plugin = (plugin_t)dlsym(info.plugin_handle, info.name.c_str());
     const char *dlsym_error3 = dlerror();


### PR DESCRIPTION
## Description
This fixes a bug in the load_plugin function that incorrectly converted `_` to `-` instead of the opposite.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix a bug

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
