### PR TITLE
Deprecate c-side frequencies

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1470,8 +1470,6 @@ def frequency(name, **kwargs):
 
     irrep = kwargs.get('irrep', None)
     vibinfo = vibanal_wfn(wfn, irrep=irrep, project_trans=project_trans, project_rot=project_rot)
-    vibonly = qcdb.vib.filter_nonvib(vibinfo)
-    wfn.set_frequencies(core.Vector.from_array(qcdb.vib.filter_omega_to_real(vibonly['omega'].data)))
     wfn.frequency_analysis = vibinfo
 
     for postcallback in hooks['frequency']['post']:

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -702,6 +702,9 @@ core.Wavefunction.arrays = _core_wavefunction_arrays
 
 
 def _core_wavefunction_frequencies(cls):
+    if not hasattr(cls, 'frequency_analysis'):
+        return None
+
     vibinfo = cls.frequency_analysis
     vibonly = qcdb.vib.filter_nonvib(vibinfo)
     return core.Vector.from_array(qcdb.vib.filter_omega_to_real(vibonly['omega'].data))

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -700,6 +700,34 @@ core.Wavefunction.get_array = _core_wavefunction_get_array
 core.Wavefunction.set_array = _core_wavefunction_set_array
 core.Wavefunction.arrays = _core_wavefunction_arrays
 
