### PR TITLE
 Enable optimized builds on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,10 +15,6 @@ jobs:
       # Check Python
       - script: |
           setlocal EnableDelayedExpansion
-          if not defined PYTHON_VERSION (
-            echo ERROR: Pipeline variable "python.version" is undefined. Define "python.version" with default value "3.6".
-            exit 1
-          )
           echo python.version: %PYTHON_VERSION%
           set VALID=false
           if "%PYTHON_VERSION%"=="3.6" set VALID=true
@@ -32,10 +28,6 @@ jobs:
       # Check cmake configuration
       - script: |
           setlocal EnableDelayedExpansion
-          if not defined CMAKE_BUILD_TYPE (
-            echo ERROR: Pipeline variable "cmake.build_type" is undefined. Define "cmake.build_type" with default value "Debug".
-            exit 1
-          )
           echo cmake.build_type: %CMAKE_BUILD_TYPE%
           set VALID=false
           if "%CMAKE_BUILD_TYPE%"=="Debug" set VALID=true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,40 @@ jobs:
     timeoutInMinutes: 360
     steps:
 
+      # Check Python
+      - script: |
+          setlocal EnableDelayedExpansion
+          if not defined PYTHON_VERSION (
+            echo ERROR: Pipeline variable "python.version" is undefined. Define "python.version" with default value "3.6".
+            exit 1
+          )
+          echo python.version: %PYTHON_VERSION%
+          set VALID=false
+          if "%PYTHON_VERSION%"=="3.6" set VALID=true
+          if "%PYTHON_VERSION%"=="3.7" set VALID=true
+          if "!VALID!"=="false" (
+            echo ERROR: Invalid "python.version" value: "%PYTHON_VERSION%". Valid values: "3.6" and "3.7".
+            exit 1
+          )
+        displayName: "Check Python version: $(python.version)"
+
+      # Check cmake configuration
+      - script: |
+          setlocal EnableDelayedExpansion
+          if not defined CMAKE_BUILD_TYPE (
+            echo ERROR: Pipeline variable "cmake.build_type" is undefined. Define "cmake.build_type" with default value "Debug".
+            exit 1
+          )
+          echo cmake.build_type: %CMAKE_BUILD_TYPE%
+          set VALID=false
+          if "%CMAKE_BUILD_TYPE%"=="Debug" set VALID=true
+          if "%CMAKE_BUILD_TYPE%"=="Release" set VALID=true
+          if "!VALID!"=="false" (
+            echo ERROR: Invalid "cmake.build_type" value: "%CMAKE_BUILD_TYPE%". Valid values: "Debug" and "Release".
+            exit 1
+          )
+        displayName: "Check cmake configuration"
+
       # Check ctest configuration
       - script: |
           setlocal EnableDelayedExpansion
@@ -73,7 +107,7 @@ jobs:
                         pybind11 ^
                         pytest ^
                         pytest-xdist ^
-                        python=3.6
+                        python=%PYTHON_VERSION%
           conda list
         displayName: "Install conda packages"
 
@@ -88,15 +122,22 @@ jobs:
 
       # Configure
       - script: |
+          setlocal EnableDelayedExpansion
           call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           mkdir build & cd build
+          if "%CMAKE_BUILD_TYPE%"=="Debug" set MAX_AM_ERI=6
+          if "%CMAKE_BUILD_TYPE%"=="Release" set MAX_AM_ERI=8
+          if not defined MAX_AM_ERI exit 1
+          if "%CMAKE_BUILD_TYPE%"=="Debug" set ENABLE_XHOST=OFF
+          if "%CMAKE_BUILD_TYPE%"=="Release" set ENABLE_XHOST=ON
+          if not defined ENABLE_XHOST exit 1
           cmake -G Ninja ^
-                -DCMAKE_BUILD_TYPE=Debug ^
+                -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
                 -DCMAKE_INSTALL_PREFIX=../install ^
                 -DCMAKE_C_COMPILER=clang-cl ^
                 -DCMAKE_CXX_COMPILER=clang-cl ^
-                -DENABLE_XHOST=OFF ^
-                -DMAX_AM_ERI=6 ^
+                -DENABLE_XHOST=!ENABLE_XHOST! ^
+                -DMAX_AM_ERI=!MAX_AM_ERI! ^
                 $(Build.SourcesDirectory)
         displayName: "Configure Psi4"
         workingDirectory: $(Build.BinariesDirectory)
@@ -105,7 +146,7 @@ jobs:
       - script: |
           call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           cmake --build . ^
-                --config Debug ^
+                --config %CMAKE_BUILD_TYPE% ^
                 -- -j %NUMBER_OF_PROCESSORS%
         displayName: "Build Psi4"
         workingDirectory: $(Build.BinariesDirectory)/build
@@ -114,7 +155,7 @@ jobs:
       - script: |
           call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
           cmake --build . ^
-                --config Debug ^
+                --config %CMAKE_BUILD_TYPE% ^
                 --target install ^
                 -- -j %NUMBER_OF_PROCESSORS%
         displayName: "Install Psi4"
@@ -131,7 +172,7 @@ jobs:
       - script: |
           setlocal EnableDelayedExpansion
           if "%CTEST_TYPE%"=="full" set CTEST_TYPE=".*"
-          ctest --build-config Debug ^
+          ctest --build-config %CMAKE_BUILD_TYPE% ^
                 --label-regex !CTEST_TYPE! ^
                 --output-on-failure ^
                 --parallel %NUMBER_OF_PROCESSORS% ^


### PR DESCRIPTION
## Description
This is a part of *Psi4* porting to Windows (#933).

Add options to *Azure* pipeline to build a optimized *Psi4* with custom *Python* version.

~~**Depends on #1527**~~

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Add an option to trigger optimized builds
- [x] Add an option to choose *Python* version
- [x] https://dev.azure.com/psi4/psi4 pipeline have to be configured to provide the following variables:
     - `cmake.build_type` with default `Debug` (settable at queuing time)
     - `python.version` with default `3.6` (settable at queuing time)

## Questions
- [x] For the optimized builds, `MAX_AM_ERI` is set 8. -- 8 is enough.
- [x]  Python 3.5 isn't supported. Some dependencies are broken. -- Python 3.5 is dropped.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
