### PR TITLE
dertype and gradient passing

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -58,7 +58,9 @@ def _find_derivative_type(ptype, method_name, user_dertype):
     a given method.
     """
 
-    if ptype not in ['gradient', 'hessian']:
+    derivatives = {"gradient": 1, "hessian": 2}
+
+    if ptype not in derivatives:
         raise ValidationError("_find_derivative_type: ptype must either be gradient or hessian.")
 
     dertype = "(auto)"
@@ -105,6 +107,8 @@ def _find_derivative_type(ptype, method_name, user_dertype):
 
         raise ValidationError("""Derivative method 'name' %s and derivative level 'dertype' %s are not available.%s"""
                               % (method_name, str(dertype), alternatives))
+
+    dertype = min(dertype, derivatives[ptype])
 
     return dertype
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1076,7 +1076,7 @@ def optimize(name, **kwargs):
             G = core.get_legacy_gradient()  # TODO
             core.IOManager.shared_object().set_specific_retention(1, True)
             core.IOManager.shared_object().set_specific_path(1, './')
-            frequencies(hessian_with_method, molecule=moleculeclone, **kwargs)
+            frequencies(hessian_with_method, molecule=moleculeclone, ref_gradient = G, **kwargs)
             steps_since_last_hessian = 0
             core.set_legacy_gradient(G)
             core.set_global_option('CART_HESS_READ', True)
@@ -1229,7 +1229,7 @@ def hessian(name, **kwargs):
     if level:
         kwargs['level'] = level
 
-    dertype = _find_derivative_type('hessian', lowername, kwargs.pop('freq_dertype', kwargs.pop('dertype', None)))
+    dertype = _find_derivative_type('hessian', lowername, kwargs.pop('freq_dertype', kwargs.get('dertype', None)))
 
     # Make sure the molecule the user provided is the active one
     molecule = kwargs.pop('molecule', core.get_active_molecule())


### PR DESCRIPTION
## Description
Previously, the `dertype` specified in a frequency or optimization-with-hessian computaiton wouldn't get passed on to the pre-hessian gradient. This is now fixed. For optimizations, we can do one better and pass in the last gradient, so we don't need to recompute it. While solving this, I uncovered that supplying a dertype that was "too high" for the derivative level would lead to the default case of energy-only computations. That is also fixed.

**Although this is an enhancement, this is also a bug fix.** Without this PR, I have no way to get a frozen core MP2 optimization with a `full_hess_every` hessian. The user is responsible for supplying the `dertype`, and they currently have no way to get the `dertype` argument to the pre-hessian gradient.

## Checklist
- [x] Tested this solved my fc-MP2 use case
- [x] Tested this solved the case of a dertype=2 RHF hessian

## Status
- [x] Ready for review
- [x] Ready for merge
