### PR TITLE
Fix printout of fort.56 file for MRCC

### DIFF
--- a/psi4/src/psi4/mrcc/mrcc.cc
+++ b/psi4/src/psi4/mrcc/mrcc.cc
@@ -916,7 +916,7 @@ PsiReturnType mrcc_generate_input(SharedWavefunction ref_wfn, Options &options, 
     auto mode2 = std::ostream::trunc;
     printer = std::make_shared<PsiOutStream>("fort.56", mode2);
     // FILE* fort56 = fopen("fort.56", "w");
-    printer->Printf("%6d%6d%6d%6d%6d      0     0%6d     0%6d%6d%6d%6d      0      0%6d     0     0    0.00    0%6lu\n",
+    printer->Printf("%6d%6d%6d%6d%6d      0     0%6d     0%6d%6d%6d%6d      0      0%6d     0     0    0.00    0%10lu\n",
                     exlevel,                                         // # 1
                     nsing,                                           // # 2
                     ntrip,                                           // # 3


### PR DESCRIPTION
The value of the 'mem' option was conflated with that for the 'dboc' option, leading to a list directed I/O error at runtime when setting memory available to a 6 digit (or more) number

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix printout of `fort.56` file in `mrcc.cc`

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
