### PR TITLE
Also mention wave function convergence in the SCF output.

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -93,7 +93,7 @@ def scf_compute_energy(self):
             # die_if_not_converged()
             raise e
         else:
-            core.print_out("  Energy and wave function did not converge, but proceeding anyway.\n\n")
+            core.print_out("  Energy and/or wave function did not converge, but proceeding anyway.\n\n")
     else:
         core.print_out("  Energy and wave function converged.\n\n")
 


### PR DESCRIPTION
## Description
SCF convergence has only been reported with the message "Energy converged." which is missing out on the more important part, i.e. the convergence of the wave function. For pedagogical reasons, this PR changes the printout so that also the wave function is mentioned in the message.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
