### PR TITLE
explicitly np.load(..., allow_pickle=True) since we're building objects

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -153,10 +153,10 @@ def _core_wavefunction_from_file(wfn_data):
     elif isinstance(wfn_data, str):
         if not wfn_data.endswith(".npy"):
             wfn_data = wfn_data + ".npy"
-        wfn_data = np.load(wfn_data).item()
+        wfn_data = np.load(wfn_data, allow_pickle=True).item()
     else:
         # Could be path-like or file-like, let `np.load` handle it
-        wfn_data = np.load(wfn_data).item()
+        wfn_data = np.load(wfn_data, allow_pickle=True).item()
 
     # variable type specific dictionaries to be passed into C++ constructor
     wfn_matrix = wfn_data['matrix']


### PR DESCRIPTION
Need to explicitly allow pickles (which we need to since building objects) in NumPy 16.3. See https://github.com/numpy/numpy/issues/12759 . @dgasmith, needed [here](https://github.com/psi4/psi4/blob/fbb2ff444490bf6b43cb6e027637d8fd857adcee/psi4/driver/p4util/numpy_helper.py#L385), too? quicktests passes w/o. This should fix travis.

## Checklist
- [ ] ~Tests added for any new features~
- [x] quicktests passes

## Status
- [x] Ready for review
- [x] Ready for merge
