### PR TITLE
move to upstream Libxc 4.3.0

### DIFF
--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -12,9 +12,8 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable Libxc could not be located, ${Magenta}Building Libxc${ColourReset} instead.")
     ExternalProject_Add(libxc_external
-        #GIT_REPOSITORY https://gitlab.com/libxc/libxc
-        GIT_REPOSITORY https://gitlab.com/loriab/libxc
-        GIT_TAG release-4.3.0
+        GIT_REPOSITORY https://gitlab.com/libxc/libxc
+        GIT_TAG 4.3.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Libxc 4.0.2 CONFIG QUIET)
+find_package(Libxc 4.3.0 CONFIG QUIET)
 
 if(${Libxc_FOUND})
     get_property(_loc TARGET Libxc::xc PROPERTY LOCATION)
@@ -12,8 +12,9 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable Libxc could not be located, ${Magenta}Building Libxc${ColourReset} instead.")
     ExternalProject_Add(libxc_external
-        GIT_REPOSITORY https://github.com/psi4/libxc
-        GIT_TAG a5eb119 # v4.0 (0387b1d1) + !62 + MVS corr + 4.0.2 bump + 2 build commits + (Win port )
+        #GIT_REPOSITORY https://gitlab.com/libxc/libxc
+        GIT_REPOSITORY https://gitlab.com/loriab/libxc
+        GIT_TAG release-4.3.0
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -21,7 +22,7 @@ else()
                    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                    -DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}
                    -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
-                   -DNAMESPACE_INSTALL_INCLUDEDIR=/libxc
+                   -DNAMESPACE_INSTALL_INCLUDEDIR=/
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    # OpenMP irrelevant
                    -DENABLE_XHOST=${ENABLE_XHOST}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -152,7 +152,7 @@ else()
     message(STATUS "Disabled simint")
 endif()
 
-find_package(Libxc 4.0.2 CONFIG REQUIRED)
+find_package(Libxc 4.3.0 CONFIG REQUIRED)
 get_property(_loc TARGET Libxc::xc PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libxc${ColourReset}: ${_loc} (version ${Libxc_VERSION})")

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -35,13 +35,12 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 
-#include "libxc/xc.h"
 #include <cmath>
 #include <string>
 #include <algorithm>
 
 // LibXC helper utility for setter functions, not really supposed to do this
-#include "libxc/xc.h"
+#include <xc.h>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libfunctional/factory.cc
+++ b/psi4/src/psi4/libfunctional/factory.cc
@@ -32,7 +32,7 @@ PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
 PRAGMA_WARNING_POP
 #include "functional.h"
-#include "libxc/xc.h"
+#include <xc.h>
 #include "psi4/psi4-dec.h"
 #include "LibXCfunctional.h"
 #include "psi4/libpsi4util/exception.h"


### PR DESCRIPTION
## Description
Kill off the last fork!

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] upstream Libxc with !62-style tweak syntax ([summary of this vs #1101](https://gitlab.com/libxc/libxc/issues/61#note_129049055))
- [x] un-namespaced the `xc.h` header so that a cmake libxc build that works for psi4 can work for other libxc users.
- [x] pulling from my fork (trivial change), so that needs conda testing and merge before updating this and merging.

## Checklist
- [ ] ~Tests added for any new features~
- [x] full test suite run

## Status
- [x] Ready for review
- [x] Ready for merge
