### PR TITLE
Fix for issue #1356.

### DIFF
--- a/psi4/driver/qcdb/intf_dftd3/runner.py
+++ b/psi4/driver/qcdb/intf_dftd3/runner.py
@@ -85,8 +85,7 @@ def run_dftd3(name, molecule, options, **kwargs):
         jobrec['error'] += repr(err)
     else:
         jobrec['success'] = True
-        jobrec['qcvars']['CURRENT ENERGY'] = copy.deepcopy(jobrec['qcvars']['DISPERSION CORRECTION ENERGY'])
-
+        
     return jobrec
 
 
@@ -135,8 +134,7 @@ def run_dftd3_from_arrays(molrec,
         raise RuntimeError(err) from err
     else:
         jobrec['success'] = True
-        jobrec['qcvars']['CURRENT ENERGY'] = copy.deepcopy(jobrec['qcvars']['DISPERSION CORRECTION ENERGY'])
-
+        
     return jobrec
 
 

--- a/psi4/driver/qcdb/intf_dftd3/runner.py
+++ b/psi4/driver/qcdb/intf_dftd3/runner.py
@@ -85,6 +85,7 @@ def run_dftd3(name, molecule, options, **kwargs):
         jobrec['error'] += repr(err)
     else:
         jobrec['success'] = True
+        jobrec['qcvars']['CURRENT ENERGY'] = copy.deepcopy(jobrec['qcvars']['DISPERSION CORRECTION ENERGY'])
         
     return jobrec
 
@@ -134,6 +135,8 @@ def run_dftd3_from_arrays(molrec,
         raise RuntimeError(err) from err
     else:
         jobrec['success'] = True
+        if ptype == "energy":
+            jobrec['qcvars']['CURRENT ENERGY'] = copy.deepcopy(jobrec['qcvars']['DISPERSION CORRECTION ENERGY'])
         
     return jobrec
 


### PR DESCRIPTION
## Description
Stops overwriting DFT energy by D3 energy only. I am not sure how to test for this, as the gradients as well as geometries with and without the patch agree to 8 DP's. I only noticed it when using the `vibrational_analysis(wfn)`, as there the current total energy plays a role...

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Resolves #1356

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
