### PR TITLE
Remove third Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,25 +77,25 @@ matrix:
       - Fortran_COMPILER='gfortran'
       - BUILD_TYPE='release'
 
-  - os: linux
-    compiler: gcc
-    addons: &4
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - python-numpy
-        - libhdf5-serial-dev
-        - liblapack-dev
-        - g++-8
-        - gcc-8
-        - gfortran-8
-    env:
-      - CXX_COMPILER='g++-8'
-      - PYTHON_VER='3.6'
-      - C_COMPILER='gcc-8'
-      - Fortran_COMPILER='gfortran-8'
-      - BUILD_TYPE='release'
+#  - os: linux
+#    compiler: gcc
+#    addons: &4
+#      apt:
+#        sources:
+#        - ubuntu-toolchain-r-test
+#        packages:
+#        - python-numpy
+#        - libhdf5-serial-dev
+#        - liblapack-dev
+#        - g++-8
+#        - gcc-8
+#        - gfortran-8
+#    env:
+#      - CXX_COMPILER='g++-8'
+#      - PYTHON_VER='3.6'
+#      - C_COMPILER='gcc-8'
+#      - Fortran_COMPILER='gfortran-8'
+#      - BUILD_TYPE='release'
 
 #  - os: linux
 #    compiler: gcc


### PR DESCRIPTION
The third Travis test is timing out too much.  This can be traced to the painfully slow download time for the GCC compiler.  We have plans to replace this test with some plugin validation, using native GCC compilers to avoid the timeouts.  For now, we'll just nuke it to allow the backlog of PRs through.

## Status
- [x] Ready for review
- [x] Ready for merge
