### PR TITLE
use upstream snsmp2

### DIFF
--- a/external/downstream/snsmp2/CMakeLists.txt
+++ b/external/downstream/snsmp2/CMakeLists.txt
@@ -19,10 +19,8 @@ if(${ENABLE_snsmp2})
         ExternalProject_Add(snsmp2_external
             DEPENDS qcelemental_external
             BUILD_ALWAYS 1
-            GIT_REPOSITORY https://github.com/loriab/sns-mp2
-            GIT_TAG a035c27
-            #GIT_REPOSITORY https://github.com/DEShawResearch/sns-mp2
-            #GIT_TAG a70c56f  # v1.0 + 13
+            GIT_REPOSITORY https://github.com/DEShawResearch/sns-mp2
+            GIT_TAG 99e2a9c  # v1.0 + 16
             CONFIGURE_COMMAND ""
             UPDATE_COMMAND ""
             BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build


### PR DESCRIPTION
## Description
Use upstream snsmp2 again after driver/qcel rearrangement. Particularly bad since I had deleted the branch this points to. Fixes #1425 

## Status
- [x] Ready for review
- [x] Ready for merge
