### PR TITLE
Enable Windows package building with Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,19 @@ jobs:
           )
         displayName: "Check pytest configuration"
 
+      # Check conda configuration
+      - script: |
+          setlocal EnableDelayedExpansion
+          echo conda.build: %CONDA_BUILD%
+          set VALID=false
+          if "%CONDA_BUILD%"=="true" set VALID=true
+          if "%CONDA_BUILD%"=="false" set VALID=true
+          if "!VALID!"=="false" (
+            echo ERROR: Invalid "conda.build" value: "%CONDA_BUILD%". Valid values: "true" and "false".
+            exit 1
+          )
+        displayName: "Check conda configuration"
+
       # Install Chocolatey (https://chocolatey.org/install#install-with-powershellexe)
       - powershell: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -196,10 +209,12 @@ jobs:
           conda build --python %PYTHON_VERSION% ^
                       conda\win
           copy /y C:\tools\miniconda3\conda-bld\win-64\psi4-*.bz2 $(Build.ArtifactStagingDirectory)
+        condition: and(succeeded(), eq(variables['conda.build'], 'true'))
         displayName: "Build Psi4 package"
 
       # Publish package
       - task: PublishBuildArtifacts@1
         inputs:
           artifactName: conda
+        condition: and(succeeded(), eq(variables['conda.build'], 'true'))
         displayName: "Publish Psi4 package"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,9 @@
 trigger:
   - master
 
+variables:
+  mkl.version: '2018.0.3'
+
 jobs:
 
   # Configure, build, install, and test job
@@ -82,24 +85,31 @@ jobs:
           conda --version
         displayName: "Install Miniconda"
 
+      # Configure Miniconda
+      - script: |
+          conda config --set always_yes yes
+          conda config --append channels conda-forge
+          conda config --append channels psi4
+          conda info
+        displayName: "Configure Miniconda"
+
       # Create conda enviroment
       # Note: conda activate doesn't work here, because it creates a new shell!
       - script: |
-          conda config --set always_yes yes
-          conda install --channel conda-forge ^
-                        cmake ^
+          conda install cmake ^
+                        conda-build ^
+                        conda-verify ^
                         deepdiff ^
-                        intel-openmp=2018.0.3 ^
-                        mkl-devel=2018.0.3 ^
+                        intel-openmp=%MKL_VERSION% ^
+                        mkl-devel=%MKL_VERSION% ^
                         mpmath ^
                         networkx ^
                         ninja ^
                         numpy ^
-                        pint ^
                         pybind11 ^
                         pytest ^
-                        pytest-xdist ^
-                        python=%PYTHON_VERSION%
+                        python=%PYTHON_VERSION% ^
+                        qcelemental
           conda list
         displayName: "Install conda packages"
 
@@ -179,3 +189,17 @@ jobs:
           psi4 --test %PYTEST_TYPE%
         displayName: "Test Psi4 (pytest $(pytest.type))"
         workingDirectory: $(Build.BinariesDirectory)
+
+      # Build package
+      - script: |
+          set INSTALL_DIR=$(Build.BinariesDirectory)\install
+          conda build --python %PYTHON_VERSION% ^
+                      conda\win
+          copy /y C:\tools\miniconda3\conda-bld\win-64\psi4-*.bz2 $(Build.ArtifactStagingDirectory)
+        displayName: "Build Psi4 package"
+
+      # Publish package
+      - task: PublishBuildArtifacts@1
+        inputs:
+          artifactName: conda
+        displayName: "Publish Psi4 package"

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -1,0 +1,39 @@
+{% set data = load_setup_py_data(setup_file='conda/_conda_vers.py') %}
+
+package:
+  name: psi4
+  version: {{ data.get('version') }}
+
+source:
+  path: ../..
+
+requirements:
+  run:
+    - deepdiff
+    - intel-openmp={{ MKL_VERSION }}
+    - mkl={{ MKL_VERSION }}
+    - networkx
+    - numpy
+    - pytest
+    - python={{ PY_VER }}
+    - qcelemental
+
+build:
+  string: py{{ environ['PY_VER'].replace('.', '') }}_{{ 'debug' if environ['CMAKE_BUILD_TYPE'] == 'Debug' else '0' }}
+  script:
+    - echo __pycache__ > exclude.txt
+    - xcopy /f /i /s /exclude:exclude.txt {{INSTALL_DIR}}\lib\psi4 {{SP_DIR}}\psi4
+    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\basis       {{PREFIX}}\Lib\share\psi4\basis
+    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\plugin      {{PREFIX}}\Lib\share\psi4\plugin
+    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\quadratures {{PREFIX}}\Lib\share\psi4\quadratures
+    {% if environ['CMAKE_BUILD_TYPE'] == 'Debug' %}
+    - copy /y {{SYSTEMROOT}}\System32\msvcp140d.dll     {{PREFIX}}
+    - copy /y {{SYSTEMROOT}}\System32\vcomp140d.dll     {{PREFIX}}
+    - copy /y {{SYSTEMROOT}}\System32\vcruntime140d.dll {{PREFIX}}
+    - copy /y {{SYSTEMROOT}}\System32\ucrtbased.dll     {{PREFIX}}
+    {% endif %}
+
+test:
+  commands:
+    - python -c "import psi4; assert psi4.test('quick') == 0"
+    - psi4 --test quick

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 build:
   string: py{{ environ['PY_VER'].replace('.', '') }}_{{ 'debug' if environ['CMAKE_BUILD_TYPE'] == 'Debug' else '0' }}
   script:
