### PR TITLE
Do not append to existing Molden file

### DIFF
--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -49,7 +49,7 @@ MoldenWriter::MoldenWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefun
 void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb,
                          std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA,
                          std::shared_ptr<Vector> OccB, bool dovirtual) {
-    auto mode = std::ostream::app;
+    auto mode = std::ostream::trunc;
     auto printer = std::make_shared<PsiOutStream>(filename, mode);
 
     int atom;


### PR DESCRIPTION
## Description
No new features were added. This is a bugfix for a minor problem described in issue #1485.

The MoldenWriter::write method was appending output to an existing Molden file, if present. This is not the desired behavior since the appended part is not read by post-processing tools, nor is it part of the definition of the file format. This becomes especially confusing when doing a test calculation, where one is trying to get a psi4 input file to work as intended with some trial and error. All results from previous trials are kept in the Molden file and only the first one is read by a post-processing tool, not the last one.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Truncate an existing Molden file, instead of appending.

## Questions
None

## Checklist
- No new tests added
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
