### PR TITLE
quadrature weights cutoff

### DIFF
--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3619,6 +3619,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
     OrientationMgr std_orientation(molecule_);
     RadialPruneMgr prune(opt);
     NuclearWeightMgr nuc(molecule_, opt.nucscheme);
+    double weightcut = opt.weights_cutoff;
 
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
@@ -3669,7 +3670,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                     mp = std_orientation.MoveIntoPosition(mp, A);
                     mp.w *= nuc.computeNuclearWeight(mp, A, stratmannCutoff);  // This ain't gonna fly. Must abate this
                                                                                // mickey mouse a most rikky tikki tavi.
-                    grid[A].push_back(mp);
+                    if (std::abs(mp.w) > weightcut) {grid[A].push_back(mp);}
                     assert(!std::isnan(mp.w));
                 }
             }
@@ -3684,7 +3685,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                 mp.w *= nuc.computeNuclearWeight(
                     mp, A,
                     stratmannCutoff);  // This ain't gonna fly. Must abate this mickey mouse a most rikky tikki tavi.
-                grid[A].push_back(mp);
+                if (std::abs(mp.w) > weightcut) {grid[A].push_back(mp);}
                 assert(!std::isnan(mp.w));
             }
         }
@@ -3724,6 +3725,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
     OrientationMgr std_orientation(molecule_);
     RadialPruneMgr prune(opt);
     NuclearWeightMgr nuc(molecule_, opt.nucscheme);
+    double weightcut=opt.weights_cutoff;
 
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
@@ -3766,7 +3768,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
                 mp.w *= nuc.computeNuclearWeight(
                     mp, A,
                     stratmannCutoff);  // This ain't gonna fly. Must abate this mickey mouse a most rikky tikki tavi.
-                grid[A].push_back(mp);
+                if (std::abs(mp.w) > weightcut) {grid[A].push_back(mp);}
                 assert(!std::isnan(mp.w));
             }
         }
