### PR TITLE
the `parent_symmetry`-ectomy

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1292,7 +1292,7 @@ def hessian(name, **kwargs):
         findif_meta_dict = driver_findif.hessian_from_gradients_geometries(molecule, irrep)
 
         # Record undisplaced symmetry for projection of displaced point groups
-        core.set_parent_symmetry(molecule.schoenflies_symbol())
+        core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())
 
         ndisp = len(findif_meta_dict["displacements"]) + 1
 
@@ -1320,7 +1320,7 @@ def hessian(name, **kwargs):
         core.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
         wfn.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
 
-        core.set_parent_symmetry('')
+        core.set_global_option("PARENT_SYMMETRY", "")
         optstash.restore()
         optstash_conv.restore()
 
@@ -1336,7 +1336,7 @@ def hessian(name, **kwargs):
         findif_meta_dict = driver_findif.hessian_from_energies_geometries(molecule, irrep)
 
         # Record undisplaced symmetry for projection of diplaced point groups
-        core.set_parent_symmetry(molecule.schoenflies_symbol())
+        core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())
 
         ndisp = len(findif_meta_dict["displacements"]) + 1
 
@@ -1363,7 +1363,7 @@ def hessian(name, **kwargs):
         core.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
         wfn.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
 
-        core.set_parent_symmetry('')
+        core.set_global_option("PARENT_SYMMETRY", "")
         optstash.restore()
         optstash_conv.restore()
 

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -276,7 +276,7 @@ class EmpiricalDispersion(object):
         molclone.fix_com(True)
 
         # Record undisplaced symmetry for projection of diplaced point groups
