### PR TITLE
Default cutoffs should be same

### DIFF
--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -115,7 +115,7 @@ void JKGrad::common_init()
     omp_num_threads_ = Process::environment.get_n_threads();
 #endif
 
-    cutoff_ = 0.0;
+    cutoff_ = 1E-12;
 
     do_J_ = true;
     do_K_ = true;

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -115,7 +115,7 @@ void JKGrad::common_init()
     omp_num_threads_ = Process::environment.get_n_threads();
 #endif
 
-    cutoff_ = 1E-12;
+    cutoff_ = Process::environment.options.get_double("INTS_TOLERANCE")
 
     do_J_ = true;
     do_K_ = true;

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -115,7 +115,7 @@ void JKGrad::common_init()
     omp_num_threads_ = Process::environment.get_n_threads();
 #endif
 
-    cutoff_ = Process::environment.options.get_double("INTS_TOLERANCE")
+    cutoff_ = Process::environment.options.get_double("INTS_TOLERANCE");
 
     do_J_ = true;
     do_K_ = true;


### PR DESCRIPTION
The default gradient and Hessian screening cutoffs should be the same as for the integrals used in SCF (#1540).

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
