### PR TITLE
DCT Gradients Compatible with ROHF Guess

### DIFF
--- a/psi4/src/psi4/dcft/dcft.cc
+++ b/psi4/src/psi4/dcft/dcft.cc
@@ -80,6 +80,14 @@ DCFTSolver::DCFTSolver(SharedWavefunction ref_wfn, Options &options) : Wavefunct
         options.get_str("DCFT_FUNCTIONAL") == "ODC-13")
         orbital_optimized_ = true;
 
+    if (ref_wfn->same_a_b_dens())
+        name_ = "R" + options.get_str("DCFT_FUNCTIONAL");
+    else {
+        // ROHF references may have the same orbitals, if not semicanonicalized
+        same_a_b_orbs_ = false;
+        name_ = "U" + options.get_str("DCFT_FUNCTIONAL");
+    }
+
     // Sets up the memory, and orbital info
     init();
 }

--- a/psi4/src/psi4/dcft/dcft_compute.cc
+++ b/psi4/src/psi4/dcft/dcft_compute.cc
@@ -66,15 +66,13 @@ double DCFTSolver::compute_energy() {
         }
     }
 
-    if (options_.get_str("REFERENCE") == "RHF")
+    if (same_a_b_orbs_ == true)
         total_energy = compute_energy_RHF();
-    else if (options_.get_str("REFERENCE") == "UHF")
+    else {
+        if (reference_wavefunction_->name() == "ROHF")
+            outfile->Printf("\n\n\t**** Warning: ROHF reference, then unrestricted DCFT ****\n");
         total_energy = compute_energy_UHF();
-    else if (options_.get_str("REFERENCE") == "ROHF") {
-        outfile->Printf("\n\n\t**** Warning: ROHF reference, then unrestricted DCFT ****\n");
-        total_energy = compute_energy_UHF();
-    } else
-        throw PSIEXCEPTION("Unknown DCFT reference.");
+    }
 
     // Compute the analytic gradients, if requested
     if (options_.get_str("DERTYPE") == "FIRST") {


### PR DESCRIPTION
Closes #1482; DCT gradients are now compatible with ROHF starting orbitals. The problem was that  UDCT wavefunctions inherited the `same_a_b_orbs_` of the reference wavefunction, which was wrong for ROHF references. This caused the derivative machinery to try to try an RDCT gradient, which failed for obvious reasons.

While I was changing features inherited from the reference wavefunction, I gave DCT "wavefunctions" proper names.

## Checklist
- [x] [All DCT tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests) and verified this fixes the original issue.

## Status
- [x] Ready for review
- [x] Ready for merge
