### PR TITLE
Cleanup response code

### DIFF
--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -49,6 +49,7 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libscf_solver/rhf.h"
 
 #include <algorithm>
 
@@ -63,7 +64,7 @@ using namespace psi;
 namespace psi {
 namespace scfgrad {
 
-std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
+std::shared_ptr<Matrix> RSCFDeriv::hessian_response()
 {
     // => Control Parameters <= //
 
@@ -1066,12 +1067,6 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
     jk->initialize();
 
 
-    /*
-     * This will not trigger currently; only OUT_OF_CORE actually uses symmetry and there's a catch
-     * Py-side to make sure that doesn't get us in here.
-     */
-    bool ignore_symmetry = nirrep_ == 1 || jk->C1();
-
     Dimension nvirpi = nmopi_ - doccpi_;
     CdSalcList SALCList(molecule_, 0xFF, false, false);
 
@@ -1089,60 +1084,6 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
     std::shared_ptr<Matrix> Cmo2mosym;
     // SO -> C1 MO (forward transformation)
     std::shared_ptr<Matrix> Cso2mofull;
-
-    // for debugging
-    // ignore_symmetry = false;
-
-    if(ignore_symmetry){
-        // This JK object uses no symmetry, so we can just pass it C1 quantities
-        // jk->set_allow_desymmetrization(false);
-        // DGAS: ACS - this is now auto detected.
-    }else{
-        C_so = Ca_subset("SO");
-        Cocc_so = Ca_subset("SO", "OCC");
-
-        /*
-         * We need to be able to map symmetric MOs into C1 MOs and vice-versa.  If we call C' the MOs with
-         * symmetry and C the MOs without, we can use the orthonormality to define an inverse transformation matrix
-         *
-         *      Ct S C = 1   =>   Cinv = Ct S
-         *
-         * which allows us to roll back to the SO basis and then forward transform, to get a matrix that will
-         * correctly account for the ordering of the MOs with and without symmetry.
-         */
-        std::shared_ptr<OneBodyAOInt> aoSint(integral_->ao_overlap());
-        auto Sao = std::make_shared<Matrix>("Sao", nso, nso);
-        aoSint->compute(Sao);
-        double **pS = Sao->pointer();
-
-        // C1 MO -> AO (backward transformation)
-        Cinvao = std::make_shared<Matrix>("Cinvao = Ct_ao Sao", nmo, nso);
-        C_DGEMM('T', 'N', nmo, nso, nso, 1.0, Cp[0], nmo, pS[0], nso, 0.0, Cinvao->pointer()[0], nso);
-
-        // C1 MO -> SO (backward transformation)
-        Cinvso = std::make_shared<Matrix>(nirrep_, nmo, nsopi_);
-        for(int h = 0; h < nirrep_; ++h){
-            if(!nsopi_[h]) continue;
-            C_DGEMM('N', 'N', nmo, nsopi_[h], nso, 1.0, Cinvao->pointer()[0], nso, AO2SO_->pointer(h)[0],
-                    nsopi_[h], 0.0, Cinvso->pointer(h)[0], nsopi_[h]);
-        }
-
-        // C1 MO -> Symmetrized MO
-        Cmo2mosym = std::make_shared<Matrix>(nirrep_, nmo, nmopi_);
-        for(int h = 0; h < nirrep_; ++h){
-            if(!doccpi_[h] || !nsopi_[h]) continue;
-            C_DGEMM('N', 'N', nmo, nmopi_[h], nsopi_[h], 1.0, Cinvso->pointer(h)[0], nsopi_[h],
-                    C_so->pointer(h)[0], nmopi_[h], 0.0, Cmo2mosym->pointer(h)[0], nmopi_[h]);
-        }
-
-        // SO -> C1 MO (forward transformation)
-        Cso2mofull = std::make_shared<Matrix>(nirrep_, (int*)nsopi_, nmo);
-        for(int h = 0; h < nirrep_; ++h){
-            if(!nsopi_[h]) continue;
-            C_DGEMM('T', 'N', nsopi_[h], nmo, nso, 1.0, AO2SO_->pointer(h)[0],
-                    nsopi_[h], C->pointer()[0], nmo, 0.0, Cso2mofull->pointer(h)[0], nmo);
-        }
-    }
 
     // => J2pi/K2pi <= //
     {
@@ -1166,29 +1107,12 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
             psio_->write(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
 
         for (int A = 0; A < max_A; A++) {
-            if(ignore_symmetry){
-                // Just pass C1 quantities in; this object doesn't respect symmetry anyway
-                L.push_back(Cocc);
-                R.push_back(std::make_shared<Matrix>("R",nso,nocc));
-            }else{
-                // Add symmetry back into the AO index of the quantities before calling.  The MO index doesn't
-                // matter too much here; it's contracted away during formation of the D matrices.
-                L.push_back(Cocc_so);
-                // This is just a placeholder; to be replaced below
-                R.push_back(Cocc_so);
-            }
+            // Just pass C1 quantities in; this object doesn't respect symmetry anyway
+            L.push_back(Cocc);
+            R.push_back(std::make_shared<Matrix>("R",nso,nocc));
         }
 
         jk->print_header();
-
-        if(!ignore_symmetry){
-            U->zero();
-            for (int a = 0; a < 3*natom; a++) {
-                // Initialize the C1 symmetry G2 contributions to zero
-                psio_address next_Gpi = psio_get_address(PSIO_ZERO, a * (size_t) nmo * nocc * sizeof(double));
-                psio_->write(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
-            }
-        }
 
         for (int A = 0; A < 3 * natom; A+=max_A) {
             int nA = max_A;
@@ -1198,90 +1122,24 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
                 R.resize(nA);
             }
             for (int a = 0; a < nA; a++) {
-                if(ignore_symmetry){
-                    psio_address next_Sij= psio_get_address(PSIO_ZERO,(A + a) * (size_t) nocc * nocc * sizeof(double));
-                    psio_->read(PSIF_HESS,"Sij^A",(char*)Sijp[0],nocc*nocc*sizeof(double),next_Sij, &next_Sij);
-                    C_DGEMM('N','N',nso,nocc,nocc,1.0,Cop[0],nocc,Sijp[0],nocc,0.0,R[a]->pointer()[0],nocc);
-                }else{
-                    // Take SALCs of the C1 overlap derivatives, and add symmetry back in to the left index.
-                    // Transform the right index to SOs, analogous to the C1 treatment above.
-
-                    const CdSalc& thissalc = SALCList[a+A];
-                    int salcirrep = thissalc.irrep();
-                    R[a] = std::make_shared<Matrix>("R", nsopi_, doccpi_, salcirrep);
-                    auto Tmpij = std::make_shared<Matrix>(nirrep_, nocc, (int*)doccpi_);
-                    for(int comp = 0; comp < thissalc.ncomponent(); ++comp){
-                        const CdSalc::Component& salccomponent = thissalc.component(comp);
-                        int salcatom = salccomponent.atom;
-                        int salcxyz = salccomponent.xyz;
-                        double coef = salccomponent.coef;
-                        int pert = 3*salcatom + salcxyz;
-                        psio_address next_Sij= psio_get_address(PSIO_ZERO,pert * (size_t) nocc * nocc * sizeof(double));
-                        psio_->read(PSIF_HESS,"Sij^A",(char*)Sijp[0],nocc*nocc*sizeof(double),next_Sij, &next_Sij);
-
-                        for(int h = 0; h < nirrep_; ++h){
-                            if(!doccpi_[h]) continue;
-                            C_DGEMM('N', 'N', nocc, doccpi_[h], nocc, 1.0, Sijp[0], nocc,
-                                    Cmo2mosym->pointer(h)[0], nmopi_[h], 0.0, Tmpij->pointer(h)[0], doccpi_[h]);
-                        }
-                        for(int h = 0; h < nirrep_; ++h){
-                            if(!doccpi_[h^salcirrep] || !nsopi_[h]) continue;
-                            C_DGEMM('N', 'N', nsopi_[h], doccpi_[h^salcirrep], nocc, coef, Cso2mofull->pointer(h)[0], nmo,
-                                    Tmpij->pointer(h^salcirrep)[0], doccpi_[h^salcirrep], 1.0, R[a]->pointer(h)[0], doccpi_[h^salcirrep]);
-                        }
-                    }
-                }
-
+                psio_address next_Sij= psio_get_address(PSIO_ZERO,(A + a) * (size_t) nocc * nocc * sizeof(double));
+                psio_->read(PSIF_HESS,"Sij^A",(char*)Sijp[0],nocc*nocc*sizeof(double),next_Sij, &next_Sij);
+                C_DGEMM('N','N',nso,nocc,nocc,1.0,Cop[0],nocc,Sijp[0],nocc,0.0,R[a]->pointer()[0],nocc);
             }
 
             jk->compute();
 
             for (int a = 0; a < nA; a++) {
-                if(ignore_symmetry){
-                    // Add the 2J contribution to G
-                    C_DGEMM('N','N',nso,nocc,nso,1.0,J[a]->pointer()[0],nso,Cop[0],nocc,0.0,Tp[0],nocc);
-                    C_DGEMM('T','N',nmo,nocc,nso,-2.0,Cp[0],nmo,Tp[0],nocc,0.0,Up[0],nocc);
+                // Add the 2J contribution to G
+                C_DGEMM('N','N',nso,nocc,nso,1.0,J[a]->pointer()[0],nso,Cop[0],nocc,0.0,Tp[0],nocc);
+                C_DGEMM('T','N',nmo,nocc,nso,-2.0,Cp[0],nmo,Tp[0],nocc,0.0,Up[0],nocc);
 
-                    // Subtract the K term from G
-                    C_DGEMM('N','N',nso,nocc,nso,1.0,K[a]->pointer()[0],nso,Cop[0],nocc,0.0,Tp[0],nocc);
-                    C_DGEMM('T','N',nmo,nocc,nso,1.0,Cp[0],nmo,Tp[0],nocc,1.0,Up[0],nocc);
+                // Subtract the K term from G
+                C_DGEMM('N','N',nso,nocc,nso,1.0,K[a]->pointer()[0],nso,Cop[0],nocc,0.0,Tp[0],nocc);
+                C_DGEMM('T','N',nmo,nocc,nso,1.0,Cp[0],nmo,Tp[0],nocc,1.0,Up[0],nocc);
 
-                    psio_address next_Gpi = psio_get_address(PSIO_ZERO,(A + a) * (size_t) nmo * nocc * sizeof(double));
-                    psio_->write(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
-                }else{
-                    const CdSalc& thissalc = SALCList[a+A];
-                    int salcirrep = thissalc.irrep();
-                    J[a]->scale(-2.0);
-                    J[a]->add(K[a]);
-
-                    // Transform from SO to C1 MO basis
-                    auto Fmat = std::make_shared<Matrix>("F derivative", nmo, nocc);
-                    auto Tmpso_occ = std::make_shared<Matrix>(nirrep_, (int*)nsopi_, nocc);
-                    for(int h = 0; h < nirrep_; ++h){
-                        if(!nsopi_[h] || !nsopi_[h^salcirrep]) continue;
-                        C_DGEMM('N', 'N', nsopi_[h], nocc, nsopi_[h^salcirrep], 1.0, J[a]->pointer(h)[0], nsopi_[h^salcirrep],
-                                Cso2mofull->pointer(h^salcirrep)[0], nmo, 0.0, Tmpso_occ->pointer(h)[0], nocc);
-                    }
-                    for(int h = 0; h < nirrep_; ++h){
-                        if(!nsopi_[h]) continue;
-                        C_DGEMM('T', 'N', nmo, nocc, nsopi_[h], 1.0, Cso2mofull->pointer(h)[0], nmo,
-                                Tmpso_occ->pointer(h)[0], nocc, 1.0, Fmat->pointer()[0], nocc);
-                    }
-
-                    // Distribute from SALCs back to C1 Cartesian derivatives
-                    for(int comp = 0; comp < thissalc.ncomponent(); ++comp){
-                        const CdSalc::Component& salccomponent = thissalc.component(comp);
-                        int salcatom = salccomponent.atom;
-                        int salcxyz = salccomponent.xyz;
-                        double coef = salccomponent.coef;
-                        int pert = 3*salcatom + salcxyz;
-                        psio_address next_Gpi = psio_get_address(PSIO_ZERO,pert * (size_t) nmo * nocc * sizeof(double));
-                        psio_->read(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
-                        C_DAXPY(nmo*nocc, coef, Fmat->pointer()[0], 1, Up[0], 1);
-                        next_Gpi = psio_get_address(PSIO_ZERO,pert * (size_t) nmo * nocc * sizeof(double));
-                        psio_->write(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
-                    }
-                }
+                psio_address next_Gpi = psio_get_address(PSIO_ZERO,(A + a) * (size_t) nmo * nocc * sizeof(double));
+                psio_->write(PSIF_HESS,"G2pi^A",(char*)Up[0],nmo*nocc*sizeof(double),next_Gpi,&next_Gpi);
             }
         }
     }
@@ -1340,7 +1198,7 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
         auto wfn = std::make_shared<Wavefunction>(options_);
         wfn->shallow_copy(this);
 
-        auto cphf = std::make_shared<RCPHF>(wfn, options_, !ignore_symmetry);
+        auto cphf = std::make_shared<RCPHF>(wfn, options_, 0);
         cphf->set_jk(jk);
 
         std::map<std::string, SharedMatrix>& b = cphf->b();
@@ -1351,16 +1209,6 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
 
         auto T = std::make_shared<Matrix>("T",nvir,nocc);
         double** Tp = T->pointer();
-
-        if(!ignore_symmetry){
-            T->zero();
-            for (int a = 0; a < 3*natom; a++) {
-                // Initialize the C1 symmetry U terms to zero
-                psio_address next_Uai = psio_get_address(PSIO_ZERO, a * (size_t) nvir * nocc * sizeof(double));
-                psio_->write(PSIF_HESS,"Uai^A",(char*)Tp[0],nvir*nocc*sizeof(double),next_Uai,&next_Uai);
-            }
-        }
-
 
         for (int A = 0; A < 3 * natom; A+=max_A) {
             int nA = max_A;
@@ -1376,42 +1224,11 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
                 std::stringstream ss;
                 ss << "Perturbation " << a + A;
                 std::shared_ptr<Matrix> B;
-                if(ignore_symmetry){
-                    B = std::make_shared<Matrix>(ss.str(),nocc,nvir);
-                    psio_->read(PSIF_HESS,"Bai^A",(char*)Tp[0],nvir * nocc * sizeof(double),next_Bai,&next_Bai);
-                    double** Bp = B->pointer();
-                    for (int i = 0; i < nocc; i++) {
-                        C_DCOPY(nvir,&Tp[0][i],nocc,Bp[i],1);
-                    }
-                }else{
-                    const CdSalc& thissalc = SALCList[a+A];
-                    int salcirrep = thissalc.irrep();
-                    auto Tmpmo = std::make_shared<Matrix>(nirrep_, nocc, (int*)nvirpi);
-                    B = std::make_shared<Matrix>(ss.str(),doccpi_,nvirpi,salcirrep);
-                    for(int comp = 0; comp < thissalc.ncomponent(); ++comp){
-                        const CdSalc::Component& salccomponent = thissalc.component(comp);
-                        int salcatom = salccomponent.atom;
-                        int salcxyz = salccomponent.xyz;
-                        double coef = salccomponent.coef;
-                        int pert = 3*salcatom + salcxyz;
-                        psio_address this_Bai = psio_get_address(PSIO_ZERO,pert * (size_t) nvir * nocc * sizeof(double));
-                        psio_->read(PSIF_HESS,"Bai^A",(char*)Tp[0],nvir * nocc * sizeof(double),this_Bai,&this_Bai);
-                        for(int h = 0; h < nirrep_; ++h){
-                            if(!nvirpi[h]) continue;
-
-                            C_DGEMM('T', 'N', nocc, nvirpi[h], nvir, 1.0, Tp[0], nocc,
-                                    &Cmo2mosym->pointer(h)[nocc][doccpi_[h]], nmopi_[h], 0.0, Tmpmo->pointer(h)[0], nvirpi[h]);
-                        }
-                        for(int h = 0; h < nirrep_; ++h){
-                            if(!doccpi_[h] || !nvirpi[h^salcirrep]) continue;
-
-                            C_DGEMM('T', 'N', doccpi_[h], nvirpi[h^salcirrep], nocc, coef, Cmo2mosym->pointer(h)[0],
-                                    nmopi_[h], Tmpmo->pointer(h^salcirrep)[0], nvirpi[h^salcirrep], 1.0, B->pointer(h)[0], nvirpi[h^salcirrep]);
-                        }
-
-                    }
-
-
+                B = std::make_shared<Matrix>(ss.str(),nocc,nvir);
+                psio_->read(PSIF_HESS,"Bai^A",(char*)Tp[0],nvir * nocc * sizeof(double),next_Bai,&next_Bai);
+                double** Bp = B->pointer();
+                for (int i = 0; i < nocc; i++) {
+                    C_DCOPY(nvir,&Tp[0][i],nocc,Bp[i],1);
                 }
                 //                B->print();
                 b[ss.str()] = B;
@@ -1425,44 +1242,10 @@ std::shared_ptr<Matrix> SCFGrad::rhf_hessian_response()
                 ss << "Perturbation " << a + A;
                 std::shared_ptr<Matrix> X = x[ss.str()];
                 double** Xp = X->pointer();
-                if(ignore_symmetry){
-                    for (int i = 0; i < nocc; i++) {
-                        C_DCOPY(nvir,Xp[i],1,&Tp[0][i],nocc);
-                    }
-                    psio_->write(PSIF_HESS,"Uai^A",(char*)Tp[0],nvir * nocc * sizeof(double),next_Uai,&next_Uai);
-                }else{
-                    // Backtransform Uai from the symmetrized SALC to the C1 Cartesian basis (ACS note: this hasn't been fully tested, but seems correct)
-                    const CdSalc& thissalc = SALCList[a+A];
-                    int salcirrep = thissalc.irrep();
-
-                    auto Tmpmo_c1 = std::make_shared<Matrix>(nvir, nocc);
-                    auto Tmpso_occ = std::make_shared<Matrix>(nirrep_, nvir, (int*)doccpi_);
-                    for(int h = 0; h < nirrep_; ++h){
-                        if(!doccpi_[h] || !nvirpi[h^salcirrep]) continue;
-
-                        C_DGEMM('N', 'T', nvir, doccpi_[h], nvirpi[h^salcirrep], 1.0, &Cmo2mosym->pointer(h^salcirrep)[nocc][doccpi_[h^salcirrep]],
-                                nmopi_[h^salcirrep], X->pointer(h)[0], nvirpi[h^salcirrep], 0.0, Tmpso_occ->pointer(h)[0], doccpi_[h]);
-                    }
-                    for(int h = 0; h < nirrep_; ++h){
-                        if(!doccpi_[h]) continue;
-
-                        C_DGEMM('N', 'T', nvir, nocc, doccpi_[h], 1.0, Tmpso_occ->pointer(h)[0], doccpi_[h],
-                                Cmo2mosym->pointer(h)[0], nmopi_[h], 1.0, Tmpmo_c1->pointer()[0], nocc);
-                    }
-                    for(int comp = 0; comp < thissalc.ncomponent(); ++comp){
-                        const CdSalc::Component& salccomponent = thissalc.component(comp);
-                        int salcatom = salccomponent.atom;
-                        int salcxyz = salccomponent.xyz;
-                        double coef = salccomponent.coef;
-                        int pert = 3*salcatom + salcxyz;
-                        psio_address next_Uai = psio_get_address(PSIO_ZERO,pert * (size_t) nvir * nocc * sizeof(double));
-                        psio_->read(PSIF_HESS,"Uai^A",(char*)Tp[0],nvir*nocc*sizeof(double),next_Uai,&next_Uai);
-                        C_DAXPY(nvir*nocc, coef, Tmpmo_c1->pointer()[0], 1, Tp[0], 1);
-                        next_Uai = psio_get_address(PSIO_ZERO,pert * (size_t) nvir * nocc * sizeof(double));
-                        psio_->write(PSIF_HESS,"Uai^A",(char*)Tp[0],nvir*nocc*sizeof(double),next_Uai,&next_Uai);
-                    }
+                for (int i = 0; i < nocc; i++) {
+                    C_DCOPY(nvir,Xp[i],1,&Tp[0][i],nocc);
                 }
-
+                psio_->write(PSIF_HESS,"Uai^A",(char*)Tp[0],nvir * nocc * sizeof(double),next_Uai,&next_Uai);
             }
 
         }

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -1288,7 +1288,8 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response()
             pdip_grad[A][2] += 4*mu_z.vector_dot(Upi);
         }
     }
-    dipole_gradient_ = dipole_gradient;
+    rhf_wfn_->set_array_variable("SCF DIPOLE GRADIENT", dipole_gradient);
+    rhf_wfn_->set_array_variable("CURRENT DIPOLE GRADIENT", dipole_gradient);
 
     // => Qpi <= //
     {

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -48,6 +48,7 @@
 #include "psi4/libfunctional/superfunctional.h"
 #include "psi4/libdisp/dispersion.h"
 #include "psi4/libscf_solver/hf.h"
+#include "psi4/libscf_solver/rhf.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
 
@@ -56,7 +57,7 @@
 namespace psi {
 namespace scfgrad {
 
-SCFGrad::SCFGrad(SharedWavefunction ref_wfn, Options& options) :
+SCFDeriv::SCFDeriv(SharedWavefunction ref_wfn, Options& options) :
     Wavefunction(options)
 {
     shallow_copy(ref_wfn);
@@ -72,17 +73,17 @@ SCFGrad::SCFGrad(SharedWavefunction ref_wfn, Options& options) :
     }
 
 }
-SCFGrad::~SCFGrad()
+SCFDeriv::~SCFDeriv()
 {
 }
-void SCFGrad::common_init()
+void SCFDeriv::common_init()
 {
 
 
     print_ = options_.get_int("PRINT");
     debug_ = options_.get_int("DEBUG");
 }
-SharedMatrix SCFGrad::compute_gradient()
+SharedMatrix SCFDeriv::compute_gradient()
 {
     // => Echo <= //
 
@@ -286,7 +287,7 @@ SharedMatrix SCFGrad::compute_gradient()
 
     return gradients_["Total"];
 }
-SharedMatrix SCFGrad::compute_hessian()
+SharedMatrix SCFDeriv::compute_hessian()
 {
     // => Echo <= //
 
@@ -1041,7 +1042,7 @@ SharedMatrix SCFGrad::compute_hessian()
 
     // => Response Terms (Brace Yourself) <= //
     if (options_.get_str("REFERENCE") == "RHF") {
-        hessians_["Response"] = rhf_hessian_response();
+        hessians_["Response"] = hessian_response();
     } else {
         throw PSIEXCEPTION("SCFHessian: Response not implemented for this reference");
     }

--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -51,7 +51,6 @@ protected:
     std::shared_ptr<VBase> potential_;
     std::map<std::string, SharedMatrix> gradients_;
     std::map<std::string, SharedMatrix> hessians_;
-    SharedMatrix dipole_gradient_;
 
 public:
     SCFDeriv(SharedWavefunction ref_wfn, Options& options);
@@ -61,7 +60,6 @@ public:
     virtual SharedMatrix compute_gradient() override;
     virtual SharedMatrix compute_hessian() override;
     virtual SharedMatrix hessian_response() { throw PSIEXCEPTION("SCFDeriv not implemented for the requested reference type."); }
-    SharedMatrix dipole_gradient() const { return dipole_gradient_; }
 };
 
 class RSCFDeriv : public SCFDeriv {

--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -35,10 +35,13 @@
 namespace psi {
 class SuperFunctional;
 class VBase;
+namespace scf {
+    class RHF;
+}
 
 namespace scfgrad {
 
-class SCFGrad : public Wavefunction {
+class SCFDeriv : public Wavefunction {
 
 protected:
 
@@ -51,18 +54,23 @@ protected:
     SharedMatrix dipole_gradient_;
 
 public:
-    SCFGrad(SharedWavefunction ref_wfn, Options& options);
-    ~SCFGrad() override;
+    SCFDeriv(SharedWavefunction ref_wfn, Options& options);
+    ~SCFDeriv() override;
 
-    double compute_energy() override { throw PSIEXCEPTION("SCFGrad needs a rehash, call Rob."); }
-
-    SharedMatrix compute_gradient() override;
-
-    SharedMatrix compute_hessian() override;
-
-    SharedMatrix rhf_hessian_response();
-
+    double compute_energy() override { throw PSIEXCEPTION("SCFDeriv not implemented for the requested reference type."); }
+    virtual SharedMatrix compute_gradient() override;
+    virtual SharedMatrix compute_hessian() override;
+    virtual SharedMatrix hessian_response() { throw PSIEXCEPTION("SCFDeriv not implemented for the requested reference type."); }
     SharedMatrix dipole_gradient() const { return dipole_gradient_; }
+};
+
+class RSCFDeriv : public SCFDeriv {
+protected:
+    std::shared_ptr<scf::RHF> rhf_wfn_;
+public:
+    RSCFDeriv(std::shared_ptr<scf::RHF> rhf_wfn, Options& options): SCFDeriv(std::dynamic_pointer_cast<Wavefunction>(rhf_wfn), options), rhf_wfn_(rhf_wfn) {}
+    ~RSCFDeriv() override {}
+    virtual SharedMatrix hessian_response() override;
 };
 
 }} // Namespaces

--- a/psi4/src/psi4/scfgrad/wrapper.cc
+++ b/psi4/src/psi4/scfgrad/wrapper.cc
@@ -56,18 +56,15 @@ SharedMatrix scfhess(SharedWavefunction ref_wfn, Options &options)
 {
     tstart();
 
-    SharedMatrix H, dipole_gradient;
+    SharedMatrix H;
     if( ref_wfn->same_a_b_orbs() && ref_wfn->same_a_b_dens()) {
         // RHF
         RSCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::RHF>(ref_wfn), options);
         H = hessian_computer.compute_hessian();
-        dipole_gradient = hessian_computer.dipole_gradient();
     } else {
         throw PSIEXCEPTION("Only RHF hessians are supported at this time.");
     }
     ref_wfn->set_hessian(H);
-    ref_wfn->set_array_variable("SCF DIPOLE GRADIENT", dipole_gradient);
-    ref_wfn->set_array_variable("CURRENT DIPOLE GRADIENT", dipole_gradient);
 
     tstop();
 

--- a/psi4/src/psi4/scfgrad/wrapper.cc
+++ b/psi4/src/psi4/scfgrad/wrapper.cc
@@ -32,6 +32,7 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libciomr/libciomr.h"
+#include "psi4/libscf_solver/rhf.h"
 
 namespace psi{
 namespace scfgrad {
@@ -40,7 +41,7 @@ SharedMatrix scfgrad(SharedWavefunction ref_wfn, Options &options)
 {
     tstart();
 
-    SCFGrad grad(ref_wfn, options);
+    SCFDeriv grad(ref_wfn, options);
     SharedMatrix G = grad.compute_gradient();
 
     Process::environment.arrays["SCF TOTAL GRADIENT"] = G;
@@ -55,12 +56,18 @@ SharedMatrix scfhess(SharedWavefunction ref_wfn, Options &options)
 {
     tstart();
 
-    SCFGrad grad(ref_wfn, options);
-    SharedMatrix H = grad.compute_hessian();
+    SharedMatrix H, dipole_gradient;
+    if( ref_wfn->same_a_b_orbs() && ref_wfn->same_a_b_dens()) {
+        // RHF
+        RSCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::RHF>(ref_wfn), options);
+        H = hessian_computer.compute_hessian();
+        dipole_gradient = hessian_computer.dipole_gradient();
+    } else {
+        throw PSIEXCEPTION("Only RHF hessians are supported at this time.");
+    }
     ref_wfn->set_hessian(H);
-    ref_wfn->set_array_variable("SCF TOTAL HESSIAN", H);
-    ref_wfn->set_array_variable("SCF DIPOLE GRADIENT", grad.dipole_gradient());
-    ref_wfn->set_array_variable("CURRENT DIPOLE GRADIENT", grad.dipole_gradient());
+    ref_wfn->set_array_variable("SCF DIPOLE GRADIENT", dipole_gradient);
+    ref_wfn->set_array_variable("CURRENT DIPOLE GRADIENT", dipole_gradient);
 
     tstop();
 


### PR DESCRIPTION
## Description
The Hessian code can be cleaned up by using the SCF class's hessian-vector products.  To avoid the need to cast pointers inside the orbital response code, this PR specializes the response class for each reference type, and removes some junk symmetry code.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Specialize response code by reference
- [x] Simplify dipole derivative handling
- [x] Remove symmetry code from response
- [x] Use the `Hx` functions from the SCF class to solve CPHF

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
