### PR TITLE
Fix formation of SAD fractional density matrix

### DIFF
--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -608,7 +608,7 @@ void SADGuess::form_C_and_D(int nocc, int norbs, SharedMatrix X, SharedMatrix F,
     }
     // Scale by occ
     for (int i = 0; i < nocc; i++) {
-        C_DSCAL(norbs, occ->get(i), &Cp[0][i], nocc);
+        C_DSCAL(norbs, occ->get(i), &Coccp[0][i], nocc);
     }
     // Form D = Cocc*Cocc'
     D->gemm(false, true, 1.0, Cocc, Cocc, 0.0);


### PR DESCRIPTION
## Description
The SAD fractional density matrix didn't actually use fractional densities. This is fixed in the present PR.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] SAD density matrix is fractionally occupied

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
