### PR TITLE
update run_json and wfn qcvars

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -441,14 +441,14 @@ def set_options(options_dict, verbose=1):
                 try:
                     core.set_local_option(module, option, v)
                 except RuntimeError as err:
-                    rejected[k] = v
+                    rejected[k] = (v, err)
                 if verbose > 1:
                     print('Setting: core.set_local_option', module, option, v)
         else:
             try:
                 core.set_global_option(option, v)
             except RuntimeError as err:
-                rejected[k] = v
+                rejected[k] = (v, err)
             if verbose > 1:
                 print('Setting: core.set_global_option', option, v)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2217,6 +2217,9 @@ def run_scf_hessian(name, **kwargs):
     H = core.scfhess(ref_wfn)
     ref_wfn.set_hessian(H)
 
+    # Clearly, add some logic when the reach of this fn expands
+    ref_wfn.set_variable('HF TOTAL HESSIAN', H)
+
     optstash.restore()
     return ref_wfn
 

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -171,6 +171,8 @@ double CCEnergyWavefunction::compute_energy() {
         psio_write_entry(PSIF_CC_INFO, "MP2 Energy", (char *)&(moinfo_.emp2), sizeof(double));
         Process::environment.globals["MP2 CORRELATION ENERGY"] = moinfo_.emp2;
         Process::environment.globals["MP2 TOTAL ENERGY"] = moinfo_.emp2 + moinfo_.eref;
+        set_scalar_variable("MP2 CORRELATION ENERGY", moinfo_.emp2);
+        set_scalar_variable("MP2 TOTAL ENERGY", moinfo_.emp2 + moinfo_.eref);
     }
 
     if (params_.print_mp2_amps) amp_write();
