### PR TITLE
Improved SAD guess

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,14 +97,12 @@ jobs:
       # Test (OpenMP)
       # Check if OpenMP configuration had not failed silently
       - script: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           python -c "from psi4 import core; core.set_num_threads(42); assert core.get_num_threads() == 42"
         displayName: "Test Psi4 (OpenMP)"
         workingDirectory: $(Build.BinariesDirectory)/install/lib
 
       # Test (quick ctest)
       - script: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           ctest --build-config Debug ^
                 --exclude-regex "^(ci-property)$" ^
                 --label-regex quick ^
@@ -127,7 +125,6 @@ jobs:
       #   - psithon2
       #
       - script: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           ctest --build-config Debug ^
                 --tests-regex "^(cbs-parser|cc46|cc47|cc53|ci-property|fci-tdm|fci-tdm-2|psimrcc-fd-freq2|psithon2)$" ^
                 --output-on-failure ^
@@ -137,8 +134,8 @@ jobs:
 
       # Test (quick pytest)
       - script: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          set PATH=$(Build.BinariesDirectory)\install\bin;%PATH%
           set PYTHONPATH=$(Build.BinariesDirectory)\install\lib;%PYTHONPATH%
-          python psi4 --test quick
-        displayName: "Test Psi4 (full pytest)"
-        workingDirectory: $(Build.BinariesDirectory)/install/bin
+          psi4 --test quick
+        displayName: "Test Psi4 (quick pytest)"
+        workingDirectory: $(Build.BinariesDirectory)

--- a/external/common/lapack/FindTargetOpenMP.cmake
+++ b/external/common/lapack/FindTargetOpenMP.cmake
@@ -39,6 +39,7 @@ cmake_policy(SET CMP0057 NEW)  # support IN_LISTS
 set(_TargetOpenMP_PN ${PN})
 set(PN TargetOpenMP)
 
+separate_arguments(${PN}_FIND_COMPONENTS)
 if(${PN}_FIND_COMPONENTS)
     set(_${PN}_FIND_LIST ${${PN}_FIND_COMPONENTS})
 else()

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -192,6 +192,13 @@ configure_file(run_psi4.py psi4 @ONLY)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/psi4
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
 
