### PR TITLE
Fix memory error in MOInfoBase::convert_int_array_to_vector

### DIFF
--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -280,8 +280,7 @@ void MOInfoBase::correlate(char* ptgrp, int irrep, int& nirreps_old, int& nirrep
 
 intvec MOInfoBase::convert_int_array_to_vector(int n, const int* array) {
     // Read an integer array and save as a STL vector
-    intvec stl_vector(&array[0], &array[n]);
-    return (stl_vector);
+    return intvec(array, array + n);
 }
 
 }  // namespace psi


### PR DESCRIPTION
## Description
This is a part of *Psi4* porting to Windows (#933).

The last element  of `array` is `array[n-1]`, so the access of  `array[n]` is not correct:
https://github.com/psi4/psi4/blob/62bb956ccfb38cad1bef7e6227aac70ddb1172f7/psi4/src/psi4/libmoinfo/moinfo_base.cc#L281-L285
It is better to use pointer arithmetics: `array + n`.

This is not a bug, just it gives a false positive in memory error detection.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix memory error in `MOInfoBase::convert_int_array_to_vector`

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
