### PR TITLE
Fix invalid memory access in psi::IntegralTransform::presort_so_tei

### DIFF
--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -109,6 +109,7 @@ void CIWavefunction::transform_ci_integrals() {
                               IntegralTransform::OutputType::DPDOnly, IntegralTransform::MOOrdering::PitzerOrder,
                               IntegralTransform::FrozenOrbitals::OccAndVir, true);
     ints_ = std::shared_ptr<IntegralTransform>(ints);
+    ints_->set_build_mo_fock(false);
     ints_->set_memory(Process::environment.get_memory() * 0.8);
 
     // Incase we do two ci runs

--- a/psi4/src/psi4/libtrans/integraltransform.cc
+++ b/psi4/src/psi4/libtrans/integraltransform.cc
@@ -84,6 +84,7 @@ IntegralTransform::IntegralTransform(std::shared_ptr<Wavefunction> wfn, SpaceVec
       keepDpdMoTpdm_(true),
       keepHtInts_(true),
       keepHtTpdm_(true),
+      buildMOFock_(true),
       tpdmAlreadyPresorted_(false),
       soIntTEIFile_(PSIF_SO_TEI) {
     // Implement set/get functions to customize any of this stuff.  Delayed initialization
@@ -160,6 +161,7 @@ IntegralTransform::IntegralTransform(SharedMatrix H, SharedMatrix c, SharedMatri
       keepDpdMoTpdm_(true),
       keepHtInts_(true),
       keepHtTpdm_(true),
+      buildMOFock_(true),
       tpdmAlreadyPresorted_(false),
       soIntTEIFile_(PSIF_SO_TEI) {
     memory_ = Process::environment.get_memory();

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -178,6 +178,8 @@ class PSI_API IntegralTransform {
     void set_write_dpd_so_tpdm(bool t_f) { write_dpd_so_tpdm_ = t_f; }
     /// Set the level of printing used during transformations (0 -> 6)
     void set_print(int n) { print_ = n; }
+    /// Whether to build the Fock matrix in the MO basis during integral presort
+    void set_build_mo_fock(bool t_f) { buildMOFock_ = t_f; }
     /// Sets the orbitals to the given C matrix. This is a hack for MCSCF wavefunctions.
     /// Use with caution.
     void set_orbitals(SharedMatrix C);
@@ -418,6 +420,8 @@ class PSI_API IntegralTransform {
     bool useDPD_;
     // Has this object already pre-sorted?
     bool tpdmAlreadyPresorted_;
+    // Whether to form the MO basis Fock matrix during TEI presort
+    bool buildMOFock_;
     // This keeps track of which labels have been assigned by other spaces
     std::map<char, int> labelsUsed_;
 };

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -47,6 +47,7 @@ void IntegralTransform::common_initialize() {
     bbIntName_ = "";
 
     keepHtInts_ = false;
+    buildMOFock_ = true;
 
     nTriSo_ = nso_ * (nso_ + 1) / 2;
     nTriMo_ = nmo_ * (nmo_ + 1) / 2;

--- a/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
@@ -38,9 +38,7 @@
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <cassert>
 #include <cmath>
-#include <cstdlib>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
@@ -208,15 +208,14 @@ void IntegralTransform::presort_so_tei() {
             for (int q = 0; q <= p; ++q) {
                 int pq = INDEX((p + soOffset), (q + soOffset));
                 for (int i = 0; i < frzcpi_[h]; ++i) aFzcD[pq] += pCa[p][i] * pCa[q][i];
-
-                assert(Ca_->colspi()[h] >= nalphapi_[h]); // Does not work with Release builds
-                if (Ca_->colspi()[h] < nalphapi_[h])
-                    exit(-1);
-                for (int i = 0; i < nalphapi_[h]; ++i) aD[pq] += pCa[p][i] * pCa[q][i];
-
                 if (transformationType_ != TransformationType::Restricted) {
                     for (int i = 0; i < frzcpi_[h]; ++i) bFzcD[pq] += pCb[p][i] * pCb[q][i];
-                    for (int i = 0; i < nbetapi_[h]; ++i) bD[pq] += pCb[p][i] * pCb[q][i];
+                }
+                if(buildMOFock_){
+                    for (int i = 0; i < nalphapi_[h]; ++i) aD[pq] += pCa[p][i] * pCa[q][i];
+                    if (transformationType_ != TransformationType::Restricted) {
+                        for (int i = 0; i < nbetapi_[h]; ++i) bD[pq] += pCb[p][i] * pCb[q][i];
+                    }
                 }
             }
         }

--- a/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
@@ -38,7 +38,9 @@
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
+#include <cassert>
 #include <cmath>
+#include <cstdlib>
 
 using namespace psi;
 
@@ -206,7 +208,12 @@ void IntegralTransform::presort_so_tei() {
             for (int q = 0; q <= p; ++q) {
                 int pq = INDEX((p + soOffset), (q + soOffset));
                 for (int i = 0; i < frzcpi_[h]; ++i) aFzcD[pq] += pCa[p][i] * pCa[q][i];
+
+                assert(Ca_->colspi()[h] >= nalphapi_[h]); // Does not work with Release builds
+                if (Ca_->colspi()[h] < nalphapi_[h])
+                    exit(-1);
                 for (int i = 0; i < nalphapi_[h]; ++i) aD[pq] += pCa[p][i] * pCa[q][i];
+
                 if (transformationType_ != TransformationType::Restricted) {
                     for (int i = 0; i < frzcpi_[h]; ++i) bFzcD[pq] += pCb[p][i] * pCb[q][i];
                     for (int i = 0; i < nbetapi_[h]; ++i) bD[pq] += pCb[p][i] * pCb[q][i];


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

There is an invalid memory access at line 209, because `Ca_->colspi()[h]` is smaller than `nalphapi_[h]`:
https://github.com/psi4/psi4/blob/ba98fb72ab73350a613ae96b56d1d4c6074c2ae9/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc#L201-L217

I have added an asset to prove that.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Prove a bug in `psi::IntegralTransform::presort_so_tei`
- [x] Fix the bug in `psi::IntegralTransform::presort_so_tei`

## Questions
- [x] Who knows how to fix this? -- https://github.com/raimis/psi4/pull/4

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
