### PR TITLE
Add SCAN family of functionals

### DIFF
--- a/psi4/driver/procrouting/dft/hyb_functionals.py
+++ b/psi4/driver/procrouting/dft/hyb_functionals.py
@@ -602,8 +602,35 @@ funcs.append({
                 '    N. Mardirossian, M. Head-Gordon, Phys. Chem. Chem. Phys, 16, 9904, 2014\n'
 })
 
+funcs.append({
+    "name": "SCAN0",
+    "x_functionals": {
+        "HYB_MGGA_X_SCAN0": {
+            "use_libxc": True
+        }
+    },
+    "c_functionals": {
+        "MGGA_C_SCAN": {}
+    },
+    "description": '    SCAN0 Hybrid Meta-GGA XC Functional\n',
+    "citation": '    K. Hui, J.-D. Chai, J. Chem. Phys. 144, 044114, 2016\n',
+    "doi": '10.1063/1.4940734',
+})
 
-
+funcs.append({
+    "name": "revSCAN0",
+    "x_functionals": {
+        "HYB_MGGA_X_REVSCAN0": {
+            "use_libxc": True
+        }
+    },
+    "c_functionals": {
+        "MGGA_C_REVSCAN": {}
+    },
+    "description": '    Revised SCAN0 Hybrid Meta-GGA XC Functional\n',
+    "citation": '    P. D. Mezei, G. I. Csonka, M. Kallay J. Chem. Theory Comput. 14, 2469, 2018\n',
+    "doi": "10.1021/acs.jctc.8b00072",
+})
 
 functional_list = {}
 for functional in funcs:

--- a/psi4/driver/procrouting/dft/hyb_functionals.py
+++ b/psi4/driver/procrouting/dft/hyb_functionals.py
@@ -643,7 +643,7 @@ funcs.append({
         "GGA_C_BMK": {}
     },
     "citation":
-    '    A. D. Boese, J. M. L. Martin, J. Chem. Phys. 121, 3405, 2004\n'
+    '    A. D. Boese, J. M. L. Martin, J. Chem. Phys. 121, 3405, 2004\n',
     "description":
     '    BMK Hybrid Meta-GGA XC Functional for kinetics\n',
 })

--- a/psi4/driver/procrouting/dft/hyb_functionals.py
+++ b/psi4/driver/procrouting/dft/hyb_functionals.py
@@ -632,6 +632,22 @@ funcs.append({
     "doi": "10.1021/acs.jctc.8b00072",
 })
 
+funcs.append({
+    "name": "BMK",
+    "x_functionals": {
+        "HYB_MGGA_X_BMK": {
+            "use_libxc": True
+        }
+    },
+    "c_functionals": {
+        "GGA_C_BMK": {}
+    },
+    "citation":
+    '    A. D. Boese, J. M. L. Martin, J. Chem. Phys. 121, 3405, 2004\n'
+    "description":
+    '    BMK Hybrid Meta-GGA XC Functional for kinetics\n',
+})
+
 functional_list = {}
 for functional in funcs:
     functional_list[functional["name"].lower()] = functional

