### PR TITLE
DFT: Adds OctreeGridBlocker -> BlockOPoints pruning check.

### DIFF
--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -4402,8 +4402,10 @@ void OctreeGridBlocker::block() {
     for (size_t A = 0; A < completed_tree.size(); A++) {
         std::vector<int> block = completed_tree[A];
         if (!block.size()) continue;
-        blocks_.push_back(
-            std::make_shared<BlockOPoints>(A, block.size(), &x_[index], &y_[index], &z_[index], &w_[index], extents_));
+        auto bop = std::make_shared<BlockOPoints>(A, block.size(), &x_[index], &y_[index], &z_[index], &w_[index], extents_);
+        // BlockOPoints construction performs additional pruning. Need to test if any points remain.
+        if (bop->local_nbf() == 0) continue;
+        blocks_.push_back(bop);
         if ((size_t)max_points_ < block.size()) {
             max_points_ = block.size();
         }

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -4404,10 +4404,11 @@ void OctreeGridBlocker::block() {
         if (!block.size()) continue;
         auto bop = std::make_shared<BlockOPoints>(A, block.size(), &x_[index], &y_[index], &z_[index], &w_[index], extents_);
         // BlockOPoints construction performs additional pruning. Need to test if any points remain.
-        if (bop->local_nbf() == 0) continue;
-        blocks_.push_back(bop);
-        if ((size_t)max_points_ < block.size()) {
-            max_points_ = block.size();
+        if (bop->local_nbf()) {
+            blocks_.push_back(bop);
+            if ((size_t)max_points_ < block.size()) {
+                max_points_ = block.size();
+            }
         }
         index += block.size();
     }


### PR DESCRIPTION
## Description
`BlockOPoints` performs additional pruning but the result is never checked.  We recently hit a case where this pruning resulted in a `BlockOPoints` object with zero points. This would cause a segfault here: https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libfock/v.cc#L262 because `ncols` would be zero.

Adds a check to `OctreeGridBlocker` where the list of `BlockOPoints` is populated, if the number of points is zero then don't add it to the list.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)  All DFT test cases pass on my machine.

## Status
- [x] Ready for review
- [x] Ready for merge
