### PR TITLE
Fix memory error in psi::IntegralTransform::process_spaces

### DIFF
--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -207,6 +207,9 @@ void IntegralTransform::process_spaces() {
                     }
                 }
                 for (int n = 0; n < aOrbsPI[h]; ++n) {
+
+                    if (qt_order && aPitzerCount >= nmo_) exit(42);
+
                     aIndex[aOrbCount++] = (qt_order ? aQT_[aPitzerCount] : aPitzerCount);
                     aPitzerCount++;
                 }


### PR DESCRIPTION
## Description
This is a part of *Psi4* porting to Windows (#933).

The size of `aQT_` is `nmo_`.  In `cookbook-rohf-orb-rot` test, `aPitzerCount` exceeds it:
https://github.com/psi4/psi4/blob/96296f1e3740b348bd207aa2ed0e3568e723a5a1/psi4/src/psi4/libtrans/integraltransform_moinfo.cc#L209-L212

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Demonstrate memory error in `psi::IntegralTransform::process_spaces`
- [x] Fix memory error in `psi::IntegralTransform::process_spaces`

## Questions
- [x] I don't know how to fix this, just highlighting the problem. Who could help? 

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
