### PR TITLE
Fix a memory error in psi::MOInfo::read_mo_spaces

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,15 +101,6 @@ jobs:
         displayName: "Test Psi4 (OpenMP)"
         workingDirectory: $(Build.BinariesDirectory)/install/lib
 
-      # Test (psimrcc-fd-freq2)
-      - script: |
-          ctest --build-config Debug ^
-                -R psimrcc-fd-freq2 ^
-                --output-on-failure ^
-                --parallel %NUMBER_OF_PROCESSORS%
-        displayName: "Test Psi4 (quick ctest)"
-        workingDirectory: $(Build.BinariesDirectory)/build
-
       # Test (quick ctest)
       - script: |
           ctest --build-config Debug ^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,15 @@ jobs:
         displayName: "Test Psi4 (OpenMP)"
         workingDirectory: $(Build.BinariesDirectory)/install/lib
 
+      # Test (psimrcc-fd-freq2)
+      - script: |
+          ctest --build-config Debug ^
+                -R psimrcc-fd-freq2 ^
+                --output-on-failure ^
+                --parallel %NUMBER_OF_PROCESSORS%
+        displayName: "Test Psi4 (quick ctest)"
+        workingDirectory: $(Build.BinariesDirectory)/build
+
       # Test (quick ctest)
       - script: |
           ctest --build-config Debug ^

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -254,6 +254,8 @@ void MOInfo::read_mo_spaces() {
         intvec fvir_ref;
         //        intvec actv_docc_ref;
 
+        if (ref_wfn.frzcpi().n() != nirreps_ref) exit(42);
+
         focc_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.frzcpi());
         docc_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.doccpi());
         actv_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.soccpi());

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -254,6 +254,7 @@ void MOInfo::read_mo_spaces() {
         intvec fvir_ref;
         //        intvec actv_docc_ref;
 
+        std::cout << "DIMENSIONS " << ref_wfn.frzcpi().n() << "  " << nirreps_ref << std::endl;
         if (ref_wfn.frzcpi().n() != nirreps_ref) exit(42);
 
         focc_ref = convert_int_array_to_vector(nirreps_ref, ref_wfn.frzcpi());


### PR DESCRIPTION
## Description
This is a part of *Psi4* porting to Windows (#933).

The size `ref_wfn.frzcpi()` is not `nirreps_ref` in `psimrcc-fd-freq2` test:
https://github.com/psi4/psi4/blob/5c0e495bdd3042795d8e39fe250ec153c4d236e9/psi4/src/psi4/libmoinfo/moinfo.cc#L257
It makes `convert_int_array_to_vector` to access invalid memory.

In the past, I replaced `nirreps` with `nirreps_ref` to solve another problem #1427 and this one became visible after fixing #1480.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Demonstrate a memory error in `psi::MOInfo::read_mo_spaces`
- [x] Fix the memory error in `psi::MOInfo::read_mo_spaces`

## Questions
- [x] I'm lacking enough understanding of the code to fix, so just highlighting the problem. Who could help?

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
