### PR TITLE
Fix invalid memory access in psi::ROHF::Hx

### DIFF
--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -585,6 +585,8 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
         C_DGEMM('N', 'N', occpi[h], virpi[h], doccpi_[h], -0.5, Fbp[0], nmopi_[h], xp[0], virpi[h], 1.0, rightp[0],
                 virpi[h]);
 
+        if (Hx_left->rowspi()[h] <= doccpi_[h]) exit(42);
+
         // Socc terms
         // left_av += 0.5 * x_oa.T Fb_ov
         C_DGEMM('T', 'N', soccpi_[h], virpi[h], occpi[h], 0.5, xp[0], virpi[h], (Fbp[0] + doccpi_[h]), nmopi_[h], 1.0,


### PR DESCRIPTION
## Description
This is a part of *Psi4* porting to Windows (#933).

The size of `leftp` is smaller than `doccpi_[h]` in `soscf-ref` tests:
https://github.com/psi4/psi4/blob/be5824d8926dd3e2c12a56944ceec50d1935ca83/psi4/src/psi4/libscf_solver/rohf.cc#L589-L591

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Demonstrate invalid memory access in psi::ROHF::Hx
- [x] Fix invalid memory access in psi::ROHF::Hx

## Questions
- [x]  I don't know how to fix this, just highlighting the problem. Who could help?

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
