### PR TITLE
Fix SAD guess energy printout

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -324,12 +324,6 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             efp_Dt_psi4_yo.add(self.Db())
             SCFE += self.molecule().EFP.get_wavefunction_dependent_energy()
 
-        if (self.iteration_ == 0) and self.sad_:
-            # SAD gives a non-variational first energy in RHF and UHF,
-            # and a completely nonsensical one in ROHF/CUHF
-            core.print_out("    First iteration: building orbitals from the SAD guess.\n")
-            SCFE = 0.0
-
         self.set_energies("Total Energy", SCFE)
         core.set_variable("SCF ITERATION ENERGY", SCFE)
         Ediff = SCFE - SCFE_old
@@ -435,8 +429,8 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             self.Db().print_out()
 
         # Print out the iteration
-        core.print_out("   @%s%s iter %3d: %20.14f   %12.5e   %-11.5e %s\n" %
-                       ("DF-" if is_dfjk else "", reference, self.iteration_, SCFE, Ediff, Dnorm, '/'.join(status)))
+        core.print_out("   @%s%s iter %3s: %20.14f   %12.5e   %-11.5e %s\n" %
+                       ("DF-" if is_dfjk else "", reference, "SAD" if ((self.iteration_ == 0) and self.sad_) else self.iteration_, SCFE, Ediff, Dnorm, '/'.join(status)))
 
         # if a an excited MOM is requested but not started, don't stop yet
         if self.MOM_excited_ and not self.MOM_performed_:

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -327,6 +327,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         if (self.iteration_ == 0) and self.sad_:
             # SAD gives a non-variational first energy in RHF and UHF,
             # and a completely nonsensical one in ROHF/CUHF
+            core.print_out("    First iteration: building orbitals from the SAD guess.\n")
             SCFE = 0.0
 
         self.set_energies("Total Energy", SCFE)

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -324,6 +324,11 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             efp_Dt_psi4_yo.add(self.Db())
             SCFE += self.molecule().EFP.get_wavefunction_dependent_energy()
 
+        if (self.iteration_ == 0) and self.sad_:
+            # SAD gives a non-variational first energy in RHF and UHF,
+            # and a completely nonsensical one in ROHF/CUHF
+            SCFE = 0.0
+
         self.set_energies("Total Energy", SCFE)
         core.set_variable("SCF ITERATION ENERGY", SCFE)
         Ediff = SCFE - SCFE_old
@@ -441,7 +446,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             continue
 
         # Call any postiteration callbacks
-        if _converged(Ediff, Dnorm, e_conv=e_conv, d_conv=d_conv):
+        if not ((self.iteration_ == 0) and self.sad_) and _converged(Ediff, Dnorm, e_conv=e_conv, d_conv=d_conv):
             break
         if self.iteration_ >= core.get_option('SCF', 'MAXITER'):
             raise SCFConvergenceError("""SCF iterations""", self.iteration_, self, Ediff, Dnorm)

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -350,7 +350,7 @@ void CUHF::form_D() {
     }
 }
 
-double CUHF::compute_initial_E() { return nuclearrep + Dt_->vector_dot(H_); }
+double CUHF::compute_initial_E() { return nuclearrep_ + Dt_->vector_dot(H_); }
 
 double CUHF::compute_E() {
     double DH = Dt_->vector_dot(H_);

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -350,12 +350,16 @@ void CUHF::form_D() {
     }
 }
 
