### PR TITLE
Add Not Implemented Messages in DCT

### DIFF
--- a/psi4/src/psi4/dcft/dcft_compute_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_compute_UHF.cc
@@ -81,9 +81,6 @@ double DCFTSolver::compute_energy_UHF() {
         throw FeatureNotImplemented("DC-12 functional", "Analytic gradients", __FILE__, __LINE__);
     if (options_.get_str("AO_BASIS") == "DISK" && options_.get_str("DCFT_FUNCTIONAL") == "CEPA0")
         throw FeatureNotImplemented("CEPA0", "AO_BASIS = DISK", __FILE__, __LINE__);
-    if (options_.get_str("AO_BASIS") == "DISK" && options_.get_str("ALGORITHM") == "QC" &&
-        options_.get_str("QC_TYPE") == "SIMULTANEOUS")
-        throw FeatureNotImplemented("Simultaneous QC", "AO_BASIS = DISK", __FILE__, __LINE__);
     if (!(options_.get_str("ALGORITHM") == "TWOSTEP") && options_.get_str("DCFT_FUNCTIONAL") == "CEPA0")
         throw FeatureNotImplemented("CEPA0", "Requested DCFT algorithm", __FILE__, __LINE__);
     if (!(options_.get_str("DCFT_FUNCTIONAL") == "ODC-06" || options_.get_str("DCFT_FUNCTIONAL") == "ODC-12" ||
@@ -92,6 +89,16 @@ double DCFTSolver::compute_energy_UHF() {
         throw FeatureNotImplemented("ODC-13/CEPA0", "Density Fitting", __FILE__, __LINE__);
     if (options_.get_str("THREE_PARTICLE") == "PERTURBATIVE" && options_.get_str("DCFT_TYPE") == "DF")
         throw FeatureNotImplemented("Three-particle energy correction", "Density Fitting", __FILE__, __LINE__);
+    if (options_.get_str("ALGORITHM") == "QC") {
+        if (options_.get_str("AO_BASIS") == "DISK" && options_.get_str("QC_TYPE") == "SIMULTANEOUS")
+            throw FeatureNotImplemented("Simultaneous QC", "AO_BASIS = DISK", __FILE__, __LINE__);
+        if (options_.get_str("DCFT_TYPE") == "DF")
+            throw FeatureNotImplemented("QC algorithm", "Density Fitting", __FILE__, __LINE__);
+        if (options_.get_str("DCFT_FUNCTIONAL") != "DC-06")
+            outfile->Printf(
+                "\n\n\t**** Warning: Using DC-06 hessian, as others not implemented. Quadratic convergence is not "
+                "guaranteed. ****\n");
+    }
 
     // Orbital-optimized stuff
     if (options_.get_str("ALGORITHM") == "TWOSTEP" && orbital_optimized_)


### PR DESCRIPTION
## Description
Fixes #1353 by raising an error that DF was never implemented with the QC algorithm in `dcft`. Per discussions with @ssh2, I also added a message that the QC algorithm employs the hessian for DC-06, as the others haven't been implemented yet.

## Checklist
- [x] `ctest -R dcft` passes

## Status
- [x] Ready for review
- [x] Ready for merge
