### PR TITLE
Fix Database for Open Shells; Rip out Reap/Sow

### DIFF
--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -38,6 +38,7 @@ import pickle
 import collections
 
 from psi4.driver import constants
+from psi4.driver import p4util
 from psi4.driver.driver import *
 # never import aliases into this file
 
@@ -276,7 +277,7 @@ def database(name, db_name, **kwargs):
         except AttributeError:
             pass
         else:
-            if yes.match(str(database.isOS)):
+            if p4util.yes.match(str(database.isOS)):
                 openshell_override = 1
                 core.print_out('\nSome reagents in database %s require an open-shell reference; will be reset to UHF/UKS as needed.\n' % (db_name))
 
@@ -429,40 +430,12 @@ def database(name, db_name, **kwargs):
     core.print_out("\n")
 
     #   write index of calcs to output file
-    if db_mode == 'continuous':
-        instructions = """\n    The database single-job procedure has been selected through mode='continuous'.\n"""
-        instructions += """    Calculations for the reagents will proceed in the order below and will be followed\n"""
-        instructions += """    by summary results for the database.\n\n"""
-        for rgt in HSYS:
-            instructions += """                    %-s\n""" % (rgt)
-        instructions += """\n    Alternatively, a farming-out of the database calculations may be accessed through\n"""
-        instructions += """    the database wrapper option mode='sow'/'reap'.\n\n"""
-        core.print_out(instructions)
-
-    #   write sow/reap instructions and index of calcs to output file and reap input file
-    if db_mode == 'sow':
-        instructions = """\n    The database sow/reap procedure has been selected through mode='sow'. In addition\n"""
-        instructions += """    to this output file (which contains no quantum chemical calculations), this job\n"""
-        instructions += """    has produced a number of input files (%s-*.in) for individual database members\n""" % (dbse)
-        instructions += """    and a single input file (%s-master.in) with a database(mode='reap') command.\n""" % (dbse)
-        instructions += """    The former may look very peculiar since processed and pickled python rather than\n"""
-        instructions += """    raw input is written. Follow the instructions below to continue.\n\n"""
-        instructions += """    (1)  Run all of the %s-*.in input files on any variety of computer architecture.\n""" % (dbse)
-        instructions += """       The output file names must be as given below.\n\n"""
-        for rgt in HSYS:
-            instructions += """             psi4 -i %-27s -o %-27s\n""" % (rgt + '.in', rgt + '.out')
-        instructions += """\n    (2)  Gather all the resulting output files in a directory. Place input file\n"""
-        instructions += """         %s-master.in into that directory and run it. The job will be trivial in\n""" % (dbse)
-        instructions += """         length and give summary results for the database in its output file.\n\n"""
-        instructions += """             psi4 -i %-27s -o %-27s\n\n""" % (dbse + '-master.in', dbse + '-master.out')
-        instructions += """    Alternatively, a single-job execution of the database may be accessed through\n"""
-        instructions += """    the database wrapper option mode='continuous'.\n\n"""
-        core.print_out(instructions)
-
-        with open('%s-master.in' % (dbse), 'w') as fmaster:
-            fmaster.write('# This is a psi4 input file auto-generated from the database() wrapper.\n\n')
-            fmaster.write("database('%s', '%s', mode='reap', cp='%s', rlxd='%s', zpe='%s', benchmark='%s', linkage=%d, subset=%s, tabulate=%s)\n\n" %
-                (name, db_name, db_cp, db_rlxd, db_zpe, db_benchmark, os.getpid(), HRXN, db_tabulate))
+    instructions = """\n    The database single-job procedure has been selected through mode='continuous'.\n"""
+    instructions += """    Calculations for the reagents will proceed in the order below and will be followed\n"""
+    instructions += """    by summary results for the database.\n\n"""
+    for rgt in HSYS:
+        instructions += """                    %-s\n""" % (rgt)
+    core.print_out(instructions)
 
     #   Loop through chemical systems
     ERGT = {}
@@ -472,150 +445,49 @@ def database(name, db_name, **kwargs):
     for rgt in HSYS:
         VRGT[rgt] = {}
 
-        # build string of title banner
-        banners = ''
-        banners += """core.print_out('\\n')\n"""
-        banners += """p4util.banner(' Database %s Computation: Reagent %s \\n   %s')\n""" % (db_name, rgt, TAGL[rgt])
-        banners += """core.print_out('\\n')\n\n"""
+        core.print_out('\n')
+        p4util.banner(' Database {} Computation: Reagent {} \n   {}'.format(db_name, rgt, TAGL[rgt]))
+        core.print_out('\n')
 
