### PR TITLE
Standardize the wfn (de)serialization path

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -128,7 +128,7 @@ def _core_wavefunction_get_scratch_filename(self, filenumber):
         so that files can be consistently written and read """
     fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(self.molecule().name())))[1]
     psi_scratch = core.IOManager.shared_object().get_default_path()
-    return os.path.join(psi_scratch, fname + str(filenumber) + '.npy')
+    return os.path.join(psi_scratch, fname + str(filenumber))
 
 core.Wavefunction.get_scratch_filename = _core_wavefunction_get_scratch_filename
 
@@ -299,6 +299,7 @@ def _core_wavefunction_to_file(wfn, filename=None):
     }  # yapf: disable
 
     if filename is not None:
+        if not filename.endswith('.npy'): filename += '.npy'
         np.save(filename, wfn_data)
 
     return wfn_data

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -123,6 +123,14 @@ def _core_wavefunction_build(mol, basis=None):
 
 core.Wavefunction.build = _core_wavefunction_build
 
+def _core_wavefunction_get_scratch_filename(self, filenumber):
+    """ Given a wavefunction and a scratch file number, canonicalizes the name
+        so that files can be consistently written and read """
+    fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(self.molecule().name())))[1]
+    psi_scratch = core.IOManager.shared_object().get_default_path()
+    return os.path.join(psi_scratch, fname + str(filenumber) + '.npy')
+
+core.Wavefunction.get_scratch_filename = _core_wavefunction_get_scratch_filename
 
 @staticmethod
 def _core_wavefunction_from_file(wfn_data):

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1281,6 +1281,8 @@ def scf_helper(name, post_scf=True, **kwargs):
     scf_wfn = scf_wavefunction_factory(name, base_wfn, core.get_option('SCF', 'REFERENCE'), **kwargs)
     core.set_legacy_wavefunction(scf_wfn)
 
+    # The wfn from_file routine adds the npy suffix if needed, but we add it here so that
+    # we can use os.path.isfile to query whether the file exists before attempting to read
     read_filename = scf_wfn.get_scratch_filename(180) + '.npy'
 
     if (core.get_option('SCF', 'GUESS') == 'READ') and os.path.isfile(read_filename):
@@ -1399,7 +1401,7 @@ def scf_helper(name, post_scf=True, **kwargs):
 
     # Write out orbitals and basis; Can be disabled, e.g., for findif displacements
     if kwargs.get('write_orbitals', True):
-        write_filename = scf_wfn.get_scratch_filename(180) + '.npy'
+        write_filename = scf_wfn.get_scratch_filename(180)
 
         scf_wfn.to_file(write_filename)
         extras.register_numpy_file(write_filename)

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1281,9 +1281,7 @@ def scf_helper(name, post_scf=True, **kwargs):
     scf_wfn = scf_wavefunction_factory(name, base_wfn, core.get_option('SCF', 'REFERENCE'), **kwargs)
     core.set_legacy_wavefunction(scf_wfn)
 
-    fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
-    psi_scratch = core.IOManager.shared_object().get_default_path()
-    read_filename = os.path.join(psi_scratch, fname + ".180.npy")
+    read_filename = scf_wfn.get_scratch_filename(180)
 
     if (core.get_option('SCF', 'GUESS') == 'READ') and os.path.isfile(read_filename):
 
@@ -1402,8 +1400,8 @@ def scf_helper(name, post_scf=True, **kwargs):
 
     # Write out orbitals and basis; Can be disabled, e.g., for findif displacements
     if kwargs.get('write_orbitals', True):
-        fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_molecule.name())))[1]
-        write_filename = os.path.join(psi_scratch, fname + ".180.npy")
+        write_filename = scf_wfn.get_scratch_filename(180)
+
         scf_wfn.to_file(write_filename)
         extras.register_numpy_file(write_filename)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1281,10 +1281,9 @@ def scf_helper(name, post_scf=True, **kwargs):
     scf_wfn = scf_wavefunction_factory(name, base_wfn, core.get_option('SCF', 'REFERENCE'), **kwargs)
     core.set_legacy_wavefunction(scf_wfn)
 
-    read_filename = scf_wfn.get_scratch_filename(180)
+    read_filename = scf_wfn.get_scratch_filename(180) + '.npy'
 
     if (core.get_option('SCF', 'GUESS') == 'READ') and os.path.isfile(read_filename):
-
         old_wfn = core.Wavefunction.from_file(read_filename)
         Ca_occ = old_wfn.Ca_subset("SO", "OCC")
         Cb_occ = old_wfn.Cb_subset("SO", "OCC")
@@ -1400,7 +1399,7 @@ def scf_helper(name, post_scf=True, **kwargs):
 
     # Write out orbitals and basis; Can be disabled, e.g., for findif displacements
     if kwargs.get('write_orbitals', True):
-        write_filename = scf_wfn.get_scratch_filename(180)
+        write_filename = scf_wfn.get_scratch_filename(180) + '.npy'
 
         scf_wfn.to_file(write_filename)
         extras.register_numpy_file(write_filename)

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -36,6 +36,7 @@ from . import core
 # Numpy place holder for files and cleanup
 numpy_files = []
 def register_numpy_file(filename):
+    if not filename.endswith('.npy'): filename += '.npy'
     if filename not in numpy_files:
         numpy_files.append(filename)
 

--- a/tests/cookbook/rohf-orb-rot/input.dat
+++ b/tests/cookbook/rohf-orb-rot/input.dat
@@ -26,8 +26,8 @@ molecule ho2 {
     H  0.9246056151  0.8646730647  0.0000000000
 }
 
-scf_e, scf_wfn = energy('scf', return_wfn=True)
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
+scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
 
 compare_values(-150.108136116503147, scf_e, 6, 'X SCF energy') #TEST
 compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
@@ -40,8 +40,8 @@ set {
     socc [1, 0]
 }
 
-scf_e, scf_wfn = energy('scf', return_wfn=True)
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
+scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
 
 compare_values(-150.087298715913619, scf_e, 6, 'A SCF energy') #TEST
 compare_values(-150.312480530946573, ccsd_e, 6, 'A CCSD energy') #TEST
@@ -62,45 +62,26 @@ molecule ho2 {
     symmetry c1
 }
 
-scf_e, scf_wfn = energy('scf', return_wfn=True)
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
+scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
 
 compare_values(-150.108136116503147, scf_e, 6, 'X SCF energy') #TEST
 compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
 
 # Rotate HOMO and SOMO by 90 degrees to obtain guess for A state of HO2 in C1.
-#orb_rotate(scf_wfn.Ca(), 0, 7, 8, 90.0)
-Matrix.rotate_columns(scf_wfn.Ca(), 0, 7, 8, math.pi / 2.0)
+# N.B. the orbitals are numbered using zero based indexing.
+ccsd_wfn.Ca().rotate_columns(0, 7, 8, math.pi / 2.0)
 
-fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(scf_wfn.molecule().name())))[1]
-filename = os.path.join(core.IOManager.shared_object().get_default_path(), fname + ".180.npz")
-data = {}
-data.update(scf_wfn.Ca().np_write(None, prefix="Ca"))
-data.update(scf_wfn.Cb().np_write(None, prefix="Cb"))
-
-Ca_occ = scf_wfn.Ca_subset("SO", "OCC")
-data.update(Ca_occ.np_write(None, prefix="Ca_occ"))
-
-Cb_occ = scf_wfn.Cb_subset("SO", "OCC")
-data.update(Cb_occ.np_write(None, prefix="Cb_occ"))
-
-data["reference"] = core.get_option('SCF', 'REFERENCE')
-data["nsoccpi"] = scf_wfn.soccpi().to_tuple()
-data["ndoccpi"] = scf_wfn.doccpi().to_tuple()
-data["nalphapi"] = scf_wfn.nalphapi().to_tuple()
-data["nbetapi"] = scf_wfn.nbetapi().to_tuple()
-data["symmetry"] = scf_wfn.molecule().schoenflies_symbol()
-data["BasisSet"] = scf_wfn.basisset().name()
-data["BasisSet PUREAM"] = scf_wfn.basisset().has_puream()
-np.savez(filename, **data)
+# Serialize the wavefunction so that the SCF code can read it as a guess.
+ccsd_wfn.to_file(ccsd_wfn.get_scratch_filename(180))
 
 # Read in rotated guess and compute CCSD/6-31G energy of A state of HO2 in C1.
 set {
     guess read
 }
 
-scf_e, scf_wfn = energy('scf', return_wfn=True)
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
+scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
 
 compare_values(-150.087298715913619, scf_e, 6, 'A SCF energy') #TEST
 compare_values(-150.312480530946573, ccsd_e, 6, 'A CCSD energy') #TEST

--- a/tests/cookbook/rohf-orb-rot/input.dat
+++ b/tests/cookbook/rohf-orb-rot/input.dat
@@ -27,7 +27,7 @@ molecule ho2 {
 }
 
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
-scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
+scf_e = ccsd_wfn.variable('HF TOTAL ENERGY')
 
 compare_values(-150.108136116503147, scf_e, 6, 'X SCF energy') #TEST
 compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
@@ -41,7 +41,7 @@ set {
 }
 
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
-scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
+scf_e = ccsd_wfn.variable('HF TOTAL ENERGY')
 
 compare_values(-150.087298715913619, scf_e, 6, 'A SCF energy') #TEST
 compare_values(-150.312480530946573, ccsd_e, 6, 'A CCSD energy') #TEST
@@ -63,7 +63,7 @@ molecule ho2 {
 }
 
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
-scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
+scf_e = ccsd_wfn.variable('HF TOTAL ENERGY')
 
 compare_values(-150.108136116503147, scf_e, 6, 'X SCF energy') #TEST
 compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
@@ -81,7 +81,7 @@ set {
 }
 
 ccsd_e, ccsd_wfn = energy('ccsd', return_wfn=True)
-scf_e = ccsd_wfn.get_variable('HF TOTAL ENERGY')
+scf_e = ccsd_wfn.variable('HF TOTAL ENERGY')
 
 compare_values(-150.087298715913619, scf_e, 6, 'A SCF energy') #TEST
 compare_values(-150.312480530946573, ccsd_e, 6, 'A CCSD energy') #TEST


### PR DESCRIPTION
## Description
Use a centralized function to determine the scratch name associated with scratch files, to make sure they're being read and written consistently.  Fixes `cookbook-rohf-orbrot`, which was writing the modified orbitals to a location other than what the SCF code expects, resulting in them being ignored.

## Checklist
- [x] Cleaned up `cookbook-rohf-orbrot` input file
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
The following (unrelated) failures persist, but are fixed in #1494 .
```
The following tests FAILED:
        223 - mints8 (Failed)
        291 - opt-irc-1 (Failed)
```

## Status
- [x] Ready for review
- [x] Ready for merge