+if(WIN32)
+    # Generate a batch script, which wraps "bin/psi4" script to "python bin/psi4"
+    configure_file(psi4.bat psi4.bat @ONLY)
+    install(PROGRAMS ${CMAKE_BINARY_DIR}/psi4.bat
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
+endif()
+
     # <<<  install lib/  >>>
 install(DIRECTORY share/psi4/
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/psi4

--- a/psi4/driver/aliases.py
+++ b/psi4/driver/aliases.py
@@ -34,8 +34,6 @@ Place in this file quickly defined procedures such as
    - simple modifications to existing methods
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import re
 import math

--- a/psi4/driver/diatomic.py
+++ b/psi4/driver/diatomic.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-
 import numpy as np
 
 from psi4 import core

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -31,8 +31,6 @@ functionality, namely single-point energies, geometry optimizations,
 properties, and vibrational frequency calculations.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import re
 import sys

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import re
 import sys
 import math

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1570,7 +1570,7 @@ def cbs(func, label, **kwargs):
         commands = '\n'
         commands += """\ncore.set_global_option('BASIS', '%s')\n""" % (mc['f_basis'])
         commands += """core.set_global_option('WRITER_FILE_LABEL', '%s')\n""" % \
-            (user_writer_file_label + ('' if user_writer_file_label == '' else '-') + mc['f_wfn'].lower() + '-' + mc['f_basis'].lower())
+            (user_writer_file_label + ('' if user_writer_file_label == '' else '-') + mc['f_wfn'].lower() + '-' + mc['f_basis'].lower().replace('*', 's'))
         exec(commands)
 
         # Stash and set options if any

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
 import math
 import itertools
 

--- a/psi4/driver/driver_nbody_helper.py
+++ b/psi4/driver/driver_nbody_helper.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 import numpy as np
 
 from psi4 import core

--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -26,7 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
 import re
 
 from psi4 import core

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -47,12 +47,7 @@ except ImportError:
 try:
     import snsmp2
 except ImportError as e:
-    if sys.version_info >= (3, 0):
-        errmsg = e.msg
-    else:
-        errmsg = e.message
-
-    if 'scipy' in errmsg:
+    if 'scipy' in e.msg:
         raise ImportError("""Psi4 plugin 'snsmp2' available, but scipy missing. Try `conda install scipy` or `pip install scipy`.""")
     else:
         pass

--- a/psi4/driver/frac.py
+++ b/psi4/driver/frac.py
@@ -26,10 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-
 from psi4 import core
 from psi4.driver import p4util
 from psi4.driver import driver

--- a/psi4/driver/gaussian_n.py
+++ b/psi4/driver/gaussian_n.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-
 from psi4 import core
 from psi4.driver import driver
 from psi4.driver import p4util

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -31,10 +31,6 @@ module calls that access the C++ side of Psi4.
 
 """
 
-## Force Python 3 print syntax, if this is python 2.X
-#if sys.hexversion < 0x03000000:
-from __future__ import print_function
-from __future__ import absolute_import
 import re
 import os
 import sys
@@ -197,12 +193,8 @@ def process_molecule_command(matchobj):
     molecule = spaces
 
     if name != "":
-        if sys.version_info >= (3, 0):
-            if not name.isidentifier():
-                raise ValidationError('Molecule name not valid Python identifier: ' + name)
-        else:
-            if not re.match(r'^[^\d\W]\w*\Z', name):
-                raise ValidationError('Molecule name not valid Python identifier: ' + name)
+        if not name.isidentifier():
+            raise ValidationError('Molecule name not valid Python identifier: ' + name)
 
     if name != "":
         molecule += '%s = ' % (name)

--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -26,7 +26,6 @@
 # @END LICENSE
 #
 """Module with utility functions that act on molecule objects."""
-from __future__ import absolute_import
 
 import numpy as np
 import qcelemental as qcel

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -42,27 +42,33 @@ class ValidationError(PsiException):
     error message *msg* to standard output stream and output file.
 
     """
+
     def __init__(self, msg):
         PsiException.__init__(self, msg)
         # print("%s" % repr(msg))
         self.message = '\nPsiException: %s\n\n' % repr(msg)
+
 
 class ParsingError(PsiException):
     """Error called for problems parsing a text file. Prints error message
     *msg* to standard output stream and output file.
 
     """
+
     def __init__(self, msg):
-        PsiException.__init__(self,msg)
+        PsiException.__init__(self, msg)
         self.message = '\nPsiException: %s\n\n' % msg
+
 
 class PsiImportError(PsiException):
     """Error called for problems import python dependencies. Prints error message
     *msg* to standard output stream and output file.
     """
+
     def __init__(self, msg):
-        PsiException.__init__(self,msg)
+        PsiException.__init__(self, msg)
         self.message = '\nPsiException: %s\n\n' % msg
+
 
 class TestComparisonError(PsiException):
     """Error called when a test case fails due to a failed
@@ -70,6 +76,7 @@ class TestComparisonError(PsiException):
     output stream and output file.
 
     """
+
     def __init__(self, msg):
         PsiException.__init__(self, msg)
         self.message = '\nPsiException: %s\n\n' % msg
@@ -86,6 +93,7 @@ class ConvergenceError(PsiException):
         What iteration we failed on
 
     """
+
     def __init__(self, eqn_description, iteration):
         msg = "Could not converge %s in %d iterations." % (eqn_description, iteration)
         PsiException.__init__(self, msg)
@@ -115,6 +123,7 @@ class SCFConvergenceError(ConvergenceError):
         RMS change in density for last iteration
 
     """
+
     def __init__(self, eqn_description, iteration, wfn, e_conv, d_conv):
         ConvergenceError.__init__(self, eqn_description, iteration)
         self.e_conv = e_conv
@@ -126,6 +135,7 @@ class CSXError(PsiException):
     """Error called when CSX generation fails.
 
     """
+
     def __init__(self, msg):
         PsiException.__init__(self, msg)
         self.message = '\nCSXException: %s\n\n' % msg
@@ -136,7 +146,8 @@ class ManagedMethodError(PsiException):
         if circs[5] == '':
             msg = """{0}: Method '{1}' with {2} '{3}' and REFERENCE '{4}' not available{5}""".format(*circs)
         else:
-            msg = """{0}: Method '{1}' with {2} '{3}' and REFERENCE '{4}' not directable to QC_MODULE '{5}'""".format(*circs)
+            msg = """{0}: Method '{1}' with {2} '{3}' and REFERENCE '{4}' not directable to QC_MODULE '{5}'""".format(
+                *circs)
         PsiException.__init__(self, msg)
         self.message = '\nPsiException: %s\n\n' % msg
 
@@ -145,9 +156,11 @@ class Dftd3Error(PsiException):
     """
 
     """
+
     def __init__(self, msg):
         PsiException.__init__(self, msg)
         self.message = '\nDftd3Error: %s\n\n' % msg
+
 
 class PastureRequiredError(PsiException):
     """Error called when the specified value of *option* requires some
@@ -180,16 +193,14 @@ class PastureRequiredError(PsiException):
          {module_args}
     to cmake command line when building psi4.
     """
-    pasture_required_modules = {
-            "RUN_CCTRANSORT": ["ccsort", "transqt2"]
-            }
+    pasture_required_modules = {"RUN_CCTRANSORT": ["ccsort", "transqt2"]}
 
     def __init__(self, option):
         mods_str = ", ".join([m for m in PastureRequiredError.pasture_required_modules[option]])
-        msg = PastureRequiredError.msg_tmpl.format(opt = option, modlist = mods_str)
+        msg = PastureRequiredError.msg_tmpl.format(opt=option, modlist=mods_str)
         PsiException.__init__(self, msg)
-        module_cmake_args = " ".join([ "-DENABLE_{}=ON".format(module)
-            for module in PastureRequiredError.pasture_required_modules[option]])
-        msg += PastureRequiredError.install_instructions.format(module_args = module_cmake_args)
+        module_cmake_args = " ".join(
+            ["-DENABLE_{}=ON".format(module) for module in PastureRequiredError.pasture_required_modules[option]])
+        msg += PastureRequiredError.install_instructions.format(module_args=module_cmake_args)
         self.message = '\nPsiException: {}\n\n'.format(msg)
         core.print_out(self.message)

--- a/psi4/driver/p4util/fcidump.py
+++ b/psi4/driver/p4util/fcidump.py
@@ -320,7 +320,9 @@ def compare_fcidumps(expected, computed, label):
     try:
         from deepdiff import DeepDiff
     except ImportError:
-        raise ImportError("""Python module deepdiff not found. Solve by installing it: `conda install deepdiff -c conda-forge` or `pip install deepdiff`""")
+        raise ImportError(
+            """Python module deepdiff not found. Solve by installing it: `conda install deepdiff -c conda-forge` or `pip install deepdiff`"""
+        )
 
     # Grab expected header and integrals
     ref_intdump = fcidump_from_file(expected)
@@ -339,10 +341,14 @@ def compare_fcidumps(expected, computed, label):
     ref_energies = _energies_from_fcidump(ref_intdump)
     energies = _energies_from_fcidump(intdump)
 
-    pass_1el = compare_values(ref_energies['ONE-ELECTRON ENERGY'], energies['ONE-ELECTRON ENERGY'], 7, label + '. 1-electron energy')
-    pass_2el = compare_values(ref_energies['TWO-ELECTRON ENERGY'], energies['TWO-ELECTRON ENERGY'], 7, label + '. 2-electron energy')
-    pass_scf = compare_values(ref_energies['SCF TOTAL ENERGY'], energies['SCF TOTAL ENERGY'], 10, label + '. SCF total energy')
-    pass_mp2 = compare_values(ref_energies['MP2 CORRELATION ENERGY'], energies['MP2 CORRELATION ENERGY'], 10, label + '. MP2 correlation energy')
+    pass_1el = compare_values(ref_energies['ONE-ELECTRON ENERGY'], energies['ONE-ELECTRON ENERGY'], 7,
+                              label + '. 1-electron energy')
+    pass_2el = compare_values(ref_energies['TWO-ELECTRON ENERGY'], energies['TWO-ELECTRON ENERGY'], 7,
+                              label + '. 2-electron energy')
+    pass_scf = compare_values(ref_energies['SCF TOTAL ENERGY'], energies['SCF TOTAL ENERGY'], 10,
+                              label + '. SCF total energy')
+    pass_mp2 = compare_values(ref_energies['MP2 CORRELATION ENERGY'], energies['MP2 CORRELATION ENERGY'], 10,
+                              label + '. MP2 correlation energy')
 
     if (pass_1el and pass_2el and pass_scf and pass_mp2):
         success(label)

--- a/psi4/driver/p4util/inpsight.py
+++ b/psi4/driver/p4util/inpsight.py
@@ -47,16 +47,16 @@ class InPsight:
     defines['Antialias_Threshold'] = '0.1'
 
     # Molecule geometry
-    atoms = [] # (Z,x,y,z,R,r,g,b,t) in bohr
-    bonds = [] # (x1,y1,z1,R1,x2,y2,z2,R2,r,g,b,t)
+    atoms = []  # (Z,x,y,z,R,r,g,b,t) in bohr
+    bonds = []  # (x1,y1,z1,R1,x2,y2,z2,R2,r,g,b,t)
 
     # Molecular geometry defines
     colors = []
     radii = []
     radial_scale = 0.25
-    bond_width = 0.2 # bohr
+    bond_width = 0.2  # bohr
     bohr_per_ang = 1.8897161646320724
-    bonding_alpha = 0.65 # Used to select/reject bonds via sum of vDW radii
+    bonding_alpha = 0.65  # Used to select/reject bonds via sum of vDW radii
 
     # View defines (high-level)
     azimuth = 0.0

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -299,6 +299,7 @@ def _to_array(matrix, copy=True, dense=False):
     else:
         return _get_raw_views(matrix, copy=copy)[0]
 
+
 @property
 def _np_shape(self):
     """
@@ -377,11 +378,7 @@ def _np_read(self, filename, prefix=""):
 
     if isinstance(filename, np.lib.npyio.NpzFile):
         data = filename
-    elif (sys.version_info[0] == 2) and isinstance(filename, (str, unicode)):
-        if not filename.endswith('.npz'):
-            filename = filename + '.npz'
-        data = np.load(filename)
-    elif (sys.version_info[0] > 2) and isinstance(filename, str):
+    elif isinstance(filename, str):
         if not filename.endswith('.npz'):
             filename = filename + '.npz'
 
@@ -482,12 +479,14 @@ def _chain_dot(*args, **kwargs):
 
     return ret
 
+
 def _irrep_access(self, *args, **kwargs):
     """
     Warns user when iterating/accessing an irreped object.
     """
     raise ValidationError("Attempted to access by index/iteration a Psi4 data object that supports multiple"
                           "irreps. Please use .np or .nph explicitly.")
+
 
 # Matrix attributes
 core.Matrix.from_array = classmethod(array_to_matrix)
@@ -588,6 +587,7 @@ def _dimension_iter(dim):
 core.Dimension.from_list = _dimension_from_list
 core.Dimension.to_tuple = _dimension_to_tuple
 core.Dimension.__iter__ = _dimension_iter
+
 
 # General functions for NumPy array manipulation
 def block_diagonal_array(*args):

--- a/psi4/driver/p4util/optproc.py
+++ b/psi4/driver/p4util/optproc.py
@@ -25,7 +25,6 @@
 #
 # @END LICENSE
 #
-
 r"""Module to provide mechanism to store and restore option states in driver.
 
 """
@@ -47,6 +46,7 @@ class OptionState(object):
         >>> print(OptionState('DF_BASIS_MP2'))
 
     """
+
     def __init__(self, option, module=None):
         self.option = option.upper()
         if module:
@@ -71,12 +71,16 @@ class OptionState(object):
         text = ''
         if self.module:
             text += """  ==> %s Option in Module %s <==\n\n""" % (self.option, self.module)
-            text += """  Global (has changed?) value: %7s %s\n""" % ('(' + str(self.haschanged_global) + ')', self.value_global)
-            text += """  Local (has changed?) value:  %7s %s\n""" % ('(' + str(self.haschanged_local) + ')', self.value_local)
-            text += """  Used (has changed?) value:   %7s %s\n""" % ('(' + str(self.haschanged_used) + ')', self.value_used)
+            text += """  Global (has changed?) value: %7s %s\n""" % ('(' + str(self.haschanged_global) + ')',
+                                                                     self.value_global)
+            text += """  Local (has changed?) value:  %7s %s\n""" % ('(' + str(self.haschanged_local) + ')',
+                                                                     self.value_local)
+            text += """  Used (has changed?) value:   %7s %s\n""" % ('(' + str(self.haschanged_used) + ')',
+                                                                     self.value_used)
         else:
             text += """  ==> %s Option in Global Scope <==\n\n""" % (self.option)
-            text += """  Global (has changed?) value: %7s %s\n""" % ('(' + str(self.haschanged_global) + ')', self.value_global)
+            text += """  Global (has changed?) value: %7s %s\n""" % ('(' + str(self.haschanged_global) + ')',
+                                                                     self.value_global)
         text += """\n"""
         return text
 
@@ -105,6 +109,7 @@ class OptionsState(object):
         >>> optstash.restore()
 
     """
+
     def __init__(self, *largs):
         self.data = {}
         for item in largs:
@@ -116,10 +121,14 @@ class OptionsState(object):
         elif len(item) == 1:
             key = (item[0], )
         else:
-            raise ValidationError('Each argument to OptionsState should be an array, the first element of which is     the module scope and the second element of which is the module name. Bad argument: %s' % (item))
+            raise ValidationError(
+                'Each argument to OptionsState should be an array, the first element of which is     the module scope and the second element of which is the module name. Bad argument: %s'
+                % (item))
 
         if key in self.data:
-            raise ValidationError('Malformed options state, duplicate key adds of "%s". This should not happen, please raise a issue on github.com/psi4/psi4' % key)
+            raise ValidationError(
+                'Malformed options state, duplicate key adds of "%s". This should not happen, please raise a issue on github.com/psi4/psi4'
+                % key)
         else:
             self.data[key] = OptionState(*key)
 

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -48,7 +48,6 @@ def kwargs_lower(kwargs):
 
     """
     caseless_kwargs = {}
-    # items() inefficient on Py2 but this is small dict
     for key, value in kwargs.items():
         lkey = key.lower()
         if lkey in ['subset', 'banner']:  # only kw for which case matters
@@ -126,8 +125,7 @@ def format_molecule_for_input(mol, name='', forcexyz=False):
             mol_string = mol.create_psi4_string_from_molecule()
         mol_name = mol.name() if name == '' else name
 
-    commands = """\nmolecule %s {\n%s%s\n}\n""" % (mol_name, mol_string,
-               '\nno_com\nno_reorient' if forcexyz else '')
+    commands = """\nmolecule %s {\n%s%s\n}\n""" % (mol_name, mol_string, '\nno_com\nno_reorient' if forcexyz else '')
     return commands
 
 
@@ -156,6 +154,8 @@ def format_options_for_input(molecule=None, **kwargs):
 
             if isinstance(chgdoptval, str):
                 commands += """core.set_global_option('%s', '%s')\n""" % (chgdopt, chgdoptval)
+
+
 # Next four lines were conflict between master and roa branches (TDC, 10/29/2014)
             elif isinstance(chgdoptval, int) or isinstance(chgdoptval, float):
                 commands += """core.set_global_option('%s', %s)\n""" % (chgdopt, chgdoptval)
@@ -288,38 +288,69 @@ def extract_sowreap_from_output(sowout, quantity, sownum, linkage, allvital=Fals
             if not line:
                 if E == 0.0:
                     if allvital:
-                        raise ValidationError('Aborting upon output file \'%s.out\' has no %s RESULT line.\n' % (sowout, quantity))
+                        raise ValidationError(
+                            'Aborting upon output file \'%s.out\' has no %s RESULT line.\n' % (sowout, quantity))
                     else:
-                        ValidationError('Aborting upon output file \'%s.out\' has no %s RESULT line.\n' % (sowout, quantity))
+                        ValidationError(
+                            'Aborting upon output file \'%s.out\' has no %s RESULT line.\n' % (sowout, quantity))
                 break
             s = line.strip().split(None, 10)
             if (len(s) != 0) and (s[0:3] == [quantity, 'RESULT:', 'computation']):
                 if int(s[3]) != linkage:
-                    raise ValidationError('Output file \'%s.out\' has linkage %s incompatible with master.in linkage %s.'
-                        % (sowout, str(s[3]), str(linkage)))
+                    raise ValidationError(
+                        'Output file \'%s.out\' has linkage %s incompatible with master.in linkage %s.' %
+                        (sowout, str(s[3]), str(linkage)))
                 if s[6] != str(sownum + 1):
-                    raise ValidationError('Output file \'%s.out\' has nominal affiliation %s incompatible with item %s.'
-                        % (sowout, s[6], str(sownum + 1)))
+                    raise ValidationError(
+                        'Output file \'%s.out\' has nominal affiliation %s incompatible with item %s.' %
+                        (sowout, s[6], str(sownum + 1)))
                 if label == 'electronic energy' and s[8:10] == ['electronic', 'energy']:
-                        E = float(s[10])
-                        core.print_out('%s RESULT: electronic energy = %20.12f\n' % (quantity, E))
+                    E = float(s[10])
+                    core.print_out('%s RESULT: electronic energy = %20.12f\n' % (quantity, E))
                 if label == 'electronic gradient' and s[8:10] == ['electronic', 'gradient']:
-                        E = ast.literal_eval(s[-1])
-                        core.print_out('%s RESULT: electronic gradient = %r\n' % (quantity, E))
+                    E = ast.literal_eval(s[-1])
+                    core.print_out('%s RESULT: electronic gradient = %r\n' % (quantity, E))
         freagent.close()
     return E
 
 
 _modules = [
-        # PSI4 Modules
-        "ADC", "CCENERGY", "CCEOM", "CCDENSITY", "CCLAMBDA", "CCHBAR",
-        "CCRESPONSE", "CCSORT", "CCTRIPLES", "CLAG", "CPHF", "CIS",
-        "DCFT", "DETCI", "DFMP2", "DFTSAPT", "FINDIF", "FNOCC", "LMP2",
-        "MCSCF", "MINTS", "MRCC", "OCC", "OPTKING", "PSIMRCC", "RESPONSE",
-        "SAPT", "SCF", "STABILITY", "THERMO", "TRANSQT", "TRANSQT2",
-        # External Modules
-        "CFOUR",
-        ]
+    # PSI4 Modules
+    "ADC",
+    "CCENERGY",
+    "CCEOM",
+    "CCDENSITY",
+    "CCLAMBDA",
+    "CCHBAR",
+    "CCRESPONSE",
+    "CCSORT",
+    "CCTRIPLES",
+    "CLAG",
+    "CPHF",
+    "CIS",
+    "DCFT",
+    "DETCI",
+    "DFMP2",
+    "DFTSAPT",
+    "FINDIF",
+    "FNOCC",
+    "LMP2",
+    "MCSCF",
+    "MINTS",
+    "MRCC",
+    "OCC",
+    "OPTKING",
+    "PSIMRCC",
+    "RESPONSE",
+    "SAPT",
+    "SCF",
+    "STABILITY",
+    "THERMO",
+    "TRANSQT",
+    "TRANSQT2",
+    # External Modules
+    "CFOUR",
+]
 
 
 def reset_pe_options(pofm):
@@ -368,9 +399,8 @@ def prepare_options_for_modules(changedOnly=False, commandsInsteadDict=False):
             if opt in ['DFT_CUSTOM_FUNCTIONAL', 'EXTERN']:  # Feb 2017 hack
                 continue
             val = core.get_global_option(opt)
-            options['GLOBALS'][opt] = {'value': val,
-                                       'has_changed': core.has_global_option_changed(opt)}
-            if isinstance(val, basestring):
+            options['GLOBALS'][opt] = {'value': val, 'has_changed': core.has_global_option_changed(opt)}
+            if isinstance(val, str):
                 commands += """core.set_global_option('%s', '%s')\n""" % (opt, val)
             else:
                 commands += """core.set_global_option('%s', %s)\n""" % (opt, val)

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -75,10 +75,8 @@ def _pybuild_basis(mol,
     # if a string, they search for a gbs file with that name.
     # if a function, it needs to apply a basis to each atom.
 
-    bs, basisdict = qcdb.BasisSet.pyconstruct(mol.to_dict(),
-                                              key, resolved_target, fitrole, other,
-                                              return_dict=True,
-                                              return_atomlist=return_atomlist)
+    bs, basisdict = qcdb.BasisSet.pyconstruct(
+        mol.to_dict(), key, resolved_target, fitrole, other, return_dict=True, return_atomlist=return_atomlist)
 
     if return_atomlist:
         atom_basis_list = []
@@ -87,8 +85,7 @@ def _pybuild_basis(mol,
             lmbs = core.BasisSet.construct_from_pydict(atommol, atbs, puream)
             atom_basis_list.append(lmbs)
         return atom_basis_list
-    if ((sys.version_info < (3, 0) and isinstance(resolved_target, basestring))
-            or (sys.version_info >= (3, 0) and isinstance(resolved_target, str))):
+    if isinstance(resolved_target, str):
         basisdict['name'] = basisdict['name'].split('/')[-1].replace('.gbs', '')
     if callable(resolved_target):
         basisdict['name'] = resolved_target.__name__.replace('basisspec_psi4_yo__', '').upper()
@@ -113,9 +110,7 @@ core.BasisSet.build = _pybuild_basis
 def _core_wavefunction_build(mol, basis=None):
     if basis is None:
         basis = core.BasisSet.build(mol)
-    elif (sys.version_info[0] == 2) and isinstance(basis, (str, unicode)):
-        basis = core.BasisSet.build(mol, "ORBITAL", basis)
-    elif (sys.version_info[0] > 2) and isinstance(basis, str):
+    elif isinstance(basis, str):
         basis = core.BasisSet.build(mol, "ORBITAL", basis)
 
     wfn = core.Wavefunction(mol, basis)
@@ -137,10 +132,10 @@ def _core_wavefunction_from_file(wfn_data):
     # otherwise a dictionary was passed in
     else:
         pass
-    
+
     # variable type specific dictionaries to be passed into C++ constructor
     wfn_matrix = wfn_data['matrix']
-    wfn_vector= wfn_data['vector']
+    wfn_vector = wfn_data['vector']
     wfn_dimension = wfn_data['dimension']
     wfn_int = wfn_data['int']
     wfn_string = wfn_data['string']
@@ -164,23 +159,23 @@ def _core_wavefunction_from_file(wfn_data):
     # change some variables to psi4 specific data types (Matrix, Vector, Dimension)
     for label in wfn_matrix:
         array = wfn_matrix[label]
-        wfn_matrix[label] = core.Matrix.from_array(array,name=label) if array is not None else None
-    
+        wfn_matrix[label] = core.Matrix.from_array(array, name=label) if array is not None else None
+
     for label in wfn_vector:
         array = wfn_vector[label]
-        wfn_vector[label] = core.Vector.from_array(array,name=label) if array else None
+        wfn_vector[label] = core.Vector.from_array(array, name=label) if array else None
 
     for label in wfn_dimension:
         tup = wfn_dimension[label]
-        wfn_dimension[label] = core.Dimension.from_list(tup,name=label) if tup else None
+        wfn_dimension[label] = core.Dimension.from_list(tup, name=label) if tup else None
 
     for label in wfn_matrixarr:
         array = wfn_dimension[label]
-        wfn_dimension[label] = core.Matrix.from_array(array,name=label) if array else None
+        wfn_dimension[label] = core.Matrix.from_array(array, name=label) if array else None
 
-    # make the wavefunction 
-    wfn = core.Wavefunction(molecule, basisset, wfn_matrix, wfn_vector, wfn_dimension, wfn_int,
-                            wfn_string, wfn_boolean, wfn_float)
+    # make the wavefunction
+    wfn = core.Wavefunction(molecule, basisset, wfn_matrix, wfn_vector, wfn_dimension, wfn_int, wfn_string,
+                            wfn_boolean, wfn_float)
 
     # some of the wavefunction's variables can be changed directly
     for k, v in wfn_floatvar.items():
@@ -260,12 +255,12 @@ def _core_wavefunction_to_file(wfn, filename=None):
             'dipole_field_y': wfn.get_dipole_field_strength()[1],
             'dipole_field_z': wfn.get_dipole_field_strength()[2]
         },
-        'floatvar' : wfn.scalar_variables(),
-        'matrixarr' : {k: v.to_array() for k, v in wfn.array_variables().items()}
+        'floatvar': wfn.scalar_variables(),
+        'matrixarr': {k: v.to_array() for k, v in wfn.array_variables().items()}
     }  # yapf: disable
 
     if filename is not None:
-        np.save(filename,wfn_data)
+        np.save(filename, wfn_data)
     else:
         return wfn_data
 
@@ -321,9 +316,8 @@ def _core_jk_build(orbital_basis, aux=None, jk_type=None):
 
     if aux is None:
         if core.get_global_option("SCF_TYPE") == "DF":
-            aux = core.BasisSet.build(orbital_basis.molecule(), "DF_BASIS_SCF",
-                                      core.get_option("SCF", "DF_BASIS_SCF"), "JKFIT",
-                                      core.get_global_option('BASIS'), orbital_basis.has_puream())
+            aux = core.BasisSet.build(orbital_basis.molecule(), "DF_BASIS_SCF", core.get_option("SCF", "DF_BASIS_SCF"),
+                                      "JKFIT", core.get_global_option('BASIS'), orbital_basis.has_puream())
         else:
             aux = core.BasisSet.zero_ao_basis_set()
 
@@ -526,7 +520,6 @@ def _core_set_global_option_python(key, EXTERN):
 
 core.set_global_option_python = _core_set_global_option_python
 
-
 ## QCvar helps
 
 
@@ -629,7 +622,6 @@ core.Wavefunction.set_variable = _core_wavefunction_set_variable
 core.Wavefunction.del_variable = _core_wavefunction_del_variable
 core.Wavefunction.variables = _core_wavefunction_variables
 
-
 ## Psi4 v1.4 Export Deprecations
 
 
@@ -707,7 +699,6 @@ core.Wavefunction.get_variable = _core_wavefunction_get_variable
 core.Wavefunction.get_array = _core_wavefunction_get_array
 core.Wavefunction.set_array = _core_wavefunction_set_array
 core.Wavefunction.arrays = _core_wavefunction_arrays
-
 
 ## Psi4 v1.3 Export Deprecations
 

--- a/psi4/driver/p4util/solvers.py
+++ b/psi4/driver/p4util/solvers.py
@@ -87,8 +87,7 @@ def cg_solver(rhs_vec, hx_function, preconditioner, guess=None, printer=None, pr
         core.print_out("    Maxiter             = %11d\n" % maxiter)
         core.print_out("    Convergence         = %11.3E\n" % rcond)
         core.print_out("    Number of equations = %11ld\n\n" % len(rhs_vec))
-        core.print_out("     %4s %14s %12s  %6s  %6s\n" %
-                       ("Iter", "Residual RMS", "Max RMS", "Remain", "Time [s]"))
+        core.print_out("     %4s %14s %12s  %6s  %6s\n" % ("Iter", "Residual RMS", "Max RMS", "Remain", "Time [s]"))
         core.print_out("   -----------------------------------------------------\n")
 
     nrhs = len(rhs_vec)
@@ -117,14 +116,14 @@ def cg_solver(rhs_vec, hx_function, preconditioner, guess=None, printer=None, pr
     # First RMS
     grad_dot = [x.sum_of_squares() for x in rhs_vec]
 
-    resid = [(r_vec[x].sum_of_squares() / grad_dot[x]) ** 0.5 for x in range(nrhs)]
+    resid = [(r_vec[x].sum_of_squares() / grad_dot[x])**0.5 for x in range(nrhs)]
 
     if printer:
         resid = printer(0, x_vec, r_vec)
     elif printlvl:
         # core.print_out('         CG Iteration Guess:    Rel. RMS = %1.5e\n' %  np.mean(resid))
-        core.print_out("    %5s %14.3e %12.3e %7d %9d\n" % (
-            "Guess", np.mean(resid), np.max(resid), len(z_vec), time.time() - tstart))
+        core.print_out("    %5s %14.3e %12.3e %7d %9d\n" % ("Guess", np.mean(resid), np.max(resid), len(z_vec),
+                                                            time.time() - tstart))
 
     rms = np.mean(resid)
     rz_old = [0.0 for x in range(nrhs)]
@@ -151,8 +150,7 @@ def cg_solver(rhs_vec, hx_function, preconditioner, guess=None, printer=None, pr
 
             x_vec[x].axpy(alpha[x], p_vec[x])
             r_vec[x].axpy(-alpha[x], Ap_vec[x])
-            resid[x] = (r_vec[x].sum_of_squares() / grad_dot[x]) ** 0.5
-
+            resid[x] = (r_vec[x].sum_of_squares() / grad_dot[x])**0.5
 
         # Print out or compute the resid function
         if printer:
@@ -165,9 +163,8 @@ def cg_solver(rhs_vec, hx_function, preconditioner, guess=None, printer=None, pr
 
         # Print out if requested
         if printlvl:
-            core.print_out("    %5d %14.3e %12.3e %7d %9d\n" % (
-                rot_iter + 1, np.mean(resid), np.max(resid), sum(active_mask), time.time() - tstart))
-
+            core.print_out("    %5d %14.3e %12.3e %7d %9d\n" % (rot_iter + 1, np.mean(resid), np.max(resid),
+                                                                sum(active_mask), time.time() - tstart))
 
         active = np.where(active_mask)[0]
 
@@ -188,7 +185,6 @@ def cg_solver(rhs_vec, hx_function, preconditioner, guess=None, printer=None, pr
 
 
 class DIIS(object):
-
     """
     An object to assist in the DIIS extrpolation procedure.
     """

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -35,6 +35,7 @@ import warnings
 from psi4 import core
 from psi4.driver import constants
 
+
 class Table(object):
     """Class defining a flexible Table object for storing data."""
 
@@ -50,7 +51,7 @@ class Table(object):
         self.rows = rows
 
         if isinstance(cols, str):
-            self.cols = (cols,)
+            self.cols = (cols, )
         else:
             self.cols = cols
 

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -183,8 +183,8 @@ def set_memory(inputval, execute=True):
     min_mem_allowed = 262144000
     if memory_amount < min_mem_allowed:
         raise ValidationError(
-            """set_memory(): Requested {:.3} MiB ({:.3} MB); minimum 250 MiB (263 MB). Please, sir, I want some more.""".format(
-                memory_amount / 1024**2, memory_amount / 1000**2))
+            """set_memory(): Requested {:.3} MiB ({:.3} MB); minimum 250 MiB (263 MB). Please, sir, I want some more."""
+            .format(memory_amount / 1024**2, memory_amount / 1000**2))
 
     if execute:
         core.set_memory_bytes(memory_amount)
@@ -217,9 +217,9 @@ def compare_values(expected, computed, digits, label, exitonfail=True):
 
     """
     if digits > 1:
-        thresh = 10 ** -digits
+        thresh = 10**-digits
         message = """\t{}: computed value ({:.{digits1}f}) does not match ({:.{digits1}f}) to {digits} digits.""".format(
-                  label, computed, expected, digits1=int(digits)+1, digits=digits)
+            label, computed, expected, digits1=int(digits) + 1, digits=digits)
     else:
         thresh = digits
         message = ("\t%s: computed value (%f) does not match (%f) to %f digits." % (label, computed, expected, digits))
@@ -271,12 +271,12 @@ def compare_matrices(expected, computed, digits, label):
 
     """
     if (expected.nirrep() != computed.nirrep()):
-        message = ("\t%s has %d irreps, but %s has %d\n." %
-                   (expected.name(), expected.nirrep(), computed.name(), computed.nirrep()))
+        message = ("\t%s has %d irreps, but %s has %d\n." % (expected.name(), expected.nirrep(), computed.name(),
+                                                             computed.nirrep()))
         raise TestComparisonError(message)
     if (expected.symmetry() != computed.symmetry()):
-        message = ("\t%s has %d symmetry, but %s has %d\n." %
-                   (expected.name(), expected.symmetry(), computed.name(), computed.symmetry()))
+        message = ("\t%s has %d symmetry, but %s has %d\n." % (expected.name(), expected.symmetry(), computed.name(),
+                                                               computed.symmetry()))
         raise TestComparisonError(message)
     nirreps = expected.nirrep()
     symmetry = expected.symmetry()
@@ -295,8 +295,8 @@ def compare_matrices(expected, computed, digits, label):
         for row in range(rows):
             for col in range(cols):
                 if (abs(expected.get(irrep, row, col) - computed.get(irrep, row, col)) > 10**(-digits)):
-                    print("\t%s: computed value (%s) does not match (%s)." %
-                          (label, expected.get(irrep, row, col), computed.get(irrep, row, col)))
+                    print("\t%s: computed value (%s) does not match (%s)." % (label, expected.get(irrep, row, col),
+                                                                              computed.get(irrep, row, col)))
                     failed = 1
                     break
 
@@ -320,8 +320,8 @@ def compare_vectors(expected, computed, digits, label):
 
     """
     if (expected.nirrep() != computed.nirrep()):
-        message = ("\t%s has %d irreps, but %s has %d\n." %
-                   (expected.name(), expected.nirrep(), computed.name(), computed.nirrep()))
+        message = ("\t%s has %d irreps, but %s has %d\n." % (expected.name(), expected.nirrep(), computed.name(),
+                                                             computed.nirrep()))
         raise TestComparisonError(message)
     nirreps = expected.nirrep()
     for irrep in range(nirreps):
@@ -341,8 +341,8 @@ def compare_vectors(expected, computed, digits, label):
             computed.print_out()
             core.print_out("The reference vector\n")
             expected.print_out()
-            message = ("\t%s: computed value (%s) does not match (%s)." %
-                       (label, computed.get(irrep, entry), expected.get(irrep, entry)))
+            message = ("\t%s: computed value (%s) does not match (%s)." % (label, computed.get(irrep, entry),
+                                                                           expected.get(irrep, entry)))
             raise TestComparisonError(message)
     success(label)
     return True
@@ -447,6 +447,7 @@ def compare_wavefunctions(expected, computed, digits=9, label='Wavefunctions equ
 
     success(label)
     return True
+
 
 # Uncomment and use if compare_arrays above is inadequate
 #def compare_lists(expected, computed, digits, label):

--- a/psi4/driver/procrouting/interface_cfour.py
+++ b/psi4/driver/procrouting/interface_cfour.py
@@ -32,8 +32,6 @@ Also calls to qcdb module are here and not elsewhere in driver.
 Organizationally, this module isolates qcdb code from psi4 code.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import re
 import sys

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1218,15 +1218,9 @@ def scf_helper(name, post_scf=True, **kwargs):
         p4util.banner('  Computing high-spin triplet guess  ')
         core.print_out('\n')
 
-    # If GUESS is auto guess what it should be
+    # If GUESS is auto, it should probably be SAD
     if core.get_option('SCF', 'GUESS') == "AUTO":
-        if (core.get_option('SCF', 'REFERENCE') in ['RHF', 'RKS']) and \
-                ((scf_molecule.natom() > 1) or core.get_option('SCF', 'SAD_FRAC_OCC')):
-            core.set_local_option('SCF', 'GUESS', 'SAD')
-        elif core.get_option('SCF', 'REFERENCE') in ['ROHF', 'ROKS', 'UHF', 'UKS']:
-            core.set_local_option('SCF', 'GUESS', 'GWH')
-        else:
-            core.set_local_option('SCF', 'GUESS', 'CORE')
+        core.set_local_option('SCF', 'GUESS', 'SAD')
 
     if core.get_global_option('BASIS') == '':
         if name in ['hf3c', 'hf-3c']:

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1350,6 +1350,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         pCb = ref_wfn.basis_projection(ref_wfn.Cb(), ref_wfn.nbetapi(), ref_wfn.basisset(), scf_wfn.basisset())
         scf_wfn.guess_Ca(pCa)
         scf_wfn.guess_Cb(pCb)
+        # Reset occupations in case of non-matching ECPs (#1439)
         scf_wfn.reset_occ_ = True
 
     # Print basis set info

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1218,9 +1218,15 @@ def scf_helper(name, post_scf=True, **kwargs):
         p4util.banner('  Computing high-spin triplet guess  ')
         core.print_out('\n')
 
-    # If GUESS is auto, it should probably be SAD
+    # If GUESS is auto guess what it should be
     if core.get_option('SCF', 'GUESS') == "AUTO":
-        core.set_local_option('SCF', 'GUESS', 'SAD')
+        if (core.get_option('SCF', 'REFERENCE') in ['RHF', 'RKS']) and \
+                ((scf_molecule.natom() > 1) or core.get_option('SCF', 'SAD_FRAC_OCC')):
+            core.set_local_option('SCF', 'GUESS', 'SAD')
+        elif core.get_option('SCF', 'REFERENCE') in ['ROHF', 'ROKS', 'UHF', 'UKS']:
+            core.set_local_option('SCF', 'GUESS', 'GWH')
+        else:
+            core.set_local_option('SCF', 'GUESS', 'CORE')
 
     if core.get_global_option('BASIS') == '':
         if name in ['hf3c', 'hf-3c']:

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1350,7 +1350,7 @@ def scf_helper(name, post_scf=True, **kwargs):
         pCb = ref_wfn.basis_projection(ref_wfn.Cb(), ref_wfn.nbetapi(), ref_wfn.basisset(), scf_wfn.basisset())
         scf_wfn.guess_Ca(pCa)
         scf_wfn.guess_Cb(pCb)
-
+        scf_wfn.reset_occ_ = True
 
     # Print basis set info
     if core.get_option("SCF", "PRINT_BASIS"):

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -31,8 +31,6 @@ calls for each of the *name* values of the energy(), optimize(),
 response(), and frequency() function. *name* can be assumed lowercase by here.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import shutil
 import subprocess
@@ -2065,7 +2063,7 @@ def run_scf(name, **kwargs):
         core.set_variable('CURRENT ENERGY', returnvalue)
         core.print_out('\n\n')
         core.print_out('    %s Energy Summary\n' % (name.upper()))
-        core.print_out('    -------------------------\n')
+        core.print_out('    ' + '-' * (15 + len(name)) + '\n')
         core.print_out('    DFT Reference Energy                  = %22.16lf\n' % (returnvalue - vdh))
         core.print_out('    Scaled MP2 Correlation                = %22.16lf\n' % (vdh))
         core.print_out('    @Final double-hybrid DFT total energy = %22.16lf\n\n' % (returnvalue))
@@ -2789,7 +2787,6 @@ def run_detci_property(name, **kwargs):
         ['OPDM'],
         ['TDM'])
 
-
     # Find valid properties
     valid_transition = ['TRANSITION_DIPOLE', 'TRANSITION_QUADRUPOLE']
 
@@ -3132,6 +3129,7 @@ def run_dfmp2(name, **kwargs):
     optstash.restore()
     core.tstop()
     return dfmp2_wfn
+
 
 def run_dfep2(name, **kwargs):
     """Function encoding sequence of PSI module calls for
@@ -4163,7 +4161,6 @@ def run_detcas(name, **kwargs):
     determinant-based multireference wavefuncations,
     namely CASSCF and RASSCF.
     """
-
     optstash = p4util.OptionsState(
         ['DETCI', 'WFN'],
         ['SCF_TYPE'],

--- a/psi4/driver/procrouting/proc_table.py
+++ b/psi4/driver/procrouting/proc_table.py
@@ -28,8 +28,6 @@
 """Module with a *procedures* dictionary specifying available quantum
 chemical methods.
 """
-from __future__ import print_function
-from __future__ import absolute_import
 
 from . import sapt
 from . import proc

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 import numpy as np
 
 from psi4 import core

--- a/psi4/driver/procrouting/roa.py
+++ b/psi4/driver/procrouting/roa.py
@@ -25,8 +25,6 @@
 #
 # @END LICENSE
 #
-from __future__ import absolute_import
-from __future__ import print_function
 import shelve
 
 from psi4 import core

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -264,13 +264,15 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         SCFE = 0.0
         self.clear_external_potentials()
 
-        core.timer_on("HF: Form G")
-        self.form_G()
-        core.timer_off("HF: Form G")
-
         # reset fractional SAD occupation
         if (self.iteration_ == 0) and self.reset_occ_:
             self.reset_occupation()
+            self.find_occupation()
+            self.form_D()
+
+        core.timer_on("HF: Form G")
+        self.form_G()
+        core.timer_off("HF: Form G")
 
         upcm = 0.0
         if core.get_option('SCF', 'PCM'):

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -361,32 +361,32 @@ def scf_iterate(self, e_conv=None, d_conv=None):
                 if self.diis_enabled_ and self.iteration_ >= self.diis_start_:
                     add_to_diis_subspace = True
 
-                    Drms = self.compute_orbital_gradient(add_to_diis_subspace, core.get_option('SCF', 'DIIS_MAX_VECS'))
+                Drms = self.compute_orbital_gradient(add_to_diis_subspace, core.get_option('SCF', 'DIIS_MAX_VECS'))
 
-                    if (self.diis_enabled_
+                if (self.diis_enabled_
                         and self.iteration_ >= self.diis_start_ + core.get_option('SCF', 'DIIS_MIN_VECS') - 1):
-                        diis_performed = self.diis()
+                    diis_performed = self.diis()
 
-                    if diis_performed:
-                        status.append("DIIS")
+                if diis_performed:
+                    status.append("DIIS")
 
-                    core.timer_off("HF: DIIS")
+                core.timer_off("HF: DIIS")
 
-                    if verbose > 4 and diis_performed:
-                        core.print_out("  After DIIS:\n")
-                        self.Fa().print_out()
-                        self.Fb().print_out()
+                if verbose > 4 and diis_performed:
+                    core.print_out("  After DIIS:\n")
+                    self.Fa().print_out()
+                    self.Fb().print_out()
 
-                    # frac, MOM invoked here from Wfn::HF::find_occupation
-                    core.timer_on("HF: Form C")
-                    self.form_C()
-                    core.timer_off("HF: Form C")
+                # frac, MOM invoked here from Wfn::HF::find_occupation
+                core.timer_on("HF: Form C")
+                self.form_C()
+                core.timer_off("HF: Form C")
 
-                    if self.MOM_performed_:
-                        status.append("MOM")
+                if self.MOM_performed_:
+                    status.append("MOM")
 
-                    if self.frac_performed_:
-                        status.append("FRAC")
+                if self.frac_performed_:
+                    status.append("FRAC")
 
         # Reset occupations if necessary
         if (self.iteration_ == 0) and self.reset_occ_:

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -304,56 +304,57 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             SCFE += self.molecule().EFP.get_wavefunction_dependent_energy()
 
         self.set_energies("Total Energy", SCFE)
+        core.set_variable("SCF ITERATION ENERGY", SCFE)
         Ediff = SCFE - SCFE_old
         SCFE_old = SCFE
 
         status = []
 
-        # SAD: form initial orbitals from the initial Fock matrix, and
-        # reset the occupations. From here on, the density matrices
-        # are correct.
-        if (self.iteration_ == 0) and self.sad_:
-            self.form_initial_C()
-            self.reset_occupation()
-            self.find_occupation()
+        # Check if we are doing SOSCF
+        if (soscf_enabled and (self.iteration_ >= 3) and (Drms < core.get_option('SCF', 'SOSCF_START_CONVERGENCE'))):
+            Drms = self.compute_orbital_gradient(False, core.get_option('SCF', 'DIIS_MAX_VECS'))
+            diis_performed = False
+            if self.functional().needs_xc():
+                base_name = "SOKS, nmicro="
+            else:
+                base_name = "SOSCF, nmicro="
 
-        # We either do SOSCF or DIIS
-        else:
-            if (soscf_enabled and (self.iteration_ > 3) and (Drms < core.get_option('SCF', 'SOSCF_START_CONVERGENCE'))):
-
-                Drms = self.compute_orbital_gradient(False, core.get_option('SCF', 'DIIS_MAX_VECS'))
-                diis_performed = False
-                if self.functional().needs_xc():
-                    base_name = "SOKS, nmicro="
+            if not _converged(Ediff, Drms, e_conv=e_conv, d_conv=d_conv):
+                nmicro = self.soscf_update(
+                    core.get_option('SCF', 'SOSCF_CONV'),
+                    core.get_option('SCF', 'SOSCF_MIN_ITER'),
+                    core.get_option('SCF', 'SOSCF_MAX_ITER'), core.get_option('SCF', 'SOSCF_PRINT'))
+                if nmicro > 0:
+                    # if zero, the soscf call bounced for some reason
+                    self.find_occupation()
+                    status.append(base_name + str(nmicro))
+                    soscf_performed = True  # Stops DIIS
                 else:
-                    base_name = "SOSCF, nmicro="
+                    if verbose > 0:
+                        core.print_out("Did not take a SOSCF step, using normal convergence methods\n")
+                        soscf_performed = False  # Back to DIIS
 
-                    if not _converged(Ediff, Drms, e_conv=e_conv, d_conv=d_conv):
-                        nmicro = self.soscf_update(
-                            core.get_option('SCF', 'SOSCF_CONV'),
-                            core.get_option('SCF', 'SOSCF_MIN_ITER'),
-                            core.get_option('SCF', 'SOSCF_MAX_ITER'), core.get_option('SCF', 'SOSCF_PRINT'))
-                        if nmicro > 0:
-                            # if zero, the soscf call bounced for some reason
-                            self.find_occupation()
-                            status.append(base_name + str(nmicro))
-                            soscf_performed = True  # Stops DIIS
-                        else:
-                            if verbose > 0:
-                                core.print_out("Did not take a SOSCF step, using normal convergence methods\n")
-                                soscf_performed = False  # Back to DIIS
+            else:
+                # need to ensure orthogonal orbitals and set epsilon
+                status.append(base_name + "conv")
+                core.timer_on("HF: Form C")
+                self.form_C()
+                core.timer_off("HF: Form C")
+                soscf_performed = True  # Stops DIIS
 
-                    else:
-                        # need to ensure orthogonal orbitals and set epsilon
-                        status.append(base_name + "conv")
-                        core.timer_on("HF: Form C")
-                        self.form_C()
-                        core.timer_off("HF: Form C")
-                        soscf_performed = True  # Stops DIIS
+        if not soscf_performed:
+            # Normal convergence procedures if we do not do SOSCF
 
-            if not soscf_performed:
-                # Normal convergence procedures if we do not do SOSCF
+            # SAD: form initial orbitals from the initial Fock matrix, and
+            # reset the occupations. From here on, the density matrices
+            # are correct.
+            if (self.iteration_ == 0) and self.sad_:
+                self.form_initial_C()
+                self.reset_occupation()
+                self.find_occupation()
 
+            else:
+                # Run DIIS
                 core.timer_on("HF: DIIS")
                 diis_performed = False
                 add_to_diis_subspace = False
@@ -388,16 +389,15 @@ def scf_iterate(self, e_conv=None, d_conv=None):
                 if self.frac_performed_:
                     status.append("FRAC")
 
-        # Reset occupations if necessary
-        if (self.iteration_ == 0) and self.reset_occ_:
-            self.reset_occupation()
-            self.find_occupation()
+                # Reset occupations if necessary
+                if (self.iteration_ == 0) and self.reset_occ_:
+                    self.reset_occupation()
+                    self.find_occupation()
 
+        # Form new density matrix
         core.timer_on("HF: Form D")
         self.form_D()
         core.timer_off("HF: Form D")
-
-        core.set_variable("SCF ITERATION ENERGY", SCFE)
 
         # After we've built the new D, damp the update
         if (damping_enabled and self.iteration_ > 1 and Drms > core.get_option('SCF', 'DAMPING_CONVERGENCE')):
@@ -424,7 +424,6 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             continue
 
         # Call any postiteration callbacks
-
         if _converged(Ediff, Drms, e_conv=e_conv, d_conv=d_conv):
             break
         if self.iteration_ >= core.get_option('SCF', 'MAXITER'):

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -324,15 +324,15 @@ def scf_iterate(self, e_conv=None, d_conv=None):
                     core.get_option('SCF', 'SOSCF_CONV'),
                     core.get_option('SCF', 'SOSCF_MIN_ITER'),
                     core.get_option('SCF', 'SOSCF_MAX_ITER'), core.get_option('SCF', 'SOSCF_PRINT'))
-                if nmicro > 0:
-                    # if zero, the soscf call bounced for some reason
+                # if zero, the soscf call bounced for some reason
+                soscf_performed = (nmicro>0)
+
+                if soscf_performed:
                     self.find_occupation()
                     status.append(base_name + str(nmicro))
-                    soscf_performed = True  # Stops DIIS
                 else:
                     if verbose > 0:
                         core.print_out("Did not take a SOSCF step, using normal convergence methods\n")
-                        soscf_performed = False  # Back to DIIS
 
             else:
                 # need to ensure orthogonal orbitals and set epsilon
@@ -364,8 +364,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
                 Drms = self.compute_orbital_gradient(add_to_diis_subspace, core.get_option('SCF', 'DIIS_MAX_VECS'))
 
-                if (self.diis_enabled_
-                        and self.iteration_ >= self.diis_start_ + core.get_option('SCF', 'DIIS_MIN_VECS') - 1):
+                if (add_to_diis_subspace + core.get_option('SCF', 'DIIS_MIN_VECS') - 1):
                     diis_performed = self.diis()
 
                 if diis_performed:

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -32,8 +32,6 @@ Also calls to qcdb module are here and not elsewhere in driver.
 Organizationally, this module isolates qcdb code from psi4 code.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import re
 import glob

--- a/psi4/driver/qcdb/__init__.py
+++ b/psi4/driver/qcdb/__init__.py
@@ -29,9 +29,6 @@
 databases. Contains Molecule class and physical constants from psi4 suite.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 __version__ = '0.4'
 __author__ = 'Lori A. Burns'
 

--- a/psi4/driver/qcdb/align.py
+++ b/psi4/driver/qcdb/align.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import time
 import itertools
 import collections
@@ -40,11 +37,6 @@ import qcelemental as qcel
 from .molecule import Molecule
 from .util import *
 from .psiutil import *
-
-try:
-    from itertools import izip as zip  # py2
-except ImportError:
-    pass  # py3
 
 
 class AlignmentMill(collections.namedtuple('AlignmentMill', 'shift rotation atommap mirror')):

--- a/psi4/driver/qcdb/basislist.py
+++ b/psi4/driver/qcdb/basislist.py
@@ -32,8 +32,6 @@ query appropriate fitting bases for any orbital basis distributed
 with Psi4.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 
 

--- a/psi4/driver/qcdb/basislistdunning.py
+++ b/psi4/driver/qcdb/basislistdunning.py
@@ -33,8 +33,6 @@ encode the Dunning basis set orbital definitions in
 orbital bases.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 from .basislist import *
 

--- a/psi4/driver/qcdb/basislistother.py
+++ b/psi4/driver/qcdb/basislistother.py
@@ -31,8 +31,6 @@ for Pople and other non-Dunning orbital basis sets. Some
 plausible fitting basis sets are supplied as defaults.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 from .basislist import *
 

--- a/psi4/driver/qcdb/bfs.py
+++ b/psi4/driver/qcdb/bfs.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import math
 import collections
 

--- a/psi4/driver/qcdb/cfour.py
+++ b/psi4/driver/qcdb/cfour.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import struct
 from collections import defaultdict

--- a/psi4/driver/qcdb/dbproc.py
+++ b/psi4/driver/qcdb/dbproc.py
@@ -29,8 +29,6 @@
 r"""File to
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import os
 import glob

--- a/psi4/driver/qcdb/dbwrap.py
+++ b/psi4/driver/qcdb/dbwrap.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
 import math

--- a/psi4/driver/qcdb/exceptions.py
+++ b/psi4/driver/qcdb/exceptions.py
@@ -27,7 +27,6 @@
 #
 
 """Module with non-generic exceptions classes."""
-from __future__ import print_function
 
 
 class QcdbException(Exception):

--- a/psi4/driver/qcdb/interface_gcp.py
+++ b/psi4/driver/qcdb/interface_gcp.py
@@ -27,8 +27,6 @@
 #
 
 """Module with functions that interface with Grimme's GCP code."""
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import re
 import uuid
@@ -68,7 +66,7 @@ def run_gcp(self, func=None, dertype=None, verbose=False):  # dashlvl=None, dash
     elif isinstance(self, core.Molecule):
         # called on a python export of a psi4.core.Molecule (py-side through Psi4's driver)
         self.create_psi4_string_from_molecule()
-    elif isinstance(self, basestring):
+    elif isinstance(self, str):
         # called on a string representation of a psi4.Molecule (c-side through psi4.Dispersion)
         self = Molecule(self)
     else:

--- a/psi4/driver/qcdb/jajo.py
+++ b/psi4/driver/qcdb/jajo.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import struct
 
 

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import os
 import sys
 import hashlib
@@ -44,8 +41,6 @@ from .libmintsgshell import ShellInfo
 from .libmintsbasissetparser import Gaussian94BasisSetParser
 from .basislist import corresponding_basis, corresponding_zeta
 
-if sys.version_info >= (3,0):
-    basestring = str
 
 basishorde = {}
 
@@ -139,12 +134,12 @@ class BasisSet(object):
             isinstance(args[1], int):
             self.constructor_basisset_center(*args)
         elif len(args) == 3 and \
-            isinstance(args[0], basestring) and \
+            isinstance(args[0], str) and \
             isinstance(args[1], Molecule) and \
             isinstance(args[2], collections.OrderedDict):
             self.constructor_role_mol_shellmap(*args)
         elif len(args) == 4 and \
-            isinstance(args[0], basestring) and \
+            isinstance(args[0], str) and \
             isinstance(args[1], Molecule) and \
             isinstance(args[2], collections.OrderedDict) and \
             isinstance(args[3], bool):
@@ -654,7 +649,7 @@ class BasisSet(object):
         elif orb in basishorde:
             basstrings['BASIS'] = basishorde[orb](mol, 'BASIS')
             callby = orb
-        elif isinstance(orb, basestring):
+        elif isinstance(orb, str):
             mol.set_basis_all_atoms(orb, role='BASIS')
             callby = orb
         else:
@@ -666,7 +661,7 @@ class BasisSet(object):
             elif callable(aux):
                 basstrings[fitrole] = aux(mol, fitrole)
                 callby = aux.__name__.replace('basisspec_psi4_yo__', '')
-            elif isinstance(aux, basestring):
+            elif isinstance(aux, str):
                 mol.set_basis_all_atoms(aux, role=fitrole)
                 callby = aux
             else:

--- a/psi4/driver/qcdb/libmintsbasissetparser.py
+++ b/psi4/driver/qcdb/libmintsbasissetparser.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import os
 import re
 import sys
@@ -36,8 +33,6 @@ import sys
 from .exceptions import *
 from .libmintsgshell import *
 
-if sys.version_info >= (3,0):
-    basestring = str
 
 class Gaussian94BasisSetParser(object):
     """Class for parsing basis sets from a text file in Gaussian 94
@@ -106,7 +101,7 @@ class Gaussian94BasisSetParser(object):
         dataset can be list of lines or a single string which will be converted to list of lines
 
         """
-        if isinstance(dataset, basestring):
+        if isinstance(dataset, str):
             lines = dataset.split('\n')
         else:
             lines = dataset

--- a/psi4/driver/qcdb/libmintscoordentry.py
+++ b/psi4/driver/qcdb/libmintscoordentry.py
@@ -32,8 +32,6 @@ Justin M. Turney, with incremental improvements by other
 psi4 developers.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import math
 import copy
 import collections

--- a/psi4/driver/qcdb/libmintsgshell.py
+++ b/psi4/driver/qcdb/libmintsgshell.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import math
 
 #MAX_IOFF = 30000

--- a/psi4/driver/qcdb/libmintspointgrp.py
+++ b/psi4/driver/qcdb/libmintspointgrp.py
@@ -26,16 +26,10 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import sys
 
 from .exceptions import *
 from .vecutil import *
-
-if sys.version_info >= (3,0):
-    basestring = str
 
 
 #
@@ -710,8 +704,8 @@ class IrreducibleRepresentation(object):
         elif len(args) == 4 and \
             isinstance(args[0], int) and \
             isinstance(args[1], int) and \
-            isinstance(args[2], basestring) and \
-            isinstance(args[3], basestring):
+            isinstance(args[2], str) and \
+            isinstance(args[3], str):
             self.constructor_order_degen_mulliken(*args)
         else:
             raise ValidationError('IrreducibleRepresentation::constructor: Inappropriate configuration of constructor arguments')
@@ -872,7 +866,7 @@ class CharacterTable(object):
         if len(args) == 0:
             pass
         elif len(args) == 1 and \
-            isinstance(args[0], basestring):
+            isinstance(args[0], str):
             self.constructor_schoenflies(*args)
         elif len(args) == 1 and \
             isinstance(args[0], int):
@@ -1529,13 +1523,13 @@ class PointGroup(object):
 #        if len(args) == 0:
 #            self.constructor_zero_ao_basis()
         if len(args) == 1 and \
-            isinstance(args[0], basestring):
+            isinstance(args[0], str):
             self.constructor_schoenflies(*args)
         elif len(args) == 1 and \
             isinstance(args[0], int):
             self.constructor_bits(*args)
         elif len(args) == 2 and \
-            isinstance(args[0], basestring) and \
+            isinstance(args[0], str) and \
             len(args[1]) == 3:
             self.constructor_schoenflies_origin(*args)
         elif len(args) == 2 and \

--- a/psi4/driver/qcdb/modelchems.py
+++ b/psi4/driver/qcdb/modelchems.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import collections
 
 # thinking now that QCEssential should have one doi and dictionary of

--- a/psi4/driver/qcdb/molpro.py
+++ b/psi4/driver/qcdb/molpro.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import math
 
 from .exceptions import *

--- a/psi4/driver/qcdb/molpro2.py
+++ b/psi4/driver/qcdb/molpro2.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import math
 from decimal import Decimal

--- a/psi4/driver/qcdb/mpl.py
+++ b/psi4/driver/qcdb/mpl.py
@@ -31,8 +31,6 @@ any particular qcdb data structures but can be called with basic
 arguments.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 #import matplotlib
 #matplotlib.use('Agg')

--- a/psi4/driver/qcdb/options.py
+++ b/psi4/driver/qcdb/options.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import math
 from .exceptions import *
 

--- a/psi4/driver/qcdb/orca.py
+++ b/psi4/driver/qcdb/orca.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from collections import defaultdict
 
 import qcelemental as qcel

--- a/psi4/driver/qcdb/orient.py
+++ b/psi4/driver/qcdb/orient.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 #import os
 #import re
 #import math

--- a/psi4/driver/qcdb/parker.py
+++ b/psi4/driver/qcdb/parker.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import math
 
 import numpy as np

--- a/psi4/driver/qcdb/pdict.py
+++ b/psi4/driver/qcdb/pdict.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from decimal import Decimal, ROUND_FLOOR, ROUND_CEILING
 from .exceptions import *
 

--- a/psi4/driver/qcdb/psiutil.py
+++ b/psi4/driver/qcdb/psiutil.py
@@ -30,8 +30,6 @@ r"""Stuff stolen from psi. Should import or not as necessary
 or some better way. Apologies to the coders.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import re
 import sys

--- a/psi4/driver/qcdb/qcformat.py
+++ b/psi4/driver/qcdb/qcformat.py
@@ -29,8 +29,6 @@
 """Parent classes for quantum chemistry program input and output file
 formats.
 """
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 
 

--- a/psi4/driver/qcdb/qchem.py
+++ b/psi4/driver/qcdb/qchem.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
 import re
 import math
 from collections import defaultdict

--- a/psi4/driver/qcdb/qcprog_psi4.py
+++ b/psi4/driver/qcdb/qcprog_psi4.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import math
 from collections import defaultdict

--- a/psi4/driver/qcdb/textables.py
+++ b/psi4/driver/qcdb/textables.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import sys
 import itertools

--- a/psi4/driver/qcdb/vecutil.py
+++ b/psi4/driver/qcdb/vecutil.py
@@ -33,9 +33,6 @@ Vectors that use these functions are overwhelmingly of length 3, so
 pure python instead of NumPy is the right choice efficiency-wise.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 import copy
 import math
 

--- a/psi4/driver/qcdb/vib.py
+++ b/psi4/driver/qcdb/vib.py
@@ -26,11 +26,9 @@
 # @END LICENSE
 #
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
 import sys
 import math
+import itertools
 import collections
 
 import numpy as np
@@ -42,10 +40,6 @@ from .util import *
 from .libmintsmolecule import compute_atom_map
 from .datastructures import QCAspect
 
-try:
-    from itertools import izip_longest as zip_longest  # py2
-except ImportError:
-    from itertools import zip_longest  # py3
 
 LINEAR_A_TOL = 1.0E-2  # tolerance (roughly max dev) for TR space
 
@@ -645,7 +639,7 @@ def print_vibs(vibinfo, atom_lbl=None, normco='x', shortlong=True, **kwargs):
         "Collect data into fixed-length chunks or blocks"
         # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
         args = [iter(iterable)] * n
-        return zip_longest(*args, fillvalue=fillvalue)
+        return itertools.zip_longest(*args, fillvalue=fillvalue)
 
     if normco not in ['q', 'w', 'x']:
         raise ValidationError("""Requested normal coordinates not among allowed q/w/x: """ + normco)

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -30,7 +30,6 @@
 a QM calculation.
 
 """
-from __future__ import absolute_import
 
 from psi4.driver import *
 

--- a/psi4/driver/wrapper_autofrag.py
+++ b/psi4/driver/wrapper_autofrag.py
@@ -26,9 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 from psi4 import core
 
 

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -31,8 +31,6 @@ functions: :py:mod:`driver.energy`, :py:mod:`driver.optimize`,
 :py:mod:`driver.response`, and :py:mod:`driver.frequency`.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import os
 import re
 import math
@@ -383,7 +381,7 @@ def database(name, db_name, **kwargs):
     if 'subset' in kwargs:
         db_subset = kwargs['subset']
 
-    if isinstance(db_subset, basestring):
+    if isinstance(db_subset, (str, bytes)):
         if db_subset.lower() == 'small':
             try:
                 database.HRXN_SM
@@ -497,7 +495,7 @@ def database(name, db_name, **kwargs):
             if core.has_global_option_changed(chgdopt):
                 chgdoptval = core.get_global_option(chgdopt)
                 #chgdoptval = core.get_option(chgdopt)
-                if isinstance(chgdoptval, basestring):
+                if isinstance(chgdoptval, (str, bytes)):
                     commands += """core.set_global_option('%s', '%s')\n""" % (chgdopt, chgdoptval)
                 elif isinstance(chgdoptval, int) or isinstance(chgdoptval, float):
                     commands += """core.set_global_option('%s', %s)\n""" % (chgdopt, chgdoptval)
@@ -776,21 +774,3 @@ db = database
 #######################
 ##  End of Database  ##
 #######################
-
-
-# Quickly normalize the types for both python 2 and 3
-try:
-    unicode = unicode
-except NameError:
-    # 'unicode' is undefined, must be Python 3
-    str = str
-    unicode = str
-    bytes = bytes
-    basestring = (str, bytes)
-else:
-    # 'unicode' exists, must be Python 2
-    str = str
-    unicode = unicode
-    bytes = str
-    basestring = basestring
-

--- a/psi4/psi4.bat
+++ b/psi4/psi4.bat
@@ -1,0 +1,29 @@
+::
+:: @BEGIN LICENSE
+::
+:: Psi4: an open-source quantum chemistry software package
+::
+:: Copyright (c) 2007-2018 The Psi4 Developers.
+::
+:: The copyrights for code used from other parties are included in
+:: the corresponding files.
+::
+:: This file is part of Psi4.
+::
+:: Psi4 is free software; you can redistribute it and/or modify
+:: it under the terms of the GNU Lesser General Public License as published by
+:: the Free Software Foundation, version 3.
+::
+:: Psi4 is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+:: GNU Lesser General Public License for more details.
+::
+:: You should have received a copy of the GNU Lesser General Public License along
+:: with Psi4; if not, write to the Free Software Foundation, Inc.,
+:: 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+::
+:: @END LICENSE
+::
+
+@PYTHON_EXECUTABLE@ %~dp0psi4 %*

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -314,6 +314,11 @@ void export_mints(py::module& m) {
     //        def(vector_indexing_suite<std::vector<double>, true >());
     //    py::bind_vector<double>(m, "VectorDouble");
 
+    typedef void (Vector::*vector_setitem_1)(int, double);
+    typedef void (Vector::*vector_setitem_2)(int, int, double);
+    typedef double (Vector::*vector_getitem_1)(int) const;
+    typedef double (Vector::*vector_getitem_2)(int, int) const;
+
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
         .def(py::init<int>())
         .def(py::init<int, const std::string&>())
@@ -352,13 +357,13 @@ void export_mints(py::module& m) {
         .def(py::init<const std::string&, const Dimension&>())
         .def_property("name", py::cpp_function(&Vector::name), py::cpp_function(&Vector::set_name),
                       "The name of the Vector. Used in printing.")
-        .def("get", py::overload_cast<int>(&Vector::get, py::const_), "Returns a single element value located at m",
+        .def("get", vector_getitem_1(&Vector::get), "Returns a single element value located at m",
              "m"_a)
-        .def("get", py::overload_cast<int, int>(&Vector::get, py::const_),
+        .def("get", vector_getitem_2(&Vector::get),
              "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
-        .def("set", py::overload_cast<int, double>(&Vector::set), "Sets a single element value located at m", "m"_a,
+        .def("set", vector_setitem_1(&Vector::set), "Sets a single element value located at m", "m"_a,
              "val"_a)
-        .def("set", py::overload_cast<int, int, double>(&Vector::set),
+        .def("set", vector_setitem_2(&Vector::set),
              "Sets a single element value located at m in irrep h", "h"_a, "m"_a, "val"_a)
         .def("print_out", &Vector::print_out, "Prints the vector to the output file")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", "sc"_a)

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -209,10 +209,12 @@ void export_wavefunction(py::module& m) {
 
     py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
         .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.")
+        .def("form_initial_C", &scf::HF::form_initial_C, "Forms the initial Orbital Matrices from the current Fock Matrices.")
         .def("form_D", &scf::HF::form_D, "Forms the Density Matrices from the current Orbitals Matrices")
         .def("form_V", &scf::HF::form_V, "Form the Kohn-Sham Potential Matrices from the current Density Matrices")
         .def("form_G", &scf::HF::form_G, "Forms the G matrix.")
         .def("form_F", &scf::HF::form_F, "Forms the F matrix.")
+        .def("form_initial_F", &scf::HF::form_initial_F, "Forms the initial F matrix.")
         .def("form_H", &scf::HF::form_H, "Forms the core Hamiltonian")
         .def("form_Shalf", &scf::HF::form_Shalf, "Forms the S^1/2 matrix")
         .def("guess", &scf::HF::guess, "Forms the guess (guarantees C, D, and E)")
@@ -227,6 +229,8 @@ void export_wavefunction(py::module& m) {
         .def("guess_Cb", &scf::HF::guess_Cb, "Sets the guess Beta Orbital Matrix")
         .def_property("reset_occ_", &scf::HF::reset_occ, &scf::HF::set_reset_occ,
                       "Do reset the occupation after the guess to the inital occupation.")
+        .def_property("sad_", &scf::HF::sad, &scf::HF::set_sad,
+                    "Do assume a non-idempotent density matrix and no orbitals after the guess.")
         .def("set_sad_basissets", &scf::HF::set_sad_basissets, "Sets the Superposition of Atomic Densities basisset.")
         .def("set_sad_fitting_basissets", &scf::HF::set_sad_fitting_basissets,
              "Sets the Superposition of Atomic Densities density-fitted basisset.")

--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -84,8 +84,8 @@ PSI_API void block_to_tri(double *a, double **b, int num_ir, int *num_so, int *i
 PSI_API void tri_to_sq(double *amat, double **bmat, int size);
 
 /* Functions under tstart.c */
-PSI_API void tstart();
-PSI_API void tstop();
+void tstart();
+void tstop();
 
 /* Functions in zero.c */
 PSI_API void zero_arr(double *a, int size);

--- a/psi4/src/psi4/libciomr/tstart.cc
+++ b/psi4/src/psi4/libciomr/tstart.cc
@@ -64,7 +64,7 @@ double user_stop, sys_stop;
 **
 ** \ingroup CIOMR
 */
-void tstart() {
+void PSI_API tstart() {
     int error;
     char *name;
     struct tms total_tmstime;
@@ -100,7 +100,7 @@ void tstart() {
 **
 ** \ingroup CIOMR
 */
-void tstop() {
+void PSI_API tstop() {
     int error;
     std::time_t total_time;
     std::time_t total_time_overall;

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -232,6 +232,7 @@ int C_DGGES(char jobvsl, char jobvsr, char sort, int n, double* a, int lda, doub
 int C_DGGESX(char jobvsl, char jobvsr, char sort, char sense, int n, double* a, int lda, double* b, int ldb, int* sdim,
              double* alphar, double* alphai, double* beta, double* vsl, int ldvsl, double* vsr, int ldvsr,
              double* rconde, double* rcondv, double* work, int lwork, int* iwork, int liwork);
+PSI_API
 int C_DGGEV(char jobvl, char jobvr, int n, double* a, int lda, double* b, int ldb, double* alphar, double* alphai,
             double* beta, double* vl, int ldvl, double* vr, int ldvr, double* work, int lwork);
 int C_DGGEVX(char balanc, char jobvl, char jobvr, char sense, int n, double* a, int lda, double* b, int ldb,

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -202,9 +202,14 @@ void CUHF::compute_spin_contamination() {
     outfile->Printf("  @S^2 Observed:              %8.5F\n", S2 + dS);
 }
 
-void CUHF::form_initialF() {
+void CUHF::form_initial_F() {
+    // Form the initial Fock matrix, closed and open variants
     Fa_->copy(H_);
-    Fb_->copy(H_);
+    Fa_->add(Ga_);
+    for (const auto& Vext : external_potentials_) {
+      Fa_->add(Vext);
+    }
+    Fb_->copy(Fa_);
 
     if (debug_) {
         outfile->Printf("Initial Fock alpha matrix:\n");

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -212,7 +212,7 @@ void CUHF::form_initial_F() {
 
     Fa_->copy(H_);
     for (const auto& Vext : external_potentials_) {
-      Fa_->add(Vext);
+        Fa_->add(Vext);
     }
     Fa_->add(Fp_);
 
@@ -291,14 +291,14 @@ void CUHF::form_F() {
     // Build the modified alpha and beta Fock matrices
     Fa_->copy(H_);
     for (const auto& Vext : external_potentials_) {
-      Fa_->add(Vext);
+        Fa_->add(Vext);
     }
     Fa_->add(Fp_);
     Fa_->add(Fm_);
 
     Fb_->copy(H_);
     for (const auto& Vext : external_potentials_) {
-      Fb_->add(Vext);
+        Fb_->add(Vext);
     }
     Fb_->add(Fp_);
     Fb_->subtract(Fm_);

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -203,12 +203,20 @@ void CUHF::compute_spin_contamination() {
 }
 
 void CUHF::form_initial_F() {
-    // Form the initial Fock matrix, closed and open variants
+    // Form the initial Fock matrix to get initial orbitals
+    Fp_->copy(J_);
+    Fp_->scale(2.0);
+    Fp_->subtract(Ka_);
+    Fp_->subtract(Kb_);
+    Fp_->scale(0.5);
+
     Fa_->copy(H_);
-    Fa_->add(Ga_);
     for (const auto& Vext : external_potentials_) {
       Fa_->add(Vext);
     }
+    Fa_->add(Fp_);
+
+    // Just reuse alpha for beta
     Fb_->copy(Fa_);
 
     if (debug_) {
@@ -282,10 +290,16 @@ void CUHF::form_F() {
 
     // Build the modified alpha and beta Fock matrices
     Fa_->copy(H_);
+    for (const auto& Vext : external_potentials_) {
+      Fa_->add(Vext);
+    }
     Fa_->add(Fp_);
     Fa_->add(Fm_);
 
     Fb_->copy(H_);
+    for (const auto& Vext : external_potentials_) {
+      Fb_->add(Vext);
+    }
     Fb_->add(Fp_);
     Fb_->subtract(Fm_);
 

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -79,7 +79,7 @@ class CUHF : public HF {
     // Natural orbital occupations
     SharedVector No_;
 
-    void form_initialF();
+    void form_initial_F();
     double compute_initial_E() override;
 
     void compute_spin_contamination() override;

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -74,7 +74,7 @@ class CUHF : public HF {
     SharedMatrix J_, Ka_, Kb_;
     // Contributions to the Fock matrix from charge and spin density
     SharedMatrix Fp_, Fm_;
-    // Charge denisty and natural orbitals (eigenvectors of charge density)
+    // Charge density and natural orbitals (eigenvectors of charge density)
     SharedMatrix Dp_, Cno_, Cno_temp_;
     // Natural orbital occupations
     SharedVector No_;

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1098,23 +1098,27 @@ void HF::guess() {
         // by Superposition of Atomic Densities", J Comput Chem 27,
         // 926 (2006).
 
-        // Build SAD density matrix
+        // Build non-idempotent, spin-restricted SAD density matrix
         compute_SAD_guess();
 
-        // Form initial spin-restricted Fock matrix from the SAD density
+        // Form initial (spin-restricted) Fock matrix from the SAD density.
         form_G();
         form_initial_F();
 
         // Diagonalize spin-restricted Fock matrix to get the same
         // orbitals for alpha and beta, also allowing spin-restricted
-        // open shell calculations to work
+        // open shell calculations to work.
         form_initial_C();
 
-        // Now can form the target density matrix
+        // Now can form the target density matrix, which may also
+        // correspond to a different charge and/or spin state than the
+        // neutral spin-restricted SAD guess. The density matrix is
+        // now also idempotent, so the energies one gets for the first
+        // printed iteration are variational.
         form_D();
 
         // This is a guess iteration: orbital occupations corresponded
-        // to SAD and must be reset in SCF
+        // to SAD and must be reset in SCF.
         iteration_ = -1;
         reset_occ_ = true;
         guess_E = compute_initial_E();

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -89,6 +89,7 @@ void HF::common_init() {
     attempt_number_ = 1;
     ref_C_ = false;
     reset_occ_ = false;
+    sad_ = false;
 
     // This quantity is needed fairly soon
     nirrep_ = factory_->nirrep();
@@ -1101,26 +1102,12 @@ void HF::guess() {
         // Build non-idempotent, spin-restricted SAD density matrix
         compute_SAD_guess();
 
-        // Form initial (spin-restricted) Fock matrix from the SAD density.
-        form_G();
-        form_initial_F();
-
-        // Diagonalize spin-restricted Fock matrix to get the same
-        // orbitals for alpha and beta, also allowing spin-restricted
-        // open shell calculations to work.
-        form_initial_C();
-
-        // Now can form the target density matrix, which may also
-        // correspond to a different charge and/or spin state than the
-        // neutral spin-restricted SAD guess. The density matrix is
-        // now also idempotent, so the energies one gets for the first
-        // printed iteration are variational.
-        form_D();
-
-        // This is a guess iteration: orbital occupations corresponded
-        // to SAD and must be reset in SCF.
+        // This is a guess iteration: orbital occupations must be
+        // reset in SCF.
         iteration_ = -1;
-        reset_occ_ = true;
+        // SAD doesn't yield orbitals so also the SCF logic is
+        // slightly different for the first iteration.
+        sad_ = true;
         guess_E = compute_initial_E();
 
     } else if (guess_type == "GWH") {

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -257,8 +257,6 @@ void HF::common_init() {
         potential_ = nullptr;
     }
 
-
-
     // -D is zero by default
     set_scalar_variable("-D Energy", 0.0);
     energies_["-D"] = 0.0;

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1093,20 +1093,28 @@ void HF::guess() {
 
         // Superposition of Atomic Density. Modified by Susi Lehtola
         // 2018-12-15 to work also for ROHF, as well as to allow using
-        // SAD with predefined orbital occupations.
+        // SAD with predefined orbital occupations. The algorithm is
+        // the same as in van Lenthe et al, "Starting SCF Calculations
+        // by Superposition of Atomic Densities", J Comput Chem 27,
+        // 926 (2006).
+
+        // Build SAD density matrix
         compute_SAD_guess();
 
-        // Form Fock matrix
+        // Form initial spin-restricted Fock matrix from the SAD density
         form_G();
-        form_initialF();
+        form_initial_F();
 
-        // Diagonalize Fock matrix to get orbitals
+        // Diagonalize spin-restricted Fock matrix to get the same
+        // orbitals for alpha and beta, also allowing spin-restricted
+        // open shell calculations to work
         form_initial_C();
 
-        // Now can form density matrix
+        // Now can form the target density matrix
         form_D();
 
-        // This is a guess iteration: orbital occupations may be reset in SCF
+        // This is a guess iteration: orbital occupations corresponded
+        // to SAD and must be reset in SCF
         iteration_ = -1;
         reset_occ_ = true;
         guess_E = compute_initial_E();

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1015,14 +1015,9 @@ void HF::guess() {
     // ref_C_-C matrices were detected in the incoming wavefunction
     // "CORE"-CORE Hamiltonain
     // "GWH"-Generalized Wolfsberg-Helmholtz
-    // "SAD"-Superposition of Atomic Denisties
+    // "SAD"-Superposition of Atomic Densities
     std::string guess_type = options_.get_str("GUESS");
 
-    // DGAS broke SAD
-    // if (guess_type == "SAD"){
-    //     outfile->Printf("\nWarning! SAD is temporarily broken, switching to CORE!\n\n");
-    //     guess_type = "CORE";
-    // }
     // Take care of options that should be overridden
     if (guess_type == "AUTO") {
         outfile->Printf("\nWarning! Guess was AUTO, switching to CORE!\n\n");
@@ -1089,17 +1084,31 @@ void HF::guess() {
         format_guess();
         form_D();
 
-        // This is a guess iteration similar to SAD
+        // This is a guess iteration: orbital occupations may be reset in SCF
         iteration_ = -1;
         guess_E = compute_initial_E();
 
     } else if (guess_type == "SAD") {
         if (print_) outfile->Printf("  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.\n\n");
 
-        // Superposition of Atomic Density
+        // Superposition of Atomic Density. Modified by Susi Lehtola
+        // 2018-12-15 to work also for ROHF, as well as to allow using
+        // SAD with predefined orbital occupations.
+        compute_SAD_guess();
+
+        // Form Fock matrix
+        form_G();
+        form_initialF();
+
+        // Diagonalize Fock matrix to get orbitals
+        form_initial_C();
+
+        // Now can form density matrix
+        form_D();
+
+        // This is a guess iteration: orbital occupations may be reset in SCF
         iteration_ = -1;
         reset_occ_ = true;
-        compute_SAD_guess();
         guess_E = compute_initial_E();
 
     } else if (guess_type == "GWH") {
@@ -1121,7 +1130,6 @@ void HF::guess() {
         }
         Fb_->copy(Fa_);
         form_initial_C();
-        find_occupation();
         form_D();
         guess_E = compute_initial_E();
 
@@ -1132,7 +1140,6 @@ void HF::guess() {
         Fb_->copy(H_);
 
         form_initial_C();
-        find_occupation();
         form_D();
         guess_E = compute_initial_E();
     } else {

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -214,6 +214,11 @@ class HF : public Wavefunction {
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);
 
+    /** Computes the initial MO coefficients (default is to call form_C) */
+    virtual void form_initial_C() { form_C(); }
+    /** Computes the initial Fock matrix (default is to call form_F) */
+    virtual void form_initialF() { form_F(); }
+
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);
 

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -214,11 +214,6 @@ class HF : public Wavefunction {
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);
 
-    /** Computes the initial MO coefficients (default is to call form_C) */
-    virtual void form_initial_C() { form_C(); }
-    /** Computes the initial Fock matrix (default is to call form_F) */
-    virtual void form_initial_F() { form_F(); }
-
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);
 

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -214,7 +214,7 @@ class HF : public Wavefunction {
     /** Computes the initial MO coefficients (default is to call form_C) */
     virtual void form_initial_C() { form_C(); }
     /** Computes the initial Fock matrix (default is to call form_F) */
-    virtual void form_initialF() { form_F(); }
+    virtual void form_initial_F() { form_F(); }
 
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -116,7 +116,10 @@ class HF : public Wavefunction {
     Dimension original_soccpi_;
     int original_nalpha_;
     int original_nbeta_;
+    // Reset occupations in SCF iteration?
     bool reset_occ_;
+    // SAD guess, non-idempotent guess density?
+    bool sad_;
 
     /// Mapping arrays
     int* so2symblk_;
@@ -210,11 +213,6 @@ class HF : public Wavefunction {
 
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);
-
-    /** Computes the initial MO coefficients (default is to call form_C) */
-    virtual void form_initial_C() { form_C(); }
-    /** Computes the initial Fock matrix (default is to call form_F) */
-    virtual void form_initial_F() { form_F(); }
 
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);
@@ -358,6 +356,8 @@ class HF : public Wavefunction {
 
     /// Compute the MO coefficients (C_)
     virtual void form_C();
+    /** Computes the initial MO coefficients (default is to call form_C) */
+    virtual void form_initial_C() { form_C(); }
 
     /// Computes the density matrix (D_)
     virtual void form_D();
@@ -367,6 +367,8 @@ class HF : public Wavefunction {
 
     /** Computes the Fock matrix */
     virtual void form_F();
+    /** Computes the initial Fock matrix (default is to call form_F) */
+    virtual void form_initial_F() { form_F(); }
 
     /** Forms the G matrix */
     virtual void form_G();
@@ -397,6 +399,9 @@ class HF : public Wavefunction {
     // Expert option to reset the occuption or not at iteration zero
     bool reset_occ() const { return reset_occ_; }
     void set_reset_occ(bool reset) { reset_occ_ = reset; }
+    // Expert option to toggle non-idempotent density matrix or not at iteration zero
+    bool sad() const { return sad_; }
+    void set_sad(bool sad) { sad_ = sad; }
 
     // SAD information
     void set_sad_basissets(std::vector<std::shared_ptr<BasisSet>> basis_vec) { sad_basissets_ = basis_vec; }

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -217,7 +217,7 @@ class HF : public Wavefunction {
     /** Computes the initial MO coefficients (default is to call form_C) */
     virtual void form_initial_C() { form_C(); }
     /** Computes the initial Fock matrix (default is to call form_F) */
-    virtual void form_initialF() { form_F(); }
+    virtual void form_initial_F() { form_F(); }
 
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -213,6 +213,8 @@ class HF : public Wavefunction {
 
     /** Computes the initial MO coefficients (default is to call form_C) */
     virtual void form_initial_C() { form_C(); }
+    /** Computes the initial Fock matrix (default is to call form_F) */
+    virtual void form_initialF() { form_F(); }
 
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -80,10 +80,10 @@ class RHF : public HF {
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;
     std::vector<SharedMatrix> twoel_Hx(std::vector<SharedMatrix> x, bool combine = true,
-                                               std::string return_basis = "MO") override;
+                                       std::string return_basis = "MO") override;
     std::vector<SharedMatrix> cphf_Hx(std::vector<SharedMatrix> x) override;
-    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4,
-                                                 int max_iter = 10, int print_lvl = 1) override;
+    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4, int max_iter = 10,
+                                         int print_lvl = 1) override;
 
     std::shared_ptr<RHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -347,7 +347,10 @@ bool ROHF::diis() { return diis_manager_->extrapolate(1, soFeff_.get()); }
 void ROHF::form_initialF() {
     // Form the initial Fock matrix, closed and open variants
     Fa_->copy(H_);
-    Fa_->transform(X_);
+    Fa_->add(Ga_);
+    for (const auto& Vext : external_potentials_) {
+      Fa_->add(Vext);
+    }
     Fb_->copy(Fa_);
 
     if (debug_) {
@@ -462,7 +465,13 @@ void ROHF::form_initial_C() {
     // Form C = XC'
     Ca_->gemm(false, false, 1.0, X_, Ct_, 0.0);
 
-    if (print_ > 3) Ca_->print("outfile", "initial C");
+    find_occupation();
+
+    if (debug_) {
+      Ca_->print("outfile");
+      outfile->Printf("In ROHF::form_initial_C:\n");
+      Ct_->eivprint(epsilon_a_);
+    }
 }
 
 void ROHF::form_D() {

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -344,7 +344,7 @@ double ROHF::compute_orbital_gradient(bool save_diis, int max_diis_vectors) {
 
 bool ROHF::diis() { return diis_manager_->extrapolate(1, soFeff_.get()); }
 
-void ROHF::form_initialF() {
+void ROHF::form_initial_F() {
     // Form the initial Fock matrix, closed and open variants
     Fa_->copy(H_);
     Fa_->add(Ga_);

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -349,7 +349,7 @@ void ROHF::form_initial_F() {
     Fa_->copy(H_);
     Fa_->add(Ga_);
     for (const auto& Vext : external_potentials_) {
-      Fa_->add(Vext);
+        Fa_->add(Vext);
     }
     Fb_->copy(Fa_);
 
@@ -468,9 +468,9 @@ void ROHF::form_initial_C() {
     find_occupation();
 
     if (debug_) {
-      Ca_->print("outfile");
-      outfile->Printf("In ROHF::form_initial_C:\n");
-      Ct_->eivprint(epsilon_a_);
+        Ca_->print("outfile");
+        outfile->Printf("In ROHF::form_initial_C:\n");
+        Ct_->eivprint(epsilon_a_);
     }
 }
 

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -52,7 +52,7 @@ class ROHF : public HF {
     SharedMatrix moFa_;
     SharedMatrix moFb_;
 
-    void form_initialF() override;
+    void form_initial_F() override;
     void form_initial_C() override;
     double compute_initial_E() override;
     void prepare_canonical_orthogonalization() override;

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -52,7 +52,7 @@ class ROHF : public HF {
     SharedMatrix moFa_;
     SharedMatrix moFb_;
 
-    void form_initialF();
+    void form_initialF() override;
     void form_initial_C() override;
     double compute_initial_E() override;
     void prepare_canonical_orthogonalization() override;

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -608,7 +608,7 @@ void SADGuess::form_C_and_D(int nocc, int norbs, SharedMatrix X, SharedMatrix F,
     }
     // Scale by occ
     for (int i = 0; i < nocc; i++) {
-        C_DSCAL(norbs, occ->get(i), &Cp[0][i], nocc);
+        C_DSCAL(norbs, occ->get(i), &Coccp[0][i], nocc);
     }
     // Form D = Cocc*Cocc'
     D->gemm(false, true, 1.0, Cocc, Cocc, 0.0);

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -146,7 +146,7 @@ void SADGuess::form_C() {
     } else {
         Cb_ = SharedMatrix(Ca_->clone());
         Cb_->set_name("Cb SAD");
-        Cb_->scale(sqrt(((double)nbeta_) / ((double)nalpha_)));
+        Cb_->scale(std::sqrt(((double)nbeta_) / ((double)nalpha_)));
     }
 
     if (debug_) {
@@ -358,61 +358,77 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
     SharedMatrix Fa(mat.create_matrix("Fa"));
     SharedMatrix Fb(mat.create_matrix("Fb"));
 
-    // Factional occupation
+    // Fractional occupation
     SharedVector occ_a, occ_b;
-    if (options_.get_bool("SAD_FRAC_OCC")) {
-        int nfzc = 0, nact = 0;
-        if (Z <= 2) {
+    // Number of partially or fully occupied orbitals
+    int nocc_a, nocc_b;
+    if (options_.get_bool("SAD_FRAC_OCC") || options_.get_bool("SAD_FRAC_SR_OCC")) {
+        // The density is spread over the whole of the possible valence shell.
+        // Only the noble gas core is doubly occupied
+        static const std::vector<int> magic_values = {0, 2, 10, 18, 36, 54, 86, 118};
+        // Find the noble gas core.
+        auto imagic = std::lower_bound(magic_values.begin(), magic_values.end(), Z);
+        if (imagic == magic_values.end()) {
+            throw PSIEXCEPTION("SAD: Fractional occupations are not supported beyond Oganesson");
+        }
+        // lower_bound gives a value that is equal or greater than the
+        // wanted value, which is handled next.
+        if (*imagic > Z) imagic--;
+
+        // Number of frozen and active orbitals
+        int nfzc, nact;
+        if ((*imagic) == Z) {
+            // Special case: we can hit the boundary at the end of the array
             nfzc = 0;
-            nact = 1;
-        } else if (Z <= 4) {
-            nfzc = 1;
-            nact = 1;
-        } else if (Z <= 10) {
-            nfzc = 2;
-            nact = 3;
-        } else if (Z <= 18) {
-            nfzc = 5;
-            nact = 4;
-        } else if (Z <= 36) {
-            nfzc = 9;
-            nact = 9;
-        } else if (Z <= 54) {
-            nfzc = 18;
-            nact = 9;
-        } else if (Z <= 54) {
-            nfzc = 18;
-            nact = 9;
-        } else if (Z <= 86) {
-            nfzc = 27;
-            nact = 16;
+            nact = (*imagic) / 2;
         } else {
-            throw PSIEXCEPTION("SAD: Fractional occupations are not supported beyond Radon");
+            nfzc = (*imagic) / 2;
+            nact = (*(++imagic)) / 2 - nfzc;
         }
 
-        nalpha = nfzc + nact;
-        nbeta = nalpha;
-        double frac_act = std::pow(((double)(Z - nfzc * 2)) / ((double)nact * 2), 0.5);
+        // Number of occupied orbitals is
+        nocc_a = nocc_b = nfzc + nact;
+        // Fractional alpha and beta occupation.
+        double frac_a, frac_b;
 
-        occ_a = std::make_shared<Vector>("Alpha fractional occupation", nalpha);
+        if (options_.get_bool("SAD_FRAC_SR_OCC")) {
+            // Spin-restricted occupations
+            frac_a = frac_b = (Z - 2.0 * nfzc) / (2.0 * nact);
+        } else {
+            // Normal occupations
+            frac_a = (double)(nalpha - nfzc) / nact;
+            frac_b = (double)(nbeta - nfzc) / nact;
+        }
+
+        // Occupations are squared in the density calculation, so take the root
+        frac_a = std::sqrt(frac_a);
+        frac_b = std::sqrt(frac_b);
+
+        occ_a = std::make_shared<Vector>("Alpha fractional occupation", nocc_a);
         for (size_t x = 0; x < nfzc; x++) occ_a->set(x, 1.0);
-        for (size_t x = nfzc; x < nalpha; x++) occ_a->set(x, frac_act);
-        occ_b = std::shared_ptr<Vector>(occ_a->clone());
+        for (size_t x = nfzc; x < nocc_a; x++) occ_a->set(x, frac_a);
+
+        occ_b = std::make_shared<Vector>("Beta fractional occupation", nocc_b);
+        for (size_t x = 0; x < nfzc; x++) occ_b->set(x, 1.0);
+        for (size_t x = nfzc; x < nocc_b; x++) occ_b->set(x, frac_b);
 
     } else {
         // Conventional occupations
+        nocc_a = nalpha;
         occ_a = std::make_shared<Vector>("Alpha occupation", nalpha);
         for (size_t x = 0; x < nalpha; x++) occ_a->set(x, 1.0);
+
+        nocc_b = nbeta;
         occ_b = std::make_shared<Vector>("Beta occupation", nbeta);
         for (size_t x = 0; x < nbeta; x++) occ_b->set(x, 1.0);
     }
 
-    auto Ca_occ = std::make_shared<Matrix>("Ca occupied", norbs, nalpha);
-    auto Cb_occ = std::make_shared<Matrix>("Cb occupied", norbs, nbeta);
+    auto Ca_occ = std::make_shared<Matrix>("Ca occupied", norbs, nocc_a);
+    auto Cb_occ = std::make_shared<Matrix>("Cb occupied", norbs, nocc_b);
 
     // Compute initial Cx, Dx, and D from core guess
-    form_C_and_D(nalpha, norbs, X, H, Ca, Ca_occ, occ_a, Da);
-    form_C_and_D(nbeta, norbs, X, H, Cb, Cb_occ, occ_b, Db);
+    form_C_and_D(X, H, Ca, Ca_occ, occ_a, Da);
+    form_C_and_D(X, H, Cb, Cb_occ, occ_b, Db);
 
     D->zero();
     D->add(Da);
@@ -513,8 +529,8 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
         double deltaE = std::fabs(E - E_old);
 
         // Build Gradient
-        form_gradient(norbs, gradient_a, Fa, Da, S, X);
-        form_gradient(norbs, gradient_b, Fb, Db, S, X);
+        form_gradient(gradient_a, Fa, Da, S, X);
+        form_gradient(gradient_b, Fb, Db, S, X);
         double Drms = 0.5 * (gradient_a->rms() + gradient_b->rms());
 
         // Add and extrapolate DIIS
@@ -522,8 +538,8 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
         diis_manager.extrapolate(2, Fa.get(), Fb.get());
 
         // Diagonalize Fa and Fb to from Ca and Cb and Da and Db
-        form_C_and_D(nalpha, norbs, X, Fa, Ca, Ca_occ, occ_a, Da);
-        form_C_and_D(nbeta, norbs, X, Fb, Cb, Cb_occ, occ_b, Db);
+        form_C_and_D(X, Fa, Ca, Ca_occ, occ_a, Da);
+        form_C_and_D(X, Fb, Cb, Cb_occ, occ_b, Db);
 
         // Form D
         D->copy(Da);
@@ -557,8 +573,8 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
     if (converged && print_ > 1)
         outfile->Printf("  @Atomic UHF Final Energy for atom %s: %20.14f\n", mol->symbol(0).c_str(), E);
 }
-void SADGuess::form_gradient(int norbs, SharedMatrix grad, SharedMatrix F, SharedMatrix D, SharedMatrix S,
-                             SharedMatrix X) {
+void SADGuess::form_gradient(SharedMatrix grad, SharedMatrix F, SharedMatrix D, SharedMatrix S, SharedMatrix X) {
+    int norbs = X->rowdim();
     auto Scratch1 = std::make_shared<Matrix>("Scratch1", norbs, norbs);
     auto Scratch2 = std::make_shared<Matrix>("Scratch2", norbs, norbs);
 
@@ -582,8 +598,10 @@ void SADGuess::form_gradient(int norbs, SharedMatrix grad, SharedMatrix F, Share
     Scratch2.reset();
 }
 
-void SADGuess::form_C_and_D(int nocc, int norbs, SharedMatrix X, SharedMatrix F, SharedMatrix C, SharedMatrix Cocc,
-                            SharedVector occ, SharedMatrix D) {
+void SADGuess::form_C_and_D(SharedMatrix X, SharedMatrix F, SharedMatrix C, SharedMatrix Cocc, SharedVector occ,
+                            SharedMatrix D) {
+    int norbs = X->rowdim();
+    int nocc = occ->dim();
     if (nocc == 0) return;
 
     // Forms C in the AO basis for SAD Guesses

--- a/psi4/src/psi4/libscf_solver/sad.h
+++ b/psi4/src/psi4/libscf_solver/sad.h
@@ -60,10 +60,10 @@ class SADGuess {
     void common_init();
 
     SharedMatrix form_D_AO();
-    void form_gradient(int norbs, SharedMatrix grad, SharedMatrix F, SharedMatrix D, SharedMatrix S, SharedMatrix X);
+    void form_gradient(SharedMatrix grad, SharedMatrix F, SharedMatrix D, SharedMatrix S, SharedMatrix X);
     void get_uhf_atomic_density(std::shared_ptr<BasisSet> atomic_basis, std::shared_ptr<BasisSet> fit_basis,
                                 int n_electrons, int multiplicity, SharedMatrix D);
-    void form_C_and_D(int nocc, int norbs, SharedMatrix X, SharedMatrix F, SharedMatrix C, SharedMatrix Cocc,
+    void form_C_and_D(SharedMatrix X, SharedMatrix F, SharedMatrix C, SharedMatrix Cocc,
                       SharedVector occ, SharedMatrix D);
 
     void form_D();

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -224,18 +224,6 @@ void UHF::form_G() {
     }
 }
 
-void UHF::form_initialF() {
-    Fa_->copy(H_);
-    Fb_->copy(H_);
-
-    if (debug_) {
-        outfile->Printf("Initial Fock alpha matrix:\n");
-        Fa_->print("outfile");
-        outfile->Printf("Initial Fock beta matrix:\n");
-        Fb_->print("outfile");
-    }
-}
-
 void UHF::form_F() {
     Fa_->copy(H_);
     Fa_->add(Ga_);

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -88,10 +88,10 @@ class UHF : public HF {
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;
     std::vector<SharedMatrix> twoel_Hx(std::vector<SharedMatrix> x, bool combine = true,
-                                               std::string return_basis = "MO") override;
+                                       std::string return_basis = "MO") override;
     std::vector<SharedMatrix> cphf_Hx(std::vector<SharedMatrix> x) override;
-    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4,
-                                                 int max_iter = 10, int print_lvl = 1) override;
+    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4, int max_iter = 10,
+                                         int print_lvl = 1) override;
 
     std::shared_ptr<UHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -41,7 +41,6 @@ class UHF : public HF {
     SharedMatrix Da_old_, Db_old_;
     SharedMatrix Ga_, Gb_, J_, Ka_, Kb_, wKa_, wKb_;
 
-    void form_initialF();
     double compute_initial_E() override;
     bool stability_analysis_pk();
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1433,6 +1433,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("SAD_SCF_TYPE", "DF", "DIRECT DF");
         /*- Do force an even distribution of occupations across the last partially occupied orbital shell? !expert -*/
         options.add_bool("SAD_FRAC_OCC", false);
+        /*- Do use spin-restricted occupations in fractional SAD? !expert -*/
+        options.add_bool("SAD_FRAC_SR_OCC", false);
         /*- Auxiliary basis for the SAD guess !expert -*/
         options.add_double("SAD_CHOL_TOLERANCE", 1E-7);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,7 +87,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-db3 pywrap-freq-e-sowreap pywrap-freq-g-sowreap
                   pywrap-molecule pywrap-opt-sowreap rasci-c2-active rasci-h2o
                   rasci-ne rasscf-sp sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
-                  sapt7 sapt8 scf-bz2 scf-dipder scf-ecp scf-guess-read1 scf-upcast-custom-basis
+                  sapt7 sapt8 scf-bz2 scf-dipder scf-ecp scf-guess scf-guess-read1 scf-upcast-custom-basis
                   scf-guess-read2 scf-bs scf1 scf-occ
                   scf2 scf3 scf4 scf5 scf6 scf7 scf-property serial-wfn soscf-large soscf-ref
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare sapt-sf1 dft-custom dft-reference

--- a/tests/gibbs/input.dat
+++ b/tests/gibbs/input.dat
@@ -41,6 +41,7 @@ compare_values( H2O_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "H2O Gibbs Fre
 #
 
 molecule nh3 {
+  symmetry cs
   N         -0.000000000075    -0.055054563313     0.000000000000
   H         -0.477097924216     0.254982462134    -0.826357845779
   H         -0.477097924216     0.254982462134     0.826357845779
@@ -59,6 +60,7 @@ compare_values( NH3_321G_RHF_G, variable('GIBBS FREE ENERGY'), 6, "NH3 Gibbs Fre
 #
 
 molecule CH4 {
+   symmetry c2v
    C
    H 1 r
    H 1 r 2 TDA

--- a/tests/gibbs/input.dat
+++ b/tests/gibbs/input.dat
@@ -51,6 +51,7 @@ molecule nh3 {
 set {
   basis 3-21G
   max_disp_g_convergence = 1e-5
+  docc [4, 1]
 }
 
 optimize('scf')
@@ -72,6 +73,7 @@ molecule CH4 {
 set {
   basis 3-21G
   max_disp_g_convergence = 1e-5
+  docc [3, 0, 1, 1]
 }
 
 optimize('scf')

--- a/tests/mp2-module/input.dat
+++ b/tests/mp2-module/input.dat
@@ -277,7 +277,7 @@ set freeze_core true
 #compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 #compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 #compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-#compare_matrices(mp2totg, retG, 6, theme)  #TEST
+#compare_matrices(mp2totg, retG, 5, theme)  #TEST
 #clean_variables()
 #clean()
 
@@ -297,7 +297,7 @@ retG = gradient('mp2', molecule=hf)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -322,7 +322,7 @@ retG = gradient('mp2', molecule=hf)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -332,7 +332,7 @@ retG = gradient('mp2', molecule=hf)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -352,7 +352,7 @@ retG = gradient('mp2', molecule=hf)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -362,7 +362,7 @@ retG = gradient('mp2', molecule=hf)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -391,7 +391,7 @@ retG = gradient('mp2', molecule=bh_h2p)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -418,7 +418,7 @@ retG = gradient('mp2', molecule=bh_h2p)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -440,7 +440,7 @@ retG = gradient('mp2', molecule=bh_h2p)
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 
@@ -483,7 +483,7 @@ theme = 'mp2 grad rohf df nfc: findif'
 compare_values(scftot, variable('hf total energy'), 6, theme)  #TEST
 compare_values(mp2corl, variable('mp2 correlation energy'), 6, theme)  #TEST
 compare_values(mp2tot, variable('mp2 total energy'), 6, theme)  #TEST
-compare_matrices(mp2totg, retG, 6, theme)  #TEST
+compare_matrices(mp2totg, retG, 5, theme)  #TEST
 clean_variables()
 clean()
 

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -22,13 +22,13 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
          'MULTIPOLE(3)', 'NO_OCCUPATIONS']
 
 mp2_e, mp2_wfn = prop('MP2', properties = props, return_wfn=True)
-compare_values(psi4.variable('CURRENT ENERGY'), -184.1840201594929454, 6, "MP2 Energy") #TEST
-compare_values(psi4.variable('MP2 DIPOLE X'), 0.000000000000, 4, "MP2 DIPOLE X") #TEST
-compare_values(psi4.variable('MP2 DIPOLE Y'), 0.000000000000, 4, "MP2 DIPOLE Y") #TEST
-compare_values(psi4.variable('MP2 DIPOLE Z'), 0.234000203994, 4, "MP2 DIPOLE Z") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE XX'), -14.731131601691, 4, "MP2 QUADRUPOLE XX") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE YY'), -14.731131601691, 4, "MP2 QUADRUPOLE YY") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE ZZ'), -19.287283345539, 4, "MP2 QUADRUPOLE ZZ") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE XY'), 0.000000000000, 4, "MP2 QUADRUPOLE XY") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE XZ'), 0.000000000000, 4, "MP2 QUADRUPOLE XZ") #TEST
-compare_values(psi4.variable('MP2 QUADRUPOLE YZ'), 0.000000000000, 4, "MP2 QUADRUPOLE YZ") #TEST
+compare_values(-184.1840201594929454, psi4.variable('CURRENT ENERGY'), 6, "MP2 Energy") #TEST
+compare_values(0.000000000000, psi4.variable('MP2 DIPOLE X'), 4, "MP2 DIPOLE X") #TEST
+compare_values(0.000000000000, psi4.variable('MP2 DIPOLE Y'), 4, "MP2 DIPOLE Y") #TEST
+compare_values(0.234000203994, psi4.variable('MP2 DIPOLE Z'), 4, "MP2 DIPOLE Z") #TEST
+compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE XX'), 4, "MP2 QUADRUPOLE XX") #TEST
+compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE YY'), 4, "MP2 QUADRUPOLE YY") #TEST
+compare_values(-19.287283345539, psi4.variable('MP2 QUADRUPOLE ZZ'), 4, "MP2 QUADRUPOLE ZZ") #TEST
+compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XY'), 4, "MP2 QUADRUPOLE XY") #TEST
+compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XZ'), 4, "MP2 QUADRUPOLE XZ") #TEST
+compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE YZ'), 4, "MP2 QUADRUPOLE YZ") #TEST

--- a/tests/pytest/test_dftd3.py
+++ b/tests/pytest/test_dftd3.py
@@ -1,4 +1,5 @@
 import pytest
+
 from utils import *
 from addons import *
 

--- a/tests/scf-guess/CMakeLists.txt
+++ b/tests/scf-guess/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(scf-guess "psi;quicktests;scf")

--- a/tests/scf-guess/input.dat
+++ b/tests/scf-guess/input.dat
@@ -18,7 +18,6 @@ set {
   df_scf_guess false
   guess core
   docc [ 3, 0, 1, 1 ]
-
 }
 energy('scf')
 

--- a/tests/scf-guess/input.dat
+++ b/tests/scf-guess/input.dat
@@ -1,0 +1,69 @@
+#! Test initial SCF guesses on FH and FH+ in cc-pVTZ basis
+
+refnuc       =    5.282967161430950  #TEST
+refneut_rhf  = -100.0584459442408587 #TEST
+refcat_uhf   =  -99.5312257221445549 #TEST
+refcat_rohf  =  -99.5261713512123976 #TEST
+
+molecule no {
+0 1
+F
+H 1 0.9015
+}
+
+set {
+  basis cc-pvtz
+  reference rhf
+  scf_type pk
+  df_scf_guess false
+  guess core
+}
+energy('scf')
+
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, GWH  guess  (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, SAD  guess (a.u.)");             #TEST
+
+molecule nocat {
+1 2
+F
+H 1 0.9015
+}
+
+set {
+  reference uhf
+  guess core
+}
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, GWH  guess (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, SAD  guess (a.u.)");             #TEST
+
+
+set {
+  reference rohf
+  guess core
+}
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, GWH  guess (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, SAD  guess (a.u.)");             #TEST

--- a/tests/scf-guess/input.dat
+++ b/tests/scf-guess/input.dat
@@ -27,7 +27,7 @@ compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, CORE 
 
 set guess gwh
 energy('scf')
-compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, GWH  guess  (a.u.)");             #TEST
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, GWH  guess (a.u.)");             #TEST
 
 set guess sad
 energy('scf')

--- a/tests/scf-guess/input.dat
+++ b/tests/scf-guess/input.dat
@@ -17,6 +17,8 @@ set {
   scf_type pk
   df_scf_guess false
   guess core
+  docc [ 3, 0, 1, 1 ]
+
 }
 energy('scf')
 
@@ -40,6 +42,8 @@ H 1 0.9015
 set {
   reference uhf
   guess core
+  docc [ 3, 0, 0, 1 ]
+  socc [ 0, 0, 1, 0 ]
 }
 energy('scf')
 compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, CORE guess (a.u.)");             #TEST

--- a/tests/scf-guess/output.ref
+++ b/tests/scf-guess/output.ref
@@ -1,0 +1,2063 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.3a2.dev305 
+
+                         Git: Rev {sad_rohf} adbd3a7 dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 16 December 2018 09:53PM
+
+    Process ID: 25041
+    Host:       dx7-lehtola.chem.helsinki.fi
+    PSIDATADIR: /home/work/psi4/install.susi/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Test initial SCF guesses on FH and FH+ in cc-pVTZ basis
+
+refnuc       =    5.282967161430950  #TEST
+refneut_rhf  = -100.0584459442408587 #TEST
+refcat_uhf   =  -99.5312257221445549 #TEST
+refcat_rohf  =  -99.5261713512123976 #TEST
+
+molecule no {
+0 1
+F
+H 1 0.9015
+}
+
+set {
+  basis cc-pvtz
+  reference rhf
+  scf_type pk
+  df_scf_guess false
+  guess core
+}
+energy('scf')
+
+compare_values(refnuc, variable("NUCLEAR REPULSION ENERGY"), 6, "Nuclear Repulsion Energy (a.u.)"); #TEST
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, GWH  guess  (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, SAD  guess (a.u.)");             #TEST
+
+molecule nocat {
+1 2
+F
+H 1 0.9015
+}
+
+set {
+  reference uhf
+  guess core
+}
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, GWH  guess (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, SAD  guess (a.u.)");             #TEST
+
+
+set {
+  reference rohf
+  guess core
+}
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, CORE guess (a.u.)");             #TEST
+
+set guess gwh
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, GWH  guess (a.u.)");             #TEST
+
+set guess sad
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, SAD  guess (a.u.)");             #TEST
+--------------------------------------------------------------------------
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     4,    0,    1,    0 ]
+
+   @RHF iter   1:   -85.33505416384978   -8.53351e+01   3.50122e-01 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+   @RHF iter   2:   -91.10767049405827   -5.77262e+00   1.51846e-01 DIIS
+   @RHF iter   3:   -98.58258052901719   -7.47491e+00   1.00097e-01 DIIS
+   @RHF iter   4:   -99.93951023567348   -1.35693e+00   2.44152e-02 DIIS
+   @RHF iter   5:  -100.05744198293387   -1.17932e-01   1.65487e-03 DIIS
+   @RHF iter   6:  -100.05827354637998   -8.31563e-04   8.34275e-04 DIIS
+   @RHF iter   7:  -100.05843724413234   -1.63698e-04   1.49650e-04 DIIS
+   @RHF iter   8:  -100.05844575714320   -8.51301e-06   2.83896e-05 DIIS
+   @RHF iter   9:  -100.05844593934070   -1.82197e-07   3.30291e-06 DIIS
+   @RHF iter  10:  -100.05844594421211   -4.87141e-09   3.71224e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.286004     2A1    -1.600001     3A1    -0.766543  
+       1B1    -0.644853     1B2    -0.644852  
+
+    Virtual:                                                              
+
+       4A1     0.145421     5A1     0.572506     6A1     0.812502  
+       2B1     0.857876     2B2     0.857876     3B1     0.986375  
+       3B2     0.986375     7A1     1.455858     8A1     1.553376  
+       9A1     2.227599     1A2     2.227599    10A1     2.263013  
+       4B2     2.544695     4B1     2.544695    11A1     3.232051  
+       2A2     3.552428    12A1     3.552428     5B1     3.853177  
+       5B2     3.853177    13A1     4.250229     6B1     4.321165  
+       6B2     4.321165    14A1     5.198270     7B1     5.364506  
+       7B2     5.364506    15A1     6.236857     8B1     7.408845  
+       8B2     7.408845     3A2     7.614739    16A1     7.614739  
+       9B2     8.497216     9B1     8.497216    17A1     8.525277  
+       4A2     8.909365    18A1     8.909365    10B2     9.336847  
+      10B1     9.336847    19A1     9.702183    20A1    12.638150  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @RHF Final Energy:  -100.05844594421211
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -150.7983411201149124
+    Two-Electron Energy =                  45.4569280144718419
+    Total Energy =                       -100.0584459442121243
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0934
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7520     Total:     0.7520
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9114     Total:     1.9114
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:30 2018
+Module time:
+	user time   =       0.13 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.13 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	Nuclear Repulsion Energy (a.u.)...................................PASSED
+	RHF  energy, CORE guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     4,    0,    0,    1 ]
+
+   @RHF iter   1:   -92.48691177199242   -9.24869e+01   2.75904e-01 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+   @RHF iter   2:   -94.06882631427098   -1.58191e+00   1.33585e-01 DIIS
+   @RHF iter   3:   -99.01396614376071   -4.94514e+00   8.36175e-02 DIIS
+   @RHF iter   4:   -99.95856431272190   -9.44598e-01   2.26760e-02 DIIS
+   @RHF iter   5:  -100.05755990561795   -9.89956e-02   1.32076e-03 DIIS
+   @RHF iter   6:  -100.05834157210909   -7.81666e-04   6.20578e-04 DIIS
+   @RHF iter   7:  -100.05844343085573   -1.01859e-04   7.64898e-05 DIIS
+   @RHF iter   8:  -100.05844588911194   -2.45826e-06   1.28304e-05 DIIS
+   @RHF iter   9:  -100.05844594195449   -5.28426e-08   2.40319e-06 DIIS
+   @RHF iter  10:  -100.05844594424084   -2.28636e-09   3.08509e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.286004     2A1    -1.600002     3A1    -0.766543  
+       1B2    -0.644853     1B1    -0.644852  
+
+    Virtual:                                                              
+
+       4A1     0.145421     5A1     0.572506     6A1     0.812502  
+       2B2     0.857876     2B1     0.857876     3B2     0.986375  
+       3B1     0.986375     7A1     1.455858     8A1     1.553376  
+       9A1     2.227599     1A2     2.227599    10A1     2.263013  
+       4B1     2.544695     4B2     2.544695    11A1     3.232050  
+       2A2     3.552428    12A1     3.552428     5B2     3.853177  
+       5B1     3.853177    13A1     4.250229     6B2     4.321164  
+       6B1     4.321164    14A1     5.198270     7B2     5.364505  
+       7B1     5.364505    15A1     6.236857     8B2     7.408845  
+       8B1     7.408845     3A2     7.614739    16A1     7.614739  
+       9B1     8.497216     9B2     8.497216    17A1     8.525277  
+       4A2     8.909364    18A1     8.909364    10B1     9.336846  
+      10B2     9.336846    19A1     9.702183    20A1    12.638149  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @RHF Final Energy:  -100.05844594424084
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -150.7983492601197781
+    Two-Electron Energy =                  45.4569361544479733
+    Total Energy =                       -100.0584459442408587
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0934
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7520     Total:     0.7520
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9114     Total:     1.9114
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:30 2018
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	RHF  energy, GWH  guess  (a.u.)...................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -100.03749947075762   -1.00037e+02   9.99042e-03 
+   @RHF iter   1:  -100.05384985156070   -1.63504e-02   5.60191e-03 
+   @RHF iter   2:  -100.05686089124127   -3.01104e-03   3.33064e-03 DIIS
+   @RHF iter   3:  -100.05843658764793   -1.57570e-03   1.43686e-04 DIIS
+   @RHF iter   4:  -100.05844520376682   -8.61612e-06   3.83489e-05 DIIS
+   @RHF iter   5:  -100.05844592860011   -7.24833e-07   5.06800e-06 DIIS
+   @RHF iter   6:  -100.05844594400700   -1.54069e-08   6.73616e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.286000     2A1    -1.599999     3A1    -0.766542  
+       1B1    -0.644851     1B2    -0.644850  
+
+    Virtual:                                                              
+
+       4A1     0.145421     5A1     0.572506     6A1     0.812503  
+       2B1     0.857876     2B2     0.857876     3B1     0.986376  
+       3B2     0.986376     7A1     1.455859     8A1     1.553377  
+       1A2     2.227601     9A1     2.227601    10A1     2.263014  
+       4B1     2.544696     4B2     2.544696    11A1     3.232051  
+       2A2     3.552428    12A1     3.552428     5B1     3.853177  
+       5B2     3.853177    13A1     4.250229     6B1     4.321165  
+       6B2     4.321165    14A1     5.198271     7B1     5.364508  
+       7B2     5.364508    15A1     6.236859     8B2     7.408847  
+       8B1     7.408847     3A2     7.614741    16A1     7.614741  
+       9B2     8.497218     9B1     8.497218    17A1     8.525279  
+      18A1     8.909368     4A2     8.909368    10B2     9.336849  
+      10B1     9.336849    19A1     9.702186    20A1    12.638152  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @RHF Final Energy:  -100.05844594400700
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -150.7983563839765111
+    Two-Electron Energy =                  45.4569432785385601
+    Total Energy =                       -100.0584459440070049
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0934
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7520     Total:     0.7520
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9114     Total:     1.9114
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:30 2018
+Module time:
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	RHF  energy, SAD  guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     4,    0,    0,    0 ]
+    SOCC [     0,    0,    1,    0 ]
+
+   @UHF iter   1:   -88.23264523695433   -8.82326e+01   3.06237e-01 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+   @UHF iter   2:   -93.00749100119293   -4.77485e+00   1.30113e-01 DIIS
+   @UHF iter   3:   -98.96650997205859   -5.95902e+00   6.12017e-02 DIIS
+   @UHF iter   4:   -99.49198201262239   -5.25472e-01   1.39170e-02 DIIS
+   @UHF iter   5:   -99.53078113448440   -3.87991e-02   1.15953e-03 DIIS
+   @UHF iter   6:   -99.53116623761149   -3.85103e-04   4.68075e-04 DIIS
+   @UHF iter   7:   -99.53122195334382   -5.57157e-05   8.74365e-05 DIIS
+   @UHF iter   8:   -99.53122530865195   -3.35531e-06   2.42067e-05 DIIS
+   @UHF iter   9:   -99.53122567350465   -3.64853e-07   8.13063e-06 DIIS
+   @UHF iter  10:   -99.53122572128875   -4.77841e-08   1.20937e-06 DIIS
+   @UHF iter  11:   -99.53122572214455   -8.55806e-10   1.27144e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.192479748E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.541924797E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -26.987379     2A1    -2.274177     1B1    -1.390064  
+       3A1    -1.381376     1B2    -1.273581  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.185343     5A1     0.174906     2B1     0.391539  
+       6A1     0.417152     2B2     0.426075     3B1     0.544611  
+       3B2     0.571665     7A1     0.965391     8A1     1.112363  
+       9A1     1.649973     1A2     1.650573    10A1     1.811016  
+       4B1     1.976746     4B2     2.027806    11A1     2.720216  
+       2A2     3.075779    12A1     3.076221     5B1     3.380642  
+       5B2     3.393759    13A1     3.778690     6B1     3.783300  
+       6B2     3.820501    14A1     4.660651     7B1     4.696121  
+       7B2     4.776301    15A1     5.646970     8B1     6.750498  
+       8B2     6.750519     3A2     6.986488    16A1     6.986719  
+       9B1     7.839722     9B2     7.908702    17A1     7.920759  
+      18A1     8.205319     4A2     8.206350    10B1     8.666404  
+      10B2     8.740687    19A1     9.081980    20A1    12.029285  
+
+    Beta Occupied:                                                        
+
+       1A1   -26.935689     2A1    -2.083726     3A1    -1.328924  
+       1B2    -1.219533  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.432044     4A1    -0.175301     5A1     0.182663  
+       6A1     0.427562     2B2     0.433746     2B1     0.482987  
+       3B2     0.575908     3B1     0.620390     7A1     1.002733  
+       8A1     1.126957     9A1     1.739198     1A2     1.739546  
+      10A1     1.819539     4B2     2.035713     4B1     2.061449  
+      11A1     2.742011     2A2     3.084546    12A1     3.084561  
+       5B1     3.387498     5B2     3.390768    13A1     3.784204  
+       6B2     3.827305     6B1     3.844507    14A1     4.682923  
+       7B2     4.799182     7B1     4.843271    15A1     5.679300  
+       8B2     6.821657     8B1     6.821659    16A1     7.036965  
+       3A2     7.037019     9B1     7.920409     9B2     7.924737  
+      17A1     7.951313     4A2     8.327834    18A1     8.328100  
+      10B2     8.757640    10B1     8.758923    19A1     9.121435  
+      20A1    12.072478  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @UHF Final Energy:   -99.53122572214455
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7539366993825070
+    Two-Electron Energy =                  39.9397438158070059
+    Total Energy =                        -99.5312257221445549
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9996019
+  HONO-1 :    3 A1 1.9984982
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0015018
+  LUNO+1 :    5 A1 0.0003981
+  LUNO+2 :    2 B2 0.0001966
+  LUNO+3 :    6 A1 0.0000010
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0698
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9152     Total:     0.9152
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3262     Total:     2.3262
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:30 2018
+Module time:
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.60 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	UHF  energy, CORE guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter   1:   -94.35585144644560   -9.43559e+01   2.43823e-01 
+   @UHF iter   2:   -98.29872799930521   -3.94288e+00   8.15661e-02 DIIS
+   @UHF iter   3:   -99.44938731771835   -1.15066e+00   2.54434e-02 DIIS
+   @UHF iter   4:   -99.53009031835913   -8.07030e-02   2.65438e-03 DIIS
+   @UHF iter   5:   -99.53120766464281   -1.11735e-03   2.15671e-04 DIIS
+   @UHF iter   6:   -99.53122427560506   -1.66110e-05   4.69404e-05 DIIS
+   @UHF iter   7:   -99.53122541947030   -1.14387e-06   1.98652e-05 DIIS
+   @UHF iter   8:   -99.53122570963504   -2.90165e-07   4.23138e-06 DIIS
+   @UHF iter   9:   -99.53122572189922   -1.22642e-08   6.97571e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.192469225E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.541924692E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -26.987380     2A1    -2.274178     1B1    -1.390066  
+       3A1    -1.381376     1B2    -1.273581  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.185343     5A1     0.174906     2B1     0.391538  
+       6A1     0.417152     2B2     0.426075     3B1     0.544610  
+       3B2     0.571665     7A1     0.965390     8A1     1.112363  
+       9A1     1.649972     1A2     1.650573    10A1     1.811016  
+       4B1     1.976746     4B2     2.027806    11A1     2.720216  
+       2A2     3.075779    12A1     3.076221     5B1     3.380642  
+       5B2     3.393759    13A1     3.778690     6B1     3.783300  
+       6B2     3.820501    14A1     4.660651     7B1     4.696120  
+       7B2     4.776300    15A1     5.646969     8B1     6.750498  
+       8B2     6.750518     3A2     6.986487    16A1     6.986719  
+       9B1     7.839721     9B2     7.908701    17A1     7.920758  
+      18A1     8.205318     4A2     8.206349    10B1     8.666403  
+      10B2     8.740687    19A1     9.081979    20A1    12.029284  
+
+    Beta Occupied:                                                        
+
+       1A1   -26.935690     2A1    -2.083727     3A1    -1.328925  
+       1B2    -1.219533  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.432045     4A1    -0.175302     5A1     0.182663  
+       6A1     0.427561     2B2     0.433746     2B1     0.482987  
+       3B2     0.575908     3B1     0.620390     7A1     1.002733  
+       8A1     1.126957     9A1     1.739197     1A2     1.739545  
+      10A1     1.819539     4B2     2.035712     4B1     2.061448  
+      11A1     2.742011     2A2     3.084546    12A1     3.084561  
+       5B1     3.387498     5B2     3.390768    13A1     3.784204  
+       6B2     3.827305     6B1     3.844507    14A1     4.682922  
+       7B2     4.799182     7B1     4.843271    15A1     5.679299  
+       8B2     6.821657     8B1     6.821659    16A1     7.036965  
+       3A2     7.037018     9B1     7.920408     9B2     7.924736  
+      17A1     7.951312     4A2     8.327834    18A1     8.328099  
+      10B2     8.757639    10B1     8.758922    19A1     9.121434  
+      20A1    12.072477  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @UHF Final Energy:   -99.53122572189922
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7539350339384043
+    Two-Electron Energy =                  39.9397421506082395
+    Total Energy =                        -99.5312257218992187
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9996020
+  HONO-1 :    3 A1 1.9984981
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0015019
+  LUNO+1 :    5 A1 0.0003980
+  LUNO+2 :    2 B2 0.0001966
+  LUNO+3 :    6 A1 0.0000010
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0698
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9152     Total:     0.9152
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3262     Total:     2.3262
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:30 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.72 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	UHF  energy, GWH  guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:30 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter   0:   -99.40576845293968   -9.94058e+01   3.25606e-02 
+   @UHF iter   1:   -99.51337182188979   -1.07603e-01   1.13874e-02 
+   @UHF iter   2:   -99.52863279199822   -1.52610e-02   4.49130e-03 DIIS
+   @UHF iter   3:   -99.53120936848374   -2.57658e-03   2.22920e-04 DIIS
+   @UHF iter   4:   -99.53122498765461   -1.56192e-05   4.13432e-05 DIIS
+   @UHF iter   5:   -99.53122566022556   -6.72571e-07   9.64058e-06 DIIS
+   @UHF iter   6:   -99.53122571231420   -5.20886e-08   3.48655e-06 DIIS
+   @UHF iter   7:   -99.53122572152137   -9.20717e-09   9.22697e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.192304784E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.541923048E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -26.987380     2A1    -2.274178     1B1    -1.390065  
+       3A1    -1.381376     1B2    -1.273580  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.185343     5A1     0.174906     2B1     0.391538  
+       6A1     0.417152     2B2     0.426075     3B1     0.544610  
+       3B2     0.571665     7A1     0.965390     8A1     1.112363  
+       9A1     1.649972     1A2     1.650572    10A1     1.811016  
+       4B1     1.976746     4B2     2.027805    11A1     2.720216  
+       2A2     3.075779    12A1     3.076221     5B1     3.380642  
+       5B2     3.393759    13A1     3.778690     6B1     3.783300  
+       6B2     3.820500    14A1     4.660651     7B1     4.696120  
+       7B2     4.776300    15A1     5.646969     8B1     6.750497  
+       8B2     6.750518     3A2     6.986487    16A1     6.986718  
+       9B1     7.839721     9B2     7.908701    17A1     7.920758  
+      18A1     8.205318     4A2     8.206349    10B1     8.666403  
+      10B2     8.740687    19A1     9.081979    20A1    12.029284  
+
+    Beta Occupied:                                                        
+
+       1A1   -26.935691     2A1    -2.083727     3A1    -1.328925  
+       1B2    -1.219535  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.432045     4A1    -0.175302     5A1     0.182663  
+       6A1     0.427562     2B2     0.433746     2B1     0.482987  
+       3B2     0.575908     3B1     0.620390     7A1     1.002733  
+       8A1     1.126957     9A1     1.739197     1A2     1.739545  
+      10A1     1.819539     4B2     2.035712     4B1     2.061448  
+      11A1     2.742011     2A2     3.084546    12A1     3.084561  
+       5B1     3.387498     5B2     3.390768    13A1     3.784204  
+       6B2     3.827305     6B1     3.844506    14A1     4.682922  
+       7B2     4.799181     7B1     4.843270    15A1     5.679299  
+       8B2     6.821656     8B1     6.821658    16A1     7.036964  
+       3A2     7.037018     9B1     7.920408     9B2     7.924735  
+      17A1     7.951312     4A2     8.327833    18A1     8.328098  
+      10B2     8.757638    10B1     8.758922    19A1     9.121434  
+      20A1    12.072477  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @UHF Final Energy:   -99.53122572152137
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7539319169771659
+    Two-Electron Energy =                  39.9397390340248535
+    Total Energy =                        -99.5312257215213663
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9996020
+  HONO-1 :    3 A1 1.9984982
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0015018
+  LUNO+1 :    5 A1 0.0003980
+  LUNO+2 :    2 B2 0.0001965
+  LUNO+3 :    6 A1 0.0000010
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0698
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9152     Total:     0.9152
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3262     Total:     2.3262
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:31 2018
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.94 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	UHF  energy, SAD  guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:31 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     4,    0,    0,    0 ]
+    SOCC [     0,    0,    1,    0 ]
+
+   @ROHF iter   1:   -88.23264523695431   -8.82326e+01   2.34402e-01 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+   @ROHF iter   2:   -92.51751086156852   -4.28487e+00   1.02434e-01 DIIS
+   @ROHF iter   3:   -98.77533046384100   -6.25782e+00   5.50901e-02 DIIS
+   @ROHF iter   4:   -99.47971277182756   -7.04382e-01   1.14694e-02 DIIS
+   @ROHF iter   5:   -99.52551842541945   -4.58057e-02   1.07188e-03 DIIS
+   @ROHF iter   6:   -99.52613461161746   -6.16186e-04   2.83637e-04 DIIS
+   @ROHF iter   7:   -99.52617029109521   -3.56795e-05   3.77913e-05 DIIS
+   @ROHF iter   8:   -99.52617132829337   -1.03720e-06   5.53341e-06 DIIS
+   @ROHF iter   9:   -99.52617134986156   -2.15682e-08   1.46470e-06 DIIS
+   @ROHF iter  10:   -99.52617135121240   -1.35084e-09   2.20122e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.962057     2A1    -2.176864     3A1    -1.355356  
+       1B1    -1.246707  
+
+    Singly Occupied:                                                      
+
+       1B2    -0.882971  
+
+    Virtual:                                                              
+
+       4A1    -0.180491     5A1     0.178550     6A1     0.422240  
+       2B2     0.429509     2B1     0.429839     3B2     0.566011  
+       3B1     0.573608     7A1     0.983899     8A1     1.119530  
+       1A2     1.695113     9A1     1.695135    10A1     1.813677  
+       4B2     2.018923     4B1     2.031681    11A1     2.730610  
+       2A2     3.079972    12A1     3.080073     5B2     3.383958  
+       5B1     3.392058    13A1     3.781202     6B2     3.813377  
+       6B1     3.823743    14A1     4.671568     7B2     4.766665  
+       7B1     4.787527    15A1     5.663032     8B2     6.785701  
+       8B1     6.785785     3A2     7.011608    16A1     7.011642  
+       9B2     7.880010     9B1     7.916625    17A1     7.935700  
+      18A1     8.266300     4A2     8.266602    10B2     8.711859  
+      10B1     8.748989    19A1     9.100782    20A1    12.050440  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @ROHF Final Energy:   -99.52617135121240
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7572776200485407
+    Two-Electron Energy =                  39.9481391074051970
+    Total Energy =                        -99.5261713512123976
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0702
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9156     Total:     0.9156
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3272     Total:     2.3272
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:31 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.06 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	ROHF energy, CORE guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:31 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     1,    0,    0,    0 ]
+
+   @ROHF iter   1:   -94.35585144644557   -9.43559e+01   1.78830e-01 
+    Occupation by irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+   @ROHF iter   2:   -97.10719850733254   -2.75135e+00   6.76387e-02 DIIS
+   @ROHF iter   3:   -99.25835680276901   -2.15116e+00   3.25568e-02 DIIS
+   @ROHF iter   4:   -99.51398971553218   -2.55633e-01   5.88017e-03 DIIS
+   @ROHF iter   5:   -99.52595624841956   -1.19665e-02   5.44037e-04 DIIS
+   @ROHF iter   6:   -99.52616175284240   -2.05504e-04   1.09006e-04 DIIS
+   @ROHF iter   7:   -99.52617123234572   -9.47950e-06   1.12144e-05 DIIS
+   @ROHF iter   8:   -99.52617134700064   -1.14655e-07   3.00064e-06 DIIS
+   @ROHF iter   9:   -99.52617135121889   -4.21825e-09   1.86028e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.962057     2A1    -2.176864     3A1    -1.355356  
+       1B2    -1.246707  
+
+    Singly Occupied:                                                      
+
+       1B1    -0.882971  
+
+    Virtual:                                                              
+
+       4A1    -0.180491     5A1     0.178550     6A1     0.422240  
+       2B1     0.429509     2B2     0.429839     3B1     0.566011  
+       3B2     0.573608     7A1     0.983899     8A1     1.119530  
+       1A2     1.695113     9A1     1.695135    10A1     1.813677  
+       4B1     2.018923     4B2     2.031681    11A1     2.730610  
+       2A2     3.079972    12A1     3.080073     5B1     3.383958  
+       5B2     3.392058    13A1     3.781202     6B1     3.813377  
+       6B2     3.823743    14A1     4.671568     7B1     4.766664  
+       7B2     4.787527    15A1     5.663032     8B1     6.785701  
+       8B2     6.785785     3A2     7.011608    16A1     7.011642  
+       9B1     7.880010     9B2     7.916625    17A1     7.935700  
+      18A1     8.266300     4A2     8.266602    10B1     8.711859  
+      10B2     8.748989    19A1     9.100782    20A1    12.050439  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @ROHF Final Energy:   -99.52617135121889
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7572982261189054
+    Two-Electron Energy =                  39.9481597134690745
+    Total Energy =                        -99.5261713512188919
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0702
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9156     Total:     0.9156
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3272     Total:     2.3272
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:31 2018
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	ROHF energy, GWH  guess (a.u.)....................................PASSED
+
+*** tstart() called on dx7-lehtola.chem.helsinki.fi
+*** at Sun Dec 16 21:53:31 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry F          line   300 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2 entry H          line    23 file /home/work/psi4/install.susi/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         F            0.000000000000     0.000000000000    -0.045413571099    18.998403162730
+         H            0.000000000000     0.000000000000     0.856086428901     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     21.67345  C =     21.67345 [cm^-1]
+  Rotational constants: A = ************  B = 649753.63037  C = 649753.63037 [MHz]
+  Nuclear repulsion =    5.282967161430950
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 16
+    Number of basis function: 44
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        20      20       0       0       0       0
+     A2         4       4       0       0       0       0
+     B1        10      10       0       0       0       0
+     B2        10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      44      44       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              16
+      Number of primitives:             34
+      Number of atomic orbitals:        50
+      Number of basis functions:        44
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 981090 doubles for integral storage.
+  We computed 9316 shell quartets total.
+  Whereas there are 9316 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.4807006011E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @ROHF iter   0:   -98.88199282615329   -9.88820e+01   5.47587e-02 
+   @ROHF iter   1:   -99.37308671364974   -4.91094e-01   2.39373e-02 
+   @ROHF iter   2:   -99.49928041819270   -1.26194e-01   1.06275e-02 DIIS
+   @ROHF iter   3:   -99.52603046506722   -2.67500e-02   5.31814e-04 DIIS
+   @ROHF iter   4:   -99.52616482892887   -1.34364e-04   1.51898e-04 DIIS
+   @ROHF iter   5:   -99.52617125059395   -6.42167e-06   1.09997e-05 DIIS
+   @ROHF iter   6:   -99.52617134223544   -9.16415e-08   2.95519e-06 DIIS
+   @ROHF iter   7:   -99.52617135114004   -8.90459e-09   3.40166e-07 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -26.962057     2A1    -2.176864     3A1    -1.355356  
+       1B2    -1.246706  
+
+    Singly Occupied:                                                      
+
+       1B1    -0.882971  
+
+    Virtual:                                                              
+
+       4A1    -0.180491     5A1     0.178550     6A1     0.422240  
+       2B1     0.429509     2B2     0.429839     3B1     0.566010  
+       3B2     0.573608     7A1     0.983899     8A1     1.119530  
+       1A2     1.695113     9A1     1.695135    10A1     1.813676  
+       4B1     2.018923     4B2     2.031681    11A1     2.730610  
+       2A2     3.079972    12A1     3.080073     5B1     3.383957  
+       5B2     3.392058    13A1     3.781202     6B1     3.813377  
+       6B2     3.823743    14A1     4.671567     7B1     4.766665  
+       7B2     4.787527    15A1     5.663032     8B1     6.785701  
+       8B2     6.785785     3A2     7.011608    16A1     7.011642  
+       9B1     7.880010     9B2     7.916625    17A1     7.935700  
+      18A1     8.266300     4A2     8.266603    10B1     8.711859  
+      10B2     8.748989    19A1     9.100782    20A1    12.050439  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @ROHF Final Energy:   -99.52617135114004
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              5.2829671614309497
+    One-Electron Energy =                -144.7572799169074642
+    Two-Electron Energy =                  39.9481414043364822
+    Total Energy =                        -99.5261713511400359
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8454
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0702
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9156     Total:     0.9156
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3272     Total:     2.3272
+
+
+*** tstop() called on dx7-lehtola.chem.helsinki.fi at Sun Dec 16 21:53:31 2018
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.40 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+	ROHF energy, SAD  guess (a.u.)....................................PASSED
+
+    Psi4 stopped on: Sunday, 16 December 2018 09:53PM
+    Psi4 wall time for execution: 0:00:01.51
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR modifies the SAD guess so that it first runs a plain Fock build and diagonalizes the obtained Fock matrix. This allows the SAD guess to also work for ROHF, as well as allowing one to manually set the orbital occupations in combination with the SAD guess.

Test calculation on the quintet state of Cr(N2)6 in aug-pcseg-1:
```
molecule {
2 5
Cr 0.0000925386 0.0000682032 0.0019012828
N 0.0004102713 2.3625659492 0.0026269619
N 0.0005967051 3.4672101357 0.0029548744
N 2.3620320503 -0.0004101212 0.0009507667
N 3.4666734940 -0.0002636830 0.0034835308
N -0.0003928082 -2.3624420331 0.0002298447
N -0.0001812896 -3.4670841683 0.0023676850
N -2.3618731053 0.0004033492 0.0009468195
N -3.4665147528 0.0006033882 0.0034481887
N 0.0000117173 -0.0007732394 2.1429780137
N -0.0000350947 -0.0013203851 3.2475238798
N 0.0002480331 0.0009562329 -2.1392146821
N 0.0003478216 0.0015074164 -3.2437570404
}

set reference rohf
set basis aug-pcseg-1
set guess core
set scf_type direct
set df_scf_guess false
energy('scf')
```
* ```CORE``` 24 iterations, energy -1696.14766109152993
* ```SAD``` 29 iterations, energy -1696.14766127128701
* ```GWH``` 38 iterations, energy -1696.14766117804697

Due to the high symmetry of the test case, ```CORE``` is surprisingly efficient. ```SAD``` still beats the current default, ```GWH```, by a large margin.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] SAD guess working for ROHF
- [x] SAD guess working with manually set occupations
- [x] Default guess switched to SAD

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