-        core.set_parent_symmetry(molecule.schoenflies_symbol())
+        core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())
 
         findif_meta_dict = driver_findif.hessian_from_gradients_geometries(molclone, -1)
         for displacement in findif_meta_dict["displacements"].values():

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -263,7 +263,7 @@ class EmpiricalDispersion(object):
             (3*nat, 3*nat) dispersion Hessian [Eh/a0/a0].
 
         """
-        optstash = p4util.OptionsState(['PRINT'])
+        optstash = p4util.OptionsState(['PRINT'], ['PARENT_SYMMETRY'])
         core.set_global_option('PRINT', 0)
 
         core.print_out("\n\n   Analytical Dispersion Hessians are not supported by dftd3 or gcp.\n")

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -839,15 +839,6 @@ void py_psi_set_legacy_molecule(std::shared_ptr<Molecule> legacy_molecule) {
     Process::environment.set_legacy_molecule(legacy_molecule);
 }
 
-void py_psi_set_parent_symmetry(std::string pg) {
-    std::shared_ptr<PointGroup> group = std::shared_ptr<PointGroup>();
-    if (pg != "") {
-        group = std::make_shared<PointGroup>(pg);
-    }
-
-    Process::environment.set_parent_symmetry(group);
-}
-
 std::shared_ptr<Molecule> py_psi_get_active_molecule() { return Process::environment.molecule(); }
 std::shared_ptr<Molecule> py_psi_get_legacy_molecule() { return Process::environment.legacy_molecule(); }
 
@@ -1060,9 +1051,6 @@ PYBIND11_MODULE(core, core) {
     core.def("get_num_threads", py_psi_get_n_threads,
              "Returns the number of threads to use in SMP parallel computations.");
     //    core.def("mol_from_file",&LibBabel::ParseFile,"Reads a molecule from another input file");
-    core.def("set_parent_symmetry", py_psi_set_parent_symmetry,
-             "Sets the symmetry of the 'parent' (undisplaced) geometry, by Schoenflies symbol, at the beginning of a "
-             "finite difference computation.");
     core.def("print_options", py_psi_print_options,
              "Prints the currently set options (to the output file) for the current module.");
     core.def("print_global_options", py_psi_print_global_options,

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1143,6 +1143,7 @@ void export_mints(py::module& m) {
         .def("symbol", &PointGroup::symbol, "Returns Schoenflies symbol for point group")
         .def("order", &PointGroup::order, "Return the order of the point group")
         .def("bits", &PointGroup::bits, "Return the bit representation of the point group")
+        .def("full_name", &PointGroup::full_name, "Return the Schoenflies symbol with direction")
         .def("char_table", &PointGroup::char_table, "Return the CharacterTable of the point group");
     // def("origin", &PointGroup::origin).
     //            def("set_symbol", &PointGroup::set_symbol);

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -134,11 +134,11 @@ void export_wavefunction(py::module& m) {
         .def("get_basisset", &Wavefunction::get_basisset, "Returns the requested auxiliary basis.")
         .def("set_basisset", &Wavefunction::set_basisset, "Sets the requested auxiliary basis.")
         .def("energy", &Wavefunction::energy, "Returns the Wavefunction's energy.")
-        .def("set_energy", &Wavefunction::set_energy, "Sets the Wavefunction's energy.")
+        .def("set_energy", &Wavefunction::set_energy, "Sets the Wavefunction's energy. Syncs with Wavefunction's QC variable ``CURRENT ENERGY``.")
         .def("gradient", &Wavefunction::gradient, "Returns the Wavefunction's gradient.")
-        .def("set_gradient", &Wavefunction::set_gradient, "Sets the Wavefunction's gradient.")
+        .def("set_gradient", &Wavefunction::set_gradient, "Sets the Wavefunction's gradient. Syncs with Wavefunction's QC variable ``CURRENT GRADIENT``.")
         .def("hessian", &Wavefunction::hessian, "Returns the Wavefunction's Hessian.")
-        .def("set_hessian", &Wavefunction::set_hessian, "Sets the Wavefunction's Hessian.")
+        .def("set_hessian", &Wavefunction::set_hessian, "Sets the Wavefunction's Hessian. Syncs with Wavefunction's QC variable ``CURRENT HESSIAN``.")
         .def("legacy_frequencies", &Wavefunction::frequencies, "Returns the frequencies of the Hessian.")
         .def("set_legacy_frequencies", &Wavefunction::set_frequencies, "Sets the frequencies of the Hessian.")
         .def("esp_at_nuclei", &Wavefunction::get_esp_at_nuclei, "returns electrostatic potentials at nuclei")
@@ -193,9 +193,9 @@ void export_wavefunction(py::module& m) {
         .def("array_variable", &Wavefunction::array_variable,
              "Returns copy of the requested (case-insensitive) Matrix QC variable.")
         .def("set_scalar_variable", &Wavefunction::set_scalar_variable,
-             "Sets the requested (case-insensitive) double QC variable.")
+             "Sets the requested (case-insensitive) double QC variable. Syncs with ``Wavefunction.energy_`` if CURRENT ENERGY.")
         .def("set_array_variable", &Wavefunction::set_array_variable,
-             "Sets the requested (case-insensitive) Matrix QC variable.")
+             "Sets the requested (case-insensitive) Matrix QC variable. Syncs with ``Wavefunction.gradient_`` or ``hessian_`` if CURRENT GRADIENT or HESSIAN.")
         .def("del_scalar_variable", &Wavefunction::del_scalar_variable,
              "Removes the requested (case-insensitive) double QC variable.")
         .def("del_array_variable", &Wavefunction::del_array_variable,

--- a/psi4/src/psi4/cc/cceom/get_eom_params.cc
+++ b/psi4/src/psi4/cc/cceom/get_eom_params.cc
@@ -77,8 +77,9 @@ void get_eom_params(SharedWavefunction ref_wfn, Options &options) {
     // Number of excited states per irrep
     if (options["ROOTS_PER_IRREP"].has_changed()) {
         // map the symmetry of the input ROOTS_PER_IRREP to account for displacements.
-        std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-        if (old_pg) {
+        auto ps = options.get_str("PARENT_SYMMETRY");
+        if (ps != "") {
+            auto old_pg = std::make_shared<PointGroup> (ps);
             // This is one of a series of displacements;  check the dimension against the parent point group
             size_t full_nirreps = old_pg->char_table().nirrep();
             if (options["ROOTS_PER_IRREP"].size() != full_nirreps)

--- a/psi4/src/psi4/libmints/pointgrp.h
+++ b/psi4/src/psi4/libmints/pointgrp.h
@@ -603,6 +603,8 @@ class PSI_API PointGroup {
 
     /// Returns the CharacterTable for this point group.
     CharacterTable char_table() const;
+    /// Returns the full name of this point group
+    const char* full_name() const { return bits_to_full_name(bits_); }
     /// Returns the order of this point group
     int order() const { return char_table().order(); }
     /// Returns the Schoenflies symbol for this point group.

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1289,21 +1289,18 @@ SharedMatrix Wavefunction::Db() const { return Db_; }
 SharedMatrix Wavefunction::X() const { return Lagrangian_; }
 
 void Wavefunction::set_energy(double ene) {
-    energy_ = ene;
     set_scalar_variable("CURRENT ENERGY", ene);
 }
 
 SharedMatrix Wavefunction::gradient() const { return gradient_; }
 
 void Wavefunction::set_gradient(SharedMatrix grad) {
-    gradient_ = grad;
     set_array_variable("CURRENT GRADIENT", grad);
 }
 
 SharedMatrix Wavefunction::hessian() const { return hessian_; }
 
 void Wavefunction::set_hessian(SharedMatrix hess) {
-    hessian_ = hess;
     set_array_variable("CURRENT HESSIAN", hess);
 }
 
@@ -1393,10 +1390,17 @@ SharedMatrix Wavefunction::array_variable(const std::string &key) {
     }
 }
 
-void Wavefunction::set_scalar_variable(const std::string &key, double val) { variables_[to_upper_copy(key)] = val; }
+void Wavefunction::set_scalar_variable(const std::string &key, double val) {
+    variables_[to_upper_copy(key)] = val;
+
+    if (to_upper_copy(key) == "CURRENT ENERGY") energy_ = val;
+}
 
 void Wavefunction::set_array_variable(const std::string &key, SharedMatrix val) {
     arrays_[to_upper_copy(key)] = val->clone();
+
+    if (to_upper_copy(key) == "CURRENT GRADIENT") gradient_ = val->clone();
+    if (to_upper_copy(key) == "CURRENT HESSIAN") hessian_ = val->clone();
 }
 
 int Wavefunction::del_scalar_variable(const std::string &key) { return variables_.erase(to_upper_copy(key)); }

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -588,9 +588,12 @@ std::array<double, 3> Wavefunction::get_dipole_field_strength() const { return d
 Wavefunction::FieldType Wavefunction::get_dipole_perturbation_type() const { return dipole_field_type_; }
 
 Dimension Wavefunction::map_irreps(const Dimension &dimpi) {
-    std::shared_ptr<PointGroup> full = Process::environment.parent_symmetry();
+    auto ps = options_.get_str("PARENT_SYMMETRY");
+
     // If the parent symmetry hasn't been set, no displacements have been made
-    if (!full) return dimpi;
+    if (ps == "") return dimpi;
+
+    auto full = std::make_shared<PointGroup> (ps);
     std::shared_ptr<PointGroup> sub = molecule_->point_group();
 
     // If the point group between the full and sub are the same return

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -143,8 +143,9 @@ void MOInfo::read_info() {
     std::string wavefunction_sym_str = options.get_str("WFN_SYM");
     bool wfn_sym_found = false;
 
-    std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-    if (old_pg) {
+    auto ps = options.get_str("PARENT_SYMMETRY");
+    if (ps != "") {
+        auto old_pg = std::make_shared<PointGroup> (ps);
         for (int h = 0; h < nirreps; ++h) {
             std::string irr_label_str = old_pg->char_table().gamma(h).symbol_ns();
             trim_spaces(irr_label_str);
@@ -244,8 +245,9 @@ void MOInfo::read_mo_spaces() {
     actv_docc.assign(nirreps, 0);
 
     // Map the symmetry of the input occupations, to account for displacements
-    std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-    if (old_pg) {
+    auto ps = options.get_str("PARENT_SYMMETRY");
+    if (ps != "") {
+        auto old_pg = std::make_shared<PointGroup> (ps);
         // This is one of a series of displacements;  check the dimension against the parent point group
         int nirreps_ref = old_pg->char_table().nirrep();
         intvec focc_ref;
@@ -274,7 +276,7 @@ void MOInfo::read_mo_spaces() {
         read_mo_space(nirreps_ref, nactv, actv_ref, "ACTIVE");
         read_mo_space(nirreps_ref, nfvir, fvir_ref, "FROZEN_UOCC");
 
-        std::shared_ptr<PointGroup> full = Process::environment.parent_symmetry();
+        auto full = std::make_shared<PointGroup> (options.get_str("PARENT_SYMMETRY"));
         std::shared_ptr<PointGroup> sub = ref_wfn.molecule()->point_group();
         // Build the correlation table between full, and subgroup
         CorrelationTable corrtab(full, sub);

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -89,8 +89,9 @@ void MOInfoSCF::read_mo_spaces() {
     actv.resize(nirreps, 0);
 
     // Map the symmetry of the input occupations, to account for displacements
-    std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-    if (old_pg) {
+    auto ps = options.get_str("PARENT_SYMMETRY");
+    if (ps != "") {
+        auto old_pg = std::make_shared<PointGroup> (ps);
         // This is one of a series of displacements;  check the dimension against the parent point group
         int nirreps_ref = old_pg->char_table().nirrep();
 
@@ -101,7 +102,7 @@ void MOInfoSCF::read_mo_spaces() {
         read_mo_space(nirreps_ref, nactv, actv_ref, "SOCC");
 
         // Build the correlation table between full, and subgroup
-        std::shared_ptr<PointGroup> full = Process::environment.parent_symmetry();
+        auto full = std::make_shared<PointGroup> (options.get_str("PARENT_SYMMETRY"));
         std::shared_ptr<PointGroup> sub = ref_wfn.molecule()->point_group();
         CorrelationTable corrtab(full, sub);
 

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -43,9 +43,7 @@ PRAGMA_WARNING_POP
 namespace psi {
 class Molecule;
 class Wavefunction;
-class PointGroup;
 class Matrix;
-class Vector;
 
 class PSI_API Process {
    public:
@@ -57,18 +55,12 @@ class PSI_API Process {
 
         std::shared_ptr<Molecule> molecule_;
         SharedMatrix gradient_;
-        std::shared_ptr<PointGroup> parent_symmetry_;
 
         std::shared_ptr<Molecule> legacy_molecule_;
         std::shared_ptr<Wavefunction> legacy_wavefunction_;
 
        public:
         void initialize();
-
-        /// The symmetry of the molecule, before any displacements have been made
-        std::shared_ptr<PointGroup> parent_symmetry() { return parent_symmetry_; }
-        /// Set the "parent" symmetry
-        void set_parent_symmetry(std::shared_ptr<PointGroup> pg) { parent_symmetry_ = pg; }
 
         /// Set active molecule
         void set_molecule(const std::shared_ptr<Molecule>& molecule);

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -121,8 +121,9 @@ void HF::common_init() {
     if (options_["DOCC"].has_changed()) {
         input_docc_ = true;
         // Map the symmetry of the input DOCC, to account for displacements
-        std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-        if (old_pg) {
+        auto ps = options_.get_str("PARENT_SYMMETRY");
+        if (ps != "") {
+            auto old_pg = std::make_shared<PointGroup> (ps);
             // This is one of a series of displacements;  check the dimension against the parent
             // point group
             size_t full_nirreps = old_pg->char_table().nirrep();
@@ -147,8 +148,9 @@ void HF::common_init() {
     if (options_["SOCC"].has_changed()) {
         input_socc_ = true;
         // Map the symmetry of the input SOCC, to account for displacements
-        std::shared_ptr<PointGroup> old_pg = Process::environment.parent_symmetry();
-        if (old_pg) {
+        auto ps = options_.get_str("PARENT_SYMMETRY");
+        if (ps != "") {
+            auto old_pg = std::make_shared<PointGroup> (ps);
             // This is one of a series of displacements;  check the dimension against the parent
             // point group
             size_t full_nirreps = old_pg->char_table().nirrep();

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -134,6 +134,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     options.add_str("WFN", "SCF");
     /*- Derivative level !expert -*/
     options.add_str("DERTYPE", "NONE", "NONE FIRST SECOND RESPONSE");
+    /*- For displacements, symmetry (Schoenflies symbol) of 'parent' (undisplaced)
+    reference molecule. Internal use only for finite difference. !expert -*/
+    options.add_str("PARENT_SYMMETRY", "");
     /*- Number of columns to print in calls to ``Matrix::print_mat``. !expert -*/
     options.add_int("MAT_NUM_COLUMN_PRINT", 5);
     /*- List of properties to compute -*/

--- a/tests/dft-grad-lr2/output.ref
+++ b/tests/dft-grad-lr2/output.ref
@@ -1,3 +1,39 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4a1.dev53 
+
+                         Git: Rev {d3abc_4} c676b5a dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 11 March 2019 02:23AM
+
+    Process ID: 33582
+    Host:       psinet
+    PSIDATADIR: /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
 #! Tests CAM gradients with and without XC pieces to narrow grid error
 
 func_reference = psi4.Matrix.from_list([                         #TEST
@@ -65,3 +101,6397 @@ anl_grad = gradient('scf', dft_functional="CAM-B3LYP", dertype=1)
 fd_grad = gradient('scf', dft_functional="CAM-B3LYP", dertype=0)
 compare_matrices(cam_b3lyp_uks_reference, anl_grad, 6, "Analytic vs Reference CAM Gradients")    #TEST
 compare_matrices(anl_grad, fd_grad, 4, "Analytic vs FD CAM Gradients")    #TEST
+--------------------------------------------------------------------------
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:27 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42342033681894   -9.64234e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86356535920473   -4.40145e-01   1.44285e-02 DIIS
+   @DF-RKS iter   2:   -96.88059964170004   -1.70343e-02   4.79424e-03 DIIS
+   @DF-RKS iter   3:   -96.88153187827078   -9.32237e-04   1.54835e-03 DIIS
+   @DF-RKS iter   4:   -96.88172203635345   -1.90158e-04   9.31802e-04 DIIS
+   @DF-RKS iter   5:   -96.88177395664725   -5.19203e-05   1.07742e-04 DIIS
+   @DF-RKS iter   6:   -96.88177615248357   -2.19584e-06   1.17741e-05 DIIS
+   @DF-RKS iter   7:   -96.88177617479921   -2.23156e-08   1.32569e-06 DIIS
+   @DF-RKS iter   8:   -96.88177617499976   -2.00544e-10   1.02337e-07 DIIS
+   @DF-RKS iter   9:   -96.88177617500075   -9.94760e-13   5.60290e-09 DIIS
+   @DF-RKS iter  10:   -96.88177617500060    1.56319e-13   6.27139e-10 DIIS
+   @DF-RKS iter  11:   -96.88177617500074   -1.42109e-13   4.67029e-11 DIIS
+   @DF-RKS iter  12:   -96.88177617500068    5.68434e-14   2.19491e-12 DIIS
+   @DF-RKS iter  13:   -96.88177617500071   -2.84217e-14   2.68793e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.640199     2A1    -1.300098     3A1    -0.578951  
+       1B2    -0.481353     1B1    -0.481353  
+
+    Virtual:                                                              
+
+       4A1     0.172634     5A1     0.719109     2B1     1.384830  
+       2B2     1.384830     6A1     1.497326     3B1     1.646535  
+       3B2     1.646535     7A1     2.040388     8A1     2.247063  
+       9A1     4.018631     1A2     4.018631     4B1     4.123888  
+       4B2     4.123888    10A1     4.754458  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88177617500071
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -147.4589088571268292
+    Two-Electron Energy =                  46.2475009584624885
+    Total Energy =                        -96.8817761750007094
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3280
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7036     Total:     0.7036
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7883     Total:     1.7883
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:28 2019
+Module time:
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:28 2019
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Nuclear repulsion =    4.329631723663637
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000    -0.052360090710
+       2        0.000000000000     0.000000000000     0.052360090710
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:28 2019
+Module time:
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.08 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients.
+    Generating geometries for use with 5-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 2.
+    Number of symmetric SALCs is 1.
+    Translations projected? 1. Rotations projected? 1.
+    Number of geometries (including reference) is 5.
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:28 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42342033681895   -9.64234e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86356535920478   -4.40145e-01   1.44285e-02 DIIS
+   @DF-RKS iter   2:   -96.88059964170016   -1.70343e-02   4.79424e-03 DIIS
+   @DF-RKS iter   3:   -96.88153187827091   -9.32237e-04   1.54835e-03 DIIS
+   @DF-RKS iter   4:   -96.88172203635361   -1.90158e-04   9.31802e-04 DIIS
+   @DF-RKS iter   5:   -96.88177395664734   -5.19203e-05   1.07742e-04 DIIS
+   @DF-RKS iter   6:   -96.88177615248365   -2.19584e-06   1.17741e-05 DIIS
+   @DF-RKS iter   7:   -96.88177617479931   -2.23157e-08   1.32569e-06 DIIS
+   @DF-RKS iter   8:   -96.88177617499981   -2.00501e-10   1.02337e-07 DIIS
+   @DF-RKS iter   9:   -96.88177617500085   -1.03739e-12   5.60290e-09 DIIS
+   @DF-RKS iter  10:   -96.88177617500079    5.68434e-14   6.27139e-10 DIIS
+   @DF-RKS iter  11:   -96.88177617500079    0.00000e+00   4.67030e-11 DIIS
+   @DF-RKS iter  12:   -96.88177617500077    2.84217e-14   2.19386e-12 DIIS
+   @DF-RKS iter  13:   -96.88177617500081   -4.26326e-14   2.68353e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.640199     2A1    -1.300098     3A1    -0.578951  
+       1B2    -0.481353     1B1    -0.481353  
+
+    Virtual:                                                              
+
+       4A1     0.172634     5A1     0.719109     2B2     1.384830  
+       2B1     1.384830     6A1     1.497326     3B1     1.646535  
+       3B2     1.646535     7A1     2.040388     8A1     2.247063  
+       9A1     4.018631     1A2     4.018631     4B1     4.123888  
+       4B2     4.123888    10A1     4.754458  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88177617500081
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -147.4589088571269144
+    Two-Electron Energy =                  46.2475009584624672
+    Total Energy =                        -96.8817761750008231
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3280
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7036     Total:     0.7036
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7883     Total:     1.7883
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:29 2019
+Module time:
+	user time   =       0.82 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.16 seconds =       0.04 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:29 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.049723582969     1.007825032230
+         F            0.000000000000     0.000000000000     0.055685611826    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.41496  C =     14.41496 [cm^-1]
+  Rotational constants: A = ************  B = 432149.51645  C = 432149.51645 [MHz]
+  Nuclear repulsion =    4.308445160807890
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.5761063924E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42019523798130   -9.64202e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86282301824362   -4.42628e-01   1.44526e-02 DIIS
+   @DF-RKS iter   2:   -96.88002470923190   -1.72017e-02   4.85168e-03 DIIS
+   @DF-RKS iter   3:   -96.88097746996563   -9.52761e-04   1.57533e-03 DIIS
+   @DF-RKS iter   4:   -96.88117388062624   -1.96411e-04   9.43822e-04 DIIS
+   @DF-RKS iter   5:   -96.88122735141761   -5.34708e-05   1.08523e-04 DIIS
+   @DF-RKS iter   6:   -96.88122957158066   -2.22016e-06   1.17121e-05 DIIS
+   @DF-RKS iter   7:   -96.88122959357659   -2.19959e-08   1.32095e-06 DIIS
+   @DF-RKS iter   8:   -96.88122959377543   -1.98838e-10   1.03405e-07 DIIS
+   @DF-RKS iter   9:   -96.88122959377624   -8.10019e-13   5.65005e-09 DIIS
+   @DF-RKS iter  10:   -96.88122959377621    2.84217e-14   6.43806e-10 DIIS
+   @DF-RKS iter  11:   -96.88122959377630   -8.52651e-14   4.67932e-11 DIIS
+   @DF-RKS iter  12:   -96.88122959377628    1.42109e-14   2.42350e-12 DIIS
+   @DF-RKS iter  13:   -96.88122959377625    2.84217e-14   3.17456e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.640594     2A1    -1.299341     3A1    -0.577839  
+       1B2    -0.481256     1B1    -0.481256  
+
+    Virtual:                                                              
+
+       4A1     0.171438     5A1     0.716248     2B2     1.383400  
+       2B1     1.383400     6A1     1.499393     3B2     1.646925  
+       3B1     1.646925     7A1     2.031144     8A1     2.247283  
+       1A2     4.018725     9A1     4.018725     4B2     4.120518  
+       4B1     4.120518    10A1     4.745844  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88122959377625
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3084451608078895
+    One-Electron Energy =                -147.4187754358310940
+    Two-Electron Energy =                  46.2291006812469689
+    Total Energy =                        -96.8812295937762542
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0366
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3323
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7044     Total:     0.7044
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7903     Total:     1.7903
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:30 2019
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.97 seconds =       0.05 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:30 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.047155231191     1.007825032230
+         F            0.000000000000     0.000000000000     0.055549366207    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.48575  C =     14.48575 [cm^-1]
+  Rotational constants: A = ************  B = 434271.97754  C = 434271.97754 [MHz]
+  Nuclear repulsion =    4.319012460153662
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.5349079623E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42180566988758   -9.64218e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86319721873610   -4.41392e-01   1.44406e-02 DIIS
+   @DF-RKS iter   2:   -96.88031509987589   -1.71179e-02   4.82275e-03 DIIS
+   @DF-RKS iter   3:   -96.88125752512195   -9.42425e-04   1.56177e-03 DIIS
+   @DF-RKS iter   4:   -96.88145078367245   -1.93259e-04   9.37813e-04 DIIS
+   @DF-RKS iter   5:   -96.88150347646297   -5.26928e-05   1.08135e-04 DIIS
+   @DF-RKS iter   6:   -96.88150568460470   -2.20814e-06   1.17433e-05 DIIS
+   @DF-RKS iter   7:   -96.88150570676072   -2.21560e-08   1.32339e-06 DIIS
+   @DF-RKS iter   8:   -96.88150570696038   -1.99663e-10   1.02873e-07 DIIS
+   @DF-RKS iter   9:   -96.88150570696128   -8.95284e-13   5.62630e-09 DIIS
+   @DF-RKS iter  10:   -96.88150570696132   -4.26326e-14   6.35434e-10 DIIS
+   @DF-RKS iter  11:   -96.88150570696124    8.52651e-14   4.67261e-11 DIIS
+   @DF-RKS iter  12:   -96.88150570696135   -1.13687e-13   2.30716e-12 DIIS
+   @DF-RKS iter  13:   -96.88150570696129    5.68434e-14   2.93247e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.640396     2A1    -1.299718     3A1    -0.578394  
+       1B1    -0.481304     1B2    -0.481304  
+
+    Virtual:                                                              
+
+       4A1     0.172037     5A1     0.717671     2B1     1.384111  
+       2B2     1.384111     6A1     1.498359     3B1     1.646733  
+       3B2     1.646733     7A1     2.035773     8A1     2.247152  
+       9A1     4.018679     1A2     4.018679     4B2     4.122196  
+       4B1     4.122196    10A1     4.750153  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88150570696129
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3190124601536617
+    One-Electron Energy =                -147.4388039506651182
+    Two-Electron Energy =                  46.2382857835501611
+    Total Energy =                        -96.8815057069612919
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0341
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3301
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7040     Total:     0.7040
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7893     Total:     1.7893
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:30 2019
+Module time:
+	user time   =       0.68 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.66 seconds =       0.06 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:30 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.042018527635     1.007825032230
+         F            0.000000000000     0.000000000000     0.055276874967    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.62892  C =     14.62892 [cm^-1]
+  Rotational constants: A = ************  B = 438564.07910  C = 438564.07910 [MHz]
+  Nuclear repulsion =    4.340303335579315
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4526910545E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42503917113682   -9.64250e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86392733548537   -4.38888e-01   1.44161e-02 DIIS
+   @DF-RKS iter   2:   -96.88087822981505   -1.69509e-02   4.76616e-03 DIIS
+   @DF-RKS iter   3:   -96.88180042194331   -9.22192e-04   1.53506e-03 DIIS
+   @DF-RKS iter   4:   -96.88198753080650   -1.87109e-04   9.25791e-04 DIIS
+   @DF-RKS iter   5:   -96.88203868427897   -5.11535e-05   1.07344e-04 DIIS
+   @DF-RKS iter   6:   -96.88204086752711   -2.18325e-06   1.18044e-05 DIIS
+   @DF-RKS iter   7:   -96.88204089000158   -2.24745e-08   1.32784e-06 DIIS
+   @DF-RKS iter   8:   -96.88204089020309   -2.01510e-10   1.01797e-07 DIIS
+   @DF-RKS iter   9:   -96.88204089020397   -8.81073e-13   5.57985e-09 DIIS
+   @DF-RKS iter  10:   -96.88204089020381    1.56319e-13   6.18930e-10 DIIS
+   @DF-RKS iter  11:   -96.88204089020395   -1.42109e-13   4.67241e-11 DIIS
+   @DF-RKS iter  12:   -96.88204089020404   -8.52651e-14   2.08993e-12 DIIS
+   @DF-RKS iter  13:   -96.88204089020391    1.27898e-13   2.45903e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.640001     2A1    -1.300484     3A1    -0.579509  
+       1B1    -0.481402     1B2    -0.481402  
+
+    Virtual:                                                              
+
+       4A1     0.173228     5A1     0.720562     2B2     1.385555  
+       2B1     1.385555     6A1     1.496292     3B2     1.646331  
+       3B1     1.646331     7A1     2.044985     8A1     2.247020  
+       1A2     4.018582     9A1     4.018582     4B2     4.125596  
+       4B1     4.125596    10A1     4.758758  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88204089020391
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3403033355793150
+    One-Electron Energy =                -147.4790905867248512
+    Two-Electron Energy =                  46.2567463609416336
+    Total Energy =                        -96.8820408902039105
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0290
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3259
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7031     Total:     0.7031
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7872     Total:     1.7872
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:31 2019
+Module time:
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.37 seconds =       0.07 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:31 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.039450175857     1.007825032230
+         F            0.000000000000     0.000000000000     0.055140629347    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.70130  C =     14.70130 [cm^-1]
+  Rotational constants: A = ************  B = 440734.03094  C = 440734.03094 [MHz]
+  Nuclear repulsion =    4.351027683939847
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4116754919E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -96.42666210338442   -9.64267e+01   0.00000e+00 
+   @DF-RKS iter   1:   -96.86428304153270   -4.37621e-01   1.44036e-02 DIIS
+   @DF-RKS iter   2:   -96.88115075745515   -1.68677e-02   4.73850e-03 DIIS
+   @DF-RKS iter   3:   -96.88206304687884   -9.12289e-04   1.52193e-03 DIIS
+   @DF-RKS iter   4:   -96.88224715735038   -1.84110e-04   9.19781e-04 DIIS
+   @DF-RKS iter   5:   -96.88229754984580   -5.03925e-05   1.06940e-04 DIIS
+   @DF-RKS iter   6:   -96.88229972022430   -2.17038e-06   1.18343e-05 DIIS
+   @DF-RKS iter   7:   -96.88229974285714   -2.26328e-08   1.32985e-06 DIIS
+   @DF-RKS iter   8:   -96.88229974305949   -2.02348e-10   1.01252e-07 DIIS
+   @DF-RKS iter   9:   -96.88229974306027   -7.81597e-13   5.55720e-09 DIIS
+   @DF-RKS iter  10:   -96.88229974306030   -2.84217e-14   6.10814e-10 DIIS
+   @DF-RKS iter  11:   -96.88229974306020    9.94760e-14   4.67925e-11 DIIS
+   @DF-RKS iter  12:   -96.88229974306020    0.00000e+00   1.99374e-12 DIIS
+   @DF-RKS iter  13:   -96.88229974306020    0.00000e+00   2.24599e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.639803     2A1    -1.300873     3A1    -0.580069  
+       1B2    -0.481454     1B1    -0.481454  
+
+    Virtual:                                                              
+
+       4A1     0.173821     5A1     0.722031     2B2     1.386286  
+       2B1     1.386286     6A1     1.495258     3B2     1.646122  
+       3B1     1.646122     7A1     2.049562     8A1     2.247026  
+       9A1     4.018532     1A2     4.018532     4B2     4.127317  
+       4B1     4.127317    10A1     4.763053  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:   -96.88229974306020
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3510276839398472
+    One-Electron Energy =                -147.4993495748707915
+    Two-Electron Energy =                  46.2660221478707427
+    Total Energy =                        -96.8822997430602157
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0265
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.3237
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7027     Total:     0.7027
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.7862     Total:     1.7862
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:32 2019
+Module time:
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.12 seconds =       0.09 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing gradient from energies.
+    Using 5-point formula.
+    Energy without displacement:  -96.8817761750
+    Check energies below for precision!
+    Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+     Coord      Energy(-2)        Energy(-1)        Energy(+1)        Energy(+2)            Force
+        0    -96.8812295938    -96.8815057070    -96.8820408902    -96.8822997431     -0.0535219443
+
+
+-------------------------------------------------------------
+  ## New Matrix (Symmetry 0) ##
+  Irrep: 1 Size: 2 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000    -0.05236009102059
+    2     0.00000000000000     0.00000000000000     0.05236009102059
+
+
+
+	Analytic vs Reference CAM-like Gradients..........................PASSED
+	Analytic vs FD CAM Gradients......................................PASSED
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:32 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.04143545011765   -1.00041e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32807610201343   -2.86641e-01   3.43752e-02 DIIS
+   @DF-RKS iter   2:  -100.31043088729491    1.76452e-02   4.37079e-02 DIIS
+   @DF-RKS iter   3:  -100.38759542601547   -7.71645e-02   1.39999e-03 DIIS
+   @DF-RKS iter   4:  -100.38766720596520   -7.17799e-05   4.18042e-04 DIIS
+   @DF-RKS iter   5:  -100.38767477716073   -7.57120e-06   3.64166e-05 DIIS
+   @DF-RKS iter   6:  -100.38767485425745   -7.70967e-08   1.88346e-06 DIIS
+   @DF-RKS iter   7:  -100.38767485487355   -6.16097e-10   3.43279e-07 DIIS
+   @DF-RKS iter   8:  -100.38767485488242   -8.86757e-12   2.49674e-08 DIIS
+   @DF-RKS iter   9:  -100.38767485488241    1.42109e-14   1.35474e-09 DIIS
+   @DF-RKS iter  10:  -100.38767485488239    1.42109e-14   2.22515e-11 DIIS
+   @DF-RKS iter  11:  -100.38767485488235    4.26326e-14   2.10677e-12 DIIS
+   @DF-RKS iter  12:  -100.38767485488235    0.00000e+00   4.78091e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737873     2A1    -1.206971     3A1    -0.550760  
+       1B2    -0.437923     1B1    -0.437923  
+
+    Virtual:                                                              
+
+       4A1     0.043325     5A1     0.523490     2B1     1.145603  
+       2B2     1.145603     6A1     1.267129     3B1     1.437235  
+       3B2     1.437235     7A1     1.765664     8A1     2.008506  
+       9A1     3.691382     1A2     3.691382     4B1     3.796435  
+       4B2     3.796435    10A1     4.418151  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38767485488235
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -149.2031835845796479
+    Two-Electron Energy =                  52.4750713046190569
+    DFT Exchange-Correlation Energy =      -7.9891942985853870
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3876748548823485
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2107
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8208     Total:     0.8208
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0863     Total:     2.0863
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:36 2019
+Module time:
+	user time   =       4.25 seconds =       0.07 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =       9.40 seconds =       0.16 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:36 2019
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Nuclear repulsion =    4.329631723663637
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000    -0.109138076559
+       2        0.000000000000     0.000000000000     0.109137315414
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:37 2019
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      10.06 seconds =       0.17 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients.
+    Generating geometries for use with 5-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 2.
+    Number of symmetric SALCs is 1.
+    Translations projected? 1. Rotations projected? 1.
+    Number of geometries (including reference) is 5.
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:37 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.04143545011765   -1.00041e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32807610201343   -2.86641e-01   3.43752e-02 DIIS
+   @DF-RKS iter   2:  -100.31043088729491    1.76452e-02   4.37079e-02 DIIS
+   @DF-RKS iter   3:  -100.38759542601552   -7.71645e-02   1.39999e-03 DIIS
+   @DF-RKS iter   4:  -100.38766720596520   -7.17799e-05   4.18042e-04 DIIS
+   @DF-RKS iter   5:  -100.38767477716068   -7.57120e-06   3.64166e-05 DIIS
+   @DF-RKS iter   6:  -100.38767485425730   -7.70966e-08   1.88346e-06 DIIS
+   @DF-RKS iter   7:  -100.38767485487352   -6.16225e-10   3.43279e-07 DIIS
+   @DF-RKS iter   8:  -100.38767485488243   -8.91021e-12   2.49674e-08 DIIS
+   @DF-RKS iter   9:  -100.38767485488243    0.00000e+00   1.35474e-09 DIIS
+   @DF-RKS iter  10:  -100.38767485488246   -2.84217e-14   2.22517e-11 DIIS
+   @DF-RKS iter  11:  -100.38767485488235    1.13687e-13   2.10653e-12 DIIS
+   @DF-RKS iter  12:  -100.38767485488236   -1.42109e-14   4.79883e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737873     2A1    -1.206971     3A1    -0.550760  
+       1B2    -0.437923     1B1    -0.437923  
+
+    Virtual:                                                              
+
+       4A1     0.043325     5A1     0.523490     2B1     1.145603  
+       2B2     1.145603     6A1     1.267129     3B1     1.437235  
+       3B2     1.437235     7A1     1.765664     8A1     2.008506  
+       9A1     3.691382     1A2     3.691382     4B1     3.796435  
+       4B2     3.796435    10A1     4.418151  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38767485488236
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -149.2031835845796763
+    Two-Electron Energy =                  52.4750713046190711
+    DFT Exchange-Correlation Energy =      -7.9891942985853888
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3876748548823770
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2107
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8208     Total:     0.8208
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0863     Total:     2.0863
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:41 2019
+Module time:
+	user time   =       4.19 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      14.27 seconds =       0.24 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:41 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.049723582969     1.007825032230
+         F            0.000000000000     0.000000000000     0.055685611826    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.41496  C =     14.41496 [cm^-1]
+  Rotational constants: A = ************  B = 432149.51645  C = 432149.51645 [MHz]
+  Nuclear repulsion =    4.308445160807890
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            804
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.5761063924E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.03858476069939   -1.00039e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32644646587063   -2.87862e-01   3.44462e-02 DIIS
+   @DF-RKS iter   2:  -100.30800837039322    1.84381e-02   4.40307e-02 DIIS
+   @DF-RKS iter   3:  -100.38646975926682   -7.84614e-02   1.42024e-03 DIIS
+   @DF-RKS iter   4:  -100.38654356982997   -7.38106e-05   4.25618e-04 DIIS
+   @DF-RKS iter   5:  -100.38655138329516   -7.81347e-06   3.73246e-05 DIIS
+   @DF-RKS iter   6:  -100.38655146343621   -8.01410e-08   1.92289e-06 DIIS
+   @DF-RKS iter   7:  -100.38655146408016   -6.43951e-10   3.52009e-07 DIIS
+   @DF-RKS iter   8:  -100.38655146408942   -9.26548e-12   2.54444e-08 DIIS
+   @DF-RKS iter   9:  -100.38655146408951   -8.52651e-14   1.38648e-09 DIIS
+   @DF-RKS iter  10:  -100.38655146408952   -1.42109e-14   2.28032e-11 DIIS
+   @DF-RKS iter  11:  -100.38655146408949    2.84217e-14   2.16439e-12 DIIS
+   @DF-RKS iter  12:  -100.38655146408946    2.84217e-14   4.91461e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737944     2A1    -1.205988     3A1    -0.549676  
+       1B2    -0.437584     1B1    -0.437584  
+
+    Virtual:                                                              
+
+       4A1     0.041565     5A1     0.521275     2B1     1.144702  
+       2B2     1.144702     6A1     1.268955     3B2     1.437434  
+       3B1     1.437434     7A1     1.757451     8A1     2.008549  
+       9A1     3.691711     1A2     3.691711     4B2     3.793386  
+       4B1     3.793386    10A1     4.409955  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38655146408946
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3084451608078895
+    One-Electron Energy =                -149.1648416973565929
+    Two-Electron Energy =                  52.4576205974272227
+    DFT Exchange-Correlation Energy =      -7.9877755249679732
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3865514640894645
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0366
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2130
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8236     Total:     0.8236
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0934     Total:     2.0934
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:45 2019
+Module time:
+	user time   =       4.04 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      18.32 seconds =       0.31 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         18 seconds =       0.30 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:45 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.047155231191     1.007825032230
+         F            0.000000000000     0.000000000000     0.055549366207    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.48575  C =     14.48575 [cm^-1]
+  Rotational constants: A = ************  B = 434271.97754  C = 434271.97754 [MHz]
+  Nuclear repulsion =    4.319012460153662
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            803
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.5349079623E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.04000842524209   -1.00040e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32726436756043   -2.87256e-01   3.44105e-02 DIIS
+   @DF-RKS iter   2:  -100.30922571322172    1.80387e-02   4.38686e-02 DIIS
+   @DF-RKS iter   3:  -100.38703453388369   -7.78088e-02   1.41007e-03 DIIS
+   @DF-RKS iter   4:  -100.38710732086615   -7.27870e-05   4.21823e-04 DIIS
+   @DF-RKS iter   5:  -100.38711501247352   -7.69161e-06   3.68678e-05 DIIS
+   @DF-RKS iter   6:  -100.38711509107574   -7.86022e-08   1.90298e-06 DIIS
+   @DF-RKS iter   7:  -100.38711509170552   -6.29782e-10   3.47623e-07 DIIS
+   @DF-RKS iter   8:  -100.38711509171453   -9.00968e-12   2.52047e-08 DIIS
+   @DF-RKS iter   9:  -100.38711509171456   -2.84217e-14   1.37060e-09 DIIS
+   @DF-RKS iter  10:  -100.38711509171461   -4.26326e-14   2.25271e-11 DIIS
+   @DF-RKS iter  11:  -100.38711509171462   -1.42109e-14   2.13521e-12 DIIS
+   @DF-RKS iter  12:  -100.38711509171463   -1.42109e-14   4.79619e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737908     2A1    -1.206477     3A1    -0.550217  
+       1B1    -0.437753     1B2    -0.437753  
+
+    Virtual:                                                              
+
+       4A1     0.042446     5A1     0.522375     2B1     1.145150  
+       2B2     1.145150     6A1     1.268042     3B1     1.437336  
+       3B2     1.437336     7A1     1.761565     8A1     2.008507  
+       9A1     3.691547     1A2     3.691547     4B2     3.794903  
+       4B1     3.794903    10A1     4.414055  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38711509171463
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3190124601536617
+    One-Electron Energy =                -149.1839734175619867
+    Two-Electron Energy =                  52.4663288504188259
+    DFT Exchange-Correlation Energy =      -7.9884829847251302
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3871150917146338
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0341
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2119
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8222     Total:     0.8222
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0899     Total:     2.0899
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:49 2019
+Module time:
+	user time   =       4.16 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      22.49 seconds =       0.37 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:49 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.042018527635     1.007825032230
+         F            0.000000000000     0.000000000000     0.055276874967    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.62892  C =     14.62892 [cm^-1]
+  Rotational constants: A = ************  B = 438564.07910  C = 438564.07910 [MHz]
+  Nuclear repulsion =    4.340303335579315
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4526910545E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.04286576744917   -1.00043e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32888157155131   -2.86016e-01   3.43403e-02 DIIS
+   @DF-RKS iter   2:  -100.31162388164653    1.72577e-02   4.35485e-02 DIIS
+   @DF-RKS iter   3:  -100.38815234119244   -7.65285e-02   1.39001e-03 DIIS
+   @DF-RKS iter   4:  -100.38822313036839   -7.07892e-05   4.14277e-04 DIIS
+   @DF-RKS iter   5:  -100.38823058257591   -7.45221e-06   3.59709e-05 DIIS
+   @DF-RKS iter   6:  -100.38823065819999   -7.56241e-08   1.86433e-06 DIIS
+   @DF-RKS iter   7:  -100.38823065880284   -6.02853e-10   3.38978e-07 DIIS
+   @DF-RKS iter   8:  -100.38823065881154   -8.69704e-12   2.47323e-08 DIIS
+   @DF-RKS iter   9:  -100.38823065881157   -2.84217e-14   1.33890e-09 DIIS
+   @DF-RKS iter  10:  -100.38823065881149    7.10543e-14   2.19744e-11 DIIS
+   @DF-RKS iter  11:  -100.38823065881161   -1.13687e-13   2.07727e-12 DIIS
+   @DF-RKS iter  12:  -100.38823065881147    1.42109e-13   4.87288e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737838     2A1    -1.207469     3A1    -0.551303  
+       1B1    -0.438095     1B2    -0.438095  
+
+    Virtual:                                                              
+
+       4A1     0.044203     5A1     0.524619     2B2     1.146061  
+       2B1     1.146061     6A1     1.266217     3B2     1.437129  
+       3B1     1.437129     7A1     1.769745     8A1     2.008550  
+       9A1     3.691216     1A2     3.691216     4B2     3.797982  
+       4B1     3.797982    10A1     4.422241  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38823065881147
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3403033355793150
+    One-Electron Energy =                -149.2224726749248020
+    Two-Electron Energy =                  52.4838481732652014
+    DFT Exchange-Correlation Energy =      -7.9899094927311749
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3882306588114659
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0290
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2096
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8194     Total:     0.8194
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0828     Total:     2.0828
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:54 2019
+Module time:
+	user time   =       4.16 seconds =       0.07 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =      26.66 seconds =       0.44 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         27 seconds =       0.45 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:54 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.039450175857     1.007825032230
+         F            0.000000000000     0.000000000000     0.055140629347    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.70130  C =     14.70130 [cm^-1]
+  Rotational constants: A = ************  B = 440734.03094  C = 440734.03094 [MHz]
+  Nuclear repulsion =    4.351027683939847
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            804
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4116754919E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:  -100.04429930759193   -1.00044e+02   0.00000e+00 
+   @DF-RKS iter   1:  -100.32968067676784   -2.85381e-01   3.43059e-02 DIIS
+   @DF-RKS iter   2:  -100.31280468272350    1.68760e-02   4.33903e-02 DIIS
+   @DF-RKS iter   3:  -100.38870518328791   -7.59005e-02   1.38011e-03 DIIS
+   @DF-RKS iter   4:  -100.38877499766298   -6.98144e-05   4.10527e-04 DIIS
+   @DF-RKS iter   5:  -100.38878233228505   -7.33462e-06   3.55307e-05 DIIS
+   @DF-RKS iter   6:  -100.38878240646862   -7.41836e-08   1.84558e-06 DIIS
+   @DF-RKS iter   7:  -100.38878240705864   -5.90020e-10   3.34719e-07 DIIS
+   @DF-RKS iter   8:  -100.38878240706705   -8.41283e-12   2.44992e-08 DIIS
+   @DF-RKS iter   9:  -100.38878240706705    0.00000e+00   1.32308e-09 DIIS
+   @DF-RKS iter  10:  -100.38878240706710   -4.26326e-14   2.16957e-11 DIIS
+   @DF-RKS iter  11:  -100.38878240706701    8.52651e-14   2.04688e-12 DIIS
+   @DF-RKS iter  12:  -100.38878240706698    2.84217e-14   4.61266e-14 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -24.737802     2A1    -1.207971     3A1    -0.551849  
+       1B2    -0.438267     1B1    -0.438267  
+
+    Virtual:                                                              
+
+       4A1     0.045080     5A1     0.525763     2B2     1.146523  
+       2B1     1.146523     6A1     1.265305     3B2     1.437019  
+       3B1     1.437019     7A1     1.773806     8A1     2.008641  
+       1A2     3.691048     9A1     3.691048     4B2     3.799543  
+       4B1     3.799543    10A1     4.426326  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RKS Final Energy:  -100.38878240706698
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3510276839398472
+    One-Electron Energy =                -149.2418411691959079
+    Two-Electron Energy =                  52.4926596718021088
+    DFT Exchange-Correlation Energy =      -7.9906285936130530
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -100.3887824070669978
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0265
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2085
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.8180     Total:     0.8180
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.0792     Total:     2.0792
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:58 2019
+Module time:
+	user time   =       4.21 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      30.88 seconds =       0.51 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing gradient from energies.
+    Using 5-point formula.
+    Energy without displacement: -100.3876748549
+    Check energies below for precision!
+    Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+     Coord      Energy(-2)        Energy(-1)        Energy(+1)        Energy(+2)            Force
+        0   -100.3865514641   -100.3871150917   -100.3882306588   -100.3887824071     -0.1115598966
+
+
+-------------------------------------------------------------
+  ## New Matrix (Symmetry 0) ##
+  Irrep: 1 Size: 2 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000    -0.10913815668640
+    2     0.00000000000000     0.00000000000000     0.10913815668640
+
+
+
+	Analytic vs Reference CAM Gradients...............................PASSED
+	Analytic vs FD CAM Gradients......................................PASSED
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients.
+    Generating geometries for use with 5-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 2.
+    Number of symmetric SALCs is 1.
+    Translations projected? 1. Rotations projected? 1.
+    Number of geometries (including reference) is 5.
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:58 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42342033681894   -9.64234e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33350242414765    8.99179e-02   4.99792e-02 DIIS
+   @DF-UKS iter   2:   -96.40904876698995   -7.55463e-02   2.77745e-02 DIIS
+   @DF-UKS iter   3:   -96.43998780728882   -3.09390e-02   1.84080e-03 DIIS
+   @DF-UKS iter   4:   -96.44020562511341   -2.17818e-04   4.00194e-04 DIIS
+   @DF-UKS iter   5:   -96.44022445345007   -1.88283e-05   1.50706e-04 DIIS
+   @DF-UKS iter   6:   -96.44022907453538   -4.62109e-06   5.75511e-05 DIIS
+   @DF-UKS iter   7:   -96.44023003872657   -9.64191e-07   1.07967e-05 DIIS
+   @DF-UKS iter   8:   -96.44023007000121   -3.12746e-08   1.76517e-06 DIIS
+   @DF-UKS iter   9:   -96.44023007047485   -4.73648e-10   1.78577e-07 DIIS
+   @DF-UKS iter  10:   -96.44023007047784   -2.98428e-12   2.55525e-08 DIIS
+   @DF-UKS iter  11:   -96.44023007047794   -9.94760e-14   1.92545e-09 DIIS
+   @DF-UKS iter  12:   -96.44023007047790    4.26326e-14   2.26133e-10 DIIS
+   @DF-UKS iter  13:   -96.44023007047790    0.00000e+00   3.80008e-11 DIIS
+   @DF-UKS iter  14:   -96.44023007047794   -4.26326e-14   4.22400e-12 DIIS
+   @DF-UKS iter  15:   -96.44023007047792    1.42109e-14   4.36502e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.474684081E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514746841E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.284307     2A1    -1.918871     1B1    -1.152639  
+       3A1    -1.139593     1B2    -1.055268  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.206135     5A1     0.306250     2B1     0.844797  
+       2B2     0.894236     6A1     1.017573     3B1     1.165731  
+       3B2     1.192403     7A1     1.523563     8A1     1.747834  
+       9A1     3.375118     1A2     3.375664     4B1     3.489727  
+       4B2     3.560464    10A1     4.185731  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.256279     2A1    -1.808613     3A1    -1.111315  
+       1B2    -1.025895  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.409493     4A1    -0.198056     5A1     0.308815  
+       2B2     0.903257     2B1     0.940241     6A1     1.032909  
+       3B2     1.195540     3B1     1.203380     7A1     1.545877  
+       8A1     1.766363     1A2     3.459453     9A1     3.459568  
+       4B1     3.569597     4B2     3.572743    10A1     4.214029  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -96.44023007047792
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -141.7869432986267384
+    Two-Electron Energy =                  41.0170815044851764
+    Total Energy =                        -96.4402300704779378
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998126
+  HONO-1 :    3 A1 1.9994843
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0005157
+  LUNO+1 :    5 A1 0.0001874
+  LUNO+2 :    2 B2 0.0000343
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0692
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1007     Total:     1.1007
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.7978     Total:     2.7978
+
+
+*** tstop() called on psinet at Mon Mar 11 02:23:59 2019
+Module time:
+	user time   =       0.77 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      31.67 seconds =       0.53 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         32 seconds =       0.53 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:23:59 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.049723582969     1.007825032230
+         F            0.000000000000     0.000000000000     0.055685611826    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.41496  C =     14.41496 [cm^-1]
+  Rotational constants: A = ************  B = 432149.51645  C = 432149.51645 [MHz]
+  Nuclear repulsion =    4.308445160807890
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.5761063924E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42019523798393   -9.64202e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33351541953698    8.66798e-02   4.99770e-02 DIIS
+   @DF-UKS iter   2:   -96.40889687051161   -7.53815e-02   2.78288e-02 DIIS
+   @DF-UKS iter   3:   -96.43999134304956   -3.10945e-02   1.84518e-03 DIIS
+   @DF-UKS iter   4:   -96.44021057640762   -2.19233e-04   4.01915e-04 DIIS
+   @DF-UKS iter   5:   -96.44022974088510   -1.91645e-05   1.52721e-04 DIIS
+   @DF-UKS iter   6:   -96.44023455451685   -4.81363e-06   5.88091e-05 DIIS
+   @DF-UKS iter   7:   -96.44023557635288   -1.02184e-06   1.10065e-05 DIIS
+   @DF-UKS iter   8:   -96.44023560920604   -3.28532e-08   1.79997e-06 DIIS
+   @DF-UKS iter   9:   -96.44023560969904   -4.93003e-10   1.81955e-07 DIIS
+   @DF-UKS iter  10:   -96.44023560970206   -3.01270e-12   2.60116e-08 DIIS
+   @DF-UKS iter  11:   -96.44023560970217   -1.13687e-13   1.97553e-09 DIIS
+   @DF-UKS iter  12:   -96.44023560970213    4.26326e-14   2.33557e-10 DIIS
+   @DF-UKS iter  13:   -96.44023560970217   -4.26326e-14   3.93375e-11 DIIS
+   @DF-UKS iter  14:   -96.44023560970214    2.84217e-14   4.32130e-12 DIIS
+   @DF-UKS iter  15:   -96.44023560970214    0.00000e+00   4.43357e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.493762870E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514937629E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.283532     2A1    -1.917337     1B1    -1.151691  
+       3A1    -1.137680     1B2    -1.054319  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.207891     5A1     0.304529     2B1     0.844518  
+       2B2     0.893740     6A1     1.020039     3B1     1.166377  
+       3B2     1.193093     7A1     1.516102     8A1     1.747605  
+       9A1     3.376050     1A2     3.376621     4B1     3.487125  
+       4B2     3.557901    10A1     4.177837  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.255497     2A1    -1.806977     3A1    -1.109385  
+       1B2    -1.024941  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.408572     4A1    -0.199822     5A1     0.306976  
+       2B2     0.902690     2B1     0.939495     6A1     1.035451  
+       3B2     1.196262     3B1     1.204283     7A1     1.537918  
+       8A1     1.766559     1A2     3.460413     9A1     3.460528  
+       4B1     3.567134     4B2     3.570217    10A1     4.206209  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -96.44023560970214
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3084451608078904
+    One-Electron Energy =                -141.7560017804248389
+    Two-Electron Energy =                  41.0073210099148113
+    Total Energy =                        -96.4402356097021425
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998094
+  HONO-1 :    3 A1 1.9994780
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0005220
+  LUNO+1 :    5 A1 0.0001906
+  LUNO+2 :    2 B2 0.0000344
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0366
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0716
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1082     Total:     1.1082
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.8168     Total:     2.8168
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:00 2019
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      32.48 seconds =       0.54 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:00 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.047155231191     1.007825032230
+         F            0.000000000000     0.000000000000     0.055549366207    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.48575  C =     14.48575 [cm^-1]
+  Rotational constants: A = ************  B = 434271.97754  C = 434271.97754 [MHz]
+  Nuclear repulsion =    4.319012460153662
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.5349079623E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42180566988756   -9.64218e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33351115565661    8.82945e-02   4.99783e-02 DIIS
+   @DF-UKS iter   2:   -96.40897565426746   -7.54645e-02   2.78018e-02 DIIS
+   @DF-UKS iter   3:   -96.43999271673353   -3.10171e-02   1.84300e-03 DIIS
+   @DF-UKS iter   4:   -96.44021124283231   -2.18526e-04   4.01054e-04 DIIS
+   @DF-UKS iter   5:   -96.44023023841049   -1.89956e-05   1.51711e-04 DIIS
+   @DF-UKS iter   6:   -96.44023495481855   -4.71641e-06   5.81776e-05 DIIS
+   @DF-UKS iter   7:   -96.44023594744516   -9.92627e-07   1.09013e-05 DIIS
+   @DF-UKS iter   8:   -96.44023597950053   -3.20554e-08   1.78250e-06 DIIS
+   @DF-UKS iter   9:   -96.44023597998375   -4.83226e-10   1.80258e-07 DIIS
+   @DF-UKS iter  10:   -96.44023597998670   -2.94165e-12   2.57813e-08 DIIS
+   @DF-UKS iter  11:   -96.44023597998684   -1.42109e-13   1.95035e-09 DIIS
+   @DF-UKS iter  12:   -96.44023597998677    7.10543e-14   2.29818e-10 DIIS
+   @DF-UKS iter  13:   -96.44023597998681   -4.26326e-14   3.86652e-11 DIIS
+   @DF-UKS iter  14:   -96.44023597998681    0.00000e+00   4.27332e-12 DIIS
+   @DF-UKS iter  15:   -96.44023597998681    0.00000e+00   4.39330e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.484149922E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514841499E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.283920     2A1    -1.918102     1B1    -1.152165  
+       3A1    -1.138635     1B2    -1.054794  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.207013     5A1     0.305383     2B1     0.844655  
+       2B2     0.893986     6A1     1.018805     3B1     1.166056  
+       3B2     1.192750     7A1     1.519850     8A1     1.747689  
+       9A1     3.375584     1A2     3.376143     4B1     3.488418  
+       4B2     3.559175    10A1     4.181786  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.255888     2A1    -1.807794     3A1    -1.110350  
+       1B2    -1.025418  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.409032     4A1    -0.198939     5A1     0.307889  
+       2B2     0.902971     2B1     0.939865     6A1     1.034180  
+       3B2     1.195904     3B1     1.203834     7A1     1.541911  
+       8A1     1.766434     1A2     3.459933     9A1     3.460048  
+       4B1     3.568358     4B2     3.571472    10A1     4.210121  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -96.44023597998681
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3190124601536617
+    One-Electron Energy =                -141.7714317689922154
+    Two-Electron Energy =                  41.0121833288517408
+    Total Energy =                        -96.4402359799868236
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998110
+  HONO-1 :    3 A1 1.9994812
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0005188
+  LUNO+1 :    5 A1 0.0001890
+  LUNO+2 :    2 B2 0.0000344
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0341
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0704
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1045     Total:     1.1045
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.8073     Total:     2.8073
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:00 2019
+Module time:
+	user time   =       0.81 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      33.30 seconds =       0.56 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:00 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.042018527635     1.007825032230
+         F            0.000000000000     0.000000000000     0.055276874967    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.62892  C =     14.62892 [cm^-1]
+  Rotational constants: A = ************  B = 438564.07910  C = 438564.07910 [MHz]
+  Nuclear repulsion =    4.340303335579315
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4526910545E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42503917113680   -9.64250e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33348912420075    9.15500e-02   4.99797e-02 DIIS
+   @DF-UKS iter   2:   -96.40911609443074   -7.56270e-02   2.77469e-02 DIIS
+   @DF-UKS iter   3:   -96.43997650413988   -3.08604e-02   1.83858e-03 DIIS
+   @DF-UKS iter   4:   -96.44019361267590   -2.17109e-04   3.99333e-04 DIIS
+   @DF-UKS iter   5:   -96.44021227541177   -1.86627e-05   1.49708e-04 DIIS
+   @DF-UKS iter   6:   -96.44021680304289   -4.52763e-06   5.69298e-05 DIIS
+   @DF-UKS iter   7:   -96.44021773955404   -9.36511e-07   1.06927e-05 DIIS
+   @DF-UKS iter   8:   -96.44021777006492   -3.05109e-08   1.74799e-06 DIIS
+   @DF-UKS iter   9:   -96.44021777052919   -4.64269e-10   1.76909e-07 DIIS
+   @DF-UKS iter  10:   -96.44021777053209   -2.89901e-12   2.53254e-08 DIIS
+   @DF-UKS iter  11:   -96.44021777053214   -5.68434e-14   1.90082e-09 DIIS
+   @DF-UKS iter  12:   -96.44021777053209    5.68434e-14   2.22502e-10 DIIS
+   @DF-UKS iter  13:   -96.44021777053216   -7.10543e-14   3.73410e-11 DIIS
+   @DF-UKS iter  14:   -96.44021777053213    2.84217e-14   4.17526e-12 DIIS
+   @DF-UKS iter  15:   -96.44021777053216   -2.84217e-14   4.32743e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.465362951E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514653630E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.284694     2A1    -1.919642     1B2    -1.153114  
+       3A1    -1.140552     1B1    -1.055743  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.205257     5A1     0.307130     2B2     0.844942  
+       2B1     0.894491     6A1     1.016342     3B2     1.165402  
+       3B1     1.192050     7A1     1.527238     8A1     1.748045  
+       9A1     3.374651     1A2     3.375185     4B2     3.491053  
+       4B1     3.561770    10A1     4.189672  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.256669     2A1    -1.809437     3A1    -1.112282  
+       1B1    -1.026373  
+
+    Beta Virtual:                                                         
+
+       1B2    -0.409954     4A1    -0.197175     5A1     0.309754  
+       2B1     0.903549     2B2     0.940623     6A1     1.031640  
+       3B1     1.195172     3B2     1.202919     7A1     1.549813  
+       8A1     1.766350     1A2     3.458973     9A1     3.459088  
+       4B2     3.570853     4B1     3.574031    10A1     4.217933  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UKS Final Energy:   -96.44021777053216
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3403033355793150
+    One-Electron Energy =                -141.8025368549151040
+    Two-Electron Energy =                  41.0220157488036321
+    Total Energy =                        -96.4402177705321719
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998142
+  HONO-1 :    3 A1 1.9994874
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0005126
+  LUNO+1 :    5 A1 0.0001858
+  LUNO+2 :    2 B1 0.0000343
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0290
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0680
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0970     Total:     1.0970
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.7883     Total:     2.7883
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:01 2019
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      34.11 seconds =       0.57 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:01 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.039450175857     1.007825032230
+         F            0.000000000000     0.000000000000     0.055140629347    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.70130  C =     14.70130 [cm^-1]
+  Rotational constants: A = ************  B = 440734.03094  C = 440734.03094 [MHz]
+  Nuclear repulsion =    4.351027683939850
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4116754919E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42666210338288   -9.64267e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33347115322903    9.31910e-02   4.99797e-02 DIIS
+   @DF-UKS iter   2:   -96.40917752049971   -7.57064e-02   2.77191e-02 DIIS
+   @DF-UKS iter   3:   -96.43995869490064   -3.07812e-02   1.83635e-03 DIIS
+   @DF-UKS iter   4:   -96.44017509313498   -2.16398e-04   3.98473e-04 DIIS
+   @DF-UKS iter   5:   -96.44019359189359   -1.84988e-05   1.48716e-04 DIIS
+   @DF-UKS iter   6:   -96.44019802790791   -4.43601e-06   5.63134e-05 DIIS
+   @DF-UKS iter   7:   -96.44019893747604   -9.09568e-07   1.05893e-05 DIIS
+   @DF-UKS iter   8:   -96.44019896723952   -2.97635e-08   1.73095e-06 DIIS
+   @DF-UKS iter   9:   -96.44019896769456   -4.55032e-10   1.75257e-07 DIIS
+   @DF-UKS iter  10:   -96.44019896769737   -2.81375e-12   2.51000e-08 DIIS
+   @DF-UKS iter  11:   -96.44019896769747   -9.94760e-14   1.87648e-09 DIIS
+   @DF-UKS iter  12:   -96.44019896769748   -1.42109e-14   2.18925e-10 DIIS
+   @DF-UKS iter  13:   -96.44019896769750   -1.42109e-14   3.66881e-11 DIIS
+   @DF-UKS iter  14:   -96.44019896769746    4.26326e-14   4.12664e-12 DIIS
+   @DF-UKS iter  15:   -96.44019896769743    2.84217e-14   4.29155e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.456184172E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514561842E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.285080     2A1    -1.920417     1B2    -1.153589  
+       3A1    -1.141514     1B1    -1.056218  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.204380     5A1     0.308022     2B2     0.845092  
+       2B1     0.894752     6A1     1.015113     3B2     1.165068  
+       3B1     1.191693     7A1     1.530874     8A1     1.748325  
+       9A1     3.374184     1A2     3.374706     4B2     3.492395  
+       4B1     3.563092    10A1     4.193608  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.257058     2A1    -1.810264     3A1    -1.113250  
+       1B1    -1.026851  
+
+    Beta Virtual:                                                         
+
+       1B2    -0.410415     4A1    -0.196294     5A1     0.310705  
+       2B1     0.903845     2B2     0.941010     6A1     1.030373  
+       3B1     1.194798     3B2     1.202453     7A1     1.553716  
+       8A1     1.766399     1A2     3.458493     9A1     3.458608  
+       4B2     3.572125     4B1     3.575335    10A1     4.221833  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UKS Final Energy:   -96.44019896769743
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3510276839398498
+    One-Electron Energy =                -141.8182129269302720
+    Two-Electron Energy =                  41.0269862752929910
+    Total Energy =                        -96.4401989676974267
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998158
+  HONO-1 :    3 A1 1.9994904
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0005096
+  LUNO+1 :    5 A1 0.0001842
+  LUNO+2 :    2 B1 0.0000343
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0265
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0668
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0933     Total:     1.0933
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.7789     Total:     2.7789
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:02 2019
+Module time:
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      34.91 seconds =       0.58 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing gradient from energies.
+    Using 5-point formula.
+    Energy without displacement:  -96.4402300705
+    Check energies below for precision!
+    Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+     Coord      Energy(-2)        Energy(-1)        Energy(+1)        Energy(+2)            Force
+        0    -96.4402356097    -96.4402359800    -96.4402177705    -96.4401989677      0.0018172272
+
+
+-------------------------------------------------------------
+  ## New Matrix (Symmetry 0) ##
+  Irrep: 1 Size: 2 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000     0.00177777887664
+    2     0.00000000000000     0.00000000000000    -0.00177777887664
+
+
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:02 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:   -96.42342033681894   -9.64234e+01   0.00000e+00 
+   @DF-UKS iter   1:   -96.33350242414758    8.99179e-02   4.99792e-02 DIIS
+   @DF-UKS iter   2:   -96.40904876698994   -7.55463e-02   2.77745e-02 DIIS
+   @DF-UKS iter   3:   -96.43998780728876   -3.09390e-02   1.84080e-03 DIIS
+   @DF-UKS iter   4:   -96.44020562511335   -2.17818e-04   4.00194e-04 DIIS
+   @DF-UKS iter   5:   -96.44022445345013   -1.88283e-05   1.50706e-04 DIIS
+   @DF-UKS iter   6:   -96.44022907453528   -4.62109e-06   5.75511e-05 DIIS
+   @DF-UKS iter   7:   -96.44023003872647   -9.64191e-07   1.07967e-05 DIIS
+   @DF-UKS iter   8:   -96.44023007000118   -3.12747e-08   1.76517e-06 DIIS
+   @DF-UKS iter   9:   -96.44023007047484   -4.73662e-10   1.78577e-07 DIIS
+   @DF-UKS iter  10:   -96.44023007047780   -2.95586e-12   2.55525e-08 DIIS
+   @DF-UKS iter  11:   -96.44023007047781   -1.42109e-14   1.92545e-09 DIIS
+   @DF-UKS iter  12:   -96.44023007047785   -4.26326e-14   2.26133e-10 DIIS
+   @DF-UKS iter  13:   -96.44023007047784    1.42109e-14   3.80005e-11 DIIS
+   @DF-UKS iter  14:   -96.44023007047788   -4.26326e-14   4.22368e-12 DIIS
+   @DF-UKS iter  15:   -96.44023007047785    2.84217e-14   4.36595e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.474684081E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.514746841E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.284307     2A1    -1.918871     1B1    -1.152639  
+       3A1    -1.139593     1B2    -1.055268  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.206135     5A1     0.306250     2B1     0.844797  
+       2B2     0.894236     6A1     1.017573     3B1     1.165731  
+       3B2     1.192403     7A1     1.523563     8A1     1.747834  
+       9A1     3.375118     1A2     3.375664     4B1     3.489727  
+       4B2     3.560464    10A1     4.185731  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.256279     2A1    -1.808613     3A1    -1.111315  
+       1B2    -1.025895  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.409493     4A1    -0.198056     5A1     0.308815  
+       2B2     0.903257     2B1     0.940241     6A1     1.032909  
+       3B2     1.195540     3B1     1.203380     7A1     1.545877  
+       8A1     1.766363     1A2     3.459453     9A1     3.459568  
+       4B1     3.569597     4B2     3.572743    10A1     4.214029  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -96.44023007047785
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -141.7869432986266247
+    Two-Electron Energy =                  41.0170815044851338
+    Total Energy =                        -96.4402300704778668
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9998126
+  HONO-1 :    3 A1 1.9994843
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0005157
+  LUNO+1 :    5 A1 0.0001874
+  LUNO+2 :    2 B2 0.0000343
+  LUNO+3 :    6 A1 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0692
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1007     Total:     1.1007
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.7978     Total:     2.7978
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:03 2019
+Module time:
+	user time   =       0.83 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      35.75 seconds =       0.60 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:03 2019
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Nuclear repulsion =    4.329631723663637
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               2.000E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000     0.001777779262
+       2        0.000000000000     0.000000000000    -0.001777779262
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:03 2019
+Module time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      35.94 seconds =       0.60 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
+	Analytic vs Reference CAM-like UKS Gradients......................PASSED
+	Analytic vs FD CAM UKS Gradients..................................PASSED
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:03 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.04143545011763   -1.00041e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80703723973457    2.34398e-01   2.40091e-02 DIIS
+   @DF-UKS iter   2:   -99.82402552607343   -1.69883e-02   1.54414e-02 DIIS
+   @DF-UKS iter   3:   -99.83389110712923   -9.86558e-03   2.35986e-03 DIIS
+   @DF-UKS iter   4:   -99.83414574611913   -2.54639e-04   3.40065e-04 DIIS
+   @DF-UKS iter   5:   -99.83415819393328   -1.24478e-05   1.11545e-04 DIIS
+   @DF-UKS iter   6:   -99.83416100916759   -2.81523e-06   2.69505e-05 DIIS
+   @DF-UKS iter   7:   -99.83416129076912   -2.81602e-07   2.77228e-06 DIIS
+   @DF-UKS iter   8:   -99.83416130978222   -1.90131e-08   2.29493e-07 DIIS
+   @DF-UKS iter   9:   -99.83416131073355   -9.51331e-10   1.50681e-08 DIIS
+   @DF-UKS iter  10:   -99.83416131072661    6.93490e-12   7.11982e-10 DIIS
+   @DF-UKS iter  11:   -99.83416131072622    3.97904e-13   4.35003e-11 DIIS
+   @DF-UKS iter  12:   -99.83416131072630   -8.52651e-14   5.85734e-12 DIIS
+   @DF-UKS iter  13:   -99.83416131072626    4.26326e-14   3.25622e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.951514546E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519515145E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.415216     2A1    -1.837636     1B1    -1.122188  
+       3A1    -1.120996     1B2    -1.028837  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.349978     5A1     0.145865     2B1     0.611601  
+       2B2     0.656460     6A1     0.790776     3B1     0.980961  
+       3B2     1.000592     7A1     1.251810     8A1     1.522310  
+       9A1     3.033371     1A2     3.033832     4B1     3.147809  
+       4B2     3.216287    10A1     3.836966  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.380920     2A1    -1.744465     3A1    -1.088538  
+       1B2    -0.993882  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.668903     4A1    -0.342401     5A1     0.144325  
+       2B2     0.668804     2B1     0.694366     6A1     0.809689  
+       3B2     1.001105     3B1     1.004765     7A1     1.281922  
+       8A1     1.543188     1A2     3.132464     9A1     3.142435  
+       4B2     3.234730     4B1     3.246184    10A1     3.878790  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -99.83416131072626
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -143.2923611115503206
+    Two-Electron Energy =                  46.8266598529230578
+    DFT Exchange-Correlation Energy =      -7.6980917757626317
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8341613107262731
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997414
+  HONO-1 :    3 A1 1.9993502
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0006498
+  LUNO+1 :    5 A1 0.0002586
+  LUNO+2 :    2 B2 0.0000676
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1472
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1788     Total:     1.1788
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.9961     Total:     2.9961
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:07 2019
+Module time:
+	user time   =       4.33 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      40.29 seconds =       0.67 minutes
+	system time =       0.47 seconds =       0.01 minutes
+	total time  =         40 seconds =       0.67 minutes
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:07 2019
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Nuclear repulsion =    4.329631723663637
+
+  ==> Basis Set <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Schwarz Cutoff:          0E+00
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000    -0.034683255246
+       2        0.000000000000     0.000000000000     0.034649905462
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:08 2019
+Module time:
+	user time   =       0.72 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      41.01 seconds =       0.68 minutes
+	system time =       0.48 seconds =       0.01 minutes
+	total time  =         41 seconds =       0.68 minutes
+gradient() will perform gradient computation by finite difference of analytic energies.
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Using finite-differences of energies to determine gradients.
+    Generating geometries for use with 5-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 2.
+    Number of symmetric SALCs is 1.
+    Translations projected? 1. Rotations projected? 1.
+    Number of geometries (including reference) is 5.
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 1 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:08 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.044586879413     1.007825032230
+         F            0.000000000000     0.000000000000     0.055413120587    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.55707  C =     14.55707 [cm^-1]
+  Rotational constants: A = ************  B = 436410.11351  C = 436410.11351 [MHz]
+  Nuclear repulsion =    4.329631723663637
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4937690280E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.04143545011763   -1.00041e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80703723973461    2.34398e-01   2.40091e-02 DIIS
+   @DF-UKS iter   2:   -99.82402552607343   -1.69883e-02   1.54414e-02 DIIS
+   @DF-UKS iter   3:   -99.83389110712920   -9.86558e-03   2.35986e-03 DIIS
+   @DF-UKS iter   4:   -99.83414574611916   -2.54639e-04   3.40065e-04 DIIS
+   @DF-UKS iter   5:   -99.83415819393323   -1.24478e-05   1.11545e-04 DIIS
+   @DF-UKS iter   6:   -99.83416100916762   -2.81523e-06   2.69505e-05 DIIS
+   @DF-UKS iter   7:   -99.83416129076910   -2.81601e-07   2.77228e-06 DIIS
+   @DF-UKS iter   8:   -99.83416130978225   -1.90131e-08   2.29493e-07 DIIS
+   @DF-UKS iter   9:   -99.83416131073349   -9.51246e-10   1.50681e-08 DIIS
+   @DF-UKS iter  10:   -99.83416131072661    6.87805e-12   7.11981e-10 DIIS
+   @DF-UKS iter  11:   -99.83416131072622    3.97904e-13   4.35002e-11 DIIS
+   @DF-UKS iter  12:   -99.83416131072633   -1.13687e-13   5.85714e-12 DIIS
+   @DF-UKS iter  13:   -99.83416131072627    5.68434e-14   3.25650e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.951514546E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519515145E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.415216     2A1    -1.837636     1B1    -1.122188  
+       3A1    -1.120996     1B2    -1.028837  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.349978     5A1     0.145865     2B1     0.611601  
+       2B2     0.656460     6A1     0.790776     3B1     0.980961  
+       3B2     1.000592     7A1     1.251810     8A1     1.522310  
+       9A1     3.033371     1A2     3.033832     4B1     3.147809  
+       4B2     3.216287    10A1     3.836966  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.380920     2A1    -1.744465     3A1    -1.088538  
+       1B2    -0.993882  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.668903     4A1    -0.342401     5A1     0.144325  
+       2B2     0.668804     2B1     0.694366     6A1     0.809689  
+       3B2     1.001105     3B1     1.004765     7A1     1.281922  
+       8A1     1.543188     1A2     3.132464     9A1     3.142435  
+       4B2     3.234730     4B1     3.246184    10A1     3.878790  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -99.83416131072627
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3296317236636366
+    One-Electron Energy =                -143.2923611115502922
+    Two-Electron Energy =                  46.8266598529230151
+    DFT Exchange-Correlation Energy =      -7.6980917757626299
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8341613107262873
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997414
+  HONO-1 :    3 A1 1.9993502
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0006498
+  LUNO+1 :    5 A1 0.0002586
+  LUNO+2 :    2 B2 0.0000676
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0315
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1472
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1788     Total:     1.1788
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.9961     Total:     2.9961
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:12 2019
+Module time:
+	user time   =       4.15 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      45.18 seconds =       0.75 minutes
+	system time =       0.51 seconds =       0.01 minutes
+	total time  =         45 seconds =       0.75 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 2 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:12 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.049723582969     1.007825032230
+         F            0.000000000000     0.000000000000     0.055685611826    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.41496  C =     14.41496 [cm^-1]
+  Rotational constants: A = ************  B = 432149.51645  C = 432149.51645 [MHz]
+  Nuclear repulsion =    4.308445160807890
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            804
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.5761063924E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.03858476069939   -1.00039e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80674271756939    2.31842e-01   2.39750e-02 DIIS
+   @DF-UKS iter   2:   -99.82366254257792   -1.69198e-02   1.54297e-02 DIIS
+   @DF-UKS iter   3:   -99.83352307220022   -9.86053e-03   2.37710e-03 DIIS
+   @DF-UKS iter   4:   -99.83378171554301   -2.58643e-04   3.41531e-04 DIIS
+   @DF-UKS iter   5:   -99.83379447700696   -1.27615e-05   1.13196e-04 DIIS
+   @DF-UKS iter   6:   -99.83379743169226   -2.95469e-06   2.75386e-05 DIIS
+   @DF-UKS iter   7:   -99.83379773108949   -2.99397e-07   2.82135e-06 DIIS
+   @DF-UKS iter   8:   -99.83379775086858   -1.97791e-08   2.33166e-07 DIIS
+   @DF-UKS iter   9:   -99.83379775184460   -9.76016e-10   1.53493e-08 DIIS
+   @DF-UKS iter  10:   -99.83379775183698    7.61702e-12   7.23249e-10 DIIS
+   @DF-UKS iter  11:   -99.83379775183656    4.26326e-13   4.42061e-11 DIIS
+   @DF-UKS iter  12:   -99.83379775183656    0.00000e+00   5.96089e-12 DIIS
+   @DF-UKS iter  13:   -99.83379775183658   -2.84217e-14   3.31696e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.977999208E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519779992E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.414121     2A1    -1.835907     1B1    -1.121033  
+       3A1    -1.119018     1B2    -1.027687  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.352095     5A1     0.144982     2B1     0.611728  
+       2B2     0.656456     6A1     0.792899     3B1     0.981660  
+       3B2     1.001271     7A1     1.245457     8A1     1.521865  
+       9A1     3.034484     1A2     3.034968     4B1     3.145413  
+       4B2     3.213933    10A1     3.829403  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.379820     2A1    -1.742648     3A1    -1.086562  
+       1B2    -0.992728  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.667776     4A1    -0.344613     5A1     0.143311  
+       2B2     0.668716     2B1     0.694183     6A1     0.811911  
+       3B2     1.001770     3B1     1.005528     7A1     1.274918  
+       8A1     1.543245     1A2     3.133599     9A1     3.143567  
+       4B2     3.232419     4B1     3.243903    10A1     3.871299  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -99.83379775183658
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3084451608078895
+    One-Electron Energy =                -143.2630026167189499
+    Two-Electron Energy =                  46.8179511918676070
+    DFT Exchange-Correlation Energy =      -7.6971914877931482
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8337977518366131
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997393
+  HONO-1 :    3 A1 1.9993391
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0006609
+  LUNO+1 :    5 A1 0.0002607
+  LUNO+2 :    2 B2 0.0000676
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0366
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1507
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1874     Total:     1.1874
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -3.0179     Total:     3.0179
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:17 2019
+Module time:
+	user time   =       4.25 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =      49.43 seconds =       0.82 minutes
+	system time =       0.54 seconds =       0.01 minutes
+	total time  =         50 seconds =       0.83 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 3 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:17 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.047155231191     1.007825032230
+         F            0.000000000000     0.000000000000     0.055549366207    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.48575  C =     14.48575 [cm^-1]
+  Rotational constants: A = ************  B = 434271.97754  C = 434271.97754 [MHz]
+  Nuclear repulsion =    4.319012460153662
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            803
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.5349079623E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.04000842524208   -1.00040e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80689171530673    2.33117e-01   2.39923e-02 DIIS
+   @DF-UKS iter   2:   -99.82384593416636   -1.69542e-02   1.54358e-02 DIIS
+   @DF-UKS iter   3:   -99.83370934203516   -9.86341e-03   2.36848e-03 DIIS
+   @DF-UKS iter   4:   -99.83396597853947   -2.56637e-04   3.40798e-04 DIIS
+   @DF-UKS iter   5:   -99.83397858229517   -1.26038e-05   1.12369e-04 DIIS
+   @DF-UKS iter   6:   -99.83398146654987   -2.88425e-06   2.72435e-05 DIIS
+   @DF-UKS iter   7:   -99.83398175693335   -2.90383e-07   2.79677e-06 DIIS
+   @DF-UKS iter   8:   -99.83398177632580   -1.93924e-08   2.31324e-07 DIIS
+   @DF-UKS iter   9:   -99.83398177728932   -9.63524e-10   1.52080e-08 DIIS
+   @DF-UKS iter  10:   -99.83398177728209    7.23333e-12   7.17607e-10 DIIS
+   @DF-UKS iter  11:   -99.83398177728166    4.26326e-13   4.38554e-11 DIIS
+   @DF-UKS iter  12:   -99.83398177728175   -8.52651e-14   5.90897e-12 DIIS
+   @DF-UKS iter  13:   -99.83398177728175    0.00000e+00   3.29005e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.964676110E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519646761E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.414669     2A1    -1.836770     1B1    -1.121610  
+       3A1    -1.120006     1B2    -1.028262  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.351038     5A1     0.145418     2B1     0.611663  
+       2B2     0.656455     6A1     0.791837     3B1     0.981313  
+       3B2     1.000934     7A1     1.248647     8A1     1.522061  
+       9A1     3.033927     1A2     3.034400     4B1     3.146603  
+       4B2     3.215102    10A1     3.833187  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.380370     2A1    -1.743555     3A1    -1.087549  
+       1B2    -0.993305  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.668339     4A1    -0.343508     5A1     0.143813  
+       2B2     0.668758     2B1     0.694272     6A1     0.810800  
+       3B2     1.001439     3B1     1.005149     7A1     1.278431  
+       8A1     1.543192     1A2     3.133032     9A1     3.143001  
+       4B2     3.233567     4B1     3.245036    10A1     3.875047  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -99.83398177728175
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3190124601536617
+    One-Electron Energy =                -143.2776409093814038
+    Two-Electron Energy =                  46.8222862336319636
+    DFT Exchange-Correlation Energy =      -7.6976395616859605
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8339817772817497
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997404
+  HONO-1 :    3 A1 1.9993447
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0006553
+  LUNO+1 :    5 A1 0.0002596
+  LUNO+2 :    2 B2 0.0000676
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0341
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1490
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1831     Total:     1.1831
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -3.0070     Total:     3.0070
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:21 2019
+Module time:
+	user time   =       4.22 seconds =       0.07 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      53.66 seconds =       0.89 minutes
+	system time =       0.58 seconds =       0.01 minutes
+	total time  =         54 seconds =       0.90 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 4 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:21 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.042018527635     1.007825032230
+         F            0.000000000000     0.000000000000     0.055276874967    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.62892  C =     14.62892 [cm^-1]
+  Rotational constants: A = ************  B = 438564.07910  C = 438564.07910 [MHz]
+  Nuclear repulsion =    4.340303335579315
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            802
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4526910545E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.04286576744917   -1.00043e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80717920550282    2.35687e-01   2.40254e-02 DIIS
+   @DF-UKS iter   2:   -99.82420122307347   -1.70220e-02   1.54465e-02 DIIS
+   @DF-UKS iter   3:   -99.83406827148900   -9.86705e-03   2.35126e-03 DIIS
+   @DF-UKS iter   4:   -99.83432092230936   -2.52651e-04   3.39330e-04 DIIS
+   @DF-UKS iter   5:   -99.83433321593277   -1.22936e-05   1.10726e-04 DIIS
+   @DF-UKS iter   6:   -99.83433596353383   -2.74760e-06   2.66597e-05 DIIS
+   @DF-UKS iter   7:   -99.83433623658016   -2.73046e-07   2.74789e-06 DIIS
+   @DF-UKS iter   8:   -99.83433625522103   -1.86409e-08   2.27672e-07 DIIS
+   @DF-UKS iter   9:   -99.83433625616023   -9.39195e-10   1.49297e-08 DIIS
+   @DF-UKS iter  10:   -99.83433625615373    6.49436e-12   7.06372e-10 DIIS
+   @DF-UKS iter  11:   -99.83433625615338    3.55271e-13   4.31407e-11 DIIS
+   @DF-UKS iter  12:   -99.83433625615342   -4.26326e-14   5.80500e-12 DIIS
+   @DF-UKS iter  13:   -99.83433625615345   -2.84217e-14   3.22887e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.938512666E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519385127E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.415762     2A1    -1.838506     1B2    -1.122766  
+       3A1    -1.121989     1B1    -1.029412  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.348915     5A1     0.146321     2B2     0.611544  
+       2B1     0.656468     6A1     0.789716     3B2     0.980606  
+       3B1     1.000247     7A1     1.254944     8A1     1.522615  
+       9A1     3.032814     1A2     3.033263     4B2     3.149032  
+       4B1     3.217489    10A1     3.840740  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.381470     2A1    -1.745380     3A1    -1.089527  
+       1B1    -0.994459  
+
+    Beta Virtual:                                                         
+
+       1B2    -0.669467     4A1    -0.341292     5A1     0.144846  
+       2B1     0.668855     2B2     0.694464     6A1     0.808580  
+       3B1     1.000765     3B2     1.004377     7A1     1.285390  
+       8A1     1.543233     1A2     3.131897     9A1     3.141869  
+       4B1     3.235910     4B2     3.247349    10A1     3.882528  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UKS Final Energy:   -99.83433625615345
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3403033355793150
+    One-Electron Energy =                -143.3071637326850123
+    Two-Electron Energy =                  46.8310723001958280
+    DFT Exchange-Correlation Energy =      -7.6985481592435772
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8343362561534491
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997425
+  HONO-1 :    3 A1 1.9993556
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0006444
+  LUNO+1 :    5 A1 0.0002575
+  LUNO+2 :    2 B1 0.0000675
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0290
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1455
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1745     Total:     1.1745
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.9853     Total:     2.9853
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:25 2019
+Module time:
+	user time   =       4.21 seconds =       0.07 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      57.87 seconds =       0.96 minutes
+	system time =       0.63 seconds =       0.01 minutes
+	total time  =         58 seconds =       0.97 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    Loading displacement 5 of 5    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+*** tstart() called on psinet
+*** at Mon Mar 11 02:24:25 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry F          line   228 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -1.039450175857     1.007825032230
+         F            0.000000000000     0.000000000000     0.055140629347    18.998403162730
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =     14.70130  C =     14.70130 [cm^-1]
+  Rotational constants: A = ************  B = 440734.03094  C = 440734.03094 [MHz]
+  Nuclear repulsion =    4.351027683939847
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis function: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for exchange GGA functionals [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           FLAT
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =            120
+    Spherical Points       =            434
+    Total Points           =         101292
+    Total Blocks           =            804
+    Max Points             =            256
+    Max Functions          =             19
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry F          line   271 file /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        10      10       0       0       0       0
+     A2         1       1       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         4       4       0       0       0       0
+   -------------------------------------------------------
+    Total      19      19       5       4       4       1
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              321
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 33
+    Number of basis function: 93
+    Number of Cartesian functions: 106
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Cached 100.0% of DFT collocation blocks in 0.052 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 7.4116754919E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter SAD:  -100.04429930759196   -1.00044e+02   0.00000e+00 
+   @DF-UKS iter   1:   -99.80731752557189    2.36982e-01   2.40412e-02 DIIS
+   @DF-UKS iter   2:   -99.82437292819125   -1.70554e-02   1.54511e-02 DIIS
+   @DF-UKS iter   3:   -99.83424073747527   -9.86781e-03   2.34265e-03 DIIS
+   @DF-UKS iter   4:   -99.83449140949128   -2.50672e-04   3.38595e-04 DIIS
+   @DF-UKS iter   5:   -99.83450355065938   -1.21412e-05   1.09910e-04 DIIS
+   @DF-UKS iter   6:   -99.83450623199147   -2.68133e-06   2.63711e-05 DIIS
+   @DF-UKS iter   7:   -99.83450649670421   -2.64713e-07   2.72359e-06 DIIS
+   @DF-UKS iter   8:   -99.83450651497989   -1.82757e-08   2.25861e-07 DIIS
+   @DF-UKS iter   9:   -99.83450651590717   -9.27272e-10   1.47925e-08 DIIS
+   @DF-UKS iter  10:   -99.83450651590105    6.11067e-12   7.00777e-10 DIIS
+   @DF-UKS iter  11:   -99.83450651590064    4.12115e-13   4.27773e-11 DIIS
+   @DF-UKS iter  12:   -99.83450651590067   -2.84217e-14   5.75302e-12 DIIS
+   @DF-UKS iter  13:   -99.83450651590074   -7.10543e-14   3.19903e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.925668635E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.519256686E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -25.416308     2A1    -1.839379     1B1    -1.123344  
+       3A1    -1.122983     1B2    -1.029988  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.347849     5A1     0.146787     2B1     0.611489  
+       2B2     0.656481     6A1     0.788657     3B1     0.980247  
+       3B2     0.999898     7A1     1.258047     8A1     1.522977  
+       9A1     3.032256     1A2     3.032695     4B1     3.150270  
+       4B2     3.218707    10A1     3.844509  
+
+    Beta Occupied:                                                        
+
+       1A1   -25.382019     2A1    -1.746297     3A1    -1.090519  
+       1B2    -0.995037  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.670032     4A1    -0.340180     5A1     0.145378  
+       2B2     0.668909     2B1     0.694567     6A1     0.807471  
+       3B2     1.000422     3B1     1.003984     7A1     1.288832  
+       8A1     1.543330     1A2     3.131328     9A1     3.141303  
+       4B2     3.237106     4B1     3.248529    10A1     3.886260  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UKS Final Energy:   -99.83450651590074
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3510276839398472
+    One-Electron Energy =                -143.3220492860148738
+    Two-Electron Energy =                  46.8355238277783883
+    DFT Exchange-Correlation Energy =      -7.6990087416040955
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -99.8345065159007419
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9997436
+  HONO-1 :    3 A1 1.9993608
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0006392
+  LUNO+1 :    5 A1 0.0002564
+  LUNO+2 :    2 B2 0.0000675
+  LUNO+3 :    6 A1 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0265
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1438
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.1702     Total:     1.1702
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.9744     Total:     2.9744
+
+
+*** tstop() called on psinet at Mon Mar 11 02:24:29 2019
+Module time:
+	user time   =       4.25 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      62.13 seconds =       1.04 minutes
+	system time =       0.66 seconds =       0.01 minutes
+	total time  =         62 seconds =       1.03 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ---------------------------------------------------------
+
+  Computing gradient from energies.
+    Using 5-point formula.
+    Energy without displacement:  -99.8341613107
+    Check energies below for precision!
+    Forces are for mass-weighted, symmetry-adapted cartesians (in au).
+
+     Coord      Energy(-2)        Energy(-1)        Energy(+1)        Energy(+2)            Force
+        0    -99.8337977518    -99.8339817773    -99.8343362562    -99.8345065159     -0.0354511152
+
+
+-------------------------------------------------------------
+  ## New Matrix (Symmetry 0) ##
+  Irrep: 1 Size: 2 x 3
+
+                 1                   2                   3
+
+    1     0.00000000000000     0.00000000000000    -0.03468154308208
+    2     0.00000000000000     0.00000000000000     0.03468154308208
+
+
+
+	Analytic vs Reference CAM Gradients...............................PASSED
+	Analytic vs FD CAM Gradients......................................PASSED
+
+    Psi4 stopped on: Monday, 11 March 2019 02:24AM
+    Psi4 wall time for execution: 0:01:02.89
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
out, damned global!

## Todos
- [x] removes `P::e.parent_symmetry` and uses a read_options keyword (global, `!expert`) in its place. this is a test before distributed driver roll-out. (globals don't play well with json.) (@JonathonMisiewicz, I was misremembering when I though optking still used this too.) 
- [x] unused but adds definition and export of Jonathon's `PointGroup.full_label()` that has directionality, e.g. `C2v(Z)`.
- [x] sync `Wavefunction.energy_`, `gradient_`, `hessian_` with qcvars `CURRENT_*` on wfn (not in `P::e.globals`)

## Checklist
- [ ] ~Tests added for any new features~
- [x] full pytest and ctest pass

## Status
- [x] Ready for review
- [x] Ready for merge
