### PR TITLE
Document code style and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+  - repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.27.0
+    hooks:
+      - id: yapf
+  - repo: https://github.com/doublify/pre-commit-clang-format.git
+    sha: master
+    hooks:
+      - id: clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,50 +74,51 @@ install:
   - conda list
 
 before_script:
-- python -V
-- python -c 'import numpy; print(numpy.version.version)'
-- cd ${TRAVIS_BUILD_DIR}
-- export CXX=${CXX_COMPILER}
-- export CC=${C_COMPILER}
-- export FC=${Fortran_COMPILER}
-- ${CXX_COMPILER} --version
-- ${Fortran_COMPILER} --version
-- ${C_COMPILER} --version
+  - python -V
+  - python -c 'import numpy; print(numpy.version.version)'
+  - cd ${TRAVIS_BUILD_DIR}
+  - export CXX=${CXX_COMPILER}
+  - export CC=${C_COMPILER}
+  - export FC=${Fortran_COMPILER}
+  - ${CXX_COMPILER} --version
+  - ${Fortran_COMPILER} --version
+  - ${C_COMPILER} --version
     # * can't use conda dist of the more complicated lib pkgs (e.g., CheMPS2, PCMSolver, v2rdm)
     #   b/c their c++ symbols don't mix with the different Travis compilers. for other
     #   reasons, pkgs are being compiled less statically, sad for CI.
     # * can't enable trivial plugins b/c no psi4 for them to detect at start (e.g., snsmp2)
-- >
-    cmake -Bbuild -H.
-    -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-    -DCMAKE_C_COMPILER=${C_COMPILER}
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-    -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
-    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_CheMPS2=OFF
-    -DENABLE_dkh=ON
-    -DENABLE_libefp=ON
-    -DENABLE_erd=OFF
-    -DENABLE_gdma=ON
-    -DENABLE_PCMSolver=OFF
-    -DENABLE_simint=ON
-    -DENABLE_snsmp2=OFF
-    -DENABLE_v2rdm_casscf=OFF
-    -DENABLE_PLUGIN_TESTING=ON
-    -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
-- cd build
-- ../.scripts/travis_build.sh
+  - >
+      cmake -Bbuild -H.
+      -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+      -DCMAKE_C_COMPILER=${C_COMPILER}
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+      -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
+      -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
+      -DENABLE_CheMPS2=OFF
+      -DENABLE_dkh=ON
+      -DENABLE_libefp=ON
+      -DENABLE_erd=OFF
+      -DENABLE_gdma=ON
+      -DENABLE_PCMSolver=OFF
+      -DENABLE_simint=ON
+      -DENABLE_snsmp2=OFF
+      -DENABLE_v2rdm_casscf=OFF
+      -DENABLE_PLUGIN_TESTING=ON
+      -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/Install
+  - cd build
+  - ../.scripts/travis_build.sh
+
 script:
-- ./stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
-- python ../.scripts/travis_run_test.py
-- python ../.scripts/travis_print_failing.py
-- PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 -n 2 -m 'quick' stage/lib/psi4/tests/
+  - ./stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
+  - python ../.scripts/travis_run_test.py
+  - python ../.scripts/travis_print_failing.py
+  - PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 -n 2 -m 'quick' stage/lib/psi4/tests/
 
 # safelist
 branches:
   only:
-  - master
-  - 1.3.x
-  - 1.2.x
-  - 1.1.x
-  - 1.0.x
+    - master
+    - 1.3.x
+    - 1.2.x
+    - 1.1.x
+    - 1.0.x

--- a/doc/sphinxman/source/code_style.rst
+++ b/doc/sphinxman/source/code_style.rst
@@ -3,7 +3,7 @@
 .. #
 .. # Psi4: an open-source quantum chemistry software package
 .. #
-.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. # Copyright (c) 2007-2019 The Psi4 Developers.
 .. #
 .. # The copyrights for code used from other parties are included in
 .. # the corresponding files.
@@ -49,7 +49,7 @@ formatting of the code can be accomplished, in decreasing order of automation:
 2. By installing Git hooks to run the formatters when committing.
 3. By running the formatters manually on the modified files.
 
-.. _`faq:editor`:
+.. _`faq:editor_code_style`:
 
 How to impose code style through your editor
 --------------------------------------------
@@ -58,7 +58,7 @@ Both ``clang-format`` and ``yapf`` can be integrated into widely used editors.
 The `Neoformat <https://github.com/sbdchd/neoformat>`_ plugin can be configured
 to format files when saving them to disk.
 
-.. _`faq:githooks`:
+.. _`faq:githooks_code_style`:
 
 How to impose code style through Git hooks
 ------------------------------------------
@@ -91,7 +91,7 @@ Hooks are powerful, but integrating the formatter into your editor will prove
 to be better. Hooks need to be installed anew for every fresh clone of the
 repository you are working on.
 
-.. _`faq:manual`:
+.. _`faq:manual_code_style`:
 
 How to run code-style tools `clang-format` and `yapf` manually
 --------------------------------------------------------------

