### PR TITLE
Restore previous DF_FITTING_CONDITION default

### DIFF
--- a/psi4/src/psi4/dfmp2/corr_grad.cc
+++ b/psi4/src/psi4/dfmp2/corr_grad.cc
@@ -428,7 +428,7 @@ void DFCorrGrad::build_AB_inv_terms() {
     // => Fitting Metric Full Inverse <= //
 
     auto metric = std::make_shared<FittingMetric>(auxiliary_, true);
-    metric->form_full_eig_inverse();
+    metric->form_full_eig_inverse(condition_);
     SharedMatrix J = metric->get_metric();
     double** Jp = J->pointer();
 

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -1060,7 +1060,7 @@ void DiskDFJK::initialize_wK_core() {
 
     // Fitting metric
     auto Jinv = std::make_shared<FittingMetric>(auxiliary_, true);
-    Jinv->form_full_eig_inverse();
+    Jinv->form_full_eig_inverse(condition_);
     double** Jinvp = Jinv->get_metric()->pointer();
 
     timer_off("JK: (A|Q)^-1");
@@ -1349,7 +1349,7 @@ void DiskDFJK::initialize_wK_disk() {
 
     // Form the J full inverse
     auto Jinv = std::make_shared<FittingMetric>(auxiliary_, true);
-    Jinv->form_full_eig_inverse();
+    Jinv->form_full_eig_inverse(condition_);
     double** Jinvp = Jinv->get_metric()->pointer();
 
     // Synch up

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -646,7 +646,7 @@ void DFJKGrad::build_AB_inv_terms()
     // => Fitting Metric Full Inverse <= //
 
     auto metric = std::make_shared<FittingMetric>(auxiliary_, true);
-    metric->form_full_eig_inverse();
+    metric->form_full_eig_inverse(condition_);
     SharedMatrix J = metric->get_metric();
     double** Jp = J->pointer();
 
@@ -1472,7 +1472,7 @@ void DFJKGrad::compute_hessian()
 
     int na = Ca_->colspi()[0];
     auto metric = std::make_shared<FittingMetric>(auxiliary_, true);
-    metric->form_full_eig_inverse();
+    metric->form_full_eig_inverse(condition_);
     SharedMatrix PQ = metric->get_metric();
     double** PQp = PQ->pointer();
 

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -480,8 +480,8 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
 
             // This probably shouldn't be recomputed here; we already needed it to get the
             // second derivative integrals.  One fine day, this should be refactored.
-            auto metric = std::make_shared<FittingMetric>(auxiliary_, true);
-            metric->form_full_eig_inverse();
+            auto metric = std::make_shared<FittingMetric>(auxiliary_, true);            
+            metric->form_full_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
             SharedMatrix PQ = metric->get_metric();
             double** PQp = PQ->pointer();
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1224,8 +1224,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("SCF_MEM_SAFETY_FACTOR", 0.75);
         /*- SO orthogonalization: symmetric or canonical? -*/
         options.add_str("S_ORTHOGONALIZATION", "SYMMETRIC", "SYMMETRIC CANONICAL");
-        /*- Minimum S matrix eigenvalue to be used before compensating for linear
-        dependencies. -*/
+        /*- Minimum S matrix eigenvalue to allow before linear dependencies are removed. -*/
         options.add_double("S_TOLERANCE", 1E-7);
         /*- Minimum absolute value below which TEI are neglected. -*/
         options.add_double("INTS_TOLERANCE", 0.0);
@@ -1404,8 +1403,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("DF_INTS_NUM_THREADS", 0);
         /*- IO caching for CP corrections, etc !expert -*/
         options.add_str("DF_INTS_IO", "NONE", "NONE SAVE LOAD");
-        /*- Fitting Condition !expert -*/
-        options.add_double("DF_FITTING_CONDITION", 1.0E-12);
+        /*- Fitting Condition, i.e. eigenvalue threshold for RI basis. Analogous to S_TOLERANCE !expert -*/
+        options.add_double("DF_FITTING_CONDITION", 1.0E-10);
         /*- FastDF Fitting Metric -*/
         options.add_str("DF_METRIC", "COULOMB", "COULOMB EWALD OVERLAP");
         /*- FastDF SR Ewald metric range separation parameter -*/


### PR DESCRIPTION
## Description
The value for ```DF_FITTING_CONDITION``` used by the code was changed in #1446, which resulted in a change of numerical values. This PR restores the previously used threshold. See discussion in #1350 and on Slack.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Restores numerical agreement with previous revisions of Psi4.

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