@@ -356,6 +358,10 @@ double CCEnergyWavefunction::compute_energy() {
         Process::environment.globals["MP2 SAME-SPIN CORRELATION ENERGY"] = moinfo_.emp2_ss;
         Process::environment.globals["MP2 CORRELATION ENERGY"] = moinfo_.emp2;
         Process::environment.globals["MP2 TOTAL ENERGY"] = moinfo_.eref + moinfo_.emp2;
+        set_scalar_variable("MP2 OPPOSITE-SPIN CORRELATION ENERGY", moinfo_.emp2_os);
+        set_scalar_variable("MP2 SAME-SPIN CORRELATION ENERGY", moinfo_.emp2_ss);
+        set_scalar_variable("MP2 CORRELATION ENERGY", moinfo_.emp2);
+        set_scalar_variable("MP2 TOTAL ENERGY", moinfo_.eref + moinfo_.emp2);
     }
     if (params_.wfn == "CC3" || params_.wfn == "EOM_CC3") {
         outfile->Printf("    CC3 correlation energy                    = %20.15f\n", moinfo_.ecc);
@@ -363,12 +369,16 @@ double CCEnergyWavefunction::compute_energy() {
 
         Process::environment.globals["CC3 CORRELATION ENERGY"] = moinfo_.ecc;
         Process::environment.globals["CC3 TOTAL ENERGY"] = moinfo_.eref + moinfo_.ecc;
+        set_scalar_variable("CC3 CORRELATION ENERGY", moinfo_.ecc);
+        set_scalar_variable("CC3 TOTAL ENERGY", moinfo_.eref + moinfo_.ecc);
     } else if (params_.wfn == "CC2" || params_.wfn == "EOM_CC2") {
         outfile->Printf("    CC2 correlation energy                    = %20.15f\n", moinfo_.ecc);
         outfile->Printf("      * CC2 total energy                      = %20.15f\n", moinfo_.eref + moinfo_.ecc);
 
         Process::environment.globals["CC2 CORRELATION ENERGY"] = moinfo_.ecc;
         Process::environment.globals["CC2 TOTAL ENERGY"] = moinfo_.eref + moinfo_.ecc;
+        set_scalar_variable("CC2 CORRELATION ENERGY", moinfo_.ecc);
+        set_scalar_variable("CC2 TOTAL ENERGY", moinfo_.eref + moinfo_.ecc);
 
         if (params_.local && local_.weakp == "MP2")
             outfile->Printf("      * LCC2 (+LMP2) total energy             = %20.15f\n",
@@ -407,6 +417,10 @@ double CCEnergyWavefunction::compute_energy() {
         Process::environment.globals["CCSD SAME-SPIN CORRELATION ENERGY"] = moinfo_.ecc_ss;
         Process::environment.globals["CCSD CORRELATION ENERGY"] = moinfo_.ecc;
         Process::environment.globals["CCSD TOTAL ENERGY"] = moinfo_.ecc + moinfo_.eref;
+        set_scalar_variable("CCSD OPPOSITE-SPIN CORRELATION ENERGY", moinfo_.ecc_os);
+        set_scalar_variable("CCSD SAME-SPIN CORRELATION ENERGY", moinfo_.ecc_ss);
+        set_scalar_variable("CCSD CORRELATION ENERGY", moinfo_.ecc);
+        set_scalar_variable("CCSD TOTAL ENERGY", moinfo_.ecc + moinfo_.eref);
 
         if (params_.local && local_.weakp == "MP2")
             outfile->Printf("      * LCCSD (+LMP2) total energy            = %20.15f\n",
@@ -460,6 +474,8 @@ double CCEnergyWavefunction::compute_energy() {
     name_ = "CCSD";
     Process::environment.globals["CURRENT ENERGY"] = moinfo_.ecc + moinfo_.eref;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = moinfo_.ecc;
+    set_scalar_variable("CURRENT ENERGY", moinfo_.ecc + moinfo_.eref);
+    set_scalar_variable("CURRENT CORRELATION ENERGY", moinfo_.ecc);
     // Process::environment.globals["CC TOTAL ENERGY"] = moinfo.ecc+moinfo.eref;
     // Process::environment.globals["CC CORRELATION ENERGY"] = moinfo.ecc;
 
@@ -470,10 +486,16 @@ double CCEnergyWavefunction::compute_energy() {
 
     if ((options_.get_str("WFN") == "CCSD_T")) {
         // Run cctriples
-        if (psi::cctriples::cctriples(reference_wavefunction_, options_) == Success)
+        if (psi::cctriples::cctriples(reference_wavefunction_, options_) == Success) {
             energy_ = Process::environment.globals["CURRENT ENERGY"];
-        else
+            set_scalar_variable("(T) CORRECTION ENERGY", reference_wavefunction_->scalar_variable("(T) CORRECTION ENERGY"));
+            set_scalar_variable("CCSD(T) CORRELATION ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("CCSD(T) TOTAL ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) TOTAL ENERGY"));
+            set_scalar_variable("CURRENT CORRELATION ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("CURRENT ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) TOTAL ENERGY"));
+        } else {
             energy_ = 0.0;
+        }
     }
 
     return energy_;

--- a/psi4/src/psi4/cc/cctriples/triples.cc
+++ b/psi4/src/psi4/cc/cctriples/triples.cc
@@ -35,6 +35,7 @@
 #include "MOInfo.h"
 #include "globals.h"
 
+#include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
@@ -150,6 +151,9 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
             Process::environment.globals["(T) CORRECTION ENERGY"] = ET;
             Process::environment.globals["CCSD(T) CORRELATION ENERGY"] = ET + moinfo.ecc;
             Process::environment.globals["CCSD(T) TOTAL ENERGY"] = ET + moinfo.ecc + moinfo.eref;
+            reference_wavefunction->set_scalar_variable("(T) CORRECTION ENERGY", ET);
+            reference_wavefunction->set_scalar_variable("CCSD(T) CORRELATION ENERGY", ET + moinfo.ecc);
+            reference_wavefunction->set_scalar_variable("CCSD(T) TOTAL ENERGY", ET + moinfo.ecc + moinfo.eref);
         } else if (params.wfn == "CCSD_AT") {
             ET = EaT_RHF();
             outfile->Printf("    (aT) energy                                = %20.15f\n", ET);
@@ -188,6 +192,9 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
         Process::environment.globals["(T) CORRECTION ENERGY"] = ET;
         Process::environment.globals["CCSD(T) CORRELATION ENERGY"] = ET + moinfo.ecc;
         Process::environment.globals["CCSD(T) TOTAL ENERGY"] = ET + moinfo.ecc + moinfo.eref;
+        reference_wavefunction->set_scalar_variable("(T) CORRECTION ENERGY", ET);
+        reference_wavefunction->set_scalar_variable("CCSD(T) CORRELATION ENERGY", ET + moinfo.ecc);
+        reference_wavefunction->set_scalar_variable("CCSD(T) TOTAL ENERGY", ET + moinfo.ecc + moinfo.eref);
     } else if (params.ref == 2) { /** UHF **/
 
         if (params.dertype == 0) {
@@ -231,6 +238,9 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
         Process::environment.globals["(T) CORRECTION ENERGY"] = ET;
         Process::environment.globals["CCSD(T) CORRELATION ENERGY"] = ET + moinfo.ecc;
         Process::environment.globals["CCSD(T) TOTAL ENERGY"] = ET + moinfo.ecc + moinfo.eref;
+        reference_wavefunction->set_scalar_variable("(T) CORRECTION ENERGY", ET);
+        reference_wavefunction->set_scalar_variable("CCSD(T) CORRELATION ENERGY", ET + moinfo.ecc);
+        reference_wavefunction->set_scalar_variable("CCSD(T) TOTAL ENERGY", ET + moinfo.ecc + moinfo.eref);
 
     }  // UHF
 
@@ -241,6 +251,8 @@ PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Op
 
     Process::environment.globals["CURRENT ENERGY"] = ET + moinfo.ecc + moinfo.eref;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = ET + moinfo.ecc;
+    reference_wavefunction->set_scalar_variable("CURRENT ENERGY", ET + moinfo.ecc + moinfo.eref);
+    reference_wavefunction->set_scalar_variable("CURRENT CORRELATION ENERGY", ET + moinfo.ecc);
 
     dpd_close(0);
 

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -775,9 +775,9 @@ void DFMP2::print_energies() {
     outfile->Printf("\t %-25s = %24.16f [-]\n", "SCS Same-Spin Scale", sss_);
     outfile->Printf("\t %-25s = %24.16f [-]\n", "SCS Opposite-Spin Scale", oss_);
     outfile->Printf("\t %-25s = %24.16f [Eh]\n", "SCS Same-Spin Energy",
-                    variables_["SCS-MP2 SAME-SPIN CORRELATION ENERGY"]);
+                    sss_ * variables_["MP2 SAME-SPIN CORRELATION ENERGY"]);
     outfile->Printf("\t %-25s = %24.16f [Eh]\n", "SCS Opposite-Spin Energy",
-                    variables_["SCS-MP2 OPPOSITE-SPIN CORRELATION ENERGY"]);
+                    oss_ * variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]);
     outfile->Printf("\t %-25s = %24.16f [Eh]\n", "SCS Correlation Energy", variables_["SCS-MP2 CORRELATION ENERGY"]);
     outfile->Printf("\t %-25s = %24.16f [Eh]\n", "SCS Total Energy", variables_["SCS-MP2 TOTAL ENERGY"]);
     outfile->Printf("\t-----------------------------------------------------------\n");

--- a/psi4/src/psi4/scfgrad/wrapper.cc
+++ b/psi4/src/psi4/scfgrad/wrapper.cc
@@ -58,6 +58,7 @@ SharedMatrix scfhess(SharedWavefunction ref_wfn, Options &options)
     SCFGrad grad(ref_wfn, options);
     SharedMatrix H = grad.compute_hessian();
     ref_wfn->set_hessian(H);
+    ref_wfn->set_array_variable("SCF TOTAL HESSIAN", H);
     ref_wfn->set_array_variable("SCF DIPOLE GRADIENT", grad.dipole_gradient());
     ref_wfn->set_array_variable("CURRENT DIPOLE GRADIENT", grad.dipole_gradient());
 

--- a/tests/json/schema-1-energy/input.py
+++ b/tests/json/schema-1-energy/input.py
@@ -68,7 +68,7 @@ with open("output.json", "w") as ofile:                                         
 
 psi4.compare_integers(True, json_ret["success"], "JSON Success")                           #TEST
 psi4.compare_values(expected_return_result, json_ret["return_result"], 5, "Return Value")  #TEST
-psi4.compare_integers(True, "MAYER_INDICES" in json_ret["psi4:qcvars"], "Mayer Indices Found")                           #TEST
+psi4.compare_integers(True, "MAYER_INDICES" in json_ret["extras"]["qcvars"], "Mayer Indices Found")                           #TEST
 
 for k in expected_properties.keys():                                                       #TEST
     psi4.compare_values(expected_properties[k], json_ret["properties"][k], 5, k.upper())   #TEST
@@ -101,7 +101,7 @@ json_ret = psi4.json_wrapper.run_json(json_data)
 
 psi4.compare_integers(True, json_ret["success"], "JSON Success")                           #TEST
 psi4.compare_values(expected_return_result, json_ret["return_result"], 5, "Return Value")  #TEST
-psi4.compare_integers(True, "MAYER_INDICES" in json_ret["psi4:qcvars"], "Mayer Indices Found")                           #TEST
+psi4.compare_integers(True, "MAYER_INDICES" in json_ret["extras"]["qcvars"], "Mayer Indices Found")                           #TEST
 
 # print(json.dumps(json_ret, indent=2))
 

--- a/tests/json/schema-1-throws/input.py
+++ b/tests/json/schema-1-throws/input.py
@@ -31,7 +31,7 @@ json_data = {
 json_ret = psi4.json_wrapper.run_json(json_data)
 
 psi4.compare_integers(False, json_ret["success"], "JSON Failure")                           #TEST
-psi4.compare_integers("non-contiguous frag" in json_ret["error"], True, "Contiguous Fragment Error")  #TEST
+psi4.compare_integers("non-contiguous frag" in json_ret["error"]['error_message'], True, "Contiguous Fragment Error")  #TEST
 
 # Check symbol length errors
 del json_data["molecule"]["fragments"]
@@ -39,7 +39,7 @@ json_data["molecule"]["symbols"] = ["O", "H"]
 json_ret = psi4.json_wrapper.run_json(json_data)
 
 psi4.compare_integers(False, json_data["success"], "JSON Failure")                           #TEST
-psi4.compare_integers("atoms" in json_data["error"], True, "Symbol Error")  #TEST
+psi4.compare_integers("atoms" in json_data["error"]['error_message'], True, "Symbol Error")  #TEST
 
 # Check keyword errors
 json_data["molecule"]["symbols"] = ["O", "H", "H"]
@@ -48,4 +48,4 @@ json_data["keywords"] = {"scf_type": "super_df"}
 json_ret = psi4.json_wrapper.run_json(json_data)
 
 psi4.compare_integers(False, json_ret["success"], "JSON Failure")                           #TEST
-psi4.compare_integers("valid choice" in json_ret["error"], True, "Keyword Error")  #TEST
+psi4.compare_integers("valid choice" in json_ret["error"]['error_message'], True, "Keyword Error")  #TEST

--- a/tests/scf-hess1/input.dat
+++ b/tests/scf-hess1/input.dat
@@ -37,14 +37,13 @@ compare_arrays(psi3_hess, psi4_hess, 1E-7, "STO-3G Hessian") #TEST
 compare_values(ref_ene, variable('CURRENT ENERGY'), 6, 'STO-3G energy')  #TEST
 compare_values(ref_ene, variable('current ENERGY'), 6, 'STO-3G energy')  #TEST
 compare_values(ref_ene, variable('HF TOTAL ENERGY'), 6, 'STO-3G energy')  #TEST
-# waiting for #1445
 #compare_arrays(psi3_hess, variable('CURRENT HESSIAN'), 7, "STO-3G Hessian")  #TEST
 #compare_arrays(psi3_hess, variable('HF TOTAL HESSIAN'), 7, "STO-3G Hessian")  #TEST
-#compare_values(ref_ene, wfn.variable('CURRENT ENERGY'), 6, 'STO-3G energy')  #TEST
-#compare_values(ref_ene, wfn.variable('current ENERGY'), 6, 'STO-3G energy')  #TEST
-#compare_values(ref_ene, wfn.variable('HF TOTAL ENERGY'), 6, 'STO-3G energy')  #TEST
-#compare_arrays(psi3_hess, wfn.variable('CURRENT HESSIAN'), 7, "STO-3G Hessian")  #TEST
-#compare_arrays(psi3_hess, wfn.variable('HF TOTAL HESSIAN'), 7, "STO-3G Hessian")  #TEST
+compare_values(ref_ene, wfn.variable('CURRENT ENERGY'), 6, 'STO-3G energy')  #TEST
+compare_values(ref_ene, wfn.variable('current ENERGY'), 6, 'STO-3G energy')  #TEST
+compare_values(ref_ene, wfn.variable('HF TOTAL ENERGY'), 6, 'STO-3G energy')  #TEST
+compare_arrays(psi3_hess, wfn.variable('CURRENT HESSIAN'), 7, "STO-3G Hessian")  #TEST
+compare_arrays(psi3_hess, wfn.variable('HF TOTAL HESSIAN'), 7, "STO-3G Hessian")  #TEST
 
 # Clean out scratch files and go again with cc-pVDZ
 psi4.clean()


### PR DESCRIPTION
## Todos
- [x] modernizes `run_json` to the level of the ddd branch
  - sets all options at once and allows module-level options (`scf__reference` --> `set scf reference`)
  - shifts `json['psi4:qcvars']` --> `json['extras']['qcvars']`
  - `json['extras']['wfn_qcvars_only']` collects qcvars only from wfn, not from `P::e`
  - uses molecule dtype=2, qcschema one-word, and new error format
- [x] adds more psivars
  - `HF TOTAL HESSIAN`
  - removes scs-mp2 ss/os psivars in dfmp2 that were getting autovivified. thereby also corrects printing of 0s
  - in cc* modules, defines psivars on wfn that I'm confident will endure

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
