### PR TITLE
openmp inheritance for plugins

### DIFF
--- a/external/common/lapack/FindTargetOpenMP.cmake
+++ b/external/common/lapack/FindTargetOpenMP.cmake
@@ -62,10 +62,10 @@ if (OpenMP_LIBRARIES AND OpenMP_FLAGS)
     target_link_libraries(OpenMP::OpenMP INTERFACE ${OpenMP_LIBRARIES})
 else()
     # 2nd precedence - target from modern FindOpenMP.cmake
-    find_package (OpenMP MODULE COMPONENTS ${${PN}_FIND_COMPONENTS})
+    find_package (OpenMP MODULE COMPONENTS ${_${PN}_FIND_LIST})
 
     if(NOT OpenMP_FOUND)
-        message(WARNING "FindOpenMP failed! Trying a custom OpenMP configuration...")
+        message(WARNING "CMake FindOpenMP failed! Trying a custom OpenMP configuration...")
     endif()
 
     foreach(_lang IN LISTS _${PN}_FIND_LIST)
@@ -134,22 +134,21 @@ else()
     endforeach()
 endif()
 
+unset(_omp_target_for_sought_langs)
 add_library(OpenMP::OpenMP INTERFACE IMPORTED)
-set(_${PN}_REQUIRED 1)
 foreach(_lang C CXX Fortran)
-    if((NOT ${PN}_FIND_COMPONENTS AND CMAKE_${_lang}_COMPILER_LOADED) OR _lang IN_LIST _${PN}_FIND_LIST)
+    if((NOT ${PN}_FIND_COMPONENTS AND CMAKE_${_lang}_COMPILER_LOADED) OR _lang IN_LIST ${PN}_FIND_COMPONENTS)
         if (TARGET OpenMP::OpenMP_${_lang})
             set(${PN}_${_lang}_FOUND 1)
             set_property(TARGET OpenMP::OpenMP APPEND PROPERTY INTERFACE_LINK_LIBRARIES OpenMP::OpenMP_${_lang})
-        else()
-            unset(_${PN}_REQUIRED)
         endif()
+        list(APPEND _omp_target_for_sought_langs "${PN}_${_lang}_FOUND")
     endif()
 endforeach()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(${PN}
-                                  REQUIRED_VARS _${PN}_REQUIRED
+                                  REQUIRED_VARS ${_omp_target_for_sought_langs}
                                   HANDLE_COMPONENTS)
 
 unset(_${PN}_FIND_LIST)

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -7,6 +7,7 @@ import time
 import importlib
 import sysconfig
 import subprocess
+import collections
 
 if sys.version_info <= (3, 0):
     print('Much of this script needs py3')
@@ -212,6 +213,29 @@ def print_math_ldd(args):
               'omp': lddout.count('libomp'),
               'gomp': lddout.count('libgomp')}
     print(report)
+    
+    if sys.platform.startswith('linux'):
+        slddout = collections.defaultdict(list)
+        key = ''
+        for ln in lddout.splitlines():
+            if ':' in ln:
+                key = ln.strip()
+            else:
+                slddout[key].append(ln.strip())
+
+        for k, v in slddout.items():
+            if modcore in k:
+                tlddout = '\n'.join(v)
+        treport = {'mkl': tlddout.count('libmkl'),
+                   'iomp5': tlddout.count('libiomp5'),
+                   'openblas': tlddout.count('libopenblas'),
+                   'omp': tlddout.count('libomp'),
+                   'gomp': tlddout.count('libgomp')}
+        print(treport)
+        if args.passfail:
+            if sys.platform.startswith('linux'):
+                assert (not treport['iomp5'] and not treport['omp'] and not treport['gomp']) is False
+
     report = {k : bool(v) for k, v in report.items()}
     okmkl = report['mkl'] and report['iomp5'] and not report['openblas'] and not report['gomp']
     okiomp5 = not report['mkl'] and report['iomp5'] and not report['openblas'] and not report['gomp']


### PR DESCRIPTION
## Description
OpenMP detection is very finely balanced to compensate for LAPACK demands, `libgomp` self aggrandizement, and psi4's need to sanely and transparently impose the psi4-compile-omp status on any derived plugins. Unfortunately, #1348 disturbed some of that for the particular case of plugins with fewer active languages than their parent psi4.

A plugin (dfmp2) wasn't inheriting openmp from psi4 and thus was giving unknown openmp pragma warnings upon compile. This wasn't getting caught on linux because I was only checking that iomp5/gomp/omp weren't mixing, not that at least one was present. By happenstance, this did trigger an error on Mac in the course of building `psi4-dev`. This seems to patch things up on Linux. Will use this branch to try out Mac again.

## Status
- [x] Ready for review
- [x] Ready for merge
