### PR TITLE
Fix memory error in psi::MultipolePropCalc::compute_mo_extents

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ jobs:
           ctest --build-config Debug ^
                 --tests-regex "^ci-property$" ^
                 --output-on-failure ^
-                --repeat-until-fail 10
+                --repeat-until-fail 10 ^
                 --parallel %NUMBER_OF_PROCESSORS%
           exit 0
         displayName: "Test Psi4 (failing ctest)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,9 +129,15 @@ jobs:
       - script: |
           call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           ctest --build-config Debug ^
-                --tests-regex "^(cbs-parser|cc46|cc47|cc53|ci-property|fci-tdm|fci-tdm-2|psimrcc-fd-freq2|psithon2)$" ^
+                --tests-regex "^(cbs-parser|cc46|cc47|cc53|fci-tdm|fci-tdm-2|psimrcc-fd-freq2|psithon2)$" ^
                 --output-on-failure ^
-                --parallel %NUMBER_OF_PROCESSORS% & exit 0
+                --parallel %NUMBER_OF_PROCESSORS%
+          ctest --build-config Debug ^
+                --tests-regex "^ci-property$" ^
+                --output-on-failure ^
+                --repeat-until-fail 10
+                --parallel %NUMBER_OF_PROCESSORS%
+          exit 0
         displayName: "Test Psi4 (failing ctest)"
         workingDirectory: $(Build.BinariesDirectory)/build
 

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1436,10 +1436,10 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
     SharedMatrix Ca = Ca_ao();
 
     std::vector<SharedVector> mo_es;
-    mo_es.push_back(SharedVector(new Vector("<x^2>", basisset_->nbf())));
-    mo_es.push_back(SharedVector(new Vector("<y^2>", basisset_->nbf())));
-    mo_es.push_back(SharedVector(new Vector("<z^2>", basisset_->nbf())));
-    mo_es.push_back(SharedVector(new Vector("<r^2>", basisset_->nbf())));
+    mo_es.push_back(std::make_shared<Vector>("<x^2>", basisset_->nbf()));
+    mo_es.push_back(std::make_shared<Vector>("<y^2>", basisset_->nbf()));
+    mo_es.push_back(std::make_shared<Vector>("<z^2>", basisset_->nbf()));
+    mo_es.push_back(std::make_shared<Vector>("<r^2>", basisset_->nbf()));
 
     // Create a vector of matrices with the proper symmetry
     std::vector<SharedMatrix> ao_Qpole;

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1463,26 +1463,9 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
     quadrupole.push_back(std::make_shared<Vector>("Orbital Quadrupole YY", Ca->ncol()));
     quadrupole.push_back(std::make_shared<Vector>("Orbital Quadrupole ZZ", Ca->ncol()));
 
-    // auto temp = std::make_shared<Matrix>("Temp", Ca->nrow(), Ca->ncol());
-    // int nao = Ca->nrow();
-    int nmo = Ca->ncol();
-
     if (same_orbs_) {
-// Quadrupoles
-#if 0
-        C_DGEMM('T','N',nmo,nao,nao,1.0,Ca->pointer()[0],nmo,ao_Qpole[0]->pointer()[0],nao,0.0,temp->pointer()[0],nao);
-        for (int i = 0; i < nmo; i++) {
-            quadrupole[0]->set(0,i,C_DDOT(nao,Ca->pointer()[i],nmo,temp->pointer()[i],1));
-        }
-        C_DGEMM('T','N',nmo,nao,nao,1.0,Ca->pointer()[0],nmo,ao_Qpole[3]->pointer()[0],nao,0.0,temp->pointer()[0],nao);
-        for (int i = 0; i < nmo; i++) {
-            quadrupole[1]->set(0,i,C_DDOT(nao,Ca->pointer()[i],nmo,temp->pointer()[i],1));
-        }
-        C_DGEMM('T','N',nmo,nao,nao,1.0,Ca->pointer()[0],nmo,ao_Qpole[5]->pointer()[0],nao,0.0,temp->pointer()[0],nao);
-        for (int i = 0; i < nmo; i++) {
-            quadrupole[2]->set(0,i,C_DDOT(nao,Ca->pointer()[i],nmo,temp->pointer()[i],1));
-        }
-#else
+
+        // Quadrupoles
         for (int i = 0; i < Ca->ncol(); ++i) {
             double sumx = 0.0, sumy = 0.0, sumz = 0.0;
             for (int k = 0; k < Ca->nrow(); ++k) {
@@ -1498,7 +1481,7 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
             quadrupole[1]->set(0, i, std::fabs(sumy));
             quadrupole[2]->set(0, i, std::fabs(sumz));
         }
-#endif
+
         std::vector<std::string> labels = basisset_->molecule()->irrep_labels();
         std::vector<std::tuple<double, int, int>> metric;
         for (int h = 0; h < epsilon_a_->nirrep(); h++) {
@@ -1512,7 +1495,7 @@ std::vector<SharedVector> MultipolePropCalc::compute_mo_extents(bool print_outpu
             outfile->Printf("    %10s%15s%15s%15s%15s\n", "MO", "<x^2>", "<y^2>", "<z^2>", "<r^2>");
         }
 
-        for (int i = 0; i < nmo; i++) {
+        for (int i = 0; i < Ca->ncol(); i++) {
             int n = std::get<1>(metric[i]);
             int h = std::get<2>(metric[i]);
 


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Repeat `ci-property` test to catch random failures
- [x] Remove memory error in `psi::MultipolePropCalc::compute_mo_extents`.
- [x] Fix `ci-property` test on Windows

## Questions
- [x] Removed some dead code, including the part with `C_DDOT`, which was segment-faulting. Could you check, it was really a dead code, not some incomplete implementation? --> Dead!

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