+    - copy /y {{INSTALL_DIR}}\bin\psi4     {{PREFIX}}\Scripts
+    - copy /y {{INSTALL_DIR}}\bin\psi4.bat {{PREFIX}}\Scripts
     - echo __pycache__ > exclude.txt
     - xcopy /f /i /s /exclude:exclude.txt {{INSTALL_DIR}}\lib\psi4 {{SP_DIR}}\psi4
     - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\basis       {{PREFIX}}\Lib\share\psi4\basis

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -21,18 +21,18 @@ requirements:
 build:
   string: py{{ environ['PY_VER'].replace('.', '') }}_{{ 'debug' if environ['CMAKE_BUILD_TYPE'] == 'Debug' else '0' }}
   script:
-    - copy /y {{INSTALL_DIR}}\bin\psi4     {{PREFIX}}\Scripts
-    - copy /y {{INSTALL_DIR}}\bin\psi4.bat {{PREFIX}}\Scripts
+    - copy /y {{ INSTALL_DIR }}\bin\psi4     {{ PREFIX }}\Scripts
+    - copy /y {{ INSTALL_DIR }}\bin\psi4.bat {{ PREFIX }}\Scripts
     - echo __pycache__ > exclude.txt
-    - xcopy /f /i /s /exclude:exclude.txt {{INSTALL_DIR}}\lib\psi4 {{SP_DIR}}\psi4
-    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\basis       {{PREFIX}}\Lib\share\psi4\basis
-    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\plugin      {{PREFIX}}\Lib\share\psi4\plugin
-    - xcopy /f /i /s {{INSTALL_DIR}}\share\psi4\quadratures {{PREFIX}}\Lib\share\psi4\quadratures
+    - xcopy /f /i /s /exclude:exclude.txt {{ INSTALL_DIR }}\lib\psi4 {{ SP_DIR }}\psi4
+    - xcopy /f /i /s {{ INSTALL_DIR }}\share\psi4\basis       {{ PREFIX }}\Lib\share\psi4\basis
+    - xcopy /f /i /s {{ INSTALL_DIR }}\share\psi4\plugin      {{ PREFIX }}\Lib\share\psi4\plugin
+    - xcopy /f /i /s {{ INSTALL_DIR }}\share\psi4\quadratures {{ PREFIX }}\Lib\share\psi4\quadratures
     {% if environ['CMAKE_BUILD_TYPE'] == 'Debug' %}
-    - copy /y {{SYSTEMROOT}}\System32\msvcp140d.dll     {{PREFIX}}
-    - copy /y {{SYSTEMROOT}}\System32\vcomp140d.dll     {{PREFIX}}
-    - copy /y {{SYSTEMROOT}}\System32\vcruntime140d.dll {{PREFIX}}
-    - copy /y {{SYSTEMROOT}}\System32\ucrtbased.dll     {{PREFIX}}
+    - copy /y {{ SYSTEMROOT }}\System32\msvcp140d.dll     {{ PREFIX }}
+    - copy /y {{ SYSTEMROOT }}\System32\vcomp140d.dll     {{ PREFIX }}
+    - copy /y {{ SYSTEMROOT }}\System32\vcruntime140d.dll {{ PREFIX }}
+    - copy /y {{ SYSTEMROOT }}\System32\ucrtbased.dll     {{ PREFIX }}
     {% endif %}
 
 test:


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

Enable *conda* package building for *Windows* with *Azure*.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Enable package building
  - [x] Add conda recipe
- [x] Add an option to trigger package building
  - [x] https://dev.azure.com/psi4/psi4 pipeline have to be configured to provide the following variables:
     - `conda.build` with default `false` (settable at queuing time)

## Questions
- [x] Currently, the conda recipe is in `conda/win`. Maybe it should be somewhere in https://github.com/psi4/psi4meta/? --> Recipe will stay in `conda/win`, for now.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
