### PR TITLE
Fix race condition in maximum orbital gradient of parallel ODCT.

### DIFF
--- a/psi4/src/psi4/dcft/dcft_oo_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_oo_RHF.cc
@@ -231,7 +231,7 @@ double DCFTSolver::compute_orbital_residual_RHF() {
     double maxGradient = 0.0;
     // Alpha spin
     for (int h = 0; h < nirrep_; ++h) {
-#pragma omp parallel for
+#pragma omp parallel for reduction(max:maxGradient)
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = 0; a < navirpi_[h]; ++a) {
                 double value = 2.0 * (Xia.matrix[h][i][a] - Xai.matrix[h][a][i]);

--- a/psi4/src/psi4/dcft/dcft_oo_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_oo_UHF.cc
@@ -252,7 +252,7 @@ double DCFTSolver::compute_orbital_residual() {
     double maxGradient = 0.0;
     // Alpha spin
     for (int h = 0; h < nirrep_; ++h) {
-#pragma omp parallel for
+#pragma omp parallel for reduction(max:maxGradient)
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = 0; a < navirpi_[h]; ++a) {
                 double value = 2.0 * (Xia.matrix[h][i][a] - Xai.matrix[h][a][i]);
@@ -275,7 +275,7 @@ double DCFTSolver::compute_orbital_residual() {
 
     // Beta spin
     for (int h = 0; h < nirrep_; ++h) {
-#pragma omp parallel for
+#pragma omp parallel for reduction(max:maxGradient)
         for (int i = 0; i < nboccpi_[h]; ++i) {
             for (int a = 0; a < nbvirpi_[h]; ++a) {
                 double value = 2.0 * (Xia.matrix[h][i][a] - Xai.matrix[h][a][i]);


### PR DESCRIPTION
## Description
Does exactly what it says in the title. We need the maximum value of `maxGradient` _across all threads_.

## Checklist
- [x] Tested that even in parallel, orbital gradients are now deterministic

## Status
- [x] Ready for review
- [x] Ready for merge
