### PR TITLE
Still more places where DF_FITTING_CONDITION wasn't used.

### DIFF
--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -433,7 +433,7 @@ SharedMatrix DFMP2::form_inverse_metric() {
     } else {
         // Form the inverse metric manually
         auto metric = std::make_shared<FittingMetric>(ribasis_, true);
-        metric->form_eig_inverse(1.0E-10);
+        metric->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
         SharedMatrix Jm12 = metric->get_metric();
 
         // Save inverse metric to the SCF three-index integral file if it exists

--- a/psi4/src/psi4/lib3index/dftensor.cc
+++ b/psi4/src/psi4/lib3index/dftensor.cc
@@ -118,7 +118,7 @@ void DFTensor::print_header() {
 }
 void DFTensor::build_metric() {
     auto met = std::make_shared<FittingMetric>(auxiliary_, true);
-    met->form_eig_inverse();
+    met->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
     metric_ = met->get_metric();
 
     if (debug_) {

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -854,7 +854,7 @@ void DiskDFJK::initialize_JK_disk() {
 
     // Form the J symmetric inverse
     auto Jinv = std::make_shared<FittingMetric>(auxiliary_, true);
-    Jinv->form_eig_inverse();
+    Jinv->form_eig_inverse(condition_);
     double** Jinvp = Jinv->get_metric()->pointer();
 
     // Synch up

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -408,7 +408,7 @@ void SAPT0::df_integrals() {
 
     // Get fitting metric
     auto metric = std::make_shared<FittingMetric>(ribasis_);
-    metric->form_eig_inverse();
+    metric->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
     double **J_temp = metric->get_metric()->pointer();
     double **J_mhalf = block_matrix(ndf_, ndf_);
     C_DCOPY(ndf_ * ndf_, J_temp[0], 1, J_mhalf[0], 1);
@@ -870,7 +870,7 @@ void SAPT0::df_integrals_aio() {
 
     // Get fitting metric
     auto metric = std::make_shared<FittingMetric>(ribasis_);
-    metric->form_eig_inverse();
+    metric->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
     double **J_temp = metric->get_metric()->pointer();
     double **J_mhalf = block_matrix(ndf_, ndf_);
     C_DCOPY(ndf_ * ndf_, J_temp[0], 1, J_mhalf[0], 1);
@@ -1614,7 +1614,7 @@ void SAPT0::oo_df_integrals() {
 
     // Get fitting metric
     auto metric = std::make_shared<FittingMetric>(elstbasis_);
-    metric->form_eig_inverse();
+    metric->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
     double **J_temp = metric->get_metric()->pointer();
     double **J_mhalf = block_matrix(ndf_, ndf_);
     C_DCOPY(ndf_ * ndf_, J_temp[0], 1, J_mhalf[0], 1);

--- a/psi4/src/psi4/libsapt_solver/sapt2.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2.cc
@@ -383,7 +383,7 @@ void SAPT2::print_results() {
 void SAPT2::df_integrals() {
     // Get fitting metric
     auto metric = std::make_shared<FittingMetric>(ribasis_);
-    metric->form_eig_inverse();
+    metric->form_eig_inverse(options_.get_double("DF_FITTING_CONDITION"));
     double **J_temp = metric->get_metric()->pointer();
     double **J_mhalf = block_matrix(ndf_, ndf_);
     C_DCOPY(ndf_ * ndf_, J_temp[0], 1, J_mhalf[0], 1);


### PR DESCRIPTION
## Description
Fix more instances where RI inverse overlap is formed without the proper value for the fitting condition.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