--- a/psi4/driver/procrouting/dft/mgga_functionals.py
+++ b/psi4/driver/procrouting/dft/mgga_functionals.py
@@ -47,6 +47,20 @@ funcs.append({
 })
 
 funcs.append({
+    "name": "revM06-L",
+    "alias": ["revM06L"],
+    "x_functionals": {
+        "MGGA_X_REVM06_L": {}
+    },
+    "c_functionals": {
+        "MGGA_C_REVM06_L": {}
+    },
+    "description": '    Revised M06-L Meta-GGA XC Functional\n',
+    "citation": '    Y. Wang, X. Jin, H. S. Yu, D. G. Truhlar, X. He, Proc. Nat. Acad. Sci. 114, 8487, 2017\n',
+    "doi": "10.1073/pnas.1705670114",
+})
+
+funcs.append({
     "name": "M11-L",
     "alias": ["M11L"],
     "x_functionals": {
@@ -205,6 +219,32 @@ funcs.append({
     "citation": '    A. Najib, L. Goerigk J. Comput. Theory Chem., 14, 5725, 2018\n'+
                 '    N. Mardirossian, M. Head-Gordon J. Chem. Phys. 142, 074111 (2015)\n',
 
+})
+
+funcs.append({
+    "name": "SCAN",
+    "x_functionals": {
+        "MGGA_X_SCAN": {}
+    },
+    "c_functionals": {
+        "MGGA_C_SCAN": {}
+    },
+    "description": '    SCAN Meta-GGA XC Functional\n',
+    "citation": '    J. Sun, A. Ruzsinszky, J. P. Perdew  Phys. Rev. Lett. 115, 036402, 2015\n',
+    "doi": "10.1103/PhysRevLett.115.036402",
+})
+
+funcs.append({
+    "name": "revSCAN",
+    "x_functionals": {
+        "MGGA_X_REVSCAN": {}
+    },
+    "c_functionals": {
+        "MGGA_C_REVSCAN": {}
+    },
+    "description": '    Revised SCAN Meta-GGA XC Functional\n',
+    "citation": '    P. D. Mezei, G. I. Csonka, M. Kallay J. Chem. Theory Comput. 14, 2469, 2018\n',
+    "doi": "10.1021/acs.jctc.8b00072",
 })
 
 functional_list = {}

--- a/tests/pytest/test_dft_benchmarks.py
+++ b/tests/pytest/test_dft_benchmarks.py
@@ -7,6 +7,8 @@ from addons import *
 import psi4
 
 
+
+
 @pytest.fixture
 def dft_bench_systems():
     ang = np.array([
@@ -54,247 +56,242 @@ def name_dft_test(val):
 @pytest.mark.scf
 @pytest.mark.dft
 @pytest.mark.parametrize("func,expected,basis", [
-    pytest.param(          'PWB6K',    0.4535664415, '6-31G', marks=pytest.mark.quick),  # Q-Chem
-    pytest.param(         'PW6B95',    0.4566580191, '6-31G'),  # Q-Chem
-    pytest.param(        'wB97X-D',    0.4575912358, '6-31G', marks=pytest.mark.quick),  # Q-Chem
-    pytest.param(        'revTPSS',    0.4499706673, '6-31G'),  # Q-Chem
-    pytest.param(           'TPSS',    0.4510368445, '6-31G'),  # Q-Chem
-    pytest.param(       'MGGA_MS2',    0.446697433,  '6-31G'),  # Q-Chem
-    pytest.param(       'MGGA_MS1',    0.4464339073, '6-31G'),  # Q-Chem
-    pytest.param(          'M11-L',    0.4598708424, '6-31G'),  # Q-Chem
-    pytest.param(       'LRC-wPBE',    0.4580992958, '6-31G'),  # Q-Chem
-    pytest.param(       'revTPSSh',    0.4497777532, '6-31G'),  # Q-Chem
-    pytest.param(       'MGGA_MS0',    0.4465224137, '6-31G'),  # Q-Chem
-    pytest.param(         'BHHLYP',    0.4474902387, '6-31G'),  # Q-Chem
-    pytest.param(          'B1LYP',    0.4497408502, '6-31G'),  # Q-Chem
-    pytest.param(         'HCTH93',    0.4587611969, '6-31G'),  # Q-Chem
-    pytest.param(          'MPW1K',    0.4527968482, '6-31G'),  # Q-Chem
-    pytest.param(          'TPSSh',    0.4505861795, '6-31G'),  # Q-Chem
-    pytest.param(           'PBE0',    0.4530422829, '6-31G'),  # Q-Chem
-    pytest.param(      'LRC-wPBEh',    0.4549011451, '6-31G', marks=pytest.mark.quick),  # Q-Chem
-    pytest.param(         'B3PW91',    0.4568637908, '6-31G'),  # Q-Chem
-    pytest.param(           'wB97',    0.4561211941, '6-31G'),  # Q-Chem
-    pytest.param(            'BOP',    0.4518711518, '6-31G'),  # Q-Chem
-    pytest.param(          'B3P86',    0.4638089921, '6-31G'),  # Q-Chem
-    pytest.param(            'M11',    0.4596599711, '6-31G'),  # Q-Chem
-    pytest.param(         'M08-HX',    0.4616204211, '6-31G'),  # Q-Chem
-    pytest.param(          'wB97X',    0.4564711283, '6-31G'),  # Q-Chem
-    pytest.param(       'B5050LYP',    0.4508657425, '6-31G'),  # Q-Chem
-    pytest.param(            'M06',    0.4610467104, '6-31G'),  # Q-Chem
-    pytest.param(           'BLYP',    0.452062348,  '6-31G'),  # Q-Chem
-    pytest.param(          'X3LYP',    0.4549534082, '6-31G'),  # Q-Chem
-    pytest.param(         'M05-2X',    0.4583363493, '6-31G'),  # Q-Chem
-    pytest.param(          'B1B95',    0.4535328884, '6-31G'),  # Q-Chem
-    pytest.param(            'M05',    0.457437892,  '6-31G'),  # Q-Chem
-    pytest.param(          'B97-3',    0.4573836831, '6-31G'),  # Q-Chem
-    pytest.param(          'B97-D',    0.4562801577, '6-31G'),  # Q-Chem
-    pytest.param(           'BB1K',    0.4523318654, '6-31G'),  # Q-Chem
-    pytest.param(         'B97-D3',    0.4562801577, '6-31G', marks=using_dftd3),  # Q-Chem
-    pytest.param('DSD-PBEPBE-D3BJ',    0.44608512,   '6-31G', marks=[using_dftd3, pytest.mark.quick]),  # Q-Chem
-    pytest.param('DSD-PBEP86-D3BJ',    0.44599836,   '6-31G', marks=using_dftd3),  # Q-Chem
-    pytest.param('DSD-PBEB95-D3BJ',    0.44615418,   '6-31G', marks=using_dftd3),  # Q-Chem
-    pytest.param(         'M06-2X',    0.4584074697, '6-31G'),  # Q-Chem
-    pytest.param(           'dlDF',    0.4620507089, '6-31G'),  # Q-Chem
-    pytest.param(           'BP86',    0.4599766012, '6-31G'),  # Q-Chem
-    pytest.param(        'HCTH120',    0.4609912502, '6-31G'),  # Q-Chem
-    pytest.param(           'EDF1',    0.4557270241, '6-31G'),  # Q-Chem
-    pytest.param(         'M08-SO',    0.4656227382, '6-31G'),  # Q-Chem
-    pytest.param(        'HCTH407',    0.4627707723, '6-31G'),  # Q-Chem
-    pytest.param(        'MPW1B95',    0.4537920011, '6-31G'),  # Q-Chem
-    pytest.param(        'HCTH147',    0.462383627,  '6-31G'),  # Q-Chem
-    pytest.param(         'M06-HF',    0.4582368218, '6-31G'),  # Q-Chem
-    pytest.param(         'B3LYP5',    0.4535575461, '6-31G'),  # Q-Chem
-    pytest.param(           'PW91',    0.4573407123, '6-31G'),  # Q-Chem
-    pytest.param(          'B3LYP',    0.4572870674, '6-31G'),  # Q-Chem
-    pytest.param(            'PBE',    0.4552076767, '6-31G'),  # Q-Chem
-    pytest.param(         'MPWB1K',    0.4525753564, '6-31G'),  # Q-Chem
-    pytest.param(          'B97-K',    0.4498949296, '6-31G'),  # Q-Chem
-    pytest.param(          'B97-0',    0.4555394941, '6-31G'),  # Q-Chem
-    pytest.param(         'B1PW91',    0.4538643591, '6-31G'),  # Q-Chem
-    pytest.param(           'EDF2',    0.457161542,  '6-31G'),  # Q-Chem
-    pytest.param(          'B97-2',    0.4562077948, '6-31G'),  # Q-Chem
-    pytest.param(          'B97-1',    0.4551137,    '6-31G'),  # Q-Chem
-    pytest.param(          'O3LYP',    0.4543928605, '6-31G'),  # Q-Chem
-    pytest.param(      'MGGA_MS2h',    0.4467710458, '6-31G'),  # Q-Chem
-    pytest.param(            'GAM',    0.4509109774, '6-31G'),  # Q-Chem
-    pytest.param(          'SOGGA',    0.451387499,  '6-31G'),  # Q-Chem
-    pytest.param(      'MGGA_MVSh',    0.4606380903, '6-31G'),  # Q-Chem
-    pytest.param(           'PKZB',    0.4468952399, '6-31G'),  # Q-Chem
-    pytest.param(        'SOGGA11',    0.4529071593, '6-31G'),  # Q-Chem
-    pytest.param(         'revPBE',    0.4527402025, '6-31G'),  # Q-Chem
-    pytest.param(          'PBEOP',    0.4515908966, '6-31G'),  # Q-Chem
-    pytest.param(         'MN12-L',    0.4541560093, '6-31G'),  # Q-Chem
-    pytest.param(         'N12-SX',    0.4522295631, '6-31G'),  # Q-Chem
-    pytest.param(       'MGGA_MVS',    0.4646978551, '6-31G'),  # Q-Chem
-    pytest.param(        'revPBE0',    0.4512137933, '6-31G'),  # Q-Chem
-    pytest.param(          'M06-L',    0.4568710032, '6-31G'),  # Q-Chem
-    pytest.param(       'MPW1PW91',    0.454429221,  '6-31G'),  # Q-Chem
-    pytest.param(        'MPW1PBE',    0.4536406557, '6-31G'),  # Q-Chem
-    pytest.param(         'MN15-L',    0.457945977,  '6-31G'),  # Q-Chem
-    pytest.param(      'SOGGA11-X',    0.4601258852, '6-31G'),  # Q-Chem
-    pytest.param(        'MN12-SX',    0.461815166,  '6-31G'),  # Q-Chem
-    pytest.param(        'MPW1LYP',    0.4503072868, '6-31G'),  # Q-Chem
-    pytest.param(          'PBE50',    0.4509652861, '6-31G'),  # Q-Chem
-    pytest.param(            'N12',    0.4479283792, '6-31G'),  # Q-Chem
-    pytest.param(           'VSXC',    0.4547894146, '6-31G'),  # Q-Chem
-    pytest.param(      'CAM-B3LYP',    0.4568003604, '6-31G'),  # Q-Chem
-    pytest.param(           'VV10',    0.4551366594, '6-31G'),  # Q-Chem
-    pytest.param(         'B97M-V',    0.4561660762, '6-31G'),  # Q-Chem
-    pytest.param(        'LC-VV10',    0.4556872545, '6-31G'),  # Q-Chem
-    pytest.param(        'wB97M-V',    0.4544676075, '6-31G'),  # Q-Chem
-    pytest.param(        'wB97X-V',    0.455302602,  '6-31G'),  # Q-Chem
-    pytest.param(           'SCAN',    0.4517181611, '6-31G'),  # Q-Chem
-    pytest.param(          'SCAN0',    0.4496859365, '6-31G'),  # Q-Chem
+    pytest.param(          'B1B95', 0.4535328884, '6-31G'),  # Q-Chem
+    pytest.param(          'B1LYP', 0.4497408502, '6-31G'),  # Q-Chem
+    pytest.param(         'B1PW91', 0.4538643591, '6-31G'),  # Q-Chem
+    pytest.param(          'B3LYP', 0.4572870674, '6-31G'),  # Q-Chem
+    pytest.param(         'B3LYP5', 0.4535575461, '6-31G'),  # Q-Chem
+    pytest.param(          'B3P86', 0.4638089921, '6-31G'),  # Q-Chem
+    pytest.param(         'B3PW91', 0.4568637908, '6-31G'),  # Q-Chem
+    pytest.param(         'B3TLAP', 0.4473764358, '6-31G'),  # Q-Chem
+    pytest.param(       'B5050LYP', 0.4508657425, '6-31G'),  # Q-Chem
+    pytest.param(          'B97-0', 0.4555394941, '6-31G'),  # Q-Chem
+    pytest.param(          'B97-1', 0.4551137,    '6-31G'),  # Q-Chem
+    pytest.param(          'B97-2', 0.4562077948, '6-31G'),  # Q-Chem
+    pytest.param(          'B97-3', 0.4573836831, '6-31G'),  # Q-Chem
+    pytest.param(          'B97-D', 0.4562801577, '6-31G'),  # Q-Chem
+    pytest.param(         'B97-D3', 0.4562801577, '6-31G', marks=using_dftd3),  # Q-Chem
+    pytest.param(          'B97-K', 0.4498949296, '6-31G'),  # Q-Chem
+    pytest.param(         'B97M-V', 0.4561660762, '6-31G'),  # Q-Chem
+    pytest.param(           'BB1K', 0.4523318654, '6-31G'),  # Q-Chem
+    pytest.param(         'BHHLYP', 0.4474902387, '6-31G'),  # Q-Chem
+    pytest.param(           'BLYP', 0.452062348,  '6-31G'),  # Q-Chem
+    pytest.param(            'BMK', 0.4586754862, '6-31G'),  # Q-Chem  # not in LibXC 3.0.0
+    pytest.param(            'BOP', 0.4518711518, '6-31G'),  # Q-Chem
+    pytest.param(           'BP86', 0.4599766012, '6-31G'),  # Q-Chem
+    pytest.param(        'BP86VWN', 0.4588991901, '6-31G'),  # Q-Chem
+    pytest.param(      'CAM-B3LYP', 0.4568003604, '6-31G'),  # Q-Chem
+    pytest.param(           'dlDF', 0.4620507089, '6-31G'),  # Q-Chem
+    pytest.param('DSD-PBEB95-D3BJ', 0.44615418,   '6-31G', marks=using_dftd3),  # Q-Chem
+    pytest.param('DSD-PBEP86-D3BJ', 0.44599836,   '6-31G', marks=using_dftd3),  # Q-Chem
+    pytest.param('DSD-PBEPBE-D3BJ', 0.44608512,   '6-31G', marks=[using_dftd3, pytest.mark.quick]),  # Q-Chem
+    pytest.param(           'EDF1', 0.4557270241, '6-31G'),  # Q-Chem
+    pytest.param(           'EDF2', 0.457161542,  '6-31G'),  # Q-Chem
+    pytest.param(            'GAM', 0.4509109774, '6-31G'),  # Q-Chem
+    pytest.param(        'HCTH120', 0.4609912502, '6-31G'),  # Q-Chem
+    pytest.param(        'HCTH147', 0.462383627,  '6-31G'),  # Q-Chem
+    pytest.param(        'HCTH407', 0.4627707723, '6-31G'),  # Q-Chem
+    pytest.param(         'HCTH93', 0.4587611969, '6-31G'),  # Q-Chem
+    pytest.param(        'LC-VV10', 0.4556872545, '6-31G'),  # Q-Chem
+    pytest.param(        'LRC-BOP', 0.4595497115, '6-31G'),  # Q-Chem
+    pytest.param(       'LRC-wPBE', 0.4580992958, '6-31G'),  # Q-Chem
+    pytest.param(      'LRC-wPBEh', 0.4549011451, '6-31G', marks=pytest.mark.quick),  # Q-Chem
+    pytest.param(            'M05', 0.457437892,  '6-31G'),  # Q-Chem
+    pytest.param(         'M05-2X', 0.4583363493, '6-31G'),  # Q-Chem
+    pytest.param(            'M06', 0.4610467104, '6-31G'),  # Q-Chem
+    pytest.param(         'M06-2X', 0.4584074697, '6-31G'),  # Q-Chem
+    pytest.param(         'M06-HF', 0.4582368218, '6-31G'),  # Q-Chem
+    pytest.param(          'M06-L', 0.4568710032, '6-31G'),  # Q-Chem
+    pytest.param(         'M08-HX', 0.4616204211, '6-31G'),  # Q-Chem
+    pytest.param(         'M08-SO', 0.4656227382, '6-31G'),  # Q-Chem
+    pytest.param(            'M11', 0.4596599711, '6-31G'),  # Q-Chem
+    pytest.param(          'M11-L', 0.4598708424, '6-31G'),  # Q-Chem
+    pytest.param(       'MGGA_MS0', 0.4465224137, '6-31G'),  # Q-Chem
+    pytest.param(       'MGGA_MS1', 0.4464339073, '6-31G'),  # Q-Chem
+    pytest.param(       'MGGA_MS2', 0.446697433,  '6-31G'),  # Q-Chem
+    pytest.param(      'MGGA_MS2h', 0.4467710458, '6-31G'),  # Q-Chem
+    pytest.param(       'MGGA_MVS', 0.4646978551, '6-31G'),  # Q-Chem
+    pytest.param(      'MGGA_MVSh', 0.4606380903, '6-31G'),  # Q-Chem
+    pytest.param(         'MN12-L', 0.4541560093, '6-31G'),  # Q-Chem
+    pytest.param(        'MN12-SX', 0.461815166,  '6-31G'),  # Q-Chem
+    pytest.param(         'MN15-L', 0.457945977,  '6-31G'),  # Q-Chem
+    pytest.param(        'MPW1B95', 0.4537920011, '6-31G'),  # Q-Chem
+    pytest.param(          'MPW1K', 0.4527968482, '6-31G'),  # Q-Chem
+    pytest.param(        'MPW1LYP', 0.4503072868, '6-31G'),  # Q-Chem
+    pytest.param(        'MPW1PBE', 0.4536406557, '6-31G'),  # Q-Chem
+    pytest.param(       'MPW1PW91', 0.454429221,  '6-31G'),  # Q-Chem
+    pytest.param(         'MPWB1K', 0.4525753564, '6-31G'),  # Q-Chem
+    pytest.param(            'N12', 0.4479283792, '6-31G'),  # Q-Chem
+    pytest.param(         'N12-SX', 0.4522295631, '6-31G'),  # Q-Chem
+    pytest.param(          'O3LYP', 0.4543928605, '6-31G'),  # Q-Chem
+    pytest.param(            'PBE', 0.4552076767, '6-31G'),  # Q-Chem
+    pytest.param(           'PBE0', 0.4530422829, '6-31G'),  # Q-Chem
+    pytest.param(          'PBE50', 0.4509652861, '6-31G'),  # Q-Chem
+    pytest.param(          'PBEOP', 0.4515908966, '6-31G'),  # Q-Chem
+    pytest.param(         'PBEsol', 0.455663707,  '6-31G'),  # Q-Chem
+    pytest.param(           'PKZB', 0.4468952399, '6-31G'),  # Q-Chem
+    pytest.param(         'PW6B95', 0.4566580191, '6-31G'),  # Q-Chem
+    pytest.param(           'PW91', 0.4573407123, '6-31G'),  # Q-Chem
+    pytest.param(          'PWB6K', 0.4535664415, '6-31G', marks=pytest.mark.quick),  # Q-Chem
+    pytest.param(         'revPBE', 0.4527402025, '6-31G'),  # Q-Chem
+    pytest.param(        'revPBE0', 0.4512137933, '6-31G'),  # Q-Chem
+    pytest.param(        'revTPSS', 0.4499706673, '6-31G'),  # Q-Chem
+    pytest.param(       'revTPSSh', 0.4497777532, '6-31G'),  # Q-Chem
+    pytest.param(           'SCAN', 0.4517181611, '6-31G'),  # Q-Chem
+    pytest.param(          'SCAN0', 0.4496859365, '6-31G'),  # Q-Chem
+    pytest.param(          'SOGGA', 0.451387499,  '6-31G'),  # Q-Chem
+    pytest.param(        'SOGGA11', 0.4529071593, '6-31G'),  # Q-Chem
+    pytest.param(      'SOGGA11-X', 0.4601258852, '6-31G'),  # Q-Chem
+    pytest.param(         't-HCTH', 0.4623451143, '6-31G'),  # Q-Chem
+    pytest.param(        't-HCTHh', 0.4601544314, '6-31G'),  # Q-Chem
+    pytest.param(           'TPSS', 0.4510368445, '6-31G'),  # Q-Chem
+    pytest.param(          'TPSSh', 0.4505861795, '6-31G'),  # Q-Chem
+    pytest.param(           'VSXC', 0.4547894146, '6-31G'),  # Q-Chem
+    pytest.param(           'VV10', 0.4551366594, '6-31G'),  # Q-Chem
+    pytest.param(           'wB97', 0.4561211941, '6-31G'),  # Q-Chem
+    pytest.param(        'wB97M-V', 0.4544676075, '6-31G'),  # Q-Chem
+    pytest.param(          'wB97X', 0.4564711283, '6-31G'),  # Q-Chem
+    pytest.param(        'wB97X-D', 0.4575912358, '6-31G', marks=pytest.mark.quick),  # Q-Chem
+    pytest.param(       'wB97X-D3', 0.4570744381, '6-31G', marks=[using_dftd3, pytest.mark.xfail]),  # Q-Chem  # needs tweaks in LibXC
+    pytest.param(        'wB97X-V', 0.455302602,  '6-31G'),  # Q-Chem
+    pytest.param(         'wM05-D', 0.4560790902, '6-31G'),  # Q-Chem
+    pytest.param(        'wM06-D3', 0.4563459267, '6-31G', marks=using_dftd3),
+    pytest.param(          'X3LYP', 0.4549534082, '6-31G'),  # Q-Chem
 ], ids=name_dft_test)
+
 def test_dft_bench_ionization(func, expected, basis, dft_bench_systems, request):
     """functionals ionization energies vs. Q-Chem"""
+    if func.lower() in psi4.driver.procedures['energy']:
+        mols = dft_bench_systems
+        psi4.set_options({'basis': basis, 'reference': 'uks'})
+        cation  = psi4.energy(func, molecule=mols['h2o_plus'])
+        psi4.set_options({'reference': 'rks'})
+        neutral = psi4.energy(func, molecule=mols['h2o'])
+        assert compare_values(expected, cation - neutral, 4, request.node.name)
+    else:
+        pytest.xfail("{0:s} not in Psi4.".format(func))
 
-    mols = dft_bench_systems
-
-    psi4.set_options({'basis': basis,
-                      'reference': 'uks'})
-    cation  = psi4.energy(func, molecule=mols['h2o_plus'])
-    psi4.set_options({'reference': 'rks'})
-    neutral = psi4.energy(func, molecule=mols['h2o'])
-
-    assert compare_values(expected, cation - neutral, 4, request.node.name)
 
 
 @pytest.mark.scf
 @pytest.mark.dft
 @pytest.mark.long
 @pytest.mark.parametrize("func,expected,basis", [
-    pytest.param(  'B97M-D3BJ',  -0.01242543212, 'cc-pVDZ', marks=using_dftd3),  # Orca
-    pytest.param( 'wB97M-D3BJ',  -0.01351626999, 'cc-pVDZ', marks=using_dftd3),  # Orca
-    pytest.param( 'wB97X-D3BJ',  -0.01295664452, 'cc-pVDZ', marks=using_dftd3),  # Orca
-    pytest.param(     'M08-SO',  -0.0154578319, '6-31G'),  # Q-Chem
-    pytest.param(       'EDF1',  -0.0112660306, '6-31G'),  # Q-Chem
-    pytest.param(    'MPW1B95',  -0.0143828237, '6-31G'),  # Q-Chem
-    pytest.param(     'B97-D3',  -0.0144570179, '6-31G', marks=using_dftd3),  # Q-Chem
-    pytest.param(     'PW6B95',  -0.0145444936, '6-31G'),  # Q-Chem
-    pytest.param(      'wB97X',  -0.0156289024, '6-31G'),  # Q-Chem
-    pytest.param(     'B3LYP5',  -0.0144957247, '6-31G'),  # Q-Chem
-    pytest.param(  'LRC-wPBEh',  -0.0147072182, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-3',  -0.0131076955, '6-31G'),  # Q-Chem
-    pytest.param(    'wB97M-V',  -0.0152233456, '6-31G'),  # Q-Chem
-    pytest.param(       'dlDF',  -0.0100880118, '6-31G'),  # Q-Chem
-    pytest.param(       'PW91',  -0.0160147465, '6-31G'),  # Q-Chem
-    pytest.param(       'VV10',  -0.0160812898, '6-31G'),  # Q-Chem
-    pytest.param(    'HCTH147',  -0.0132522028, '6-31G'),  # Q-Chem
-    pytest.param(    'wB97X-D',  -0.0146246032, '6-31G'),  # Q-Chem
-    pytest.param(      'B1B95',  -0.0132525420, '6-31G'),  # Q-Chem
-    pytest.param(   'B5050LYP',  -0.0149474908, '6-31G'),  # Q-Chem
-    pytest.param(    'HCTH407',  -0.0135769693, '6-31G'),  # Q-Chem
-    pytest.param(     'M08-HX',  -0.0150796776, '6-31G'),  # Q-Chem
-    pytest.param(        'M06',  -0.0143374034, '6-31G'),  # Q-Chem
-    pytest.param(     'MPWB1K',  -0.0143991465, '6-31G'),  # Q-Chem
-    pytest.param(      'B3LYP',  -0.0145306919, '6-31G'),  # Q-Chem
-    pytest.param(     'B1PW91',  -0.0130688293, '6-31G'),  # Q-Chem
-    pytest.param(      'MPW1K',  -0.0142603959, '6-31G'),  # Q-Chem
-    pytest.param(      'M11-L',  -0.0120196336, '6-31G'),  # Q-Chem
-    pytest.param(   'MGGA_MS1',  -0.0135190604, '6-31G'),  # Q-Chem
-    pytest.param(  'CAM-B3LYP',  -0.0159494700, '6-31G'),  # Q-Chem
-    pytest.param(    'HCTH120',  -0.0140214969, '6-31G'),  # Q-Chem
-    pytest.param(     'B97M-V',  -0.0140939544, '6-31G'),  # Q-Chem
-    pytest.param(       'TPSS',  -0.0141667663, '6-31G'),  # Q-Chem
-    pytest.param(     'M06-2X',  -0.0149081161, '6-31G'),  # Q-Chem
-    pytest.param(        'M05',  -0.0156581803, '6-31G'),  # Q-Chem
-    pytest.param(     'BHHLYP',  -0.0148261610, '6-31G'),  # Q-Chem
-    pytest.param(     'B3PW91',  -0.0133871214, '6-31G'),  # Q-Chem
-    pytest.param(       'BB1K',  -0.0134816841, '6-31G'),  # Q-Chem
-    pytest.param(     'M06-HF',  -0.0153050734, '6-31G'),  # Q-Chem
-    pytest.param(        'BOP',  -0.0117582062, '6-31G'),  # Q-Chem
-    pytest.param(   'MGGA_MS2',  -0.0138641589, '6-31G'),  # Q-Chem
-    pytest.param(   'MGGA_MS0',  -0.0141108035, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-K',  -0.0143346234, '6-31G'),  # Q-Chem
-    pytest.param(    'revTPSS',  -0.0140137038, '6-31G'),  # Q-Chem
-    pytest.param(     'HCTH93',  -0.0110370744, '6-31G'),  # Q-Chem
-    pytest.param(       'wB97',  -0.0160148410, '6-31G'),  # Q-Chem
-    pytest.param(       'BP86',  -0.0138889593, '6-31G'),  # Q-Chem
-    pytest.param(       'PBE0',  -0.0149591069, '6-31G'),  # Q-Chem
-    pytest.param(       'BLYP',  -0.0142958198, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-0',  -0.0139591073, '6-31G'),  # Q-Chem
-    pytest.param(      'X3LYP',  -0.0151870467, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-1',  -0.0146773380, '6-31G'),  # Q-Chem
-    pytest.param(   'revTPSSh',  -0.0139563411, '6-31G'),  # Q-Chem
-    pytest.param(    'LC-VV10',  -0.0156463704, '6-31G'),  # Q-Chem
-    pytest.param(      'O3LYP',  -0.0124587623, '6-31G'),  # Q-Chem
-    pytest.param(      'PWB6K',  -0.0150275431, '6-31G'),  # Q-Chem
-    pytest.param(     'M05-2X',  -0.0151408376, '6-31G'),  # Q-Chem
-    pytest.param(        'M11',  -0.0152106441, '6-31G'),  # Q-Chem
-    pytest.param(      'B1LYP',  -0.0144226937, '6-31G'),  # Q-Chem
-    pytest.param(       'EDF2',  -0.0155177142, '6-31G'),  # Q-Chem
-    pytest.param(      'B3P86',  -0.0142045385, '6-31G'),  # Q-Chem
-    pytest.param(        'PBE',  -0.0154580371, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-2',  -0.0132026212, '6-31G'),  # Q-Chem
-    pytest.param(    'wB97X-V',  -0.0151102751, '6-31G'),  # Q-Chem
-    pytest.param(   'LRC-wPBE',  -0.0147152576, '6-31G'),  # Q-Chem
-    pytest.param(      'TPSSh',  -0.0140808774, '6-31G'),  # Q-Chem
-    pytest.param(      'B97-D',  -0.0140422551, '6-31G'),  # Q-Chem
-    pytest.param(   'wB97X-D3',  -0.0148666307, '6-31G', marks=[using_dftd3, pytest.mark.xfail]),  # Q-Chem
-    pytest.param(      'SCAN0',  -0.0151046408, '6-31G'),  # Q-Chem
-    pytest.param(     'revPBE',  -0.0129363604, '6-31G'),  # Q-Chem
-    pytest.param(    'SOGGA11',  -0.0133998476, '6-31G'),  # Q-Chem
-    pytest.param(    'MN12-SX',  -0.0130140323, '6-31G'),  # Q-Chem
-    pytest.param(  'MGGA_MS2h',  -0.0138846318, '6-31G'),  # Q-Chem
-    pytest.param(     'MN12-L',  -0.0122476159, '6-31G'),  # Q-Chem
-    pytest.param(        'BMK',  -0.0134597648, '6-31G'),  # Q-Chem
-    pytest.param(        'N12',  -0.0153151670, '6-31G'),  # Q-Chem
-    pytest.param(   'MGGA_MVS',  -0.0145231638, '6-31G'),  # Q-Chem
-    pytest.param(       'PKZB',  -0.0107309601, '6-31G'),  # Q-Chem
-    pytest.param(      'SOGGA',  -0.0171800268, '6-31G'),  # Q-Chem
-    pytest.param(     'MN15-L',  -0.0122572417, '6-31G'),  # Q-Chem
-    pytest.param(      'PBE50',  -0.01474869,   '6-31G'),  # Q-Chem
-    pytest.param(  'MGGA_MVSh',  -0.0145138947, '6-31G'),  # Q-Chem
-    pytest.param(  'SOGGA11-X',  -0.0141398574, '6-31G'),  # Q-Chem
-    pytest.param(      'M06-L',  -0.0131734851, '6-31G'),  # Q-Chem
-    pytest.param(     'N12-SX',  -0.015641602,  '6-31G'),  # Q-Chem
-    pytest.param(      'PBEOP',  -0.0142184544, '6-31G'),  # Q-Chem
-    pytest.param(       'SCAN',  -0.0151696769, '6-31G'),  # Q-Chem
-    pytest.param(    'MPW1LYP',  -0.0156088011, '6-31G'),  # Q-Chem
-    pytest.param(        'GAM',  -0.0149107345, '6-31G'),  # Q-Chem
-
-    
+    pytest.param(     'B1B95', -0.0132525420,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B1LYP', -0.0144226937,  '6-31G'),  #   Q-Chem
+    pytest.param(    'B1PW91', -0.0130688293,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B3LYP', -0.0145306919,  '6-31G'),  #   Q-Chem
+    pytest.param(    'B3LYP5', -0.0144957247,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B3P86', -0.0142045385,  '6-31G'),  #   Q-Chem
+    pytest.param(    'B3PW91', -0.0133871214,  '6-31G'),  #   Q-Chem
+    pytest.param(    'B3TLAP', -0.0155221815,  '6-31G'),  #   Q-Chem
+    pytest.param(  'B5050LYP', -0.0149474908,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B97-0', -0.0139591073,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B97-1', -0.0146773380,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B97-2', -0.0132026212,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B97-3', -0.0131076955,  '6-31G'),  #   Q-Chem
+    pytest.param(     'B97-D', -0.0140422551,  '6-31G'),  #   Q-Chem
+    pytest.param(    'B97-D3', -0.0144570179,  '6-31G', marks=using_dftd3), #   Q-Chem
+    pytest.param(     'B97-K', -0.0143346234,  '6-31G'),  #   Q-Chem
+    pytest.param( 'B97M-D3BJ', -0.01242543212, 'cc-pVDZ', marks=using_dftd3), #   Orca
+    pytest.param(    'B97M-V', -0.0140939544,  '6-31G'),  #   Q-Chem
+    pytest.param(      'BB1K', -0.0134816841,  '6-31G'),  #   Q-Chem
+    pytest.param(    'BHHLYP', -0.0148261610,  '6-31G'),  #   Q-Chem
+    pytest.param(      'BLYP', -0.0142958198,  '6-31G'),  #   Q-Chem
+    pytest.param(       'BMK', -0.0134597648,  '6-31G'),  #   Q-Chem
+    pytest.param(       'BOP', -0.0117582062,  '6-31G'),  #   Q-Chem
+    pytest.param(      'BP86', -0.0138889593,  '6-31G'),  #   Q-Chem
+    pytest.param(   'BP86VWN', -0.0138884252,  '6-31G'),  #   Q-Chem
+    pytest.param( 'CAM-B3LYP', -0.0159494700,  '6-31G'),  #   Q-Chem
+    pytest.param(      'dlDF', -0.0100880118,  '6-31G'),  #   Q-Chem
+    pytest.param(      'EDF1', -0.0112660306,  '6-31G'),  #   Q-Chem
+    pytest.param(      'EDF2', -0.0155177142,  '6-31G'),  #   Q-Chem
+    pytest.param(       'GAM', -0.0149107345,  '6-31G'),  #   Q-Chem
+    pytest.param(   'HCTH120', -0.0140214969,  '6-31G'),  #   Q-Chem
+    pytest.param(   'HCTH147', -0.0132522028,  '6-31G'),  #   Q-Chem
+    pytest.param(   'HCTH407', -0.0135769693,  '6-31G'),  #   Q-Chem
+    pytest.param(    'HCTH93', -0.0110370744,  '6-31G'),  #   Q-Chem
+    pytest.param(   'LC-VV10', -0.0156463704,  '6-31G'),  #   Q-Chem
+    pytest.param(   'LRC-BOP', -0.0157298937,  '6-31G'),  #   Q-Chem
+    pytest.param(  'LRC-wPBE', -0.0147152576,  '6-31G'),  #   Q-Chem
+    pytest.param( 'LRC-wPBEh', -0.0147072182,  '6-31G'),  #   Q-Chem
+    pytest.param(       'M05', -0.0156581803,  '6-31G'),  #   Q-Chem
+    pytest.param(    'M05-2X', -0.0151408376,  '6-31G'),  #   Q-Chem
+    pytest.param(       'M06', -0.0143374034,  '6-31G'),  #   Q-Chem
+    pytest.param(    'M06-2X', -0.0149081161,  '6-31G'),  #   Q-Chem
+    pytest.param(    'M06-HF', -0.0153050734,  '6-31G'),  #   Q-Chem
+    pytest.param(     'M06-L', -0.0131734851,  '6-31G'),  #   Q-Chem
+    pytest.param(    'M08-HX', -0.0150796776,  '6-31G'),  #   Q-Chem
+    pytest.param(    'M08-SO', -0.0154578319,  '6-31G'),  #   Q-Chem
+    pytest.param(       'M11', -0.0152106441,  '6-31G'),  #   Q-Chem
+    pytest.param(     'M11-L', -0.0120196336,  '6-31G'),  #   Q-Chem
+    pytest.param(  'MGGA_MS0', -0.0141108035,  '6-31G'),  #   Q-Chem
+    pytest.param(  'MGGA_MS1', -0.0135190604,  '6-31G'),  #   Q-Chem
+    pytest.param(  'MGGA_MS2', -0.0138641589,  '6-31G'),  #   Q-Chem
+    pytest.param( 'MGGA_MS2h', -0.0138846318,  '6-31G'),  #   Q-Chem
+    pytest.param(  'MGGA_MVS', -0.0145231638,  '6-31G'),  #   Q-Chem
+    pytest.param( 'MGGA_MVSh', -0.0145138947,  '6-31G'),  #   Q-Chem
+    pytest.param(    'MN12-L', -0.0122476159,  '6-31G'),  #   Q-Chem
+    pytest.param(   'MN12-SX', -0.0130140323,  '6-31G'),  #   Q-Chem
+    pytest.param(    'MN15-L', -0.0122572417,  '6-31G'),  #   Q-Chem
+    pytest.param(   'MPW1B95', -0.0143828237,  '6-31G'),  #   Q-Chem
+    pytest.param(     'MPW1K', -0.0142603959,  '6-31G'),  #   Q-Chem
+    pytest.param(   'MPW1LYP', -0.0156088011,  '6-31G'),  #   Q-Chem
+    pytest.param(   'MPW1PBE', -0.0142137779,  '6-31G'),  #   Q-Chem
+    pytest.param(  'MPW1PW91', -0.0142534651,  '6-31G'),  #   Q-Chem
+    pytest.param(    'MPWB1K', -0.0143991465,  '6-31G'),  #   Q-Chem
+    pytest.param(       'N12', -0.0153151670,  '6-31G'),  #   Q-Chem
+    pytest.param(    'N12-SX', -0.015641602,   '6-31G'),  #   Q-Chem
+    pytest.param(     'O3LYP', -0.0124587623,  '6-31G'),  #   Q-Chem
+    pytest.param(       'PBE', -0.0154580371,  '6-31G'),  #   Q-Chem
+    pytest.param(      'PBE0', -0.0149591069,  '6-31G'),  #   Q-Chem
+    pytest.param(     'PBE50', -0.01474869,    '6-31G'),  #   Q-Chem
+    pytest.param(     'PBEOP', -0.0142184544,  '6-31G'),  #   Q-Chem
+    pytest.param(    'PBEsol', -0.0169733502,  '6-31G'),  #   Q-Chem
+    pytest.param(      'PKZB', -0.0107309601,  '6-31G'),  #   Q-Chem
+    pytest.param(    'PW6B95', -0.0145444936,  '6-31G'),  #   Q-Chem
+    pytest.param(      'PW91', -0.0160147465,  '6-31G'),  #   Q-Chem
+    pytest.param(     'PWB6K', -0.0150275431,  '6-31G'),  #   Q-Chem
+    pytest.param(    'revPBE', -0.0129363604,  '6-31G'),  #   Q-Chem
+    pytest.param(   'revPBE0', -0.0131251963,  '6-31G'),  #   Q-Chem
+    pytest.param(   'revTPSS', -0.0140137038,  '6-31G'),  #   Q-Chem
+    pytest.param(  'revTPSSh', -0.0139563411,  '6-31G'),  #   Q-Chem
+    pytest.param(      'SCAN', -0.0151696769,  '6-31G'),  #   Q-Chem
+    pytest.param(     'SCAN0', -0.0151046408,  '6-31G'),  #   Q-Chem
+    pytest.param(     'SOGGA', -0.0171800268,  '6-31G'),  #   Q-Chem
+    pytest.param(   'SOGGA11', -0.0133998476,  '6-31G'),  #   Q-Chem
+    pytest.param( 'SOGGA11-X', -0.0141398574,  '6-31G'),  #   Q-Chem
+    pytest.param(    't-HCTH', -0.0139348053,  '6-31G'),  #   Q-Chem
+    pytest.param(   't-HCTHh', -0.0143195773,  '6-31G'),  #   Q-Chem
+    pytest.param(      'TPSS', -0.0141667663,  '6-31G'),  #   Q-Chem
+    pytest.param(     'TPSSh', -0.0140808774,  '6-31G'),  #   Q-Chem
+    pytest.param(      'VSXC', -0.0138314231,  '6-31G'),  #   Q-Chem
+    pytest.param(      'VV10', -0.0160812898,  '6-31G'),  #   Q-Chem
+    pytest.param(      'wB97', -0.0160148410,  '6-31G'),  #   Q-Chem
+    pytest.param('wB97M-D3BJ', -0.01351626999, 'cc-pVDZ', marks=using_dftd3), #   Orca
+    pytest.param(   'wB97M-V', -0.0152233456,  '6-31G'),  #   Q-Chem
+    pytest.param(     'wB97X', -0.0156289024,  '6-31G'),  #   Q-Chem
+    pytest.param(   'wB97X-D', -0.0146246032,  '6-31G'),  #   Q-Chem
+    pytest.param(  'wB97X-D3', -0.0148666307,  '6-31G', marks=[using_dftd3, pytest.mark.xfail]), #  Q-Chem
+    pytest.param('wB97X-D3BJ', -0.01295664452, 'cc-pVDZ', marks=using_dftd3), #   Orca
+    pytest.param(   'wB97X-V', -0.0151102751,  '6-31G'),  #   Q-Chem
+    pytest.param(    'wM05-D', -0.0147496512,  '6-31G'),  #   Q-Chem
+    pytest.param(   'wM06-D3', -0.0151611219,  '6-31G'),  #   Q-Chem
+    pytest.param(     'X3LYP', -0.0151870467,  '6-31G'),  #   Q-Chem
 ], ids=name_dft_test)
+
 def test_dft_bench_interaction(func, expected, basis, dft_bench_systems, request):
     """functionals interaction energies vs. Q-Chem & Orca"""
-
-    mols = dft_bench_systems
-
-    psi4.set_options({'basis': basis})
-    psi4_ie = psi4.energy(func, molecule=mols['h2o_dimer'], bsse_type='nocp')
-
-    assert compare_values(expected, psi4_ie, 4, request.node.name)
+    if func.lower() in psi4.driver.procedures['energy']:
+        mols = dft_bench_systems
+        psi4.set_options({'basis': basis})
+        psi4_ie = psi4.energy(func, molecule=mols['h2o_dimer'], bsse_type='nocp')
+        assert compare_values(expected, psi4_ie, 4, request.node.name)
+    else:
+        pytest.xfail("{0:s} not in Psi4.".format(func))
 
 # Current version of Psi4 does not match Q-Chem for these tests
 #expected_fail_qchem = ['B97-D', 'wB97X-D3'] #TEST
-
-
-# ionization energy references for functionals not included in Psi4 at the moment.
-    #pytest.param(       'wB97X-D3',    0.4570744381, '6-31G', marks=using_dftd3),  # Q-Chem  # needs tweaks in LibXC
-    #pytest.param(            'BMK',    0.4586754862, '6-31G'),  # Q-Chem  # not in LibXC 3.0.0
-    #pytest.param(         't-HCTH',    0.4623451143, '6-31G'),  # Q-Chem
-    #pytest.param(         'B3TLAP',    0.4473764358, '6-31G'),  # Q-Chem
-    #pytest.param(         'PBEsol',    0.455663707,  '6-31G'),  # Q-Chem
-    #pytest.param(        'LRC-BOP',    0.4595497115, '6-31G'),  # Q-Chem
-    #pytest.param(        't-HCTHh',    0.4601544314, '6-31G'),  # Q-Chem
-    #pytest.param(         'wM05-D',    0.4560790902, '6-31G'),  # Q-Chem
-    #pytest.param(        'BP86VWN',    0.4588991901, '6-31G'),  # Q-Chem
-    #pytest.param(        'wM06-D3',    0.4563459267, '6-31G', marks=using_dftd3),
-
-# interaction energy references for functionals not included in Psi4 at the moment.
-    #pytest.param(       'VSXC',  -0.0138314231, '6-31G'),  # Q-Chem
-    #pytest.param(    'wM06-D3',  -0.0151611219, '6-31G'),  # Q-Chem
-    #pytest.param(    'revPBE0',  -0.0131251963, '6-31G'),  # Q-Chem
-    #pytest.param(   'MPW1PW91',  -0.0142534651, '6-31G'),  # Q-Chem
-    #pytest.param(    'MPW1PBE',  -0.0142137779, '6-31G'),  # Q-Chem
-    #pytest.param(     't-HCTH',  -0.0139348053, '6-31G'),  # Q-Chem
-    #pytest.param(     'B3TLAP',  -0.0155221815, '6-31G'),  # Q-Chem
-    #pytest.param(    'BP86VWN',  -0.0138884252, '6-31G'),  # Q-Chem
-    #pytest.param(    'LRC-BOP',  -0.0157298937, '6-31G'),  # Q-Chem
-    #pytest.param(    't-HCTHh',  -0.0143195773, '6-31G'),  # Q-Chem
-    #pytest.param(     'PBEsol',  -0.0169733502, '6-31G'),  # Q-Chem
-    #pytest.param(     'wM05-D',  -0.0147496512, '6-31G'),  # Q-Chem
 
 
 # ionization energy references from an older version of Psi4 (~April 2017, SHA: 53e752c)

--- a/tests/pytest/test_dft_benchmarks.py
+++ b/tests/pytest/test_dft_benchmarks.py
@@ -169,7 +169,7 @@ def test_dft_bench_ionization(func, expected, basis, dft_bench_systems, request)
         neutral = psi4.energy(func, molecule=mols['h2o'])
         assert compare_values(expected, cation - neutral, 4, request.node.name)
     else:
-        pytest.xfail("{0:s} not in Psi4.".format(func))
+        pytest.skip("{0:s} not in Psi4.".format(func))
 
 
 
@@ -288,7 +288,7 @@ def test_dft_bench_interaction(func, expected, basis, dft_bench_systems, request
         psi4_ie = psi4.energy(func, molecule=mols['h2o_dimer'], bsse_type='nocp')
         assert compare_values(expected, psi4_ie, 4, request.node.name)
     else:
-        pytest.xfail("{0:s} not in Psi4.".format(func))
+        pytest.skip("{0:s} not in Psi4.".format(func))
 
 # Current version of Psi4 does not match Q-Chem for these tests
 #expected_fail_qchem = ['B97-D', 'wB97X-D3'] #TEST

--- a/tests/pytest/test_dft_benchmarks.py
+++ b/tests/pytest/test_dft_benchmarks.py
@@ -143,6 +143,8 @@ def name_dft_test(val):
     pytest.param(        'LC-VV10',    0.4556872545, '6-31G'),  # Q-Chem
     pytest.param(        'wB97M-V',    0.4544676075, '6-31G'),  # Q-Chem
     pytest.param(        'wB97X-V',    0.455302602,  '6-31G'),  # Q-Chem
+    pytest.param(           'SCAN',    0.4517181611, '6-31G'),  # Q-Chem
+    pytest.param(          'SCAN0',    0.4496859365, '6-31G'),  # Q-Chem
 ], ids=name_dft_test)
 def test_dft_bench_ionization(func, expected, basis, dft_bench_systems, request):
     """functionals ionization energies vs. Q-Chem"""
@@ -230,6 +232,29 @@ def test_dft_bench_ionization(func, expected, basis, dft_bench_systems, request)
     pytest.param(      'TPSSh',  -0.0140808774, '6-31G'),  # Q-Chem
     pytest.param(      'B97-D',  -0.0140422551, '6-31G'),  # Q-Chem
     pytest.param(   'wB97X-D3',  -0.0148666307, '6-31G', marks=[using_dftd3, pytest.mark.xfail]),  # Q-Chem
+    pytest.param(      'SCAN0',  -0.0151046408, '6-31G'),  # Q-Chem
+    pytest.param(     'revPBE',  -0.0129363604, '6-31G'),  # Q-Chem
+    pytest.param(    'SOGGA11',  -0.0133998476, '6-31G'),  # Q-Chem
+    pytest.param(    'MN12-SX',  -0.0130140323, '6-31G'),  # Q-Chem
+    pytest.param(  'MGGA_MS2h',  -0.0138846318, '6-31G'),  # Q-Chem
+    pytest.param(     'MN12-L',  -0.0122476159, '6-31G'),  # Q-Chem
+    pytest.param(        'BMK',  -0.0134597648, '6-31G'),  # Q-Chem
+    pytest.param(        'N12',  -0.0153151670, '6-31G'),  # Q-Chem
+    pytest.param(   'MGGA_MVS',  -0.0145231638, '6-31G'),  # Q-Chem
+    pytest.param(       'PKZB',  -0.0107309601, '6-31G'),  # Q-Chem
+    pytest.param(      'SOGGA',  -0.0171800268, '6-31G'),  # Q-Chem
+    pytest.param(     'MN15-L',  -0.0122572417, '6-31G'),  # Q-Chem
+    pytest.param(      'PBE50',  -0.01474869,   '6-31G'),  # Q-Chem
+    pytest.param(  'MGGA_MVSh',  -0.0145138947, '6-31G'),  # Q-Chem
+    pytest.param(  'SOGGA11-X',  -0.0141398574, '6-31G'),  # Q-Chem
+    pytest.param(      'M06-L',  -0.0131734851, '6-31G'),  # Q-Chem
+    pytest.param(     'N12-SX',  -0.015641602,  '6-31G'),  # Q-Chem
+    pytest.param(      'PBEOP',  -0.0142184544, '6-31G'),  # Q-Chem
+    pytest.param(       'SCAN',  -0.0151696769, '6-31G'),  # Q-Chem
+    pytest.param(    'MPW1LYP',  -0.0156088011, '6-31G'),  # Q-Chem
+    pytest.param(        'GAM',  -0.0149107345, '6-31G'),  # Q-Chem
+
+    
 ], ids=name_dft_test)
 def test_dft_bench_interaction(func, expected, basis, dft_bench_systems, request):
     """functionals interaction energies vs. Q-Chem & Orca"""
@@ -248,11 +273,9 @@ def test_dft_bench_interaction(func, expected, basis, dft_bench_systems, request
 # ionization energy references for functionals not included in Psi4 at the moment.
     #pytest.param(       'wB97X-D3',    0.4570744381, '6-31G', marks=using_dftd3),  # Q-Chem  # needs tweaks in LibXC
     #pytest.param(            'BMK',    0.4586754862, '6-31G'),  # Q-Chem  # not in LibXC 3.0.0
-    #pytest.param(           'SCAN',    0.4517181611, '6-31G'),  # Q-Chem  # not in LibXC 3.0.0
     #pytest.param(         't-HCTH',    0.4623451143, '6-31G'),  # Q-Chem
     #pytest.param(         'B3TLAP',    0.4473764358, '6-31G'),  # Q-Chem
     #pytest.param(         'PBEsol',    0.455663707,  '6-31G'),  # Q-Chem
-    #pytest.param(          'SCAN0',    0.4496859365, '6-31G'),  # Q-Chem  # not in LibXC 3.0.0
     #pytest.param(        'LRC-BOP',    0.4595497115, '6-31G'),  # Q-Chem
     #pytest.param(        't-HCTHh',    0.4601544314, '6-31G'),  # Q-Chem
     #pytest.param(         'wM05-D',    0.4560790902, '6-31G'),  # Q-Chem
@@ -262,37 +285,16 @@ def test_dft_bench_interaction(func, expected, basis, dft_bench_systems, request
 # interaction energy references for functionals not included in Psi4 at the moment.
     #pytest.param(       'VSXC',  -0.0138314231, '6-31G'),  # Q-Chem
     #pytest.param(    'wM06-D3',  -0.0151611219, '6-31G'),  # Q-Chem
-    #pytest.param(      'SCAN0',  -0.0151046408, '6-31G'),  # Q-Chem
     #pytest.param(    'revPBE0',  -0.0131251963, '6-31G'),  # Q-Chem
-    #pytest.param(     'revPBE',  -0.0129363604, '6-31G'),  # Q-Chem
-    #pytest.param(    'SOGGA11',  -0.0133998476, '6-31G'),  # Q-Chem
     #pytest.param(   'MPW1PW91',  -0.0142534651, '6-31G'),  # Q-Chem
-    #pytest.param(    'MN12-SX',  -0.0130140323, '6-31G'),  # Q-Chem
-    #pytest.param(  'MGGA_MS2h',  -0.0138846318, '6-31G'),  # Q-Chem
-    #pytest.param(     'MN12-L',  -0.0122476159, '6-31G'),  # Q-Chem
-    #pytest.param(        'BMK',  -0.0134597648, '6-31G'),  # Q-Chem
-    #pytest.param(        'N12',  -0.0153151670, '6-31G'),  # Q-Chem
-    #pytest.param(   'MGGA_MVS',  -0.0145231638, '6-31G'),  # Q-Chem
     #pytest.param(    'MPW1PBE',  -0.0142137779, '6-31G'),  # Q-Chem
-    #pytest.param(       'PKZB',  -0.0107309601, '6-31G'),  # Q-Chem
-    #pytest.param(      'SOGGA',  -0.0171800268, '6-31G'),  # Q-Chem
-    #pytest.param(     'MN15-L',  -0.0122572417, '6-31G'),  # Q-Chem
     #pytest.param(     't-HCTH',  -0.0139348053, '6-31G'),  # Q-Chem
     #pytest.param(     'B3TLAP',  -0.0155221815, '6-31G'),  # Q-Chem
     #pytest.param(    'BP86VWN',  -0.0138884252, '6-31G'),  # Q-Chem
-    #pytest.param(      'PBE50',  -0.01474869,   '6-31G'),  # Q-Chem
     #pytest.param(    'LRC-BOP',  -0.0157298937, '6-31G'),  # Q-Chem
-    #pytest.param(  'MGGA_MVSh',  -0.0145138947, '6-31G'),  # Q-Chem
-    #pytest.param(  'SOGGA11-X',  -0.0141398574, '6-31G'),  # Q-Chem
     #pytest.param(    't-HCTHh',  -0.0143195773, '6-31G'),  # Q-Chem
     #pytest.param(     'PBEsol',  -0.0169733502, '6-31G'),  # Q-Chem
     #pytest.param(     'wM05-D',  -0.0147496512, '6-31G'),  # Q-Chem
-    #pytest.param(      'M06-L',  -0.0131734851, '6-31G'),  # Q-Chem
-    #pytest.param(     'N12-SX',  -0.015641602,  '6-31G'),  # Q-Chem
-    #pytest.param(      'PBEOP',  -0.0142184544, '6-31G'),  # Q-Chem
-    #pytest.param(       'SCAN',  -0.0151696769, '6-31G'),  # Q-Chem
-    #pytest.param(    'MPW1LYP',  -0.0156088011, '6-31G'),  # Q-Chem
-    #pytest.param(        'GAM',  -0.0149107345, '6-31G'),  # Q-Chem
 
 
 # ionization energy references from an older version of Psi4 (~April 2017, SHA: 53e752c)


### PR DESCRIPTION
## Description
Adds a few functionals (SCAN0, revSCAN0, SCAN, revSCAN, BMK, revM06-L).
~Enables `dft_bench_i*` tests for SCAN, SCAN0, revPBE, SOGGA, SOGGA11, MN12-SX, MGGA_MS2h, MN12-L, BMK, N12, MGGA_MVS, PKZB, MN15-L, PBE50, MGGA_MVSh, SOGGA11-X, M06-L, N12-SX, PBEOP, MPW1LYP and GAM.~
Enables all reference values in `dft_bench_i*` tests, now sorted alphabetically. Functionals not present in Psi4 are automatically ~marked with `xfail`~ skipped - this currently includes B3TLAP, BP86VWN, LRC-BOP, PBEsol, t-HCTH, t-HCTHh, wM05-D and wM06-D3, in addition to wB97X-D3 which was already marked `xfail`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] adds SCAN and SCAN0
- [ ] tests for revSCAN, revSCAN0, revM06-L are missing - if anyone has access to these in other codes, I'd appreciate reference values!

## Checklist
- [x] Tests added for functionals, where available
- [x] `dft_bench_interaction` and `dft_bench_ionization` pass.

## Status
- [x] Ready for review
- [ ] Ready for merge
