### PR TITLE
Fix multiple declaration of psi::cctriples::thread_data

### DIFF
--- a/psi4/src/psi4/cc/cctriples/ET_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_RHF.cc
@@ -53,7 +53,7 @@
 namespace psi {
 namespace cctriples {
 
-struct thread_data {
+struct ET_RHF_thread_data {
     dpdfile2 *fIJ;
     dpdfile2 *fAB;
     dpdfile2 *fIA;
@@ -70,7 +70,7 @@ struct thread_data {
     int last_ijk;
 };
 
-void ET_RHF_thread(thread_data *);
+void ET_RHF_thread(ET_RHF_thread_data *);
 
 double ET_RHF() {
     int i, j, k, I, J, K, Gi, Gj, Gk, h, nirreps, cnt;
@@ -122,7 +122,7 @@ double ET_RHF() {
     outfile->Printf("    MKL num_threads set to 1 for explicit threading.\n\n");
 #endif
 
-    std::vector<thread_data> thread_data_array(nthreads);
+    std::vector<ET_RHF_thread_data> thread_data_array(nthreads);
 
     global_dpd_->file2_init(&fIJ, PSIF_CC_OEI, 0, 0, 0, "fIJ");
     global_dpd_->file2_init(&fAB, PSIF_CC_OEI, 0, 1, 1, "fAB");
@@ -283,7 +283,7 @@ double ET_RHF() {
     return ET;
 }
 
-void ET_RHF_thread(thread_data *data) {
+void ET_RHF_thread(ET_RHF_thread_data *data) {
     int h, nirreps, cnt_ijk;
     int Gp, p, nump;
     int nrows, ncols, nlinks;

--- a/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
@@ -53,7 +53,7 @@
 namespace psi {
 namespace cctriples {
 
-struct thread_data {
+struct EaT_RHF_thread_data {
     dpdfile2 *fIJ;
     dpdfile2 *fAB;
     dpdfile2 *fIA;
@@ -71,7 +71,7 @@ struct thread_data {
     int last_ijk;
 };
 
-void EaT_RHF_thread(thread_data *);
+void EaT_RHF_thread(EaT_RHF_thread_data *);
 
 double EaT_RHF() {
     int i, j, k, I, J, K, Gi, Gj, Gk, h, nirreps, cnt;
@@ -91,7 +91,7 @@ double EaT_RHF() {
     vir_off = moinfo.vir_off;
 
     nthreads = params.nthreads;
-    std::vector<thread_data> thread_data_array(nthreads);
+    std::vector<EaT_RHF_thread_data> thread_data_array(nthreads);
 
 #ifdef USING_LAPACK_MKL
     int old_threads = mkl_get_max_threads();
@@ -266,7 +266,7 @@ double EaT_RHF() {
     return ET;
 }
 
-void EaT_RHF_thread(thread_data *data) {
+void EaT_RHF_thread(EaT_RHF_thread_data *data) {
     int h, nirreps, cnt_ijk;
     int Gp, p, nump;
     int nrows, ncols, nlinks;


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

`EaT_RHF.cc` and `ET_RHF.cc` contain incompatible declarations of `psi::cctriples::thread_data`.

During compilation, templates (i.e. `std::vector<psi::cctriples::thread_data>`) are generated once and reused, while memory access  instructions to `psi::cctriples::thread_data` are generate at each translation unit.

That results into an overflow:
```
==29447==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60800007a380 at pc 0x7fa994502627 bp 0x7fffc3cb6560 sp 0x7fffc3cb6558
WRITE of size 4 at 0x60800007a380 thread T0
    #0 0x7fa994502626 in psi::cctriples::EaT_RHF() /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cctriples/EaT_RHF.cc:206
    #1 0x7fa993ee2cec in psi::cctriples::cctriples(std::shared_ptr<psi::Wavefunction>, psi::Options&) /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cctriples/triples.cc:154
    #2 0x7fa993dfd890 in psi::cclambda::CCLambdaWavefunction::compute_energy() /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cclambda/cclambda.cc:324
    #3 0x7fa9937cfa84 in py_psi_cclambda(std::shared_ptr<psi::Wavefunction>) /home/raimis/prj/psi4.git/psi4/src/core.cc:382
    #4 0x7fa9938b8a3c in std::shared_ptr<psi::Wavefunction> pybind11::detail::argument_loader<std::shared_ptr<psi::Wavefunction> >::call_impl<std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), 0ul, pybind11::detail::void_type>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::integer_sequence<unsigned long, 0ul>, pybind11::detail::void_type&&) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/cast.h:1874
    #5 0x7fa9938a441c in std::enable_if<!std::is_void<std::shared_ptr<psi::Wavefunction> >::value, std::shared_ptr<psi::Wavefunction> >::type pybind11::detail::argument_loader<std::shared_ptr<psi::Wavefunction> >::call<std::shared_ptr<psi::Wavefunction>, pybind11::detail::void_type, std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>)>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>)) && /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/cast.h:1851
    #6 0x7fa993875298 in void pybind11::cpp_function::initialize<std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction>, pybind11::name, pybind11::scope, pybind11::sibling, char [48]>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction> (*)(std::shared_ptr<psi::Wavefunction>), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&, char const (&) [48])::{lambda(pybind11::detail::function_call&)#3}::operator()(pybind11::detail::function_call&) const /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:154
    #7 0x7fa9938754c1 in void pybind11::cpp_function::initialize<std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction>, pybind11::name, pybind11::scope, pybind11::sibling, char [48]>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction> (*)(std::shared_ptr<psi::Wavefunction>), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&, char const (&) [48])::{lambda(pybind11::detail::function_call&)#3}::_FUN(pybind11::detail::function_call&) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:132
    #8 0x7fa99261be8f in pybind11::cpp_function::dispatcher(_object*, _object*, _object*) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:627
    #9 0x7fa9b5205cbc in _PyCFunction_FastCallDict Objects/methodobject.c:231
    #10 0x7fa9b529f0d9 in call_function Python/ceval.c:4837
    #11 0x7fa9b52a2901 in _PyEval_EvalFrameDefault Python/ceval.c:3335
    #12 0x7fa9b529ecdd in _PyEval_EvalCodeWithName Python/ceval.c:4166
    #13 0x7fa9b529f30c in PyEval_EvalCodeEx Python/ceval.c:4187
    #14 0x7fa9b51df002 in function_call Objects/funcobject.c:604
    #15 0x7fa9b51ac8a9 in PyObject_Call Objects/abstract.c:2261
    #16 0x7fa9b52a0a44 in do_call_core Python/ceval.c:5106
    #17 0x7fa9b52a0a44 in _PyEval_EvalFrameDefault Python/ceval.c:3404
    #18 0x7fa9b529ecdd in _PyEval_EvalCodeWithName Python/ceval.c:4166
    #19 0x7fa9b529f30c in PyEval_EvalCodeEx Python/ceval.c:4187
    #20 0x7fa9b51df002 in function_call Objects/funcobject.c:604
    #21 0x7fa9b51ac8a9 in PyObject_Call Objects/abstract.c:2261
    #22 0x7fa9b52a0a44 in do_call_core Python/ceval.c:5106
    #23 0x7fa9b52a0a44 in _PyEval_EvalFrameDefault Python/ceval.c:3404
    #24 0x7fa9b529ecdd in _PyEval_EvalCodeWithName Python/ceval.c:4166
    #25 0x7fa9b529eff1 in fast_function Python/ceval.c:4978
    #26 0x7fa9b529eff1 in call_function Python/ceval.c:4858
    #27 0x7fa9b52a2901 in _PyEval_EvalFrameDefault Python/ceval.c:3335
    #28 0x7fa9b529ecdd in _PyEval_EvalCodeWithName Python/ceval.c:4166
    #29 0x7fa9b529f30c in PyEval_EvalCodeEx Python/ceval.c:4187
    #30 0x7fa9b529f35a in PyEval_EvalCode Python/ceval.c:731
    #31 0x7fa9b52da771 in run_mod Python/pythonrun.c:1025
    #32 0x7fa9b52da771 in PyRun_StringFlags Python/pythonrun.c:949
    #33 0x7fa9b529c45a in builtin_exec_impl Python/bltinmodule.c:999
    #34 0x7fa9b529c45a in builtin_exec Python/clinic/bltinmodule.c.h:283
    #35 0x7fa9b5205c1d in _PyCFunction_FastCallDict Objects/methodobject.c:234
    #36 0x7fa9b529f0d9 in call_function Python/ceval.c:4837
    #37 0x7fa9b52a2901 in _PyEval_EvalFrameDefault Python/ceval.c:3335
    #38 0x7fa9b529ecdd in _PyEval_EvalCodeWithName Python/ceval.c:4166
    #39 0x7fa9b529f30c in PyEval_EvalCodeEx Python/ceval.c:4187
    #40 0x7fa9b529f35a in PyEval_EvalCode Python/ceval.c:731
    #41 0x7fa9b52db3b1 in run_mod Python/pythonrun.c:1025
    #42 0x7fa9b52db3b1 in PyRun_FileExFlags Python/pythonrun.c:978
    #43 0x7fa9b52db516 in PyRun_SimpleFileExFlags Python/pythonrun.c:419
    #44 0x7fa9b52f7b0c in run_file Modules/main.c:340
    #45 0x7fa9b52f7b0c in Py_Main Modules/main.c:810
    #46 0x400bbb in main Programs/python.c:69
    #47 0x7fa9b422cfe9 in __libc_start_main (/lib64/libc.so.6+0x20fe9)
    #48 0x400c7c  (/home/raimis/opt/conda/envs/psi4/bin/python3.6+0x400c7c)

0x60800007a380 is located 0 bytes to the right of 96-byte region [0x60800007a320,0x60800007a380)
allocated by thread T0 here:
    #0 0x7fa9b5721e10 in operator new(unsigned long) /opt/conda/conda-bld/compilers_linux-64_1520532893746/work/.build/src/gcc-7.2.0/libsanitizer/asan/asan_new_delete.cc:80
    #1 0x7fa9944a3281 in __gnu_cxx::new_allocator<psi::cctriples::thread_data>::allocate(unsigned long, void const*) /usr/include/c++/7/ext/new_allocator.h:111
    #2 0x7fa9944a2ba8 in std::allocator_traits<std::allocator<psi::cctriples::thread_data> >::allocate(std::allocator<psi::cctriples::thread_data>&, unsigned long) /usr/include/c++/7/bits/alloc_traits.h:436
    #3 0x7fa9944a2892 in std::_Vector_base<psi::cctriples::thread_data, std::allocator<psi::cctriples::thread_data> >::_M_allocate(unsigned long) /usr/include/c++/7/bits/stl_vector.h:172
    #4 0x7fa9944a2506 in std::_Vector_base<psi::cctriples::thread_data, std::allocator<psi::cctriples::thread_data> >::_M_create_storage(unsigned long) (/home/raimis/prj/psi4.git/linux_build/stage/lib/psi4/core.cpython-36m-x86_64-linux-gnu.so+0xcf0a506)
    #5 0x7fa9944a1e64 in std::_Vector_base<psi::cctriples::thread_data, std::allocator<psi::cctriples::thread_data> >::_Vector_base(unsigned long, std::allocator<psi::cctriples::thread_data> const&) /usr/include/c++/7/bits/stl_vector.h:138
    #6 0x7fa9944a18a0 in std::vector<psi::cctriples::thread_data, std::allocator<psi::cctriples::thread_data> >::vector(unsigned long, std::allocator<psi::cctriples::thread_data> const&) /usr/include/c++/7/bits/stl_vector.h:284
    #7 0x7fa9945002af in psi::cctriples::EaT_RHF() /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cctriples/EaT_RHF.cc:94
    #8 0x7fa993ee2cec in psi::cctriples::cctriples(std::shared_ptr<psi::Wavefunction>, psi::Options&) /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cctriples/triples.cc:154
    #9 0x7fa993dfd890 in psi::cclambda::CCLambdaWavefunction::compute_energy() /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cclambda/cclambda.cc:324
    #10 0x7fa9937cfa84 in py_psi_cclambda(std::shared_ptr<psi::Wavefunction>) /home/raimis/prj/psi4.git/psi4/src/core.cc:382
    #11 0x7fa9938b8a3c in std::shared_ptr<psi::Wavefunction> pybind11::detail::argument_loader<std::shared_ptr<psi::Wavefunction> >::call_impl<std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), 0ul, pybind11::detail::void_type>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::integer_sequence<unsigned long, 0ul>, pybind11::detail::void_type&&) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/cast.h:1874
    #12 0x7fa9938a441c in std::enable_if<!std::is_void<std::shared_ptr<psi::Wavefunction> >::value, std::shared_ptr<psi::Wavefunction> >::type pybind11::detail::argument_loader<std::shared_ptr<psi::Wavefunction> >::call<std::shared_ptr<psi::Wavefunction>, pybind11::detail::void_type, std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>)>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>)) && /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/cast.h:1851
    #13 0x7fa993875298 in void pybind11::cpp_function::initialize<std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction>, pybind11::name, pybind11::scope, pybind11::sibling, char [48]>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction> (*)(std::shared_ptr<psi::Wavefunction>), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&, char const (&) [48])::{lambda(pybind11::detail::function_call&)#3}::operator()(pybind11::detail::function_call&) const /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:154
    #14 0x7fa9938754c1 in void pybind11::cpp_function::initialize<std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction>, std::shared_ptr<psi::Wavefunction>, pybind11::name, pybind11::scope, pybind11::sibling, char [48]>(std::shared_ptr<psi::Wavefunction> (*&)(std::shared_ptr<psi::Wavefunction>), std::shared_ptr<psi::Wavefunction> (*)(std::shared_ptr<psi::Wavefunction>), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&, char const (&) [48])::{lambda(pybind11::detail::function_call&)#3}::_FUN(pybind11::detail::function_call&) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:132
    #15 0x7fa99261be8f in pybind11::cpp_function::dispatcher(_object*, _object*, _object*) /home/raimis/opt/conda/envs/psi4/include/python3.6m/pybind11/pybind11.h:627
    #16 0x7fa9b5205cbc in _PyCFunction_FastCallDict Objects/methodobject.c:231

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/raimis/prj/psi4.git/psi4/src/psi4/cc/cctriples/EaT_RHF.cc:206 in psi::cctriples::EaT_RHF()
Shadow bytes around the buggy address:
  0x0c1080007420: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1080007430: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1080007440: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1080007450: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1080007460: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c1080007470:[fa]fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1080007480: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1080007490: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c10800074a0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c10800074b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c10800074c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==29447==ABORTING
```

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Rename `psi::cctriples::thread_data` (in `EaT_RHF.cc`) to `psi::cctriples::EaT_RHF_thread_data`
- [x] Rename `psi::cctriples::thread_data` (in `ET_RHF.cc`) to `psi::cctriples::ET_RHF_thread_data`

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
