### PR TITLE
Fix inconsistencies in formatted checkpoint files

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1687,7 +1687,6 @@ def fchk(wfn, filename):
     * A description of the FCHK format is http://wild.life.nctu.edu.tw/~jsyu/compchem/g09/g09ur/f_formchk.htm
     * The allowed headers for methods are general and limited, i.e., "Total SCF|MP2|CI|CC Density",
       so "CC" is always used for the post-HF case.
-    * At present, only SCF quantities will appear in the FCHK.
 
     :examples:
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1682,6 +1682,13 @@ def fchk(wfn, filename):
     :type wfn: :py:class:`~psi4.core.Wavefunction`
     :param wfn: set of molecule, basis, orbitals from which to generate fchk file
 
+    Notes
+    -----
+    * A description of the FCHK format is http://wild.life.nctu.edu.tw/~jsyu/compchem/g09/g09ur/f_formchk.htm
+    * The allowed headers for methods are general and limited, i.e., "Total SCF|MP2|CI|CC Density",
+      so "CC" is always used for the post-HF case.
+    * At present, only SCF quantities will appear in the FCHK.
+
     :examples:
 
     >>> # [1] FCHK file for DFT calculation

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -318,7 +318,6 @@ void FCHKWriter::write(const std::string &filename) {
     chk_ = fopen(filename.c_str(), "w");
     std::shared_ptr<BasisSet> basis = wavefunction_->basisset();
     int maxam = basis->max_am();
-    if (maxam > 4) throw PSIEXCEPTION("The Psi4 FCHK writer only supports up to G functions");
     std::shared_ptr<Molecule> mol = wavefunction_->molecule();
     SharedMatrix Ca_ao = wavefunction_->Ca_subset("AO");
     SharedMatrix Cb_ao = wavefunction_->Cb_subset("AO");
@@ -469,18 +468,29 @@ void FCHKWriter::write(const std::string &filename) {
                     for (int col = 0; col < 3; ++col) transmat->set(offset + row, offset + col, pureP[row][col]);
             }
         } else {
-            // Cartesians - P orbitals are fine, but higher terms need reordering
-            if (am == 2) {
-                for (int row = 0; row < 6; ++row)
-                    for (int col = 0; col < 6; ++col) transmat->set(offset + row, offset + col, cartD[row][col]);
-            }
-            if (am == 3) {
-                for (int row = 0; row < 10; ++row)
-                    for (int col = 0; col < 10; ++col) transmat->set(offset + row, offset + col, cartF[row][col]);
-            }
-            if (am == 4) {
-                for (int row = 0; row < 15; ++row)
-                    for (int col = 0; col < 15; ++col) transmat->set(offset + row, offset + col, cartG[row][col]);
+            // Cartesians - S and P orbitals are fine, but higher terms need reordering
+            switch (am) {
+                case (0):
+                case (1):
+                    break;
+
+                case (2):
+                    for (int row = 0; row < 6; ++row)
+                        for (int col = 0; col < 6; ++col) transmat->set(offset + row, offset + col, cartD[row][col]);
+                    break;
+
+                case (3):
+                    for (int row = 0; row < 10; ++row)
+                        for (int col = 0; col < 10; ++col) transmat->set(offset + row, offset + col, cartF[row][col]);
+                    break;
+
+                case (4):
+                    for (int row = 0; row < 15; ++row)
+                        for (int col = 0; col < 15; ++col) transmat->set(offset + row, offset + col, cartG[row][col]);
+                    break;
+
+                default:
+                    throw PSIEXCEPTION("The Psi4 FCHK writer only supports up to G shell (l=4) cartesian functions");
             }
         }
         offset += nfunc;

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -563,21 +563,15 @@ void FCHKWriter::write(const std::string &filename) {
     write_matrix("Contraction coefficients", coefficients);
     write_matrix("Coordinates of each shell", shell_coords);
     write_number("Total Energy", wavefunction_->energy());
-    // write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
-    write_matrix(wavefunction_->epsilon_a()->name().c_str(), wavefunction_->epsilon_a_subset("AO"));
-    // write_matrix("Alpha MO coefficients", reorderedCa);
-    write_matrix(wavefunction_->Ca()->name().c_str(), reorderedCa);
-    // write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
-    write_matrix(wavefunction_->epsilon_b()->name().c_str(), wavefunction_->epsilon_b_subset("AO"));
-    // write_matrix("Beta MO coefficients", reorderedCb);
-    write_matrix(wavefunction_->Cb()->name().c_str(), reorderedCb);
-    auto *label = new char[256];
-    std::string type = name == "DFT" ? "SCF" : name;
-    sprintf(label, "Total %s Density", type.c_str());
-    write_sym_matrix(label, reorderedDt);
-    sprintf(label, "Spin %s Density", type.c_str());
-    write_sym_matrix(label, reorderedDs);
-    delete[] label;
+
+    // This is the format expected in the formatted checkpoint file
+    write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
+    write_matrix("Alpha MO coefficients", reorderedCa);
+    write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
+    write_matrix("Beta MO coefficients", reorderedCb);
+    write_sym_matrix("Total SCF Density", reorderedDt);
+    write_sym_matrix("Spin SCF Density", reorderedDs);
+
     SharedMatrix gradient = wavefunction_->gradient();
     if (gradient) write_matrix("Cartesian Gradient", gradient);
 

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -236,8 +236,7 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
     }
 }
 
