### PR TITLE
Fix possible typo in ADC integral setup

### DIFF
--- a/psi4/src/psi4/adc/init_tensors.cc
+++ b/psi4/src/psi4/adc/init_tensors.cc
@@ -84,7 +84,7 @@ double ADCWfn::rhf_init_tensors() {
     global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "MO Ints 2 V1234 - V1243");
     global_dpd_->buf4_init(&V, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
-                           "MO Ints V1243)");
+                           "MO Ints V1243");
     global_dpd_->buf4_axpy(&V, &K, -1);
     global_dpd_->buf4_close(&V);
     global_dpd_->buf4_close(&K);


### PR DESCRIPTION
## Description
At the risk of gaining a reputation for single-character PR's,  I think I have a fix for #1596.  The extra character in the error message looked suspicious, so I nuked it and the `adc` tests still pass.   I'll show the output of the OP's calculation below.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix a probable typo in ADC, which introduced a bug.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