+
+def _core_wavefunction_frequencies(cls):
+    vibinfo = cls.frequency_analysis
+    vibonly = qcdb.vib.filter_nonvib(vibinfo)
+    return core.Vector.from_array(qcdb.vib.filter_omega_to_real(vibonly['omega'].data))
+
+
+def _core_wavefunction_legacy_frequencies(cls):
+    warnings.warn(
+        "Using `psi4.core.Wavefunction.legacy_frequencies` (accessing c-side member data) is deprecated, and in 1.4 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+    return cls.legacy_frequencies()
+
+
+def _core_wavefunction_set_frequencies(cls, val):
+    warnings.warn(
+        "Using `psi4.core.Wavefunction.set_frequencies` (accessing c-side member data) instead of `psi4.core.Wavefunction.frequency_analysis` (py-side member data) is deprecated, and in 1.4 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+    return cls.set_legacy_frequencies(val)
+
+
+core.Wavefunction.frequencies = _core_wavefunction_frequencies
+core.Wavefunction.legacy_frequencies = _core_wavefunction_legacy_frequencies
+core.Wavefunction.set_frequencies = _core_wavefunction_set_frequencies
+
+
 ## Psi4 v1.3 Export Deprecations
 
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -131,7 +131,7 @@ void export_wavefunction(py::module& m) {
         .def("sobasisset", &Wavefunction::sobasisset, "Returns the symmetry orbitals basis.")
         .def("get_basisset", &Wavefunction::get_basisset, "Returns the requested auxiliary basis.")
         .def("set_basisset", &Wavefunction::set_basisset, "Sets the requested auxiliary basis.")
-        .def("energy", &Wavefunction::reference_energy, "Returns the Wavefunction's energy.")
+        .def("energy", &Wavefunction::energy, "Returns the Wavefunction's energy.")
         .def("set_energy", &Wavefunction::set_energy, "Sets the Wavefunction's energy.")
         .def("gradient", &Wavefunction::gradient, "Returns the Wavefunction's gradient.")
         .def("set_gradient", &Wavefunction::set_gradient, "Sets the Wavefunction's gradient.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -137,8 +137,8 @@ void export_wavefunction(py::module& m) {
         .def("set_gradient", &Wavefunction::set_gradient, "Sets the Wavefunction's gradient.")
         .def("hessian", &Wavefunction::hessian, "Returns the Wavefunction's Hessian.")
         .def("set_hessian", &Wavefunction::set_hessian, "Sets the Wavefunction's Hessian.")
-        .def("frequencies", &Wavefunction::frequencies, "Returns the frequencies of the Hessian.")
-        .def("set_frequencies", &Wavefunction::set_frequencies, "Sets the frequencies of the Hessian.")
+        .def("legacy_frequencies", &Wavefunction::frequencies, "Returns the frequencies of the Hessian.")
+        .def("set_legacy_frequencies", &Wavefunction::set_frequencies, "Sets the frequencies of the Hessian.")
         .def("esp_at_nuclei", &Wavefunction::get_esp_at_nuclei, "returns electrostatic potentials at nuclei")
         .def("mo_extents", &Wavefunction::get_mo_extents, "returns the wavefunction's electronic orbital extents.")
         .def("no_occupations", &Wavefunction::get_no_occupations,

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -69,9 +69,9 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.labels = wfn->molecule()->irrep_labels();
     moinfo.enuc = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     if (wfn->reference_wavefunction())
-        moinfo.escf = wfn->reference_wavefunction()->reference_energy();
+        moinfo.escf = wfn->reference_wavefunction()->energy();
     else
-        moinfo.escf = wfn->reference_energy();
+        moinfo.escf = wfn->energy();
 
     moinfo.orbspi = init_int_array(moinfo.nirreps);
     moinfo.clsdpi = init_int_array(moinfo.nirreps);

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -73,7 +73,7 @@ void CCEnergyWavefunction::get_moinfo() {
     moinfo_.enuc = molecule_->nuclear_repulsion_energy(dipole_field_strength_);
     moinfo_.conv = 0.0;
     if (reference_wavefunction_)
-        moinfo_.escf = reference_wavefunction_->reference_energy();
+        moinfo_.escf = reference_wavefunction_->energy();
     else
         moinfo_.escf = energy_;
     moinfo_.sopi = nsopi_;

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -70,9 +70,9 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.irr_labs = wfn->molecule()->irrep_labels();
     moinfo.enuc = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     if (wfn->reference_wavefunction())
-        moinfo.escf = wfn->reference_wavefunction()->reference_energy();
+        moinfo.escf = wfn->reference_wavefunction()->energy();
     else
-        moinfo.escf = wfn->reference_energy();
+        moinfo.escf = wfn->energy();
 
     moinfo.sopi = init_int_array(moinfo.nirreps);
     moinfo.orbspi = init_int_array(moinfo.nirreps);

--- a/psi4/src/psi4/cc/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cclambda/get_moinfo.cc
@@ -68,9 +68,9 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.labels = wfn->molecule()->irrep_labels();
     moinfo.enuc = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     if (wfn->reference_wavefunction())
-        moinfo.escf = wfn->reference_wavefunction()->reference_energy();
+        moinfo.escf = wfn->reference_wavefunction()->energy();
     else
-        moinfo.escf = wfn->reference_energy();
+        moinfo.escf = wfn->energy();
 
     moinfo.sopi = init_int_array(moinfo.nirreps);
     moinfo.orbspi = init_int_array(moinfo.nirreps);

--- a/psi4/src/psi4/cc/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cctriples/get_moinfo.cc
@@ -68,9 +68,9 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
     moinfo.labels = wfn->molecule()->irrep_labels();
     moinfo.enuc = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     if (wfn->reference_wavefunction())
-        moinfo.escf = wfn->reference_wavefunction()->reference_energy();
+        moinfo.escf = wfn->reference_wavefunction()->energy();
     else
-        moinfo.escf = wfn->reference_energy();
+        moinfo.escf = wfn->energy();
 
     moinfo.orbspi = init_int_array(moinfo.nirreps);
     moinfo.clsdpi = init_int_array(moinfo.nirreps);

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -116,9 +116,9 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
     double enuc = ref->molecule()->nuclear_repulsion_energy(ref->get_dipole_field_strength());
     double escf;
     if (ref->reference_wavefunction()) {
-        escf = ref->reference_wavefunction()->reference_energy();
+        escf = ref->reference_wavefunction()->energy();
     } else {
-        escf = ref->reference_energy();
+        escf = ref->energy();
     }
     double epcm = 0.0;
 #ifdef USING_PCMSolver

--- a/psi4/src/psi4/dcft/dcft_memory.cc
+++ b/psi4/src/psi4/dcft/dcft_memory.cc
@@ -52,7 +52,7 @@ void DCFTSolver::init() {
     nmo_ = reference_wavefunction_->nmo();
     enuc_ = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
         reference_wavefunction_->get_dipole_field_strength());
-    scf_energy_ = reference_wavefunction_->reference_energy();
+    scf_energy_ = reference_wavefunction_->energy();
     ntriso_ = nso_ * (nso_ + 1) / 2;
     soccpi_ = reference_wavefunction_->soccpi();
     doccpi_ = reference_wavefunction_->doccpi();

--- a/psi4/src/psi4/detci/get_mo_info.cc
+++ b/psi4/src/psi4/detci/get_mo_info.cc
@@ -79,7 +79,7 @@ void CIWavefunction::get_mo_info() {
     CalcInfo_->docc = doccpi();
     CalcInfo_->socc = soccpi();
     CalcInfo_->enuc = molecule()->nuclear_repulsion_energy(dipole_field_strength_);
-    CalcInfo_->escf = reference_energy();
+    CalcInfo_->escf = energy();
     CalcInfo_->edrc = 0.0;
 
     if (CalcInfo_->iopen && Parameters_->opentype == PARM_OPENTYPE_NONE) {

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -177,7 +177,7 @@ void DFMP2::common_init() {
     variables_["MP2 SINGLES ENERGY"] = 0.0;
     variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = 0.0;
     variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = 0.0;
-    variables_["SCF TOTAL ENERGY"] = reference_wavefunction_->reference_energy();
+    variables_["SCF TOTAL ENERGY"] = reference_wavefunction_->energy();
 
     sss_ = options_.get_double("MP2_SS_SCALE");
     oss_ = options_.get_double("MP2_OS_SCALE");

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -69,7 +69,7 @@ void DFOCC::get_moinfo() {
             reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
-        Escf = reference_wavefunction_->reference_energy();
+        Escf = reference_wavefunction_->energy();
         Eref = Escf;
         Eelec = Escf - Enuc;
 
@@ -175,7 +175,7 @@ void DFOCC::get_moinfo() {
             reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
-        Escf = reference_wavefunction_->reference_energy();
+        Escf = reference_wavefunction_->energy();
         Eref = Escf;
         Eelec = Escf - Enuc;
 

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -872,7 +872,7 @@ void FISAPT::dHF() {
 
     // => Dimer HF (Already done) <= //
 
-    double EABC = reference_->reference_energy();
+    double EABC = reference_->energy();
 
     // => Monomer AC Energy <= //
 

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -86,7 +86,7 @@ void CoupledCluster::common_init() {
     mp3_only = options_.get_bool("RUN_MP3");
     isccsd = options_.get_bool("RUN_CCSD");
 
-    escf = reference_wavefunction_->reference_energy();
+    escf = reference_wavefunction_->energy();
     doccpi_ = reference_wavefunction_->doccpi();
     soccpi_ = reference_wavefunction_->soccpi();
     frzcpi_ = reference_wavefunction_->frzcpi();

--- a/psi4/src/psi4/libfock/apps.cc
+++ b/psi4/src/psi4/libfock/apps.cc
@@ -84,7 +84,7 @@ void RBase::set_reference(SharedWavefunction ref_wfn) {
         throw PSIEXCEPTION("RBase: Reference is not restricted");
     }
 
-    Eref_ = reference_wavefunction_->reference_energy();
+    Eref_ = reference_wavefunction_->energy();
 
     if (use_symmetry_) {
         Cocc_ = Ca_subset("SO", "OCC");

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -409,8 +409,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     int nmo() const { return nmo_; }
     /// Returns the number of irreps
     int nirrep() const { return nirrep_; }
-    /// Returns the reference energy
+    /// Returns the energy
+    PSI_DEPRECATED(
+        "Using `Wavefunction.reference_energy` instead of `Wavefunction.energy` is deprecated, and in 1.4 it will "
+        "stop working")
     double reference_energy() const { return energy_; }
+    double energy() const { return energy_; }
     /// Sets the energy
     void set_energy(double ene) { energy_ = ene; }
     /// Returns the frozen-core energy
@@ -632,8 +636,13 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     }
 
     /// Returns the frequencies
+    PSI_DEPRECATED(
+        "Using `Wavefunction.frequencies` c-side instead of `Wavefunction.frequencies` py-side is deprecated, and in "
+        "1.4 it will stop working")
     SharedVector frequencies() const;
+
     /// Set the frequencies for the wavefunction
+    PSI_DEPRECATED("Using `Wavefunction.set_frequencies` is deprecated, and in 1.4 it will stop working")
     void set_frequencies(std::shared_ptr<Vector> freqs);
 
     /// Set the wavefunction name (e.g. "RHF", "ROHF", "UHF", "CCEnergyWavefunction")

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -562,7 +562,7 @@ void FCHKWriter::write(const std::string &filename) {
     write_matrix("Primitive exponents", exponents);
     write_matrix("Contraction coefficients", coefficients);
     write_matrix("Coordinates of each shell", shell_coords);
-    write_number("Total Energy", wavefunction_->reference_energy());
+    write_number("Total Energy", wavefunction_->energy());
     // write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
     write_matrix(wavefunction_->epsilon_a()->name().c_str(), wavefunction_->epsilon_a_subset("AO"));
     // write_matrix("Alpha MO coefficients", reorderedCa);

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -113,7 +113,7 @@ void MOInfo::read_info() {
     read_data();
     nmo = ref_wfn.nmo();
     compute_number_of_electrons();
-    scf_energy = ref_wfn.reference_energy();
+    scf_energy = ref_wfn.energy();
     mopi = convert_int_array_to_vector(nirreps, ref_wfn.nmopi());
     SharedMatrix matCa = ref_wfn.Ca();
     scf = block_matrix(nso, nmo);

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -167,7 +167,7 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
     noccA_ = MonomerA->doccpi().sum();
     nvirA_ = nmoA_ - noccA_;
     NA_ = 2 * noccA_;
-    eHFA = MonomerA->reference_energy();
+    eHFA = MonomerA->energy();
     enucA = MonomerA->molecule()->nuclear_repulsion_energy(dipole_field_strength_);
     aoccA_ = noccA_ - foccA_;
 
@@ -177,7 +177,7 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
     noccB_ = MonomerB->doccpi().sum();
     nvirB_ = nmoB_ - noccB_;
     NB_ = 2 * noccB_;
-    eHFB = MonomerB->reference_energy();
+    eHFB = MonomerB->energy();
     enucB = MonomerB->molecule()->nuclear_repulsion_energy(dipole_field_strength_);
     aoccB_ = noccB_ - foccB_;
 

--- a/psi4/src/psi4/libsapt_solver/usapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/usapt0.cc
@@ -64,9 +64,9 @@ USAPT0::USAPT0(SharedWavefunction d, SharedWavefunction mA, SharedWavefunction m
     monomer_A_ = mA->molecule();
     monomer_B_ = mB->molecule();
 
-    E_dimer_ = d->reference_energy();
-    E_monomer_A_ = mA->reference_energy();
-    E_monomer_B_ = mB->reference_energy();
+    E_dimer_ = d->energy();
+    E_monomer_A_ = mA->energy();
+    E_monomer_B_ = mB->energy();
 
     primary_ = d->basisset();
     primary_A_ = mA->basisset();

--- a/psi4/src/psi4/libscf_solver/stability.cc
+++ b/psi4/src/psi4/libscf_solver/stability.cc
@@ -99,7 +99,7 @@ void UStab::set_reference(std::shared_ptr<Wavefunction> wfn) {
     eps_virb_ = wfn->epsilon_b_subset("SO", "VIR");
     molecule_ = wfn->molecule();
     basis_ = wfn->basisset();
-    Eref_ = wfn->reference_energy();
+    Eref_ = wfn->energy();
 }
 
 void UStab::print_header() {

--- a/psi4/src/psi4/mcscf/mcscf.cc
+++ b/psi4/src/psi4/mcscf/mcscf.cc
@@ -90,9 +90,9 @@ SharedWavefunction mcscf(SharedWavefunction ref_wfn, Options& options) {
         moinfo_scf = new psi::MOInfoSCF(*(wfn.get()), options);
         wfn->compute_energy();
 
-        Process::environment.globals["CURRENT ENERGY"] = wfn->reference_energy();
-        Process::environment.globals["CURRENT REFERENCE ENERGY"] = wfn->reference_energy();
-        Process::environment.globals["SCF TOTAL ENERGY"] = wfn->reference_energy();
+        Process::environment.globals["CURRENT ENERGY"] = wfn->energy();
+        Process::environment.globals["CURRENT REFERENCE ENERGY"] = wfn->energy();
+        Process::environment.globals["SCF TOTAL ENERGY"] = wfn->energy();
 
     } else if (options.get_str("REFERENCE") == "MCSCF") {
         throw PSIEXCEPTION("REFERENCE = MCSCF not implemented yet");

--- a/psi4/src/psi4/occ/get_moinfo.cc
+++ b/psi4/src/psi4/occ/get_moinfo.cc
@@ -101,7 +101,7 @@ void OCCWave::get_moinfo() {
             reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
-        Escf = reference_wavefunction_->reference_energy();
+        Escf = reference_wavefunction_->energy();
         Eref = Escf;
         Eelec = Escf - Enuc;
 
@@ -449,7 +449,7 @@ void OCCWave::get_moinfo() {
             reference_wavefunction_->get_dipole_field_strength());
 
         // Read SCF energy
-        Escf = reference_wavefunction_->reference_energy();
+        Escf = reference_wavefunction_->energy();
         Eref = Escf;
         Eelec = Escf - Enuc;
 


### PR DESCRIPTION
## Description
Cramming a few more deprecations into v1.2

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `Wavefunction.reference_energy()` --> `Wavefunction.energy()` in keeping with grad/hess and because reference is not apt. py-side was already plain `energy()`.
- [x] deprecate the c-side `Wavefunction.frequencies` member data and getter/setter. getter now reads off the py-side member data. setter will go away entirely.

## Questions
- [ ] can one suppress compile-time deprecation warnings for two lines? the export_mints legacy_freq lines are properly throwing errors and disrupting the clean build.

## Checklist
- [ ] ~Tests added for any new features~
- [x] ran the freq tests with earlier v of code

## Status
- [x] Ready for review. ~This has got bits of #1454 and #1449 in it. I'll rebase once they're in.~
- [x] Ready for merge
