### PR TITLE
Fix memory error in psi::ccresponse::roa

### DIFF
--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -235,7 +235,7 @@ void roa() {
                             pert_y, moinfo.mu_irreps[beta], +params.omega[i]);
                 }
             }
-            psio_write_entry(PSIF_CC_INFO, lbl3, (char *)tensor_rr[0], 9 * sizeof(double));
+            psio_write_entry(PSIF_CC_INFO, lbl3, (char *)tensor_rr[i][0], 9 * sizeof(double));
 
             if (compute_rl) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl1);


### PR DESCRIPTION
## Description
This is a part of Psi4 porting to Windows (#933).

`tensor_rr` is `double***`, so it needs double dereferencing to have a pointer to data: 
https://github.com/psi4/psi4/blob/c9be896dd4b4c550b6f7ac792cf11a1274a9a038/psi4/src/psi4/cc/ccresponse/roa.cc#L238
I guess, it should be like here:
https://github.com/psi4/psi4/blob/c9be896dd4b4c550b6f7ac792cf11a1274a9a038/psi4/src/psi4/cc/ccresponse/roa.cc#L289

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix memory error in `psi::ccresponse::roa`

## Questions
- [ ] I don't real know what that part of code is doing. The fix has to be verified by someone who does.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
