### PR TITLE
Implement DIIS absolute error criterion

### DIFF
--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -660,7 +660,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     double sum_of_squares();
     /// Returns the rms of this
     double rms();
-    /// Returns the absoluate maximum balue
+    /// Returns the absolute maximum value
     double absmax();
     /// Add val to an element of this
     void add(int h, int m, int n, double val) {

--- a/psi4/src/psi4/libscf_solver/frac.cc
+++ b/psi4/src/psi4/libscf_solver/frac.cc
@@ -178,7 +178,7 @@ void HF::frac() {
         double** Cp = ((is_alpha) ? Ca_->pointer(h) : Cb_->pointer(h));
 
         // And I say all that to say this
-        C_DSCAL(nso, sqrt(val), &Cp[0][i], nmo);
+        C_DSCAL(nso, std::sqrt(val), &Cp[0][i], nmo);
     }
 }
 void HF::frac_renormalize() {
@@ -218,7 +218,7 @@ void HF::frac_renormalize() {
         double** Cp = ((is_alpha) ? Ca_->pointer(h) : Cb_->pointer(h));
 
         // And I say all that to say this: TODO: This destroys FMP2 computations if val == 0
-        if (val != 0.0) C_DSCAL(nso, 1.0 / sqrt(val), &Cp[0][i], nmo);
+        if (val != 0.0) C_DSCAL(nso, 1.0 / std::sqrt(val), &Cp[0][i], nmo);
     }
 }
 

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -343,7 +343,6 @@ void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     tmp.reset();
 }
 void HF::initialize_gtfock_jk() {
-
     // Build the JK from options, symmetric type
 #ifdef HAVE_JK_FACTORY
     // DGAS is adding to the ghetto, this Python -> C++ -> C -> C++ -> back to C is FUBAR
@@ -718,7 +717,7 @@ void HF::form_Shalf() {
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < dimpi[h]; ++i) {
             if (min_S > eigval->get(h, i)) min_S = eigval->get(h, i);
-            double scale = 1.0 / sqrt(eigval->get(h, i));
+            double scale = 1.0 / std::sqrt(eigval->get(h, i));
             eigval->set(h, i, scale);
         }
     }
@@ -748,7 +747,7 @@ void HF::form_Shalf() {
             int start_index = 0;
             for (int i = 0; i < dimpi[h]; ++i) {
                 if (S_cutoff < eigval->get(h, i)) {
-                    double scale = 1.0 / sqrt(eigval->get(h, i));
+                    double scale = 1.0 / std::sqrt(eigval->get(h, i));
                     eigvec->scale_column(h, i, scale);
                 } else {
                     start_index++;

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -47,8 +47,6 @@ namespace scf {
 
 class HF : public Wavefunction {
    protected:
-    double Drms_;
-
     /// The kinetic energy matrix
     SharedMatrix T_;
     /// The 1e potential energy matrix

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -496,9 +496,9 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
     // Print a header
     bool converged = false;
     if (print_ > 1) {
+        std::string measure = diis_rms ? "RMS |[F,P]|  " : "MAX |[F,P]|  ";
         outfile->Printf("\n  Initial Atomic UHF Energy:    %14.10f\n\n", E);
-        outfile->Printf(
-            "                                         Total Energy            Delta E              Density RMS\n\n");
+        outfile->Printf("  %33s %20s    %20s %20s\n", "","Total Energy   ","Delta E   ",measure.c_str());
     }
 
     // Run the iterations

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1294,6 +1294,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         set. A value of ``TRUE`` turns on density fitting with the
         default basis, otherwise the specified basis is used. -*/
         options.add_str("DF_BASIS_GUESS", "FALSE", "");
+        /*- Use RMS error instead of the more robust absolute error? -*/
+        options.add_bool("DIIS_RMS_ERROR", true);
         /*- The minimum iteration to start storing DIIS vectors -*/
         options.add_int("DIIS_START", 1);
         /*- Minimum number of error vectors stored for DIIS extrapolation -*/
@@ -2449,7 +2451,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         or RMS_*_G_CONVERGENCE options will append to overwrite the criteria set here
         unless |optking__flexible_g_convergence| is also on.      See Table :ref:`Geometry Convergence
         <table:optkingconv>` for details. -*/
-        options.add_str("G_CONVERGENCE", "QCHEM", "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT INTERFRAG_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
+        options.add_str(
+            "G_CONVERGENCE", "QCHEM",
+            "QCHEM MOLPRO GAU GAU_LOOSE GAU_TIGHT INTERFRAG_TIGHT GAU_VERYTIGHT TURBOMOLE CFOUR NWCHEM_LOOSE");
         /*- Convergence criterion for geometry optmization: maximum force
         (internal coordinates, atomic units). -*/
         options.add_double("MAX_FORCE_G_CONVERGENCE", 3.0e-4);


### PR DESCRIPTION
## Description
Psi4 is currently using the RMS norm to check for wave function convergence. However, it's well known that the RMS norm isn't as robust as the absolute error in some pathological cases: even though the RMS error is small, you may still have significant gradients for a few orbitals.

This PR implements the maximum absolute norm for DIIS in SCF calculations, which can be toggled by setting ```DIIS_RMS_ERROR false```

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Implemented absolute error criterion for DIIS

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
