### PR TITLE
CBS() option handling fix

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -995,6 +995,7 @@ def _validate_cbs_inputs(cbs_metadata, molecule):
             scf["scheme"] = _get_default_xtpl(len(scf["basis"][1]), scf["treatment"])
             scf["alpha"] = None
             scf["options"] = False
+            scf["options_lo"] = False
             metadata.append(scf)
     # 2c) keep processing current stage
         stage["treatment"] = item.get("treatment", "scf" if len(metadata) == 0 else "corl")
@@ -1016,6 +1017,7 @@ def _validate_cbs_inputs(cbs_metadata, molecule):
                     len(stage["basis"][0]), len(stage["basis_lo"][0])))
         stage["alpha"] = item.get("alpha", None)
         stage["options"] = item.get("options", False)
+        stage["options_lo"] = item.get("options_lo", False)
         metadata.append(stage)
     return (metadata)
 
@@ -1361,7 +1363,8 @@ def cbs(func, label, **kwargs):
         * ```scheme```: scf extrapolation scheme function, by default it is worked out from the number of
         basis sets (1 - 3) supplied as ```basis```.
         * ```alpha```: alpha for the above scheme, if the default is to be overriden
-        * ```options```: if special options are required for a step, they should be entered as a dict here.
+        * ```options```: if special options are required for a step, they should be entered as a dict here. If some options should be used for both parts of the stage, they should be entered
+        in both ```options``` and ```options_lo```.
         This is helpful for calculating all electron corrections in otherwise frozen core calculations, or
         relativistic (DKH) Hamiltionian corrections for otherwise 2-component Hamiltonians.
         * ```treatment```: treat extrapolation stage as ```scf``` or ```corl```, by default only the first
