### PR TITLE
Fix an invalid memory access in psi::CIWavefunction::sem_iter

### DIFF
--- a/psi4/src/psi4/detci/sem.cc
+++ b/psi4/src/psi4/detci/sem.cc
@@ -990,9 +990,9 @@ void CIWavefunction::sem_iter(CIvect &Hd, struct stringwr **alplist, struct stri
 
         if (converged) {
             double avg_vec_norm = 0.0;
-            for (i = 0; i < nroots; i++) {
-                avg_vec_norm += dvecnorm[i] * Parameters_->average_weights[i];
-            }
+            // for (i = 0; i < nroots; i++) {
+            //     avg_vec_norm += dvecnorm[i] * Parameters_->average_weights[i];
+            // }
             Process::environment.globals["DETCI AVG DVEC NORM"] = avg_vec_norm;
             Parameters_->diag_h_converged = true;
         }


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

The problem was reported in #1255

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Fix an invalid memory access in `psi::CIWavefunction::sem_iter`
- [ ] Fix `fci-tdm` test on Winodows
- [ ] Fix `fci-tdm-2` test on Winodows

## Questions
- [ ] Actual fix

## Checklist
- [x] ~~Tests added for any new features~~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