-FCHKWriter::FCHKWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefunction_(wavefunction) {
-}
+FCHKWriter::FCHKWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefunction_(wavefunction) {}
 
 void FCHKWriter::write_number(const char *label, double value) { fprintf(chk_, "%-43sR%27.15e\n", label, value); }
 
@@ -318,16 +317,55 @@ void FCHKWriter::write(const std::string &filename) {
     std::shared_ptr<BasisSet> basis = wavefunction_->basisset();
     int maxam = basis->max_am();
     std::shared_ptr<Molecule> mol = wavefunction_->molecule();
+    std::shared_ptr<Wavefunction> refwf = wavefunction_->reference_wavefunction();
+
+    // Orbitals
     SharedMatrix Ca_ao = wavefunction_->Ca_subset("AO");
     SharedMatrix Cb_ao = wavefunction_->Cb_subset("AO");
-    SharedMatrix Da_ao = wavefunction_->Da_subset("AO");
-    SharedMatrix Db_ao = wavefunction_->Db_subset("AO");
-    SharedMatrix Dtot_ao(Da_ao->clone());
-    SharedMatrix Dspin_ao(Da_ao->clone());
+
+    // SCF density matrices
+    SharedMatrix Da_ao;
+    SharedMatrix Db_ao;
+    // Post-Hartree-Fock density matrices
+    SharedMatrix DPHFa_ao;
+    SharedMatrix DPHFb_ao;
+
+    // Post Hartree Fock?
+    bool pHF = (refwf != NULL);
+
+    if (pHF) {
+        // Level of theory may be correlated
+        Da_ao = refwf->Da_subset("AO");
+        Db_ao = refwf->Db_subset("AO");
+
+        DPHFa_ao = wavefunction_->Da_subset("AO");
+        DPHFb_ao = wavefunction_->Db_subset("AO");
+    } else {
+        // SCF level of theory
+        Da_ao = wavefunction_->Da_subset("AO");
+        Db_ao = wavefunction_->Db_subset("AO");
+    }
+
+    // Total and spin density
+    SharedMatrix Dtot_ao;
+    SharedMatrix Dspin_ao;
+    SharedMatrix DPHFtot_ao;
+    SharedMatrix DPHFspin_ao;
+
+    Dtot_ao = Da_ao->clone();
+    Dtot_ao->add(Db_ao);
+    Dspin_ao = Da_ao->clone();
+    Dspin_ao->subtract(Db_ao);
+
+    if (pHF) {
+        DPHFtot_ao = DPHFa_ao->clone();
+        DPHFtot_ao->add(DPHFb_ao);
+        DPHFspin_ao = DPHFa_ao->clone();
+        DPHFspin_ao->subtract(DPHFb_ao);
+    }
+
     const std::string &name = wavefunction_->name();
     const std::string &basisname = basis->name();
-    Dtot_ao->add(Db_ao);
-    Dspin_ao->subtract(Db_ao);
     int nbf = basis->nbf();
     assert(Ca_ao->nrow() == nbf);
     int nmo = Ca_ao->ncol();
@@ -498,9 +536,19 @@ void FCHKWriter::write(const std::string &filename) {
     }
 
     SharedMatrix reorderedDt(Dtot_ao->clone());
-    SharedMatrix reorderedDs(Dtot_ao->clone());
     reorderedDt->back_transform(Dtot_ao, transmat);
+    SharedMatrix reorderedDs(Dspin_ao->clone());
     reorderedDs->back_transform(Dspin_ao, transmat);
+
+    SharedMatrix reorderedDPHFt;
+    SharedMatrix reorderedDPHFs;
+    if (pHF) {
+        reorderedDPHFt = (DPHFtot_ao->clone());
+        reorderedDPHFt->back_transform(DPHFtot_ao, transmat);
+        reorderedDPHFs = (DPHFspin_ao->clone());
+        reorderedDPHFs->back_transform(DPHFspin_ao, transmat);
+    }
+
     auto reorderedCa = std::make_shared<Matrix>("Reordered Ca", Ca_ao->ncol(), Ca_ao->nrow());
     auto reorderedCb = std::make_shared<Matrix>("Reordered Cb", Cb_ao->ncol(), Cb_ao->nrow());
     reorderedCa->gemm(true, true, 1.0, Ca_ao, transmat, 0.0);
@@ -579,11 +627,16 @@ void FCHKWriter::write(const std::string &filename) {
     write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
     write_matrix("Alpha MO coefficients", reorderedCa);
     write_sym_matrix("Total SCF Density", reorderedDt);
-    if(!wavefunction_->same_a_b_orbs() || !wavefunction_->same_a_b_dens()) {
-      // These are only printed out if the orbitals or density is not spin-restricted
-      write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
-      write_matrix("Beta MO coefficients", reorderedCb);
-      write_sym_matrix("Spin SCF Density", reorderedDs);
+    // In theory, the correlated density should be printed out with a
+    // legend depending on the method (MP2, MP3, MP4, CI, CC) but this
+    // is probably the most common anyhow
+    if (pHF) write_sym_matrix("Total CC Density", reorderedDPHFt);
+    if (!wavefunction_->same_a_b_orbs() || !wavefunction_->same_a_b_dens()) {
+        // These are only printed out if the orbitals or density is not spin-restricted
+        write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
+        write_matrix("Beta MO coefficients", reorderedCb);
+        write_sym_matrix("Spin SCF Density", reorderedDs);
+        if (pHF) write_sym_matrix("Spin CC Density", reorderedDPHFs);
     }
 
     SharedMatrix gradient = wavefunction_->gradient();

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -25,6 +25,7 @@
  *
  * @END LICENSE
  */
+#include <cassert>
 #include <cstdio>
 #include <utility>
 #include <algorithm>
@@ -328,6 +329,8 @@ void FCHKWriter::write(const std::string &filename) {
     Dtot_ao->add(Db_ao);
     Dspin_ao->subtract(Db_ao);
     int nbf = basis->nbf();
+    assert(Ca_ao->nrow() == nbf);
+    int nmo = Ca_ao->ncol();
     int nalpha = wavefunction_->nalpha();
     int nbeta = wavefunction_->nbeta();
     int natoms = mol->natom();
@@ -552,7 +555,7 @@ void FCHKWriter::write(const std::string &filename) {
     write_number("Number of alpha electrons", nalpha);
     write_number("Number of beta electrons", nbeta);
     write_number("Number of basis functions", nbf);
-    write_number("Number of independent functions", nbf);
+    write_number("Number of independent functions", nmo);
     write_matrix("Atomic numbers", atomic_numbers);
     write_matrix("Nuclear charges", nuc_charges);
     write_matrix("Current cartesian coordinates", coords);

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -236,8 +236,6 @@ void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca
 }
 
 FCHKWriter::FCHKWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefunction_(wavefunction) {
-    SharedMatrix Ca = wavefunction_->Ca();
-    Ca->print();
 }
 
 void FCHKWriter::write_number(const char *label, double value) { fprintf(chk_, "%-43sR%27.15e\n", label, value); }

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -508,28 +508,17 @@ void FCHKWriter::write(const std::string &filename) {
             }
         } else {
             // Cartesians - S and P orbitals are fine, but higher terms need reordering
-            switch (am) {
-                case (0):
-                case (1):
-                    break;
-
-                case (2):
-                    for (int row = 0; row < 6; ++row)
-                        for (int col = 0; col < 6; ++col) transmat->set(offset + row, offset + col, cartD[row][col]);
-                    break;
-
-                case (3):
-                    for (int row = 0; row < 10; ++row)
-                        for (int col = 0; col < 10; ++col) transmat->set(offset + row, offset + col, cartF[row][col]);
-                    break;
-
-                case (4):
-                    for (int row = 0; row < 15; ++row)
-                        for (int col = 0; col < 15; ++col) transmat->set(offset + row, offset + col, cartG[row][col]);
-                    break;
-
-                default:
-                    throw PSIEXCEPTION("The Psi4 FCHK writer only supports up to G shell (l=4) cartesian functions");
+            if (am == 2) {
+                for (int row = 0; row < 6; ++row)
+                    for (int col = 0; col < 6; ++col) transmat->set(offset + row, offset + col, cartD[row][col]);
+            } else if (am == 3) {
+                for (int row = 0; row < 10; ++row)
+                    for (int col = 0; col < 10; ++col) transmat->set(offset + row, offset + col, cartF[row][col]);
+            } else if (am == 4) {
+                for (int row = 0; row < 15; ++row)
+                    for (int col = 0; col < 15; ++col) transmat->set(offset + row, offset + col, cartG[row][col]);
+            } else if (am >= 5) {
+                throw PSIEXCEPTION("The Psi4 FCHK writer only supports up to G shell (l=4) cartesian functions");
             }
         }
         offset += nfunc;

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -578,10 +578,13 @@ void FCHKWriter::write(const std::string &filename) {
     // This is the format expected in the formatted checkpoint file
     write_matrix("Alpha Orbital Energies", wavefunction_->epsilon_a_subset("AO"));
     write_matrix("Alpha MO coefficients", reorderedCa);
-    write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
-    write_matrix("Beta MO coefficients", reorderedCb);
     write_sym_matrix("Total SCF Density", reorderedDt);
-    write_sym_matrix("Spin SCF Density", reorderedDs);
+    if(!wavefunction_->same_a_b_orbs() || !wavefunction_->same_a_b_dens()) {
+      // These are only printed out if the orbitals or density is not spin-restricted
+      write_matrix("Beta Orbital Energies", wavefunction_->epsilon_b_subset("AO"));
+      write_matrix("Beta MO coefficients", reorderedCb);
+      write_sym_matrix("Spin SCF Density", reorderedDs);
+    }
 
     SharedMatrix gradient = wavefunction_->gradient();
     if (gradient) write_matrix("Cartesian Gradient", gradient);

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -25,7 +25,6 @@
  *
  * @END LICENSE
  */
-#include <cassert>
 #include <cstdio>
 #include <utility>
 #include <algorithm>

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -367,7 +367,6 @@ void FCHKWriter::write(const std::string &filename) {
     const std::string &name = wavefunction_->name();
     const std::string &basisname = basis->name();
     int nbf = basis->nbf();
-    assert(Ca_ao->nrow() == nbf);
     int nmo = Ca_ao->ncol();
     int nalpha = wavefunction_->nalpha();
     int nbeta = wavefunction_->nbeta();


### PR DESCRIPTION
## Description
The formatted checkpoint files currently produced by Psi4 misname the orbital coefficient and the density matrix fields. This PR (re)establishes the expected behavior, as well as fixes other bugs in the code.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix labels of MO energies and coefficients
- [x] Fix labels of density matrices
- [x] Fix printout of number of linearly independent functions
- [x] Don't print the MO coefficients into the log file
- [x] Only print out beta orbs and spin density if wave function is not spin-restricted.
- [ ] Identify if density is correlated; if it is, print out both SCF and correlated density. Otherwise only print out SCF density.

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