@@ -1490,7 +1493,7 @@ def cbs(func, label, **kwargs):
                         delta["alpha"]
                     ])))
             NEED = _expand_scheme_orders(delta["scheme"], delta["basis_lo"][0], delta["basis_lo"][1], delta["wfn_lo"],
-                                         False, natom)
+                                         delta["options_lo"], natom)
             GRAND_NEED.append(
                 dict(
                     zip(d_fields, [

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1587,7 +1587,7 @@ def cbs(func, label, **kwargs):
 
         # Stash and set options if any
         if mc["f_options"]:
-            optionstash = p4util.OptionsState(list(mc["f_options"]))
+            optionstash = p4util.OptionsState(*[[opt] for opt in list(mc["f_options"])])
             for k, v, in mc["f_options"].items():
                 core.set_global_option(k.upper(), v)
         else:

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1522,7 +1522,7 @@ def cbs(func, label, **kwargs):
         dups = -1
         for indx_job, job in enumerate(JOBS):
             if (job['f_wfn'] == mc['f_wfn']) and (job['f_basis'] == mc['f_basis']) and \
-               (job['f_options'] == mc['f_options']):
+               (job['f_options'] == mc['f_options']) and (job['f_options'] != False):
                 dups += 1
                 if dups >= 1:
                     del JOBS[indx_job]
@@ -1534,7 +1534,8 @@ def cbs(func, label, **kwargs):
                 for indx_job, job in enumerate(JOBS):
                     if (VARH[mc['f_wfn']][wfn] == VARH[job['f_wfn']][job['f_wfn']]) and \
                        (mc['f_basis'] == job['f_basis']) and not \
-                       (mc['f_wfn'] == job['f_wfn']):
+                       (mc['f_wfn'] == job['f_wfn']) and \
+                       (mc['f_options'] == False):
                         del JOBS[indx_job]
 
     instructions += """\n    Enlightened listing of computations required.\n"""

--- a/tests/cbs-xtpl-dict/input.dat
+++ b/tests/cbs-xtpl-dict/input.dat
@@ -10,6 +10,8 @@ mp2_adtz_ref  = -76.3667778886      #TEST
 cbs_ref       = -76.371589026502    #TEST
 ae_ref        = -76.34300450653124  #TEST
 b_lo_ref      = -76.3482732705      #TEST
+fc_dtz_ref    = -76.368558833602    #TEST
+
 
 molecule h2o {
     O
@@ -67,7 +69,18 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
 
+# Basis_lo check
 b_lo  = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "cc-pvtz", "stage": "corr"},
                                     {"wfn": "mp2", "wfn_lo": "mp2", 
                                      "basis": "aug-cc-pvdz", "basis_lo": "cc-pvdz", "stage": "diff"}])
 compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #TEST
+
+# Options check (FC-CCSD - FC-MP2) as a last stage in an otherwise AE calculation
+set freeze_core False
+fc_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                     {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                     {"wfn": "ccsd", "basis": "cc-pvdz",
+                                      "options": {"freeze_core": "True"},
+                                      "wfn_lo": "mp2", "basis_lo": "cc-pvdz",
+                                      "options_lo": {"freeze_core": "True"}}])
+compare_values(fc_dtz_ref, fc_dtz, 6, "MP2/[DT]Z + D:FC-CCSD/DZ (options_lo check)")  #TEST                                      

--- a/tests/cbs-xtpl-dict/output.ref
+++ b/tests/cbs-xtpl-dict/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.3a2.dev71 
+                               Psi4 1.4a1.dev62 
 
-                         Git: Rev {cbs_dict} 51d75f9 dirty
+                         Git: Rev {cbs_options_v2} 09439ee dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -17,18 +17,19 @@
 
 
                          Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 29 October 2018 10:03PM
+    Psi4 started on: Tuesday, 26 March 2019 10:41PM
 
-    Process ID: 19048
-    Host:       dream
-    PSIDATADIR: /home/kraus/Applications/psi4-cbs_dict/share/psi4
+    Process ID: 31946
+    Host:       dorje
+    PSIDATADIR: /home/kraus/Applications/psi4-cbs_options_v2/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    4
     
   ==> Input File <==
 
@@ -45,6 +46,8 @@ mp2_adtz_ref  = -76.3667778886      #TEST
 cbs_ref       = -76.371589026502    #TEST
 ae_ref        = -76.34300450653124  #TEST
 b_lo_ref      = -76.3482732705      #TEST
+fc_dtz_ref    = -76.368558833602    #TEST
+
 
 molecule h2o {
     O
@@ -102,10 +105,21 @@ ae_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
                                        
 compare_values(ae_ref, ae_dtz, 6, "MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check")  #TEST
 
+# Basis_lo check
 b_lo  = energy(cbs, cbs_metadata = [{"wfn": "mp2", "basis": "cc-pvtz", "stage": "corr"},
                                     {"wfn": "mp2", "wfn_lo": "mp2", 
                                      "basis": "aug-cc-pvdz", "basis_lo": "cc-pvdz", "stage": "diff"}])
 compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #TEST
+
+# Options check (FC-CCSD - FC-MP2) as a last stage in an otherwise AE calculation
+set freeze_core False
+fc_dtz = energy(cbs, cbs_metadata = [{"wfn": "hf", "basis": "cc-pvtz"},
+                                     {"wfn": "mp2", "basis": "cc-pv[dt]z"},
+                                     {"wfn": "ccsd", "basis": "cc-pvdz",
+                                      "options": {"freeze_core": "True"},
+                                      "wfn_lo": "mp2", "basis_lo": "cc-pvdz",
+                                      "options_lo": {"freeze_core": "True"}}])
+compare_values(fc_dtz_ref, fc_dtz, 6, "MP2/[DT]Z + D:FC-CCSD/DZ (options_lo check)")  #TEST                                      
 --------------------------------------------------------------------------
 	Nuclear repulsion energy..........................................PASSED
 
@@ -127,24 +141,24 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:52 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:37 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -156,15 +170,15 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -198,8 +212,8 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -223,12 +237,12 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -249,16 +263,16 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474960   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112389   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099500   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759631   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091364   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763932   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202501   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368353   -3.16585e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459127   -9.07747e-10   4.57981e-07 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -273,26 +287,26 @@ compare_values(b_lo_ref, b_lo, 6, "MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)")  #
 
     Virtual:                                                              
 
-       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       4A1     0.178016     2B2     0.249486     3B2     0.760312  
        5A1     0.816144     6A1     1.166347     2B1     1.198686  
-       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       4B2     1.256577     7A1     1.452880     1A2     1.466534  
        3B1     1.668515     8A1     1.877409     5B2     1.890443  
-       6B2     2.355075     9A1     2.388631     4B1     3.249433  
-       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       6B2     2.355076     9A1     2.388631     4B1     3.249434  
+       2A2     3.298364    10A1     3.454608    11A1     3.821967  
        7B2     4.099335  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465018
+  @DF-RHF Final Energy:   -76.02139746459127
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453045310542336
-    Two-Electron Energy =                  37.6224415018366827
-    Total Energy =                        -76.0213974646501924
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453039752599892
+    Two-Electron Energy =                  37.6224409461013423
+    Total Energy =                        -76.0213974645912742
 
 Computation Completed
 
@@ -314,15 +328,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:52 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:38 2019
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.60 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.60 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -331,7 +345,7 @@ Total time:
 
    ==> HF <==
 
-   HI-zeta (0) Energy:               -76.021397464650
+   HI-zeta (0) Energy:               -76.021397464591
 
    ==> Components <==
 
@@ -362,8 +376,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	SCF/DZ Energy Check...............................................PASSED
 
@@ -388,24 +402,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:52 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:38 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   254 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -417,15 +431,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -459,8 +473,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -484,12 +498,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -510,16 +524,16 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
-   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
-   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
-   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
-   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
-   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
-   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
-   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
-   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.41489041839820   -7.54149e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94939227239756   -5.34502e-01   1.95452e-02 DIIS
+   @DF-RHF iter   2:   -76.00125190400573   -5.18596e-02   1.33894e-02 DIIS
+   @DF-RHF iter   3:   -76.03520106505171   -3.39492e-02   9.56773e-04 DIIS
+   @DF-RHF iter   4:   -76.03563686660343   -4.35802e-04   2.35729e-04 DIIS
+   @DF-RHF iter   5:   -76.03566703840997   -3.01718e-05   5.52447e-05 DIIS
+   @DF-RHF iter   6:   -76.03566957892120   -2.54051e-06   1.09701e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968197997   -1.03059e-07   1.79724e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968447467   -2.49470e-09   3.03719e-07 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -530,35 +544,35 @@ Total time:
     Doubly Occupied:                                                      
 
        1A1   -20.584239     2A1    -1.335646     1B2    -0.696479  
-       3A1    -0.577438     1B1    -0.506107  
+       3A1    -0.577440     1B1    -0.506106  
 
     Virtual:                                                              
 
        4A1     0.034658     2B2     0.057722     5A1     0.174901  
-       2B1     0.198750     6A1     0.219018     3B2     0.232772  
-       4B2     0.278550     7A1     0.326071     1A2     0.382614  
+       2B1     0.198751     6A1     0.219018     3B2     0.232772  
+       4B2     0.278550     7A1     0.326071     1A2     0.382613  
        8A1     0.397881     3B1     0.427473     5B2     0.532911  
        9A1     0.636696     6B2     0.654104     7B2     0.794625  
       10A1     0.917437     4B1     1.105428    11A1     1.117509  
-       2A2     1.145099    12A1     1.291955     8B2     1.454194  
-       5B1     1.470010    13A1     1.572206     9B2     1.971535  
+       2A2     1.145099    12A1     1.291954     8B2     1.454194  
+       5B1     1.470011    13A1     1.572206     9B2     1.971534  
        3A2     1.988356     6B1     2.082925    14A1     2.346452  
       10B2     2.398798    15A1     2.533949    11B2     2.701650  
       16A1     2.959676     7B1     3.671283    17A1     3.683511  
-       4A2     3.694440    18A1     3.974412    12B2     4.219132  
+       4A2     3.694440    18A1     3.974412    12B2     4.219133  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.03566968441635
+  @DF-RHF Final Energy:   -76.03566968447467
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.2744532990845414
-    Two-Electron Energy =                  37.4373180501008278
-    Total Energy =                        -76.0356696844163480
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.2744553901263487
+    Two-Electron Energy =                  37.4373201410843066
+    Total Energy =                        -76.0356696844746693
 
 Computation Completed
 
@@ -580,39 +594,39 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:53 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:39 2019
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.49 seconds =       0.02 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.88 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       3.74 seconds =       0.06 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: HF / AUG-CC-PVTZ //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:53 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:39 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   331 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -624,15 +638,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -666,8 +680,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -684,19 +698,19 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.015 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -717,15 +731,16 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
-   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
-   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
-   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
-   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
-   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
-   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
-   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.42760527148080   -7.54276e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.96811378081951   -5.40509e-01   9.46438e-03 DIIS
+   @DF-RHF iter   2:   -76.01927680942968   -5.11630e-02   6.75437e-03 DIIS
+   @DF-RHF iter   3:   -76.05404053367936   -3.47637e-02   4.62514e-04 DIIS
+   @DF-RHF iter   4:   -76.05449173305576   -4.51199e-04   1.20594e-04 DIIS
+   @DF-RHF iter   5:   -76.05452607126470   -3.43382e-05   2.83036e-05 DIIS
+   @DF-RHF iter   6:   -76.05452903339437   -2.96213e-06   6.19488e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918551890   -1.52125e-07   1.08170e-06 DIIS
+   @DF-RHF iter   8:   -76.05452918950198   -3.98308e-09   1.93594e-07 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -735,53 +750,53 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1   -20.574539     2A1    -1.332638     1B2    -0.695024  
-       3A1    -0.576753     1B1    -0.507036  
+       1A1   -20.574535     2A1    -1.332636     1B2    -0.695021  
+       3A1    -0.576754     1B1    -0.507035  
 
     Virtual:                                                              
 
        4A1     0.028857     2B2     0.047504     5A1     0.135675  
        2B1     0.160604     6A1     0.173592     3B2     0.182889  
-       4B2     0.223508     7A1     0.243195     1A2     0.265014  
+       4B2     0.223509     7A1     0.243195     1A2     0.265014  
        3B1     0.298614     8A1     0.308977     5B2     0.364390  
-       9A1     0.429252     6B2     0.458076     7B2     0.597483  
-      10A1     0.654324    11A1     0.706924     2A2     0.723448  
+       9A1     0.429252     6B2     0.458078     7B2     0.597483  
+      10A1     0.654325    11A1     0.706925     2A2     0.723449  
        4B1     0.733308    12A1     0.817266     5B1     0.842069  
       13A1     0.900258     8B2     0.903876     3A2     0.917595  
-       6B1     0.923740     9B2     0.927192    14A1     0.958248  
-      15A1     1.007272    10B2     1.031146     7B1     1.076378  
-      11B2     1.099813     4A2     1.166222    16A1     1.167626  
-      12B2     1.275446     5A2     1.496498    17A1     1.544368  
-       8B1     1.561529    13B2     1.783358    18A1     1.823747  
-      14B2     1.937333    19A1     2.076507     9B1     2.257870  
-       6A2     2.306761    20A1     2.330896    21A1     2.409897  
-      10B1     2.411769    15B2     2.442435    22A1     2.495911  
-      11B1     2.705590    16B2     2.706415    23A1     2.728639  
-      17B2     2.811108     7A2     2.862490    18B2     3.585310  
-      24A1     3.686446     8A2     3.985704    12B1     4.040917  
-      25A1     4.142823    19B2     4.188612    13B1     4.267485  
-       9A2     4.359029    14B1     4.374579    26A1     4.388443  
-      20B2     4.475531    27A1     4.665372    21B2     4.732011  
-      22B2     5.043219    10A2     5.047932    28A1     5.175757  
-      23B2     5.205684    15B1     5.398353    29A1     5.595097  
-      30A1     6.124197    24B2     6.530717    16B1     6.702525  
-      31A1     6.832480    17B1     7.082729    11A2     7.217367  
-      25B2     7.222436    18B1     7.238114    32A1     7.320931  
-      12A2     7.361765    33A1     7.429305    26B2     7.817219  
-      34A1     7.850720    27B2     8.591961    35A1    14.586348  
+       6B1     0.923741     9B2     0.927192    14A1     0.958248  
+      15A1     1.007272    10B2     1.031147     7B1     1.076378  
+      11B2     1.099814     4A2     1.166223    16A1     1.167626  
+      12B2     1.275447     5A2     1.496499    17A1     1.544368  
+       8B1     1.561530    13B2     1.783358    18A1     1.823748  
+      14B2     1.937335    19A1     2.076508     9B1     2.257872  
+       6A2     2.306763    20A1     2.330898    21A1     2.409898  
+      10B1     2.411770    15B2     2.442436    22A1     2.495912  
+      11B1     2.705592    16B2     2.706416    23A1     2.728641  
+      17B2     2.811110     7A2     2.862492    18B2     3.585311  
+      24A1     3.686447     8A2     3.985705    12B1     4.040919  
+      25A1     4.142824    19B2     4.188613    13B1     4.267486  
+       9A2     4.359030    14B1     4.374580    26A1     4.388444  
+      20B2     4.475533    27A1     4.665373    21B2     4.732013  
+      22B2     5.043220    10A2     5.047934    28A1     5.175758  
+      23B2     5.205686    15B1     5.398355    29A1     5.595098  
+      30A1     6.124199    24B2     6.530719    16B1     6.702528  
+      31A1     6.832483    17B1     7.082731    11A2     7.217370  
+      25B2     7.222438    18B1     7.238117    32A1     7.320934  
+      12A2     7.361768    33A1     7.429308    26B2     7.817222  
+      34A1     7.850722    27B2     8.591963    35A1    14.586350  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05452918814437
+  @DF-RHF Final Energy:   -76.05452918950198
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.3400347680288718
-    Two-Electron Energy =                  37.4840400153171203
-    Total Energy =                        -76.0545291881443717
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.3400379613266011
+    Two-Electron Energy =                  37.4840432072572440
+    Total Energy =                        -76.0545291895019773
 
 Computation Completed
 
@@ -803,15 +818,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:53 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:40 2019
 Module time:
-	user time   =       0.51 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.40 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.49 seconds =       0.04 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.26 seconds =       0.10 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -820,12 +835,12 @@ Total time:
 
    ==> Helgaker 2-point exponential SCF extrapolation for method: HF <==
 
-   LO-zeta (2) Energy:               -76.035669684416
-   HI-zeta (3) Energy:               -76.054529188144
+   LO-zeta (2) Energy:               -76.035669684475
+   HI-zeta (3) Energy:               -76.054529189502
    Alpha (exponent) Value:             1.630000000000
-   Beta (coefficient) Value:           0.610992926794
+   Beta (coefficient) Value:           0.610992968887
 
-   @Extrapolated HF/(D,T):          -76.059124724076
+   @Extrapolated HF/(D,T):          -76.059124725750
 
 
    ==> Components <==
@@ -842,7 +857,7 @@ Total time:
   ---------------------------------------------------------------------------------------------------------
       Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
   ---------------------------------------------------------------------------------------------------------
-        scf                   hf / aug-cc-pv[dt]z               1     -76.05912472   scf_xtpl_helgaker_2
+        scf                   hf / aug-cc-pv[dt]z               1     -76.05912473   scf_xtpl_helgaker_2
   ---------------------------------------------------------------------------------------------------------
 
    ==> CBS <==
@@ -850,16 +865,16 @@ Total time:
   ---------------------------------------------------------------------------------------------------------
       Stage               Method / Basis                               Energy [Eh]   Scheme
   ---------------------------------------------------------------------------------------------------------
-        scf                   hf / aug-cc-pv[dt]z                     -76.05912472   scf_xtpl_helgaker_2
-      total                  CBS                                      -76.05912472   
+        scf                   hf / aug-cc-pv[dt]z                     -76.05912473   scf_xtpl_helgaker_2
+      total                  CBS                                      -76.05912473   
   ---------------------------------------------------------------------------------------------------------
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	SCF/a[DT]Z Energy Check...........................................PASSED
 
@@ -884,24 +899,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:54 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:40 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   331 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -913,15 +928,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -955,8 +970,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -973,19 +988,19 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.015 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -1006,18 +1021,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
-   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
-   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
-   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
-   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
-   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
-   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
-   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
-   @DF-RHF iter   8:   -76.05452918958582   -1.44145e-09   1.06395e-07 DIIS
-   @DF-RHF iter   9:   -76.05452918962280   -3.69766e-11   2.36221e-08 DIIS
-   @DF-RHF iter  10:   -76.05452918962467   -1.87583e-12   3.66594e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.42760527148079   -7.54276e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.96811378081944   -5.40509e-01   9.46438e-03 DIIS
+   @DF-RHF iter   2:   -76.01927680942961   -5.11630e-02   6.75437e-03 DIIS
+   @DF-RHF iter   3:   -76.05404053367943   -3.47637e-02   4.62514e-04 DIIS
+   @DF-RHF iter   4:   -76.05449173305564   -4.51199e-04   1.20594e-04 DIIS
+   @DF-RHF iter   5:   -76.05452607126477   -3.43382e-05   2.83036e-05 DIIS
+   @DF-RHF iter   6:   -76.05452903339449   -2.96213e-06   6.19488e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918551885   -1.52124e-07   1.08170e-06 DIIS
+   @DF-RHF iter   8:   -76.05452918950201   -3.98316e-09   1.93594e-07 DIIS
+   @DF-RHF iter   9:   -76.05452918960766   -1.05658e-10   5.12908e-08 DIIS
+   @DF-RHF iter  10:   -76.05452918961498   -7.31859e-12   7.40888e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1059,21 +1074,21 @@ Total time:
       30A1     6.124199    24B2     6.530718    16B1     6.702527  
       31A1     6.832482    17B1     7.082730    11A2     7.217369  
       25B2     7.222438    18B1     7.238116    32A1     7.320933  
-      12A2     7.361767    33A1     7.429307    26B2     7.817221  
-      34A1     7.850722    27B2     8.591962    35A1    14.586349  
+      12A2     7.361767    33A1     7.429307    26B2     7.817220  
+      34A1     7.850721    27B2     8.591962    35A1    14.586349  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05452918962467
+  @DF-RHF Final Energy:   -76.05452918961498
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.3400215788308003
-    Two-Electron Energy =                  37.4840268246387680
-    Total Energy =                        -76.0545291896246738
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.3400215531870856
+    Two-Electron Energy =                  37.4840267990047238
+    Total Energy =                        -76.0545291896149820
 
 Computation Completed
 
@@ -1095,18 +1110,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:54 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:41 2019
 Module time:
-	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.04 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.08 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       8.95 seconds =       0.15 minutes
+	system time =       0.53 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:54 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:41 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1118,13 +1133,13 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1150,33 +1165,33 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0545291896246738 [Eh]
+	 Reference Energy          =     -76.0545291896149820 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0690823043574056 [Eh]
-	 Opposite-Spin Energy      =      -0.2174769846217335 [Eh]
-	 Correlation Energy        =      -0.2865592889791391 [Eh]
-	 Total Energy              =     -76.3410884786038082 [Eh]
+	 Same-Spin Energy          =      -0.0690823042795233 [Eh]
+	 Opposite-Spin Energy      =      -0.2174769844178245 [Eh]
+	 Correlation Energy        =      -0.2865592886973478 [Eh]
+	 Total Energy              =     -76.3410884783123294 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0230274347858019 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2609723815460802 [Eh]
-	 SCS Correlation Energy    =      -0.2839998163318820 [Eh]
-	 SCS Total Energy          =     -76.3385290059565591 [Eh]
+	 SCS Same-Spin Energy      =      -0.0230274347598411 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2609723813013894 [Eh]
+	 SCS Correlation Energy    =      -0.2839998160612305 [Eh]
+	 SCS Total Energy          =     -76.3385290056762074 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:54 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:41 2019
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.23 seconds =       0.04 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       9.75 seconds =       0.16 minutes
+	system time =       0.57 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -1185,15 +1200,15 @@ Total time:
 
    ==> HF <==
 
-   HI-zeta (0) Energy:               -76.054529189625
+   HI-zeta (0) Energy:               -76.054529189615
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.341088478604
+   HI-zeta (0) Energy:               -76.341088478312
 
    ==> HF <==
 
-   HI-zeta (0) Energy:               -76.054529189625
+   HI-zeta (0) Energy:               -76.054529189615
 
    ==> Components <==
 
@@ -1228,8 +1243,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/aTZ Energy Check..............................................PASSED
 
@@ -1259,24 +1274,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:55 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:41 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   254 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1288,15 +1303,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -1330,8 +1345,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1355,12 +1370,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -1381,18 +1396,19 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
-   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
-   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
-   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
-   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
-   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
-   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
-   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
-   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
-   @DF-RHF iter   9:   -76.03566968454179   -1.25439e-10   8.11191e-08 DIIS
-   @DF-RHF iter  10:   -76.03566968454702   -5.22959e-12   8.06200e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.41489041839819   -7.54149e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94939227239757   -5.34502e-01   1.95452e-02 DIIS
+   @DF-RHF iter   2:   -76.00125190400567   -5.18596e-02   1.33894e-02 DIIS
+   @DF-RHF iter   3:   -76.03520106505175   -3.39492e-02   9.56773e-04 DIIS
+   @DF-RHF iter   4:   -76.03563686660333   -4.35802e-04   2.35729e-04 DIIS
+   @DF-RHF iter   5:   -76.03566703841005   -3.01718e-05   5.52447e-05 DIIS
+   @DF-RHF iter   6:   -76.03566957892127   -2.54051e-06   1.09701e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968197994   -1.03059e-07   1.79724e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968447463   -2.49469e-09   3.03719e-07 DIIS
+   @DF-RHF iter   9:   -76.03566968454025   -6.56257e-11   8.41247e-08 DIIS
+   @DF-RHF iter  10:   -76.03566968454521   -4.95959e-12   1.10136e-08 DIIS
+   @DF-RHF iter  11:   -76.03566968454537   -1.56319e-13   1.69242e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1417,21 +1433,21 @@ Total time:
        5B1     1.470010    13A1     1.572206     9B2     1.971534  
        3A2     1.988356     6B1     2.082925    14A1     2.346452  
       10B2     2.398798    15A1     2.533949    11B2     2.701650  
-      16A1     2.959675     7B1     3.671282    17A1     3.683511  
+      16A1     2.959675     7B1     3.671282    17A1     3.683510  
        4A2     3.694439    18A1     3.974411    12B2     4.219132  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.03566968454702
+  @DF-RHF Final Energy:   -76.03566968454537
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.2744487679137961
-    Two-Electron Energy =                  37.4373135187993995
-    Total Energy =                        -76.0356696845470168
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.2744484853403435
+    Two-Electron Energy =                  37.4373132362275953
+    Total Energy =                        -76.0356696845453683
 
 Computation Completed
 
@@ -1453,18 +1469,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:55 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:42 2019
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.48 seconds =       0.02 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.87 seconds =       0.05 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      12.14 seconds =       0.20 minutes
+	system time =       0.73 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:55 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:42 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1476,13 +1492,13 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1508,57 +1524,57 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0356696845470168 [Eh]
+	 Reference Energy          =     -76.0356696845453683 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0575478414024630 [Eh]
-	 Opposite-Spin Energy      =      -0.1679991764235108 [Eh]
-	 Correlation Energy        =      -0.2255470178259738 [Eh]
-	 Total Energy              =     -76.2612167023729910 [Eh]
+	 Same-Spin Energy          =      -0.0575478414988638 [Eh]
+	 Opposite-Spin Energy      =      -0.1679991767436082 [Eh]
+	 Correlation Energy        =      -0.2255470182424720 [Eh]
+	 Total Energy              =     -76.2612167027878343 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0191826138008210 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2015990117082130 [Eh]
-	 SCS Correlation Energy    =      -0.2207816255090339 [Eh]
-	 SCS Total Energy          =     -76.2564513100560504 [Eh]
+	 SCS Same-Spin Energy      =      -0.0191826138329546 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2015990120923299 [Eh]
+	 SCS Correlation Energy    =      -0.2207816259252844 [Eh]
+	 SCS Total Energy          =     -76.2564513104706521 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:55 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:42 2019
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.96 seconds =       0.05 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      12.81 seconds =       0.21 minutes
+	system time =       0.77 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: MP2 / AUG-CC-PVTZ //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:55 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:42 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   327 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   331 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1570,15 +1586,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -1612,8 +1628,8 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -1630,19 +1646,19 @@ Total time:
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.014 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.015 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -1663,18 +1679,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82347253276782   -7.58235e+01   3.15899e-02 
-   @DF-RHF iter   1:   -76.03028052291803   -2.06808e-01   5.00280e-03 
-   @DF-RHF iter   2:   -76.04722402026870   -1.69435e-02   3.06655e-03 DIIS
-   @DF-RHF iter   3:   -76.05433933900613   -7.11532e-03   3.30208e-04 DIIS
-   @DF-RHF iter   4:   -76.05450531720139   -1.65978e-04   8.64231e-05 DIIS
-   @DF-RHF iter   5:   -76.05452714562570   -2.18284e-05   2.27979e-05 DIIS
-   @DF-RHF iter   6:   -76.05452911147846   -1.96585e-06   4.73873e-06 DIIS
-   @DF-RHF iter   7:   -76.05452918814437   -7.66659e-08   6.82564e-07 DIIS
-   @DF-RHF iter   8:   -76.05452918958582   -1.44145e-09   1.06395e-07 DIIS
-   @DF-RHF iter   9:   -76.05452918962280   -3.69766e-11   2.36221e-08 DIIS
-   @DF-RHF iter  10:   -76.05452918962467   -1.87583e-12   3.66594e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.42760527148083   -7.54276e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.96811378081952   -5.40509e-01   9.46438e-03 DIIS
+   @DF-RHF iter   2:   -76.01927680942964   -5.11630e-02   6.75437e-03 DIIS
+   @DF-RHF iter   3:   -76.05404053367948   -3.47637e-02   4.62514e-04 DIIS
+   @DF-RHF iter   4:   -76.05449173305584   -4.51199e-04   1.20594e-04 DIIS
+   @DF-RHF iter   5:   -76.05452607126477   -3.43382e-05   2.83036e-05 DIIS
+   @DF-RHF iter   6:   -76.05452903339440   -2.96213e-06   6.19488e-06 DIIS
+   @DF-RHF iter   7:   -76.05452918551890   -1.52124e-07   1.08170e-06 DIIS
+   @DF-RHF iter   8:   -76.05452918950202   -3.98312e-09   1.93594e-07 DIIS
+   @DF-RHF iter   9:   -76.05452918960785   -1.05828e-10   5.12908e-08 DIIS
+   @DF-RHF iter  10:   -76.05452918961511   -7.26175e-12   7.40888e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1716,21 +1732,21 @@ Total time:
       30A1     6.124199    24B2     6.530718    16B1     6.702527  
       31A1     6.832482    17B1     7.082730    11A2     7.217369  
       25B2     7.222438    18B1     7.238116    32A1     7.320933  
-      12A2     7.361767    33A1     7.429307    26B2     7.817221  
-      34A1     7.850722    27B2     8.591962    35A1    14.586349  
+      12A2     7.361767    33A1     7.429307    26B2     7.817220  
+      34A1     7.850721    27B2     8.591962    35A1    14.586349  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05452918962467
+  @DF-RHF Final Energy:   -76.05452918961511
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.3400215788308003
-    Two-Electron Energy =                  37.4840268246387680
-    Total Energy =                        -76.0545291896246738
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.3400215531872419
+    Two-Electron Energy =                  37.4840267990047522
+    Total Energy =                        -76.0545291896151099
 
 Computation Completed
 
@@ -1752,18 +1768,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0171     Total:     2.0171
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:56 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:43 2019
 Module time:
-	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.58 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.49 seconds =       0.06 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      15.40 seconds =       0.26 minutes
+	system time =       0.91 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:56 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:43 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1775,13 +1791,13 @@ Total time:
     Name: (AUG-CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   264 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1807,33 +1823,33 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0545291896246738 [Eh]
+	 Reference Energy          =     -76.0545291896151099 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0690823043574056 [Eh]
-	 Opposite-Spin Energy      =      -0.2174769846217335 [Eh]
-	 Correlation Energy        =      -0.2865592889791391 [Eh]
-	 Total Energy              =     -76.3410884786038082 [Eh]
+	 Same-Spin Energy          =      -0.0690823042795223 [Eh]
+	 Opposite-Spin Energy      =      -0.2174769844178234 [Eh]
+	 Correlation Energy        =      -0.2865592886973457 [Eh]
+	 Total Energy              =     -76.3410884783124573 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0230274347858019 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2609723815460802 [Eh]
-	 SCS Correlation Energy    =      -0.2839998163318820 [Eh]
-	 SCS Total Energy          =     -76.3385290059565591 [Eh]
+	 SCS Same-Spin Energy      =      -0.0230274347598408 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2609723813013881 [Eh]
+	 SCS Correlation Energy    =      -0.2839998160612288 [Eh]
+	 SCS Total Energy          =     -76.3385290056763353 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:56 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:43 2019
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.64 seconds =       0.06 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      16.17 seconds =       0.27 minutes
+	system time =       0.98 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -1842,28 +1858,28 @@ Total time:
 
    ==> HF <==
 
-   HI-zeta (0) Energy:               -76.054529189625
+   HI-zeta (0) Energy:               -76.054529189615
 
 
    ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
 
-   LO-zeta (2) Energy:               -76.261216702373
-   HI-zeta (3) Energy:               -76.341088478604
+   LO-zeta (2) Energy:               -76.261216702788
+   HI-zeta (3) Energy:               -76.341088478312
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.374718700175
+   Extrapolated Energy:              -76.374718699586
 
-   @Extrapolated MP2/(D,T):          -76.374718700175
+   @Extrapolated MP2/(D,T):          -76.374718699586
 
 
 
    ==> Helgaker 2-point correlated extrapolation for method: HF <==
 
-   LO-zeta (2) Energy:               -76.035669684547
-   HI-zeta (3) Energy:               -76.054529189625
+   LO-zeta (2) Energy:               -76.035669684545
+   HI-zeta (3) Energy:               -76.054529189615
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.062470033868
+   Extrapolated Energy:              -76.062470033855
 
-   @Extrapolated HF/(D,T):           -76.062470033868
+   @Extrapolated HF/(D,T):           -76.062470033855
 
 
    ==> Components <==
@@ -1901,8 +1917,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/a[DT]Z Energy Check...........................................PASSED
 
@@ -1936,24 +1952,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:56 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:44 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1965,15 +1981,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -2007,8 +2023,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2032,12 +2048,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -2058,18 +2074,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
-   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
-   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
-   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
-   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
-   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
-   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
-   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
-   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
-   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
-   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.44807830241524   -7.54481e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.97024965857918   -5.22171e-01   1.42962e-02 DIIS
+   @DF-RHF iter   2:   -76.02234132073791   -5.20917e-02   9.66285e-03 DIIS
+   @DF-RHF iter   3:   -76.05049330686082   -2.81520e-02   7.32828e-04 DIIS
+   @DF-RHF iter   4:   -76.05094958141223   -4.56275e-04   1.94076e-04 DIIS
+   @DF-RHF iter   5:   -76.05098397707894   -3.43957e-05   4.02515e-05 DIIS
+   @DF-RHF iter   6:   -76.05098612317035   -2.14609e-06   7.76317e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620210694   -7.89366e-08   1.25011e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620385539   -1.74845e-09   2.23160e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391610   -6.07088e-11   6.43251e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392133   -5.22959e-12   7.27806e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2107,14 +2123,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05098620392070
+  @DF-RHF Final Energy:   -76.05098620392133
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4153442205643501
-    Two-Electron Energy =                  37.5628924520762908
-    Total Energy =                        -76.0509862039207007
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4153443996646331
+    Two-Electron Energy =                  37.5628926311759272
+    Total Energy =                        -76.0509862039213260
 
 Computation Completed
 
@@ -2136,18 +2152,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:56 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:44 2019
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.40 seconds =       0.07 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      18.80 seconds =       0.31 minutes
+	system time =       1.13 seconds =       0.02 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:56 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:44 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2159,13 +2175,13 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -2191,33 +2207,33 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Reference Energy          =     -76.0509862039213260 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0671893164872170 [Eh]
-	 Opposite-Spin Energy      =      -0.2107317227474363 [Eh]
-	 Correlation Energy        =      -0.2779210392346533 [Eh]
-	 Total Energy              =     -76.3289072431553564 [Eh]
+	 Same-Spin Energy          =      -0.0671893165761000 [Eh]
+	 Opposite-Spin Energy      =      -0.2107317228308503 [Eh]
+	 Correlation Energy        =      -0.2779210394069503 [Eh]
+	 Total Energy              =     -76.3289072433282740 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0223964388290723 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2528780672969235 [Eh]
-	 SCS Correlation Energy    =      -0.2752745061259959 [Eh]
-	 SCS Total Energy          =     -76.3262607100466965 [Eh]
+	 SCS Same-Spin Energy      =      -0.0223964388587000 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2528780673970203 [Eh]
+	 SCS Correlation Energy    =      -0.2752745062557204 [Eh]
+	 SCS Total Energy          =     -76.3262607101770527 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:57 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:45 2019
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.52 seconds =       0.08 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      19.45 seconds =       0.32 minutes
+	system time =       1.17 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: CCSD(T) / CC-PVDZ //
@@ -2225,24 +2241,24 @@ Total time:
 
     Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:57 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:45 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2254,15 +2270,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -2296,8 +2312,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2319,13 +2335,13 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           SAVE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -2346,18 +2362,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223862   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294925   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823113   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972314   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684775   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720758   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108557   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439252   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465032   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465760   -7.27596e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465772   -1.27898e-13   2.84108e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474957   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112389   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099494   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759631   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091365   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763931   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202494   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368346   -3.16585e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459123   -9.07775e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465321   -6.19735e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465458   -1.37845e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2384,14 +2400,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465772
+  @DF-RHF Final Energy:   -76.02139746465458
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756146686
-    Two-Electron Energy =                  37.6224401463895788
-    Total Energy =                        -76.0213974646577242
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892429919
+    Two-Electron Energy =                  37.6224401600210285
+    Total Energy =                        -76.0213974646545836
 
 Computation Completed
 
@@ -2413,15 +2429,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:57 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:45 2019
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.89 seconds =       0.08 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      21.43 seconds =       0.36 minutes
+	system time =       1.33 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -2432,20 +2448,20 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_CC
-    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:57 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:45 2019
 
 
 
@@ -2493,7 +2509,7 @@ Total time:
             3-index integrals:                0.40 mb
             CCSD intermediates:               0.74 mb
 
-        (T) part (regular algorithm):         0.31 mb
+        (T) part (regular algorithm):         0.78 mb
 
   ==> Input parameters <==
 
@@ -2511,54 +2527,54 @@ Total time:
   Begin singles and doubles coupled cluster iterations
 
    Iter  DIIS          Energy       d(Energy)          |d(T)|     time
-      0   0 1   -0.2069166881   -0.2069166881    0.1987680224        0
-      1   1 1   -0.2115086020   -0.0045919139    0.0285450513        0
-      2   2 1   -0.2150893167   -0.0035807147    0.0104812617        0
-      3   3 1   -0.2164079298   -0.0013186131    0.0041114403        0
-      4   4 1   -0.2164214813   -0.0000135515    0.0006921551        0
-      5   5 1   -0.2164352956   -0.0000138142    0.0002259101        0
-      6   6 1   -0.2164322775    0.0000030180    0.0000766918        0
-      7   7 1   -0.2164319614    0.0000003161    0.0000190236        0
+      0   0 1   -0.2069166879   -0.2069166879    0.1987680222        0
+      1   1 1   -0.2115086019   -0.0045919140    0.0285450521        0
+      2   2 1   -0.2150893166   -0.0035807147    0.0104812618        0
+      3   3 1   -0.2164079298   -0.0013186132    0.0041114405        0
+      4   4 1   -0.2164214813   -0.0000135515    0.0006921552        1
+      5   5 1   -0.2164352955   -0.0000138142    0.0002259101        0
+      6   6 1   -0.2164322775    0.0000030180    0.0000766919        0
+      7   7 1   -0.2164319613    0.0000003161    0.0000190236        0
       8   8 1   -0.2164317633    0.0000001981    0.0000033759        0
       9   8 2   -0.2164317097    0.0000000536    0.0000008461        0
-     10   8 3   -0.2164317283   -0.0000000185    0.0000001639        0
+     10   8 3   -0.2164317282   -0.0000000185    0.0000001639        0
      11   8 4   -0.2164317252    0.0000000031    0.0000000356        0
 
   CCSD iterations converged!
 
-        T1 diagnostic:                        0.005907931879
-        D1 diagnostic:                        0.012980613017
+        T1 diagnostic:                        0.005907932772
+        D1 diagnostic:                        0.012980617302
 
-        OS MP2 correlation energy:           -0.154889086934
-        SS MP2 correlation energy:           -0.052027601148
-        MP2 correlation energy:              -0.206916688082
-      * MP2 total energy:                   -76.228314152740
+        OS MP2 correlation energy:           -0.154889086824
+        SS MP2 correlation energy:           -0.052027601047
+        MP2 correlation energy:              -0.206916687872
+      * MP2 total energy:                   -76.228314152526
 
-        OS CCSD correlation energy:          -0.170520745005
-        SS CCSD correlation energy:          -0.045910980201
-        CCSD correlation energy:             -0.216431725206
-      * CCSD total energy:                  -76.237829189864
+        OS CCSD correlation energy:          -0.170520745000
+        SS CCSD correlation energy:          -0.045910980170
+        CCSD correlation energy:             -0.216431725170
+      * CCSD total energy:                  -76.237829189824
 
-  Total time for CCSD iterations:       0.04 s (user)
-                                        0.02 s (system)
-                                           0 s (total)
+  Total time for CCSD iterations:       0.36 s (user)
+                                        0.06 s (system)
+                                           1 s (total)
 
-  Time per iteration:                   0.00 s (user)
-                                        0.00 s (system)
-                                        0.00 s (total)
+  Time per iteration:                   0.03 s (user)
+                                        0.01 s (system)
+                                        0.09 s (total)
 
-*** tstop() called on dream at Mon Oct 29 22:03:57 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:46 2019
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.10 seconds =       0.08 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      22.92 seconds =       0.38 minutes
+	system time =       1.46 seconds =       0.02 minutes
+	total time  =          9 seconds =       0.15 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:57 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:46 2019
 
 
         *******************************************************
@@ -2567,50 +2583,48 @@ Total time:
         *                                                     *
         *******************************************************
 
-        num_threads:                      1
+        num_threads:                      4
         available memory:         500.00 mb
-        memory requirements:        0.31 mb
+        memory requirements:        0.78 mb
 
         Number of ijk combinations: 35
 
         Computing (T) correction...
 
         % complete  total time
-              11.4         0 s
               20.0         0 s
-              31.4         0 s
+              28.6         0 s
               40.0         0 s
               51.4         0 s
-              60.0         0 s
-              71.4         0 s
-              80.0         0 s
-              91.4         0 s
+              62.9         0 s
+              74.3         0 s
+              88.6         0 s
 
-        (T) energy                            -0.003270177621
+        (T) energy                            -0.003270177606
 
-        CCSD(T) correlation energy            -0.219701902827
-      * CCSD(T) total energy                 -76.241099367485
+        CCSD(T) correlation energy            -0.219701902776
+      * CCSD(T) total energy                 -76.241099367431
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:57 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:46 2019
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.11 seconds =       0.09 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      22.94 seconds =       0.38 minutes
+	system time =       1.47 seconds =       0.02 minutes
+	total time  =          9 seconds =       0.15 minutes
 
-*** tstop() called on dream at Mon Oct 29 22:03:57 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:46 2019
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.11 seconds =       0.09 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      22.94 seconds =       0.38 minutes
+	system time =       1.47 seconds =       0.02 minutes
+	total time  =          9 seconds =       0.15 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -2624,32 +2638,32 @@ Total time:
 
    ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
 
-   LO-zeta (2) Energy:               -76.228314152740
-   HI-zeta (3) Energy:               -76.328907243155
+   LO-zeta (2) Energy:               -76.228314152526
+   HI-zeta (3) Energy:               -76.328907243328
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.371262228593
+   Extrapolated Energy:              -76.371262228929
 
-   @Extrapolated MP2/(D,T):          -76.371262228593
+   @Extrapolated MP2/(D,T):          -76.371262228929
 
 
 
    ==> Helgaker 2-point correlated extrapolation for method: HF <==
 
-   LO-zeta (2) Energy:               -76.021397464658
+   LO-zeta (2) Energy:               -76.021397464655
    HI-zeta (3) Energy:               -76.050986203921
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.063444620452
+   Extrapolated Energy:              -76.063444620455
 
-   @Extrapolated HF/(D,T):           -76.063444620452
+   @Extrapolated HF/(D,T):           -76.063444620455
 
 
    ==> CCSD(T) <==
 
-   HI-zeta (0) Energy:               -76.241099367485
+   HI-zeta (0) Energy:               -76.241099367431
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.228314152740
+   HI-zeta (0) Energy:               -76.228314152526
 
    ==> Components <==
 
@@ -2691,8 +2705,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:CCSD(T)/DZ Energy Check.............................PASSED
 
@@ -2726,24 +2740,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:58 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:46 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2755,15 +2769,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -2797,8 +2811,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -2822,12 +2836,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -2848,18 +2862,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
-   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
-   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
-   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
-   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
-   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
-   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
-   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
-   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
-   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
-   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.44807830241527   -7.54481e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.97024965857921   -5.22171e-01   1.42962e-02 DIIS
+   @DF-RHF iter   2:   -76.02234132073784   -5.20917e-02   9.66285e-03 DIIS
+   @DF-RHF iter   3:   -76.05049330686082   -2.81520e-02   7.32828e-04 DIIS
+   @DF-RHF iter   4:   -76.05094958141217   -4.56275e-04   1.94076e-04 DIIS
+   @DF-RHF iter   5:   -76.05098397707886   -3.43957e-05   4.02515e-05 DIIS
+   @DF-RHF iter   6:   -76.05098612317039   -2.14609e-06   7.76317e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620210694   -7.89366e-08   1.25011e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620385537   -1.74843e-09   2.23160e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391610   -6.07230e-11   6.43251e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392134   -5.24381e-12   7.27806e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2897,14 +2911,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05098620392070
+  @DF-RHF Final Energy:   -76.05098620392134
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4153442205643501
-    Two-Electron Energy =                  37.5628924520762908
-    Total Energy =                        -76.0509862039207007
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4153443996646615
+    Two-Electron Energy =                  37.5628926311759415
+    Total Energy =                        -76.0509862039213402
 
 Computation Completed
 
@@ -2926,18 +2940,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:58 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:47 2019
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.66 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.85 seconds =       0.10 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      25.57 seconds =       0.43 minutes
+	system time =       1.58 seconds =       0.03 minutes
+	total time  =         10 seconds =       0.17 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:58 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:47 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2949,13 +2963,13 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -2981,33 +2995,33 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Reference Energy          =     -76.0509862039213402 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0671893164872170 [Eh]
-	 Opposite-Spin Energy      =      -0.2107317227474363 [Eh]
-	 Correlation Energy        =      -0.2779210392346533 [Eh]
-	 Total Energy              =     -76.3289072431553564 [Eh]
+	 Same-Spin Energy          =      -0.0671893165761002 [Eh]
+	 Opposite-Spin Energy      =      -0.2107317228308509 [Eh]
+	 Correlation Energy        =      -0.2779210394069511 [Eh]
+	 Total Energy              =     -76.3289072433282882 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0223964388290723 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2528780672969235 [Eh]
-	 SCS Correlation Energy    =      -0.2752745061259959 [Eh]
-	 SCS Total Energy          =     -76.3262607100466965 [Eh]
+	 SCS Same-Spin Energy      =      -0.0223964388587001 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2528780673970211 [Eh]
+	 SCS Correlation Energy    =      -0.2752745062557212 [Eh]
+	 SCS Total Energy          =     -76.3262607101770669 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:58 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:47 2019
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.96 seconds =       0.10 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      26.20 seconds =       0.44 minutes
+	system time =       1.63 seconds =       0.03 minutes
+	total time  =         10 seconds =       0.17 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: CCSD(T) / CC-PVDZ //
@@ -3015,24 +3029,24 @@ Total time:
 
     Method 'CCSD(T)' requires SCF_TYPE = DISK_DF, setting.
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:58 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:47 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3044,15 +3058,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -3086,8 +3100,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3109,13 +3123,13 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              4
+    Integrals threads:           4
     Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           SAVE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -3136,18 +3150,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223862   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294925   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823113   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972314   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684775   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720758   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108557   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439252   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465032   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465760   -7.27596e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465772   -1.27898e-13   2.84108e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474947   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112389   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099501   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759624   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091366   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763932   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202497   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368354   -3.16586e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459123   -9.07690e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465322   -6.19877e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465463   -1.40687e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3174,14 +3188,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465772
+  @DF-RHF Final Energy:   -76.02139746465463
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756146686
-    Two-Electron Energy =                  37.6224401463895788
-    Total Energy =                        -76.0213974646577242
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892430488
+    Two-Electron Energy =                  37.6224401600210570
+    Total Energy =                        -76.0213974646546120
 
 Computation Completed
 
@@ -3203,15 +3217,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:59 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:47 2019
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.94 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.33 seconds =       0.11 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      28.17 seconds =       0.47 minutes
+	system time =       1.76 seconds =       0.03 minutes
+	total time  =         10 seconds =       0.17 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -3222,20 +3236,20 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_CC
-    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:59 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:48 2019
 
 
 
@@ -3283,7 +3297,7 @@ Total time:
             3-index integrals:                0.40 mb
             CCSD intermediates:               0.74 mb
 
-        (T) part (regular algorithm):         0.31 mb
+        (T) part (regular algorithm):         0.78 mb
 
   ==> Input parameters <==
 
@@ -3301,54 +3315,54 @@ Total time:
   Begin singles and doubles coupled cluster iterations
 
    Iter  DIIS          Energy       d(Energy)          |d(T)|     time
-      0   0 1   -0.2069166881   -0.2069166881    0.1987680224        0
-      1   1 1   -0.2115086020   -0.0045919139    0.0285450513        0
-      2   2 1   -0.2150893167   -0.0035807147    0.0104812617        0
-      3   3 1   -0.2164079298   -0.0013186131    0.0041114403        0
-      4   4 1   -0.2164214813   -0.0000135515    0.0006921551        0
-      5   5 1   -0.2164352956   -0.0000138142    0.0002259101        0
-      6   6 1   -0.2164322775    0.0000030180    0.0000766918        0
-      7   7 1   -0.2164319614    0.0000003161    0.0000190236        0
+      0   0 1   -0.2069166879   -0.2069166879    0.1987680222        0
+      1   1 1   -0.2115086019   -0.0045919140    0.0285450521        0
+      2   2 1   -0.2150893166   -0.0035807147    0.0104812618        0
+      3   3 1   -0.2164079298   -0.0013186132    0.0041114405        0
+      4   4 1   -0.2164214813   -0.0000135515    0.0006921552        0
+      5   5 1   -0.2164352955   -0.0000138142    0.0002259101        0
+      6   6 1   -0.2164322775    0.0000030180    0.0000766919        0
+      7   7 1   -0.2164319613    0.0000003161    0.0000190236        0
       8   8 1   -0.2164317633    0.0000001981    0.0000033759        0
       9   8 2   -0.2164317097    0.0000000536    0.0000008461        0
-     10   8 3   -0.2164317283   -0.0000000185    0.0000001639        0
+     10   8 3   -0.2164317282   -0.0000000185    0.0000001639        0
      11   8 4   -0.2164317252    0.0000000031    0.0000000356        0
 
   CCSD iterations converged!
 
-        T1 diagnostic:                        0.005907931879
-        D1 diagnostic:                        0.012980613017
+        T1 diagnostic:                        0.005907932772
+        D1 diagnostic:                        0.012980617302
 
-        OS MP2 correlation energy:           -0.154889086934
-        SS MP2 correlation energy:           -0.052027601148
-        MP2 correlation energy:              -0.206916688082
-      * MP2 total energy:                   -76.228314152740
+        OS MP2 correlation energy:           -0.154889086824
+        SS MP2 correlation energy:           -0.052027601047
+        MP2 correlation energy:              -0.206916687872
+      * MP2 total energy:                   -76.228314152526
 
-        OS CCSD correlation energy:          -0.170520745005
-        SS CCSD correlation energy:          -0.045910980201
-        CCSD correlation energy:             -0.216431725206
-      * CCSD total energy:                  -76.237829189864
+        OS CCSD correlation energy:          -0.170520745000
+        SS CCSD correlation energy:          -0.045910980170
+        CCSD correlation energy:             -0.216431725170
+      * CCSD total energy:                  -76.237829189824
 
-  Total time for CCSD iterations:       0.05 s (user)
-                                        0.01 s (system)
+  Total time for CCSD iterations:       0.32 s (user)
+                                        0.04 s (system)
                                            0 s (total)
 
-  Time per iteration:                   0.00 s (user)
+  Time per iteration:                   0.03 s (user)
                                         0.00 s (system)
                                         0.00 s (total)
 
-*** tstop() called on dream at Mon Oct 29 22:03:59 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:48 2019
 Module time:
-	user time   =       0.10 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.55 seconds =       0.11 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      29.51 seconds =       0.49 minutes
+	system time =       1.90 seconds =       0.03 minutes
+	total time  =         11 seconds =       0.18 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:59 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:48 2019
 
 
         *******************************************************
@@ -3357,9 +3371,9 @@ Total time:
         *                                                     *
         *******************************************************
 
-        num_threads:                      1
+        num_threads:                      4
         available memory:         500.00 mb
-        memory requirements:        0.31 mb
+        memory requirements:        0.78 mb
 
         Number of ijk combinations: 35
 
@@ -3367,40 +3381,39 @@ Total time:
 
         % complete  total time
               11.4         0 s
-              20.0         0 s
-              31.4         0 s
-              40.0         0 s
-              51.4         0 s
-              60.0         0 s
-              71.4         0 s
-              80.0         0 s
-              91.4         0 s
+              22.9         0 s
+              34.3         0 s
+              45.7         0 s
+              54.3         0 s
+              65.7         0 s
+              85.7         0 s
+              97.1         0 s
 
-        (T) energy                            -0.003270177621
+        (T) energy                            -0.003270177606
 
-        CCSD(T) correlation energy            -0.219701902827
-      * CCSD(T) total energy                 -76.241099367485
+        CCSD(T) correlation energy            -0.219701902776
+      * CCSD(T) total energy                 -76.241099367431
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:59 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:48 2019
 Module time:
-	user time   =       0.00 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.55 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      29.55 seconds =       0.49 minutes
+	system time =       1.90 seconds =       0.03 minutes
+	total time  =         11 seconds =       0.18 minutes
 
-*** tstop() called on dream at Mon Oct 29 22:03:59 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:48 2019
 Module time:
-	user time   =       0.00 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.55 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      29.55 seconds =       0.49 minutes
+	system time =       1.90 seconds =       0.03 minutes
+	total time  =         11 seconds =       0.18 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -3414,32 +3427,32 @@ Total time:
 
    ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
 
-   LO-zeta (2) Energy:               -76.228314152740
-   HI-zeta (3) Energy:               -76.328907243155
+   LO-zeta (2) Energy:               -76.228314152526
+   HI-zeta (3) Energy:               -76.328907243328
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.371262228593
+   Extrapolated Energy:              -76.371262228929
 
-   @Extrapolated MP2/(D,T):          -76.371262228593
+   @Extrapolated MP2/(D,T):          -76.371262228929
 
 
 
    ==> Helgaker 2-point correlated extrapolation for method: HF <==
 
-   LO-zeta (2) Energy:               -76.021397464658
+   LO-zeta (2) Energy:               -76.021397464655
    HI-zeta (3) Energy:               -76.050986203921
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.063444620452
+   Extrapolated Energy:              -76.063444620455
 
-   @Extrapolated HF/(D,T):           -76.063444620452
+   @Extrapolated HF/(D,T):           -76.063444620455
 
 
    ==> CCSD(T) <==
 
-   HI-zeta (0) Energy:               -76.241099367485
+   HI-zeta (0) Energy:               -76.241099367431
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.228314152740
+   HI-zeta (0) Energy:               -76.228314152526
 
    ==> Components <==
 
@@ -3481,8 +3494,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:CCSD(T)/DZ without explicit SCF stage...............PASSED
 
@@ -3503,6 +3516,7 @@ Total time:
             mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
             mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
             mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
 
     Full listing of computations to be obtained (required and bonus).
              hf / cc-pvdz                  for  HF TOTAL ENERGY
@@ -3511,30 +3525,32 @@ Total time:
             mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
              hf / cc-pvdz + options        for  HF TOTAL ENERGY
             mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //   CBS Computation: MP2 / CC-PVDZ  //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:59 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:48 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3546,15 +3562,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -3588,8 +3604,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3613,12 +3629,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -3639,18 +3655,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474957   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112396   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099496   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759632   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091365   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763929   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202504   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368356   -3.16585e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459127   -9.07718e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465333   -6.20588e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465467   -1.33582e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3677,14 +3693,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465751
+  @DF-RHF Final Energy:   -76.02139746465467
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756143702
-    Two-Electron Energy =                  37.6224401463894793
-    Total Energy =                        -76.0213974646575110
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892431056
+    Two-Electron Energy =                  37.6224401600210570
+    Total Energy =                        -76.0213974646546689
 
 Computation Completed
 
@@ -3706,18 +3722,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:03:59 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:49 2019
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.24 seconds =       0.12 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      31.90 seconds =       0.53 minutes
+	system time =       2.05 seconds =       0.03 minutes
+	total time  =         12 seconds =       0.20 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:03:59 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:49 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3729,13 +3745,13 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -3761,57 +3777,57 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Reference Energy          =     -76.0213974646546689 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
-	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
-	 Correlation Energy        =      -0.2046601442173612 [Eh]
-	 Total Energy              =     -76.2260576088748678 [Eh]
+	 Same-Spin Energy          =      -0.0512503268907450 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172436573 [Eh]
+	 Correlation Energy        =      -0.2046601441344024 [Eh]
+	 Total Energy              =     -76.2260576087890769 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
-	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
-	 SCS Total Energy          =     -76.2225726876842913 [Eh]
+	 SCS Same-Spin Energy      =      -0.0170834422969150 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917806923888 [Eh]
+	 SCS Correlation Energy    =      -0.2011752229893038 [Eh]
+	 SCS Total Energy          =     -76.2225726876439751 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:00 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:49 2019
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.32 seconds =       0.12 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      32.40 seconds =       0.54 minutes
+	system time =       2.08 seconds =       0.03 minutes
+	total time  =         12 seconds =       0.20 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //   CBS Computation: MP2 / CC-PVTZ  //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:00 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:49 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3823,15 +3839,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -3865,8 +3881,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -3890,12 +3906,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -3916,18 +3932,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
-   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
-   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
-   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
-   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
-   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
-   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
-   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
-   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
-   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
-   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.44807830241530   -7.54481e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.97024965857919   -5.22171e-01   1.42962e-02 DIIS
+   @DF-RHF iter   2:   -76.02234132073788   -5.20917e-02   9.66285e-03 DIIS
+   @DF-RHF iter   3:   -76.05049330686084   -2.81520e-02   7.32828e-04 DIIS
+   @DF-RHF iter   4:   -76.05094958141221   -4.56275e-04   1.94076e-04 DIIS
+   @DF-RHF iter   5:   -76.05098397707887   -3.43957e-05   4.02515e-05 DIIS
+   @DF-RHF iter   6:   -76.05098612317039   -2.14609e-06   7.76317e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620210693   -7.89365e-08   1.25011e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620385539   -1.74846e-09   2.23160e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391611   -6.07230e-11   6.43251e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392141   -5.30065e-12   7.27806e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3965,14 +3981,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05098620392070
+  @DF-RHF Final Energy:   -76.05098620392141
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4153442205643501
-    Two-Electron Energy =                  37.5628924520762908
-    Total Energy =                        -76.0509862039207007
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4153443996647184
+    Two-Electron Energy =                  37.5628926311759201
+    Total Energy =                        -76.0509862039214113
 
 Computation Completed
 
@@ -3994,18 +4010,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:00 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:50 2019
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.76 seconds =       0.13 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      34.65 seconds =       0.58 minutes
+	system time =       2.22 seconds =       0.04 minutes
+	total time  =         13 seconds =       0.22 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:00 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:50 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4017,13 +4033,13 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -4049,57 +4065,57 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Reference Energy          =     -76.0509862039214113 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
-	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
-	 Correlation Energy        =      -0.2645464656227105 [Eh]
-	 Total Energy              =     -76.3155326695434155 [Eh]
+	 Same-Spin Energy          =      -0.0641750318836537 [Eh]
+	 Opposite-Spin Energy      =      -0.2003714338968925 [Eh]
+	 Correlation Energy        =      -0.2645464657805462 [Eh]
+	 Total Energy              =     -76.3155326697019518 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
-	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
-	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	 SCS Same-Spin Energy      =      -0.0213916772945512 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2404457206762710 [Eh]
+	 SCS Correlation Energy    =      -0.2618373979708222 [Eh]
+	 SCS Total Energy          =     -76.3128236018922337 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:00 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:50 2019
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.87 seconds =       0.13 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      35.28 seconds =       0.59 minutes
+	system time =       2.27 seconds =       0.04 minutes
+	total time  =         13 seconds =       0.22 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: MP2 / CC-PVDZ + opts. //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:00 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:50 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4111,15 +4127,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -4153,8 +4169,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4178,12 +4194,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -4204,18 +4220,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474960   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112390   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099499   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759634   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091371   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763927   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202491   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368357   -3.16587e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459122   -9.07647e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465326   -6.20446e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465457   -1.30740e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4242,14 +4258,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465751
+  @DF-RHF Final Energy:   -76.02139746465457
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756143702
-    Two-Electron Energy =                  37.6224401463894793
-    Total Energy =                        -76.0213974646575110
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892430630
+    Two-Electron Energy =                  37.6224401600211138
+    Total Energy =                        -76.0213974646545694
 
 Computation Completed
 
@@ -4271,18 +4287,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:00 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:51 2019
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.93 seconds =       0.03 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.22 seconds =       0.14 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      37.23 seconds =       0.62 minutes
+	system time =       2.41 seconds =       0.04 minutes
+	total time  =         14 seconds =       0.23 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:00 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:51 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4294,13 +4310,13 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -4326,33 +4342,310 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Reference Energy          =     -76.0213974646545694 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0520276011385693 [Eh]
-	 Opposite-Spin Energy      =      -0.1548890869185279 [Eh]
-	 Correlation Energy        =      -0.2069166880570971 [Eh]
-	 Total Energy              =     -76.2283141527146029 [Eh]
+	 Same-Spin Energy          =      -0.0520276010679817 [Eh]
+	 Opposite-Spin Energy      =      -0.1548890869075476 [Eh]
+	 Correlation Energy        =      -0.2069166879755293 [Eh]
+	 Total Energy              =     -76.2283141526301051 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0173425337128564 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1858669043022334 [Eh]
-	 SCS Correlation Energy    =      -0.2032094380150899 [Eh]
-	 SCS Total Energy          =     -76.2246069026726047 [Eh]
+	 SCS Same-Spin Energy      =      -0.0173425336893272 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1858669042890571 [Eh]
+	 SCS Correlation Energy    =      -0.2032094379783843 [Eh]
+	 SCS Total Energy          =     -76.2246069026329565 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:01 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:51 2019
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.54 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.30 seconds =       0.14 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      37.77 seconds =       0.63 minutes
+	system time =       2.46 seconds =       0.04 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVDZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:51 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.45137243474956   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112396   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099500   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759634   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091365   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763935   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202493   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368350   -3.16586e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459119   -9.07690e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465329   -6.21014e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465456   -1.26477e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465456
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892429777
+    Two-Electron Energy =                  37.6224401600210356
+    Total Energy =                        -76.0213974646545694
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:51 2019
+Module time:
+	user time   =       1.97 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      39.76 seconds =       0.66 minutes
+	system time =       2.57 seconds =       0.04 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:51 2019
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   4 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646545552 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0512503268907449 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172436570 [Eh]
+	 Correlation Energy        =      -0.2046601441344019 [Eh]
+	 Total Energy              =     -76.2260576087889632 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0170834422969150 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917806923884 [Eh]
+	 SCS Correlation Energy    =      -0.2011752229893034 [Eh]
+	 SCS Total Energy          =     -76.2225726876438614 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:51 2019
+Module time:
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      40.26 seconds =       0.67 minutes
+	system time =       2.60 seconds =       0.04 minutes
+	total time  =         14 seconds =       0.23 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -4366,32 +4659,32 @@ Total time:
 
    ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
 
-   LO-zeta (2) Energy:               -76.226057608875
-   HI-zeta (3) Energy:               -76.315532669543
+   LO-zeta (2) Energy:               -76.226057608789
+   HI-zeta (3) Energy:               -76.315532669702
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.353206379299
+   Extrapolated Energy:              -76.353206379560
 
-   @Extrapolated MP2/(D,T):          -76.353206379299
+   @Extrapolated MP2/(D,T):          -76.353206379560
 
 
 
    ==> Helgaker 2-point correlated extrapolation for method: HF <==
 
-   LO-zeta (2) Energy:               -76.021397464658
+   LO-zeta (2) Energy:               -76.021397464655
    HI-zeta (3) Energy:               -76.050986203921
    Alpha (exponent) Value:             3.000000000000
-   Extrapolated Energy:              -76.063444620453
+   Extrapolated Energy:              -76.063444620455
 
-   @Extrapolated HF/(D,T):           -76.063444620453
+   @Extrapolated HF/(D,T):           -76.063444620455
 
-
-   ==> MP2 <==
-
-   HI-zeta (0) Energy:               -76.228314152715
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.226057608875
+   HI-zeta (0) Energy:               -76.228314152630
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.226057608789
 
    ==> Components <==
 
@@ -4404,6 +4697,8 @@ Total time:
                              mp2 / cc-pvtz                      *     -76.31553267   MP2 TOTAL ENERGY
                               hf / cc-pvdz + options            *     -76.02139746   HF TOTAL ENERGY
                              mp2 / cc-pvdz + options            *     -76.22831415   MP2 TOTAL ENERGY
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22605761   MP2 TOTAL ENERGY
   ---------------------------------------------------------------------------------------------------------
 
    ==> Stages <==
@@ -4433,8 +4728,8 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/[DT]Z + D:(AE-FC)MP2/DZ Energy Check..........................PASSED
 
@@ -4467,24 +4762,24 @@ Total time:
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:01 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:52 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4496,15 +4791,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -4538,8 +4833,8 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4563,12 +4858,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -4589,18 +4884,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.92357266039929   -7.59236e+01   5.00974e-02 
-   @DF-RHF iter   1:   -76.01451177101835   -9.09391e-02   9.21472e-03 
-   @DF-RHF iter   2:   -76.04124158443562   -2.67298e-02   5.42537e-03 DIIS
-   @DF-RHF iter   3:   -76.05037508659487   -9.13350e-03   7.78961e-04 DIIS
-   @DF-RHF iter   4:   -76.05089693790927   -5.21851e-04   2.59014e-04 DIIS
-   @DF-RHF iter   5:   -76.05098074865160   -8.38107e-05   5.69091e-05 DIIS
-   @DF-RHF iter   6:   -76.05098606332709   -5.31468e-06   9.75125e-06 DIIS
-   @DF-RHF iter   7:   -76.05098620206576   -1.38739e-07   1.23260e-06 DIIS
-   @DF-RHF iter   8:   -76.05098620386752   -1.80177e-09   2.06954e-07 DIIS
-   @DF-RHF iter   9:   -76.05098620391895   -5.14291e-11   3.82695e-08 DIIS
-   @DF-RHF iter  10:   -76.05098620392070   -1.74794e-12   3.68890e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.44807830241521   -7.54481e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.97024965857922   -5.22171e-01   1.42962e-02 DIIS
+   @DF-RHF iter   2:   -76.02234132073788   -5.20917e-02   9.66285e-03 DIIS
+   @DF-RHF iter   3:   -76.05049330686083   -2.81520e-02   7.32828e-04 DIIS
+   @DF-RHF iter   4:   -76.05094958141223   -4.56275e-04   1.94076e-04 DIIS
+   @DF-RHF iter   5:   -76.05098397707890   -3.43957e-05   4.02515e-05 DIIS
+   @DF-RHF iter   6:   -76.05098612317040   -2.14609e-06   7.76317e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620210691   -7.89365e-08   1.25011e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620385533   -1.74842e-09   2.23160e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391607   -6.07372e-11   6.43251e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392138   -5.31486e-12   7.27806e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4638,14 +4933,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.05098620392070
+  @DF-RHF Final Energy:   -76.05098620392138
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4153442205643501
-    Two-Electron Energy =                  37.5628924520762908
-    Total Energy =                        -76.0509862039207007
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4153443996647184
+    Two-Electron Energy =                  37.5628926311759486
+    Total Energy =                        -76.0509862039213829
 
 Computation Completed
 
@@ -4667,18 +4962,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:01 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:52 2019
 Module time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.98 seconds =       0.15 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      42.84 seconds =       0.71 minutes
+	system time =       2.76 seconds =       0.05 minutes
+	total time  =         15 seconds =       0.25 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:01 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:52 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4690,13 +4985,13 @@ Total time:
     Name: (CC-PVTZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -4722,57 +5017,57 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0509862039207007 [Eh]
+	 Reference Energy          =     -76.0509862039213829 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0641750318056445 [Eh]
-	 Opposite-Spin Energy      =      -0.2003714338170660 [Eh]
-	 Correlation Energy        =      -0.2645464656227105 [Eh]
-	 Total Energy              =     -76.3155326695434155 [Eh]
+	 Same-Spin Energy          =      -0.0641750318836538 [Eh]
+	 Opposite-Spin Energy      =      -0.2003714338968928 [Eh]
+	 Correlation Energy        =      -0.2645464657805466 [Eh]
+	 Total Energy              =     -76.3155326697019234 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0213916772685482 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.2404457205804792 [Eh]
-	 SCS Correlation Energy    =      -0.2618373978490274 [Eh]
-	 SCS Total Energy          =     -76.3128236017697219 [Eh]
+	 SCS Same-Spin Energy      =      -0.0213916772945513 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2404457206762713 [Eh]
+	 SCS Correlation Energy    =      -0.2618373979708226 [Eh]
+	 SCS Total Energy          =     -76.3128236018922053 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:01 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:53 2019
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.09 seconds =       0.15 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      43.47 seconds =       0.72 minutes
+	system time =       2.82 seconds =       0.05 minutes
+	total time  =         16 seconds =       0.27 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   // CBS Computation: MP2 / AUG-CC-PVDZ //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:01 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:53 2019
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   250 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    36 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   254 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4784,15 +5079,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -4826,8 +5121,8 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -4851,12 +5146,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -4877,18 +5172,19 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -76.01166384242420   -7.60117e+01   6.87554e-02 
-   @DF-RHF iter   1:   -75.98482334442306    2.68405e-02   1.39770e-02 
-   @DF-RHF iter   2:   -76.02137568957853   -3.65523e-02   8.10797e-03 DIIS
-   @DF-RHF iter   3:   -76.03453409811783   -1.31584e-02   1.52253e-03 DIIS
-   @DF-RHF iter   4:   -76.03553580114973   -1.00170e-03   4.22645e-04 DIIS
-   @DF-RHF iter   5:   -76.03566411835585   -1.28317e-04   8.18000e-05 DIIS
-   @DF-RHF iter   6:   -76.03566959805772   -5.47970e-06   1.14661e-05 DIIS
-   @DF-RHF iter   7:   -76.03566968214609   -8.40884e-08   1.68290e-06 DIIS
-   @DF-RHF iter   8:   -76.03566968441635   -2.27026e-09   3.60757e-07 DIIS
-   @DF-RHF iter   9:   -76.03566968454179   -1.25439e-10   8.11191e-08 DIIS
-   @DF-RHF iter  10:   -76.03566968454702   -5.22959e-12   8.06200e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.41489041839823   -7.54149e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94939227239756   -5.34502e-01   1.95452e-02 DIIS
+   @DF-RHF iter   2:   -76.00125190400567   -5.18596e-02   1.33894e-02 DIIS
+   @DF-RHF iter   3:   -76.03520106505167   -3.39492e-02   9.56773e-04 DIIS
+   @DF-RHF iter   4:   -76.03563686660341   -4.35802e-04   2.35729e-04 DIIS
+   @DF-RHF iter   5:   -76.03566703840994   -3.01718e-05   5.52447e-05 DIIS
+   @DF-RHF iter   6:   -76.03566957892127   -2.54051e-06   1.09701e-05 DIIS
+   @DF-RHF iter   7:   -76.03566968197993   -1.03059e-07   1.79724e-06 DIIS
+   @DF-RHF iter   8:   -76.03566968447460   -2.49467e-09   3.03719e-07 DIIS
+   @DF-RHF iter   9:   -76.03566968454025   -6.56541e-11   8.41247e-08 DIIS
+   @DF-RHF iter  10:   -76.03566968454530   -5.04485e-12   1.10136e-08 DIIS
+   @DF-RHF iter  11:   -76.03566968454537   -7.10543e-14   1.69242e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4913,21 +5209,21 @@ Total time:
        5B1     1.470010    13A1     1.572206     9B2     1.971534  
        3A2     1.988356     6B1     2.082925    14A1     2.346452  
       10B2     2.398798    15A1     2.533949    11B2     2.701650  
-      16A1     2.959675     7B1     3.671282    17A1     3.683511  
+      16A1     2.959675     7B1     3.671282    17A1     3.683510  
        4A2     3.694439    18A1     3.974411    12B2     4.219132  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.03566968454702
+  @DF-RHF Final Energy:   -76.03566968454537
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.2744487679137961
-    Two-Electron Energy =                  37.4373135187993995
-    Total Energy =                        -76.0356696845470168
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.2744484853402582
+    Two-Electron Energy =                  37.4373132362275030
+    Total Energy =                        -76.0356696845453826
 
 Computation Completed
 
@@ -4949,18 +5245,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0319     Total:     2.0319
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:53 2019
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.47 seconds =       0.16 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      45.59 seconds =       0.76 minutes
+	system time =       2.93 seconds =       0.05 minutes
+	total time  =         16 seconds =       0.27 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:02 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:53 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4972,13 +5268,13 @@ Total time:
     Name: (AUG-CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   204 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/aug-cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -5004,57 +5300,57 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0356696845470168 [Eh]
+	 Reference Energy          =     -76.0356696845453683 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0567122937952484 [Eh]
-	 Opposite-Spin Energy      =      -0.1664162315254514 [Eh]
-	 Correlation Energy        =      -0.2231285253206998 [Eh]
-	 Total Energy              =     -76.2587982098677202 [Eh]
+	 Same-Spin Energy          =      -0.0567122938968020 [Eh]
+	 Opposite-Spin Energy      =      -0.1664162318477736 [Eh]
+	 Correlation Energy        =      -0.2231285257445756 [Eh]
+	 Total Energy              =     -76.2587982102899389 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0189040979317495 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1996994778305416 [Eh]
-	 SCS Correlation Energy    =      -0.2186035757622911 [Eh]
-	 SCS Total Energy          =     -76.2542732603093043 [Eh]
+	 SCS Same-Spin Energy      =      -0.0189040979656007 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1996994782173283 [Eh]
+	 SCS Correlation Energy    =      -0.2186035761829290 [Eh]
+	 SCS Total Energy          =     -76.2542732607282971 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:53 2019
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.56 seconds =       0.16 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      46.10 seconds =       0.77 minutes
+	system time =       2.96 seconds =       0.05 minutes
+	total time  =         16 seconds =       0.27 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //   CBS Computation: MP2 / CC-PVDZ  //
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
 
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:02 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:53 2019
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        4 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5066,15 +5362,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         O            0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-         H            0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-         H            0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.07160  B = 401042.16713  C = 261705.25477 [MHz]
-  Nuclear repulsion =    8.801465564567373
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -5108,8 +5404,8 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Pre-Iterations <==
 
@@ -5133,12 +5429,12 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               4
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -5159,18 +5455,18 @@ Total time:
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -75.82480873223847   -7.58248e+01   1.11077e-01 
-   @DF-RHF iter   1:   -75.99930442294911   -1.74496e-01   1.70164e-02 
-   @DF-RHF iter   2:   -76.01635178823101   -1.70474e-02   8.40783e-03 DIIS
-   @DF-RHF iter   3:   -76.02118072972299   -4.82894e-03   1.27866e-03 DIIS
-   @DF-RHF iter   4:   -76.02137158684761   -1.90857e-04   3.07048e-04 DIIS
-   @DF-RHF iter   5:   -76.02139539720748   -2.38104e-05   8.07107e-05 DIIS
-   @DF-RHF iter   6:   -76.02139742108535   -2.02388e-06   1.28304e-05 DIIS
-   @DF-RHF iter   7:   -76.02139746439238   -4.33070e-08   1.13318e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746465018   -2.57799e-10   1.92508e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465744   -7.26175e-12   2.81764e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465751   -7.10543e-14   2.84108e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -75.45137243474956   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112389   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099499   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759639   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091366   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763928   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202490   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368357   -3.16587e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459125   -9.07676e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465333   -6.20872e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465458   -1.25056e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -5197,14 +5493,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:   -76.02139746465751
+  @DF-RHF Final Energy:   -76.02139746465458
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655645673727
-    One-Electron Energy =                -122.4453031756143702
-    Two-Electron Energy =                  37.6224401463894793
-    Total Energy =                        -76.0213974646575110
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892430062
+    Two-Electron Energy =                  37.6224401600210356
+    Total Energy =                        -76.0213974646545978
 
 Computation Completed
 
@@ -5226,18 +5522,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:54 2019
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       9.91 seconds =       0.17 minutes
+	user time   =       1.89 seconds =       0.03 minutes
 	system time =       0.13 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      48.00 seconds =       0.80 minutes
+	system time =       3.09 seconds =       0.05 minutes
+	total time  =         17 seconds =       0.28 minutes
 
-*** tstart() called on dream
-*** at Mon Oct 29 22:04:02 2018
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:54 2019
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -5249,13 +5545,13 @@ Total time:
     Name: (CC-PVDZ AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
-    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   4 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -5281,33 +5577,33 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =     -76.0213974646575110 [Eh]
+	 Reference Energy          =     -76.0213974646545836 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0512503269623627 [Eh]
-	 Opposite-Spin Energy      =      -0.1534098172549985 [Eh]
-	 Correlation Energy        =      -0.2046601442173612 [Eh]
-	 Total Energy              =     -76.2260576088748678 [Eh]
+	 Same-Spin Energy          =      -0.0512503268907449 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172436571 [Eh]
+	 Correlation Energy        =      -0.2046601441344020 [Eh]
+	 Total Energy              =     -76.2260576087889916 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0170834423207876 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1840917807059982 [Eh]
-	 SCS Correlation Energy    =      -0.2011752230267858 [Eh]
-	 SCS Total Energy          =     -76.2225726876842913 [Eh]
+	 SCS Same-Spin Energy      =      -0.0170834422969150 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917806923885 [Eh]
+	 SCS Correlation Energy    =      -0.2011752229893035 [Eh]
+	 SCS Total Energy          =     -76.2225726876438898 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Mon Oct 29 22:04:02 2018
+*** tstop() called on dorje at Tue Mar 26 22:41:54 2019
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.99 seconds =       0.17 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      48.52 seconds =       0.81 minutes
+	system time =       3.14 seconds =       0.05 minutes
+	total time  =         17 seconds =       0.28 minutes
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
   //    CBS Results: custom function   //
@@ -5320,7 +5616,7 @@ Total time:
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.315532669543
+   HI-zeta (0) Energy:               -76.315532669702
 
    ==> HF <==
 
@@ -5328,11 +5624,11 @@ Total time:
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.258798209868
+   HI-zeta (0) Energy:               -76.258798210290
 
    ==> MP2 <==
 
-   HI-zeta (0) Energy:               -76.226057608875
+   HI-zeta (0) Energy:               -76.226057608789
 
    ==> Components <==
 
@@ -5374,12 +5670,1317 @@ Total time:
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_dict/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
 
 	MP2/TZ + D:MP2/(aDZ-DZ) (basis_lo check)..........................PASSED
 
-    Psi4 stopped on: Monday, 29 October 2018 10:04PM
-    Psi4 wall time for execution: 0:00:10.48
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //     CBS Setup: custom function    //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Naive listing of computations required.
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+           ccsd / cc-pvdz + options        for  CCSD TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+    Enlightened listing of computations required.
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+           ccsd / cc-pvdz + options        for  CCSD TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+    Full listing of computations to be obtained (required and bonus).
+             hf / cc-pvdz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvdz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvtz                  for  HF TOTAL ENERGY
+            mp2 / cc-pvtz                  for  MP2 TOTAL ENERGY
+             hf / cc-pvdz + options        for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+           ccsd / cc-pvdz + options        for  CCSD TOTAL ENERGY
+             hf / cc-pvdz + options        for  HF TOTAL ENERGY
+            mp2 / cc-pvdz + options        for  MP2 TOTAL ENERGY
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVDZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:55 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.45137243474956   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112395   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099500   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759632   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091365   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763929   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202497   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368357   -3.16586e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459126   -9.07690e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465328   -6.20162e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465457   -1.29319e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465457
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892429777
+    Two-Electron Energy =                  37.6224401600210285
+    Total Energy =                        -76.0213974646545694
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:55 2019
+Module time:
+	user time   =       1.48 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      51.09 seconds =       0.85 minutes
+	system time =       3.24 seconds =       0.05 minutes
+	total time  =         18 seconds =       0.30 minutes
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:55 2019
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   4 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646545694 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0520276010679822 [Eh]
+	 Opposite-Spin Energy      =      -0.1548890869075484 [Eh]
+	 Correlation Energy        =      -0.2069166879755305 [Eh]
+	 Total Energy              =     -76.2283141526301051 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0173425336893274 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1858669042890580 [Eh]
+	 SCS Correlation Energy    =      -0.2032094379783854 [Eh]
+	 SCS Total Energy          =     -76.2246069026329565 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:56 2019
+Module time:
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      51.59 seconds =       0.86 minutes
+	system time =       3.28 seconds =       0.05 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //   CBS Computation: MP2 / CC-PVTZ  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:56 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   262 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 22
+    Number of basis function: 58
+    Number of Cartesian functions: 65
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   229 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        23      23       0       0       0       0
+     A2         7       7       0       0       0       0
+     B1        11      11       0       0       0       0
+     B2        17      17       0       0       0       0
+   -------------------------------------------------------
+    Total      58      58       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-JKFIT
+    Number of shells: 45
+    Number of basis function: 139
+    Number of Cartesian functions: 166
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.9026033530E-03.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.44807830241514   -7.54481e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.97024965857916   -5.22171e-01   1.42962e-02 DIIS
+   @DF-RHF iter   2:   -76.02234132073792   -5.20917e-02   9.66285e-03 DIIS
+   @DF-RHF iter   3:   -76.05049330686077   -2.81520e-02   7.32828e-04 DIIS
+   @DF-RHF iter   4:   -76.05094958141218   -4.56275e-04   1.94076e-04 DIIS
+   @DF-RHF iter   5:   -76.05098397707889   -3.43957e-05   4.02515e-05 DIIS
+   @DF-RHF iter   6:   -76.05098612317047   -2.14609e-06   7.76317e-06 DIIS
+   @DF-RHF iter   7:   -76.05098620210696   -7.89365e-08   1.25011e-06 DIIS
+   @DF-RHF iter   8:   -76.05098620385535   -1.74839e-09   2.23160e-07 DIIS
+   @DF-RHF iter   9:   -76.05098620391608   -6.07372e-11   6.43251e-08 DIIS
+   @DF-RHF iter  10:   -76.05098620392144   -5.35749e-12   7.27806e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.562138     2A1    -1.324719     1B2    -0.687037  
+       3A1    -0.569630     1B1    -0.501255  
+
+    Virtual:                                                              
+
+       4A1     0.137557     2B2     0.199842     3B2     0.526492  
+       5A1     0.576831     6A1     0.677461     2B1     0.785997  
+       7A1     0.793875     4B2     0.805787     1A2     0.852292  
+       3B1     0.951778     8A1     1.165822     5B2     1.172443  
+       6B2     1.489228     9A1     1.501210     4B1     2.019244  
+       2A2     2.048947     7B2     2.115800    10A1     2.157398  
+      11A1     2.253311    12A1     2.570131     8B2     2.925729  
+       5B1     3.356690    13A1     3.471321     3A2     3.552110  
+       9B2     3.599876     6B1     3.766354    10B2     3.826770  
+      14A1     3.874687     4A2     3.936042     7B1     4.015354  
+      11B2     4.055492    15A1     4.135577     5A2     4.246989  
+      16A1     4.323614    12B2     4.478353     8B1     4.645991  
+      13B2     4.776742    17A1     5.012617    18A1     5.229074  
+      14B2     5.516784     9B1     5.976687    19A1     6.414996  
+      10B1     6.772506     6A2     6.849685    20A1     6.905158  
+      15B2     6.934087    11B1     7.012922    21A1     7.168713  
+       7A2     7.181120    22A1     7.433881    16B2     7.697134  
+      17B2     8.106356    23A1    12.196039  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.05098620392144
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4153443996648036
+    Two-Electron Energy =                  37.5628926311759983
+    Total Energy =                        -76.0509862039214255
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2092
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8099     Total:     0.8099
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0586     Total:     2.0586
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:56 2019
+Module time:
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      53.84 seconds =       0.90 minutes
+	system time =       3.45 seconds =       0.06 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:56 2019
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   305 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvtz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   4 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVTZ AUX)
+    Blend: CC-PVTZ-RI
+    Number of shells: 43
+    Number of basis function: 141
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 --------------------------------------------------------
+	                 NBF =    58, NAUX =   141
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0       5       5      53      53       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0509862039214397 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0671893165761005 [Eh]
+	 Opposite-Spin Energy      =      -0.2107317228308514 [Eh]
+	 Correlation Energy        =      -0.2779210394069519 [Eh]
+	 Total Energy              =     -76.3289072433283877 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0223964388587002 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.2528780673970216 [Eh]
+	 SCS Correlation Energy    =      -0.2752745062557218 [Eh]
+	 SCS Total Energy          =     -76.3262607101771664 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:56 2019
+Module time:
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      54.48 seconds =       0.91 minutes
+	system time =       3.50 seconds =       0.06 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: CCSD / CC-PVDZ + opts. //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+    Method 'CCSD' requires SCF_TYPE = DISK_DF, setting.
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:56 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.45137243474947   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112386   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099493   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759622   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091364   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763929   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202488   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368351   -3.16586e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459122   -9.07704e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465323   -6.20162e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465460   -1.36424e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465460
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892430630
+    Two-Electron Energy =                  37.6224401600210783
+    Total Energy =                        -76.0213974646545978
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:57 2019
+Module time:
+	user time   =       1.96 seconds =       0.03 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      56.47 seconds =       0.94 minutes
+	system time =       3.67 seconds =       0.06 minutes
+	total time  =         20 seconds =       0.33 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for FNOCC...
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:57 2019
+
+
+
+        *******************************************************
+        *                                                     *
+        *                       DF-CCSD                       *
+        *                 Density-fitted CCSD                 *
+        *                                                     *
+        *                   Eugene DePrince                   *
+        *                                                     *
+        *******************************************************
+
+
+  ==> 3-index integrals <==
+
+  ==> DF Tensor (by Rob Parrish) <==
+
+ => Primary Basis Set <= 
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+ => Auxiliary Basis Set <= 
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+    Number of auxiliary functions:          84
+
+  ==> Memory <==
+
+        Total memory available:             500.00 mb
+
+        CCSD memory requirements:             1.05 mb
+            3-index integrals:                0.38 mb
+            CCSD intermediates:               0.67 mb
+
+  ==> Input parameters <==
+
+        Freeze core orbitals?                 yes
+        Use frozen natural orbitals?           no
+        r_convergence:                  1.000e-07
+        e_convergence:                  1.000e-07
+        Number of DIIS vectors:                 8
+        Number of frozen core orbitals:         1
+        Number of active occupied orbitals:     4
+        Number of active virtual orbitals:     19
+        Number of frozen virtual orbitals:      0
+
+
+  Begin singles and doubles coupled cluster iterations
+
+   Iter  DIIS          Energy       d(Energy)          |d(T)|     time
+      0   0 1   -0.2046601440   -0.2046601440    0.1986373032        0
+      1   1 1   -0.2094879221   -0.0048277781    0.0286190613        0
+      2   2 1   -0.2130628624   -0.0035749403    0.0104915367        0
+      3   3 1   -0.2143914158   -0.0013285534    0.0041236065        0
+      4   4 1   -0.2144053258   -0.0000139100    0.0006953773        0
+      5   5 1   -0.2144187479   -0.0000134221    0.0002268918        0
+      6   6 1   -0.2144157128    0.0000030351    0.0000768857        0
+      7   7 1   -0.2144154093    0.0000003035    0.0000190094        0
+      8   8 1   -0.2144152004    0.0000002089    0.0000033721        0
+      9   8 2   -0.2144151509    0.0000000495    0.0000008368        0
+     10   8 3   -0.2144151682   -0.0000000173    0.0000001607        1
+     11   8 4   -0.2144151653    0.0000000029    0.0000000349        0
+
+  CCSD iterations converged!
+
+        T1 diagnostic:                        0.006625987095
+        D1 diagnostic:                        0.013038820552
+
+        OS MP2 correlation energy:           -0.153409817161
+        SS MP2 correlation energy:           -0.051250326870
+        MP2 correlation energy:              -0.204660144031
+      * MP2 total energy:                   -76.226057608686
+
+        OS CCSD correlation energy:          -0.169201990611
+        SS CCSD correlation energy:          -0.045213174684
+        CCSD correlation energy:             -0.214415165295
+      * CCSD total energy:                  -76.235812629950
+
+  Total time for CCSD iterations:       0.42 s (user)
+                                        0.05 s (system)
+                                           1 s (total)
+
+  Time per iteration:                   0.04 s (user)
+                                        0.00 s (system)
+                                        0.09 s (total)
+
+*** tstop() called on dorje at Tue Mar 26 22:41:58 2019
+Module time:
+	user time   =       0.84 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      58.05 seconds =       0.97 minutes
+	system time =       3.79 seconds =       0.06 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+*** tstop() called on dorje at Tue Mar 26 22:41:58 2019
+Module time:
+	user time   =       0.84 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      58.05 seconds =       0.97 minutes
+	system time =       3.79 seconds =       0.06 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  // CBS Computation: MP2 / CC-PVDZ + opts. //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:58 2019
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-07
+  Density threshold  = 1.00e-08
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        11      11       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      24      24       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis function: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.7382439197E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.45137243474962   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112393   -4.94429e-01   3.03025e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099496   -5.38477e-02   1.81940e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759638   -2.12676e-02   1.67012e-03 DIIS
+   @DF-RHF iter   4:   -76.02136941091365   -4.53103e-04   4.20110e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623763935   -2.68267e-05   7.52794e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202487   -1.19439e-06   1.16774e-05 DIIS
+   @DF-RHF iter   7:   -76.02139746368350   -3.16586e-08   1.86515e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459127   -9.07775e-10   4.57981e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465329   -6.20162e-11   7.24939e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465461   -1.32161e-12   6.28034e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.557851     2A1    -1.316186     1B2    -0.677076  
+       3A1    -0.558723     1B1    -0.490375  
+
+    Virtual:                                                              
+
+       4A1     0.178016     2B2     0.249486     3B2     0.760311  
+       5A1     0.816144     6A1     1.166347     2B1     1.198686  
+       4B2     1.256576     7A1     1.452880     1A2     1.466534  
+       3B1     1.668515     8A1     1.877409     5B2     1.890443  
+       6B2     2.355075     9A1     2.388631     4B1     3.249433  
+       2A2     3.298364    10A1     3.454607    11A1     3.821967  
+       7B2     4.099335  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:   -76.02139746465461
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.4453031892430488
+    Two-Electron Energy =                  37.6224401600210570
+    Total Energy =                        -76.0213974646546120
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:58 2019
+Module time:
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      60.08 seconds =       1.00 minutes
+	system time =       3.88 seconds =       0.06 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+*** tstart() called on dorje
+*** at Tue Mar 26 22:41:58 2019
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry O          line   235 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/cc-pvdz-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   4 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-RI
+    Number of shells: 30
+    Number of basis function: 84
+    Number of Cartesian functions: 96
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 --------------------------------------------------------
+	                 NBF =    24, NAUX =    84
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4      19      19       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =     -76.0213974646546120 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0512503268907450 [Eh]
+	 Opposite-Spin Energy      =      -0.1534098172436574 [Eh]
+	 Correlation Energy        =      -0.2046601441344024 [Eh]
+	 Total Energy              =     -76.2260576087890200 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0170834422969150 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1840917806923889 [Eh]
+	 SCS Correlation Energy    =      -0.2011752229893039 [Eh]
+	 SCS Total Energy          =     -76.2225726876439182 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Tue Mar 26 22:41:58 2019
+Module time:
+	user time   =       0.59 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      60.68 seconds =       1.01 minutes
+	system time =       3.92 seconds =       0.07 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    CBS Results: custom function   //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+   ==> HF <==
+
+   HI-zeta (0) Energy:               -76.050986203921
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: MP2 <==
+
+   LO-zeta (2) Energy:               -76.228314152630
+   HI-zeta (3) Energy:               -76.328907243328
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.371262228886
+
+   @Extrapolated MP2/(D,T):          -76.371262228886
+
+
+
+   ==> Helgaker 2-point correlated extrapolation for method: HF <==
+
+   LO-zeta (2) Energy:               -76.021397464655
+   HI-zeta (3) Energy:               -76.050986203921
+   Alpha (exponent) Value:             3.000000000000
+   Extrapolated Energy:              -76.063444620455
+
+   @Extrapolated HF/(D,T):           -76.063444620455
+
+
+   ==> CCSD <==
+
+   HI-zeta (0) Energy:               -76.235812629950
+
+   ==> MP2 <==
+
+   HI-zeta (0) Energy:               -76.226057608789
+
+   ==> Components <==
+
+  ---------------------------------------------------------------------------------------------------------
+                          Method / Basis                      Rqd      Energy [Eh]   Variable
+  ---------------------------------------------------------------------------------------------------------
+                              hf / cc-pvdz                      *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz                      *     -76.22831415   MP2 TOTAL ENERGY
+                              hf / cc-pvtz                      *     -76.05098620   HF TOTAL ENERGY
+                             mp2 / cc-pvtz                      *     -76.32890724   MP2 TOTAL ENERGY
+                              hf / cc-pvdz + options            *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz + options            *     -76.22605761   MP2 TOTAL ENERGY
+                            ccsd / cc-pvdz + options            *     -76.23581263   CCSD TOTAL ENERGY
+                              hf / cc-pvdz + options            *     -76.02139746   HF TOTAL ENERGY
+                             mp2 / cc-pvdz + options            *     -76.22605761   MP2 TOTAL ENERGY
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> Stages <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                       Wt      Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                      1     -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                   1     -76.37126223   corl_xtpl_helgaker_2
+       corl                   hf / cc-pv[dt]z                  -1     -76.06344462   corl_xtpl_helgaker_2
+     delta1                 ccsd / cc-pvdz                      1     -76.23581263   xtpl_highest_1
+     delta1                  mp2 / cc-pvdz                     -1     -76.22605761   xtpl_highest_1
+  ---------------------------------------------------------------------------------------------------------
+
+   ==> CBS <==
+
+  ---------------------------------------------------------------------------------------------------------
+      Stage               Method / Basis                               Energy [Eh]   Scheme
+  ---------------------------------------------------------------------------------------------------------
+        scf                   hf / cc-pvtz                            -76.05098620   xtpl_highest_1
+       corl                  mp2 / cc-pv[dt]z                          -0.30781761   corl_xtpl_helgaker_2
+     delta1           ccsd - mp2 / cc-pvdz                             -0.00975502   xtpl_highest_1
+      total                  CBS                                      -76.36855883   
+  ---------------------------------------------------------------------------------------------------------
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/kraus/Applications/psi4-cbs_options_v2/share/psi4/basis/def2-svp.gbs 
+
+	MP2/[DT]Z + D:FC-CCSD/DZ (options_lo check).......................PASSED
+
+    Psi4 stopped on: Tuesday, 26 March 2019 10:41PM
+    Psi4 wall time for execution: 0:00:21.10
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This fixes a bug in "options" handling - previously, options requested in CBS() stage were not stashed properly, as OptionsStash requires an array of arrays with option names, instead of an array of option names.

I've also added "options_lo" keyword, so that one can do, say, `"cc_type": "conv"` calculation in an otherwise `"cc_type": "df"` recipe, or as shown in the test, a frozen-core stage in an all-electron recipe.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixed "options" handling
- [x] Implemented "options_lo" keyword


## Checklist
- [x] Tests added for any new features
- [x] All or relevant fraction of full tests run: `ctest -L cbs` works fine.

## Status
- [x] Ready for review
- [x] Ready for merge