-        # build string of lines that defines contribution of rgt to each rxn
-        actives = ''
-        actives += """core.print_out('   Database Contributions Map:\\n   %s\\n')\n""" % ('-' * 75)
-        for rxn in HRXN:
-            db_rxn = dbse + '-' + str(rxn)
-            if rgt in ACTV[db_rxn]:
-                actives += """core.print_out('   reagent %s contributes by %.4f to reaction %s\\n')\n""" \
-                   % (rgt, RXNM[db_rxn][rgt], db_rxn)
-        actives += """core.print_out('\\n')\n\n"""
-
-        # build string of commands for options from the input file  TODO: handle local options too
-        commands = ''
-        commands += """\ncore.set_memory_bytes(%s)\n\n""" % (core.get_memory())
-        for chgdopt in core.get_global_option_list():
-            if core.has_global_option_changed(chgdopt):
-                chgdoptval = core.get_global_option(chgdopt)
-                #chgdoptval = core.get_option(chgdopt)
-                if isinstance(chgdoptval, (str, bytes)):
-                    commands += """core.set_global_option('%s', '%s')\n""" % (chgdopt, chgdoptval)
-                elif isinstance(chgdoptval, int) or isinstance(chgdoptval, float):
-                    commands += """core.set_global_option('%s', %s)\n""" % (chgdopt, chgdoptval)
-                else:
-                    pass
-                    #raise ValidationError('Option \'%s\' is not of a type (string, int, float, bool) that can be processed by database wrapper.' % (chgdopt))
-
-        # build string of molecule and commands that are dependent on the database
-        commands += '\n'
+        molecule = core.Molecule.from_dict(GEOS[rgt].to_dict())
+        molecule.set_name(rgt)
+        molecule.update_geometry()
 
         if symmetry_override:
-            commands += """molecule.reset_point_group('c1')\n"""
-            commands += """molecule.fix_orientation(True)\n"""
-            commands += """molecule.fix_com(True)\n"""
-            commands += """molecule.update_geometry()\n"""
+            molecule.reset_point_group('c1')
+            molecule.fix_orientation(True)
+            molecule.fix_com(True)
+            molecule.update_geometry()
 
         if (openshell_override) and (molecule.multiplicity() != 1):
             if user_reference == 'RHF':
-                commands += """core.set_global_option('REFERENCE', 'UHF')\n"""
+                core.set_global_option('REFERENCE', 'UHF')
             elif user_reference == 'RKS':
-                commands += """core.set_global_option('REFERENCE', 'UKS')\n"""
+                core.set_global_option('REFERENCE', 'UKS')
 
-        commands += """core.set_global_option('WRITER_FILE_LABEL', '%s')\n""" % \
-            (user_writer_file_label + ('' if user_writer_file_label == '' else '-') + rgt)
+        core.set_global_option('WRITER_FILE_LABEL', user_writer_file_label + ('' if user_writer_file_label == '' else '-') + rgt)
 
-        # all modes need to step through the reagents but all for different purposes
-        # continuous: defines necessary commands, executes energy(method) call, and collects results into dictionary
-        # sow: opens individual reagent input file, writes the necessary commands, and writes energy(method) call
-        # reap: opens individual reagent output file, collects results into a dictionary
-        if db_mode == 'continuous':
-            exec(banners)
-
-            molecule = core.Molecule.from_dict(GEOS[rgt].to_dict())
-            molecule.set_name(rgt)
-            molecule.update_geometry()
-
-            exec(commands)
-            #print 'MOLECULE LIVES %23s %8s %4d %4d %4s' % (rgt, core.get_global_option('REFERENCE'),
-            #    molecule.molecular_charge(), molecule.multiplicity(), molecule.schoenflies_symbol())
-            if allowoptexceeded:
-                try:
-                    ERGT[rgt] = func(molecule=molecule, **kwargs)
-                except ConvergenceError:
-                    core.print_out("Optimization exceeded cycles for %s" % (rgt))
-                    ERGT[rgt] = 0.0
-            else:
-                ERGT[rgt] = func(molecule=molecule, **kwargs)
-            core.print_variables()
-            exec(actives)
-            for envv in db_tabulate:
-                VRGT[rgt][envv.upper()] = core.variable(envv)
-            core.set_global_option("REFERENCE", user_reference)
-            core.clean()
-            #core.opt_clean()
-            core.clean_variables()
-
-        elif db_mode == 'sow':
-            with open('%s.in' % (rgt), 'w') as freagent:
-                freagent.write('# This is a psi4 input file auto-generated from the database() wrapper.\n\n')
-                freagent.write(banners)
-                freagent.write(p4util.format_molecule_for_input(GEOS[rgt], 'dbmol'))
-
-                freagent.write(commands)
-                freagent.write('''\npickle_kw = ("""''')
-                pickle.dump(kwargs, freagent)
-                freagent.write('''""")\n''')
-                freagent.write("""\nkwargs = pickle.loads(pickle_kw)\n""")
-                freagent.write("""electronic_energy = %s(**kwargs)\n\n""" % (func.__name__))
-                freagent.write("""core.print_variables()\n""")
-                freagent.write("""core.print_out('\\nDATABASE RESULT: computation %d for reagent %s """
-                    % (os.getpid(), rgt))
-                freagent.write("""yields electronic energy %20.12f\\n' % (electronic_energy))\n\n""")
-                freagent.write("""core.set_variable('NATOM', dbmol.natom())\n""")
-                for envv in db_tabulate:
-                    freagent.write("""core.print_out('DATABASE RESULT: computation %d for reagent %s """
-                        % (os.getpid(), rgt))
-                    freagent.write("""yields variable value    %20.12f for variable %s\\n' % (core.variable(""")
-                    freagent.write("""'%s'), '%s'))\n""" % (envv.upper(), envv.upper()))
-
-        elif db_mode == 'reap':
-            ERGT[rgt] = 0.0
-            for envv in db_tabulate:
-                VRGT[rgt][envv.upper()] = 0.0
-            exec(banners)
-            exec(actives)
+        if allowoptexceeded:
             try:
-                freagent = open('%s.out' % (rgt), 'r')
-            except IOError:
-                core.print_out('Warning: Output file \'%s.out\' not found.\n' % (rgt))
-                core.print_out('         Database summary will have 0.0 and **** in its place.\n')
-            else:
-                while 1:
-                    line = freagent.readline()
-                    if not line:
-                        if ERGT[rgt] == 0.0:
-                            core.print_out('Warning: Output file \'%s.out\' has no DATABASE RESULT line.\n' % (rgt))
-                            core.print_out('         Database summary will have 0.0 and **** in its place.\n')
-                        break
-                    s = line.split()
-                    if (len(s) != 0) and (s[0:3] == ['DATABASE', 'RESULT:', 'computation']):
-                        if int(s[3]) != db_linkage:
-                            raise ValidationError('Output file \'%s.out\' has linkage %s incompatible with master.in linkage %s.'
-                                % (rgt, str(s[3]), str(db_linkage)))
-                        if s[6] != rgt:
-                            raise ValidationError('Output file \'%s.out\' has nominal affiliation %s incompatible with reagent %s.'
-                                % (rgt, s[6], rgt))
-                        if (s[8:10] == ['electronic', 'energy']):
-                            ERGT[rgt] = float(s[10])
-                            core.print_out('DATABASE RESULT: electronic energy = %20.12f\n' % (ERGT[rgt]))
-                        elif (s[8:10] == ['variable', 'value']):
-                            for envv in db_tabulate:
-                                envv = envv.upper()
-                                if (s[13:] == envv.split()):
-                                    VRGT[rgt][envv] = float(s[10])
-                                    core.print_out('DATABASE RESULT: variable %s value    = %20.12f\n' % (envv, VRGT[rgt][envv]))
-                freagent.close()
-
-    #   end sow after writing files
-    if db_mode == 'sow':
-        return 0.0
+                ERGT[rgt] = func(molecule=molecule, **kwargs)
+            except ConvergenceError:
+                core.print_out(f"Optimization exceeded cycles for {rgt}")
+                ERGT[rgt] = 0.0
+        else:
+            ERGT[rgt] = func(molecule=molecule, **kwargs)
+        core.print_variables()
+        core.print_out("   Database Contributions Map:\n   {}\n".format('-' * 75))
+        for rxn in HRXN:
+            db_rxn = dbse + '-' + str(rxn)
+            if rgt in ACTV[db_rxn]:
+                core.print_out('   reagent {} contributes by {:.4f} to reaction {}\n'.format(rgt, RXNM[db_rxn][rgt], db_rxn))
+        core.print_out('\n')
+        for envv in db_tabulate:
+            VRGT[rgt][envv.upper()] = core.variable(envv)
+        core.set_global_option("REFERENCE", user_reference)
+        core.clean()
+        #core.opt_clean()
+        core.clean_variables()
 
     # Reap all the necessary reaction computations
     core.print_out("\n")


### PR DESCRIPTION
## Description
Fix the ability to use database computations when open-shell molecules, and thus reference changes, are involved. Because the time at which `molecule` exists, the fix I implemented would be incompatible with reap and sow, so those have been removed. I've simplified the code accordingly.

## Checklist
- [x] `pywrap-db1` and `pywrab-db3` pass. There doesn't seem to be a Ctest tag for wrapper_database

## Status
- [x] Ready for review
- [x] Ready for merge