@@ -4096,6 +4098,7 @@ void DFTGrid::buildGridFromOptions(std::map<std::string, int> int_opts_map,
     opt.namedGrid = StandardGridMgr::WhichGrid(full_str_options["DFT_GRID_NAME"].c_str());
     opt.nradpts = full_int_options["DFT_RADIAL_POINTS"];
     opt.nangpts = full_int_options["DFT_SPHERICAL_POINTS"];
+    opt.weights_cutoff = options_.get_double("DFT_WEIGHTS_TOLERANCE");
 
     // handle pruning options
     static const std::vector<std::string> function_names = {"FLAT",       "P_SLATER",   "D_SLATER",    "LOG_SLATER",
@@ -4288,6 +4291,7 @@ void MolecularGrid::print(std::string out, int /*print*/) const {
     printer->Printf("    Total Blocks           = %14zu\n", blocks_.size());
     printer->Printf("    Max Points             = %14d\n", max_points_);
     printer->Printf("    Max Functions          = %14d\n", max_functions_);
+    printer->Printf("    Weights Tolerance      = %14.2E\n", options_.weights_cutoff);
     // printer->Printf("    Collocation Size [MiB] = %14d\n", (int)((8.0 * collocation_size_) / (1024.0 * 1024.0)));
     printer->Printf("\n");
     Process::environment.globals["XC GRID TOTAL POINTS"] = npoints_;

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -120,6 +120,7 @@ class MolecularGrid {
         short namedGrid;  // -1 = None, 0 = SG-0, 1 = SG-1
         int nradpts;
         int nangpts;
+        double weights_cutoff;
         std::string prunescheme;
         std::string prunetype;
     };

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1494,8 +1494,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("DFT_BS_RADIUS_ALPHA", 1.0);
         /*- DFT basis cutoff. -*/
         options.add_double("DFT_BASIS_TOLERANCE", 1.0E-12);
-        /*- grid weight cutoff. !expert -*/
-        options.add_double("DFT_WEIGHTS_TOLERANCE", 1.0E-14);
+        /*- grid weight cutoff. Disable with -1.0. !expert -*/
+        options.add_double("DFT_WEIGHTS_TOLERANCE", 1.0E-15);
         /*- The DFT grid specification, such as SG1.!expert -*/
         options.add_str("DFT_GRID_NAME", "", "SG0 SG1");
         /*- Select approach for pruning. Options ``ROBUST`` and ``TREUTLER`` prune based on regions (proximity to nucleus) while

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1494,6 +1494,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("DFT_BS_RADIUS_ALPHA", 1.0);
         /*- DFT basis cutoff. -*/
         options.add_double("DFT_BASIS_TOLERANCE", 1.0E-12);
+        /*- grid weight cutoff. !expert -*/
+        options.add_double("DFT_WEIGHTS_TOLERANCE", 1.0E-14);
         /*- The DFT grid specification, such as SG1.!expert -*/
         options.add_str("DFT_GRID_NAME", "", "SG0 SG1");
         /*- Select approach for pruning. Options ``ROBUST`` and ``TREUTLER`` prune based on regions (proximity to nucleus) while

--- a/tests/dft-pruning/input.dat
+++ b/tests/dft-pruning/input.dat
@@ -12,32 +12,29 @@ set maxiter 1
 set FAIL_ON_MAXITER false
 set DFT_WEIGHTS_TOLERANCE -1.0
 
-SCHEMES={
-"NONE" : 66989, #TEST
-"FLAT" : 66989, #TEST
-"TREUTLER" : 37217, #TEST
-"ROBUST" : 45929, #TEST
-"P_SLATER" : 21465, #TEST
-"D_SLATER" : 15681, #TEST
-"LOG_SLATER" : 13377, #TEST
-"P_GAUSSIAN" : 16059, #TEST
-"D_GAUSSIAN" : 11727, #TEST
-"LOG_GAUSSIAN" : 15948, #TEST
+
+SCHEMES = {
+    "NONE": 66989,  #TEST
+    "FLAT": 66989,  #TEST
+    "TREUTLER": 37217,  #TEST
+    "ROBUST": 45929,  #TEST
+    "P_SLATER": 21465,  #TEST
+    "D_SLATER": 15681,  #TEST
+    "LOG_SLATER": 13377,  #TEST
+    "P_GAUSSIAN": 16059,  #TEST
+    "D_GAUSSIAN": 11727,  #TEST
+    "LOG_GAUSSIAN": 15948,  #TEST
 }
 
 for scheme in SCHEMES:
-  set DFT_PRUNING_SCHEME $scheme
-  energy('pbe/sto-3g')
-  compare_integers(SCHEMES[scheme], int(variable('XC GRID TOTAL POINTS')), 'grid points for '+scheme) #TEST
+    set DFT_PRUNING_SCHEME $scheme
+    energy('pbe/sto-3g')
+    compare_integers(SCHEMES[scheme], int(variable('XC GRID TOTAL POINTS')), 'grid points for ' + scheme)  #TEST
 
 # screening based on small weights
 set DFT_PRUNING_SCHEME ROBUST
-screening={
-1e-12:45198,
-1e-14:45429,
-1e-16:45679
-}
+screening = {1e-12: 45198, 1e-14: 45429, 1e-16: 45679}
 for val in screening:
-  set DFT_WEIGHTS_TOLERANCE $val
-  energy('pbe/sto-3g')
-  compare_integers(screening[val], int(variable('XC GRID TOTAL POINTS')), 'grid points for weights_tolerance: '+str(val)) #TEST
+    energy('pbe/sto-3g')
+    compare_integers(screening[val], int(variable('XC GRID TOTAL POINTS')),
+                     'grid points for weights_tolerance: ' + str(val))  #TEST

--- a/tests/dft-pruning/input.dat
+++ b/tests/dft-pruning/input.dat
@@ -1,4 +1,4 @@
-#! Tests all grid pruning options available and check grid size
+#! Tests all grid pruning options available and screening of small weights. Check against grid size.
 
 molecule water{ 
 0 1
@@ -10,6 +10,7 @@ molecule water{
 set scf_type pk
 set maxiter 1
 set FAIL_ON_MAXITER false
+set DFT_WEIGHTS_TOLERANCE -1.0
 
 SCHEMES={
 "NONE" : 66989, #TEST
@@ -27,4 +28,16 @@ SCHEMES={
 for scheme in SCHEMES:
   set DFT_PRUNING_SCHEME $scheme
   energy('pbe/sto-3g')
-  compare_integers(SCHEMES[scheme], int(variable('XC GRID TOTAL POINTS')), 'grid porints for '+scheme) #TEST
+  compare_integers(SCHEMES[scheme], int(variable('XC GRID TOTAL POINTS')), 'grid points for '+scheme) #TEST
+
+# screening based on small weights
+set DFT_PRUNING_SCHEME ROBUST
+screening={
+1e-12:45198,
+1e-14:45429,
+1e-16:45679
+}
+for val in screening:
+  set DFT_WEIGHTS_TOLERANCE $val
+  energy('pbe/sto-3g')
+  compare_integers(screening[val], int(variable('XC GRID TOTAL POINTS')), 'grid points for weights_tolerance: '+str(val)) #TEST


### PR DESCRIPTION
## Description
XC quadrature weights can become very small and thus their contributions are negligible. This PR introduces a cutoff for small weights. The grid points with small weights are not included in the final grid. Such a cutoff is a standard procedure in many programs.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] expert option `DFT_WEIGHTS_TOLERANCE` keyword (current default `1e-14`).
- [x] small error overview added
- [x] together with pruning ca. 40% faster calculation for C60 compared to `v1.3` :-)
- [x] simple test added

## Questions
- [x] which default value? -> `1e-15` conservative or `1e-14` like in ORCA

## Checklist
- [x] all `ctest -L dft` pass

## Status
- [x] Ready for review
- [x] Ready for merge

------
water dimer (RKS total energy): `PBE/aug-cc-pVTZ (99,520)` econv=1e-10 dconv=1e-8

 | tolerance | error | #points |
 | --- | --- | ---|
 | off | 0.0 | 350460 |                                                 
 | 1e-30 | 1.36e-12 | 349417 |
 | 1e-25 | 1.65e-12 | 348670 |
 | 1e-20 | 1.65e-12 | 346918 |
 | 1e-18 | 1.68e-12 | 345747 |
 | 1e-16 | 1.63e-11 | 340646 |
 | 1e-15 | 2.74e-11 | 339647|
 | 1e-14 | 5.73e-09  |  335089 |
 | 1e-13 | 3.65e-08  |  331285 |
 | 1e-12 | 3.18e-07 | 326462 |


c2 sym. C60 isomer  (RKS total energy): `PBE/aug-cc-pVDZ (75,302)` econv=1e-10 dconv=1e-8

 | tolerance | error | #points |
 | --- | --- | ---|
 | off | 0.0 |  1359000 |    
 | 1e-30 -| 3.17e-10| 1229846|
 | 1e-25 | -5.34e-10| 1209622|
 | 1e-20 | 5.94e-10 |1183674|
 | 1e-18 | 5.41e-10 |1171102|
 | 1e-16 | -6.25e-10 |1156776|
 | 1e-15 | 2.48e-09| 1131228|
 | 1e-14 | 3.54e-09| 1123018|
 | 1e-13 | 1.25e-07 |1110668 |
 | 1e-12 |1.07e-06 |1085824 |

-----

*further timings*
C60 fullerene (C2h) :PBE/aug-cc-pVDZ with grid (434,75); 16 Threads; comparison to `v1.3.1`
* pruning `ROBUST`=1.33 // `1361880/1953000` grid points // dE=2E-11
* pruning `TREUTLER=1.36`// `1064520/1953000` grid points // dE=-4E-05
* pruning `ROBUST` +  `screening(1e-14)` = 1.39; `1070388/1953000` grid points //dE=-2E-09
* pruning `TREUTLER` +  `screening(1e-14)` = 1.44; `773028/1953000` grid points //dE=-4E-05