--- a/doc/sphinxman/source/code_style.rst
+++ b/doc/sphinxman/source/code_style.rst
@@ -1,0 +1,122 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2017 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. _`sec:code_style`:
+
+Code style conventions
+======================
+
+It is important to keep a consistent formatting of the C++ and Python code
+to avoid hard-to-read diffs and merge conflicts.
+``clang-format``_ and ``yapf``_ can be used to format C++ and Python code,
+respectively, according to a predefined style file.
+|PSIfour| provides the :source:`.clang-format` and :source:`.style.yapf` files in the root
+folder of the project.
+It is **recommended** that modifications and/or new files checked into the
+repository are formatted according to these style files using ``clang-format``
+and ``yapf``. It is then helpful if these tools be part of your development toolchain.
+Once ``clang-format`` and ``yapf`` are installed, there are three ways in which
+formatting of the code can be accomplished, in decreasing order of automation:
+
+1. By integrating the formatters into your editor.
+2. By installing Git hooks to run the formatters when committing.
+3. By running the formatters manually on the modified files.
+
+.. _`faq:editor`:
+
+How to impose code style through your editor
+--------------------------------------------
+
+Both ``clang-format`` and ``yapf`` can be integrated into widely used editors.
+The `Neoformat <https://github.com/sbdchd/neoformat>`_ plugin can be configured
+to format files when saving them to disk.
+
+.. _`faq:githooks`:
+
+How to impose code style through Git hooks
+------------------------------------------
+
+Git hooks are scripts that are run before or after certain Git events.
+In this particular case, we want to make sure that all files that have been
+added to the staging area with ``git add`` are formatted according to the style
+*before* they committing them with ``git commit``.
+The hook to be modified is then the *pre-commit* hook.
+|PSIfour| uses the `pre-commit`_ framework, with configuration file :source:`.pre-commit-config.yaml`.
+To take advantage of pre-commit hooks, you will need to install the ``pre-commit`` utility:
+
+::
+  pip install pre-commit
+
+or using Conda:
+
+::
+  conda install pre_commit -c conda-forge
+
+Finally, you need to install the actual hooks:
+
+::
+  pre-commit install
+
+Pre-commit hooks will be run on every ``git commit``, but the ``--no-verify``
+option can be used to skip their execution.
+
+Hooks are powerful, but integrating the formatter into your editor will prove
+to be better. Hooks need to be installed anew for every fresh clone of the
+repository you are working on.
+
+.. _`faq:manual`:
+
+How to run code-style tools `clang-format` and `yapf` manually
+--------------------------------------------------------------
+
+The least recommended approach to formatting your code is to run manually the
+formatters. The following commands will format only the files that have been
+modified:
+
+::
+  clang-format -style=file -i `git diff --relative --name-only HEAD -- *.cc *.h`
+  yapf -i `git diff --relative --name-only HEAD -- *.py`
+
+How and when to *not* apply code styling to your contributions
+--------------------------------------------------------------
+
+TODO
+
+.. _``clang-format``: https://clang.llvm.org/docs/ClangFormat.html
+
+.. _``yapf``: https://github.com/google/yapf
+
+.. _``.clang-format``: https://github.com/psi4/psi4/blob/master/.clang-format
+
+.. _``.style.yapf``: https://github.com/psi4/psi4/blob/master/.style.yapf
+
+.. _pre-commit: https://pre-commit.com/
+
+.. _``.pre-commit-config.yaml``: https://github.com/psi4/psi4/blob/master/.pre-commit-config.yaml

--- a/doc/sphinxman/source/prog_faq.rst
+++ b/doc/sphinxman/source/prog_faq.rst
@@ -39,6 +39,9 @@ C++ Style in |PSIfour|
 #. :ref:`faq:nullptr`
 #. :ref:`faq:automakeshared`
 #. :ref:`faq:autodecl`
+#. :ref:`faq:editor`
+#. :ref:`faq:githooks`
+#. :ref:`faq:manual`
 
 Modules in |PSIfour|
 --------------------

--- a/doc/sphinxman/source/prog_faq.rst
+++ b/doc/sphinxman/source/prog_faq.rst
@@ -39,9 +39,9 @@ C++ Style in |PSIfour|
 #. :ref:`faq:nullptr`
 #. :ref:`faq:automakeshared`
 #. :ref:`faq:autodecl`
-#. :ref:`faq:editor`
-#. :ref:`faq:githooks`
-#. :ref:`faq:manual`
+#. :ref:`faq:editor_code_style`
+#. :ref:`faq:githooks_code_style`
+#. :ref:`faq:manual_code_style`
 
 Modules in |PSIfour|
 --------------------


### PR DESCRIPTION
## Description
Breaks off documentation and `.travis.yml` linting off of #809. I have added a `.pre-commit-config.yaml` that will check for:
- Filenames that would conflict on a case-insensitive filesystem
- Files that contain merge conflict strings.
- Python formatting with YAPF.
- C++ formatting with clang-format.

Hooks are **opt-in** and require you to install [`pre-commit`](https://pre-commit.com/) (with pip or conda) and then run `pre-commit install` to integrate the actual hooks.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Document code style and how to enforce it.
- [x] Add `.pre-commit-config.yaml` and explain how to use it.
- [x] Use build stages on Travis and lint/clean up `.travis.yml` 

## Status
- [x] Ready for review
- [x] Ready for merge
