### PR TITLE
Hessian CPHF options

### DIFF
--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -1205,7 +1205,7 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response()
             }
 
             auto u_matrices = rhf_wfn_->cphf_solve(b_vecs, options_.get_double("SOLVER_CONVERGENCE"),
-                                                   options_.get_double("SOLVER_MAXITER"), print_);
+                                                   options_.get_int("SOLVER_MAXITER"), print_);
 
             // Result in x
             for (int a = 0; a < nA; a++) {

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -1204,7 +1204,8 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response()
                 b_vecs.push_back(B);
             }
 
-            auto u_matrices = rhf_wfn_->cphf_solve(b_vecs);
+            auto u_matrices = rhf_wfn_->cphf_solve(b_vecs, options_.get_double("SOLVER_CONVERGENCE"),
+                                                   options_.get_double("SOLVER_MAXITER"), print_);
 
             // Result in x
             for (int a = 0; a < nA; a++) {


### PR DESCRIPTION
## Description
#1550 switched the CPHF solver for analytic Hessians from libfock to the wfn one. That switched the CPHF from 1e-6 to 1e-4 and the HOOH_TS-analytic test case in test_vibanalysis took exception. This PR sends the relevant `CPHF` module (aka libfock) options to the Hessian CPHF call. So returns the default to 6. Thanks to @andysim for difference-hunting.

## Questions
- [ ] user set-able via `set solver_convergence 5`. but `set cphf solver_convergence 5` has no effect b/c "SCF" module is the active options set at this time. I think that calls for a greater overhaul than this fix.

## Checklist
- [x] full tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