-// TODO: Once Dt_ is refactored to D_ the only difference between this and RHF::compute_initial_E is a factor of 0.5
-double CUHF::compute_initial_E() { return nuclearrep_ + 0.5 * (Dt_->vector_dot(H_)); }
+double CUHF::compute_initial_E() { return nuclearrep + Dt_->vector_dot(H_); }
 
 double CUHF::compute_E() {
-    double one_electron_E = Dt_->vector_dot(H_);
-    double two_electron_E = 0.5 * (Da_->vector_dot(Fa_) + Db_->vector_dot(Fb_) - one_electron_E);
+    double DH = Dt_->vector_dot(H_);
+    double DFa = Da_->vector_dot(Fa_);
+    double DFb = Db_->vector_dot(Fb_);
+
+    double one_electron_E = DH;
+    double two_electron_E = 0.5 * (DFa + DFb - one_electron_E);
+    double Eelec = 0.5 * (DH + DFa + DFb);
 
     energies_["Nuclear"] = nuclearrep_;
     energies_["One-Electron"] = one_electron_E;
@@ -364,10 +368,6 @@ double CUHF::compute_E() {
     energies_["VV10_E"] = 0.0;
     energies_["-D"] = 0.0;
 
-    double DH = Dt_->vector_dot(H_);
-    double DFa = Da_->vector_dot(Fa_);
-    double DFb = Db_->vector_dot(Fb_);
-    double Eelec = 0.5 * (DH + DFa + DFb);
     // outfile->Printf( "electronic energy = %20.14f\n", Eelec);
     double Etotal = nuclearrep_ + Eelec;
     return Etotal;
@@ -422,6 +422,14 @@ std::shared_ptr<CUHF> CUHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
 
     return hf_wfn;
+}
+
+void CUHF::compute_SAD_guess() {
+    // Form the SAD guess
+    HF::compute_SAD_guess();
+    // Form the total density used in energy evaluation
+    Dt_->copy(Da_);
+    Dt_->add(Db_);
 }
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -107,6 +107,8 @@ class CUHF : public HF {
     bool stability_analysis() override;
 
     std::shared_ptr<CUHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
+
+    void compute_SAD_guess() override;
 };
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -207,7 +207,7 @@ class HF : public Wavefunction {
     int multiplicity_;
 
     /// SAD Guess and propagation
-    void compute_SAD_guess();
+    virtual void compute_SAD_guess();
 
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -80,10 +80,10 @@ class RHF : public HF {
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;
     std::vector<SharedMatrix> twoel_Hx(std::vector<SharedMatrix> x, bool combine = true,
-                                               std::string return_basis = "MO") override;
+                                       std::string return_basis = "MO") override;
     std::vector<SharedMatrix> cphf_Hx(std::vector<SharedMatrix> x) override;
-    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4,
-                                                 int max_iter = 10, int print_lvl = 1) override;
+    std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4, int max_iter = 10,
+                                         int print_lvl = 1) override;
 
     std::shared_ptr<RHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -509,7 +509,7 @@ void ROHF::form_D() {
     }
 }
 
-double ROHF::compute_initial_E() { return 0.5 * (compute_E() + nuclearrep_); }
+double ROHF::compute_initial_E() { return nuclearrep_ + Dt_->vector_dot(H_); }
 
 double ROHF::compute_E() {
     double one_electron_E = Dt_->vector_dot(H_);
@@ -1331,6 +1331,14 @@ std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
 
     return hf_wfn;
+}
+
+void ROHF::compute_SAD_guess() {
+    // Form the SAD guess
+    HF::compute_SAD_guess();
+    // Form the total density matrix that's used in energy evaluation
+    Dt_->copy(Da_);
+    Dt_->add(Db_);
 }
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -86,6 +86,8 @@ class ROHF : public HF {
     double compute_E() override;
     void finalize() override;
 
+    void compute_SAD_guess() override;
+
     void damping_update(double) override;
     int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
     bool stability_analysis() override;


### PR DESCRIPTION
## Description
The first iteration energy in SAD is at best non-variational (RHF, UHF), and at worst completely nonsensical (ROHF, CUHF). As neither a DIIS error can be formed in the lack of a proper density matrix, this PR sets the first iteration energy to zero, so that only sensical energies are printed out.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Guess energy correctly evaluated in ROHF and CUHF
- [x] Guess energy properly labeled

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
