### PR TITLE
Fix a filesystem error in psi.driver.cbs

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1570,7 +1570,7 @@ def cbs(func, label, **kwargs):
         commands = '\n'
         commands += """\ncore.set_global_option('BASIS', '%s')\n""" % (mc['f_basis'])
         commands += """core.set_global_option('WRITER_FILE_LABEL', '%s')\n""" % \
-            (user_writer_file_label + ('' if user_writer_file_label == '' else '-') + mc['f_wfn'].lower() + '-' + mc['f_basis'].lower())
+            (user_writer_file_label + ('' if user_writer_file_label == '' else '-') + mc['f_wfn'].lower() + '-' + mc['f_basis'].lower().replace('*', 's'))
         exec(commands)
 
         # Stash and set options if any


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix a filesystem error in `psi.driver.cbs`. Windows does not support `*` in filenames.
- [x] Fix `cbs-parser` test on Windows

## Questions
- [x] How *Psi4* is suppose to sanitize filenames? Have I missed some function? --> That suppose to be removed in 1.4, so just a quick fix for now.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
