### PR TITLE
ambit v0.3, parallel pytest, binder start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
       pylibefp
       snsmp2
       mp2d
+      pytest-xdist
       -c psi4/label/dev
       # * even if name package removed later, this installs their deps
   - >
@@ -110,7 +111,7 @@ script:
 - ./stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
 - python ../.scripts/travis_run_test.py
 - python ../.scripts/travis_print_failing.py
-- PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 -m 'quick' stage/lib/psi4/tests/
+- PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 -n 2 -m 'quick' stage/lib/psi4/tests/
 
 # safelist
 branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ jobs:
                         pint ^
                         pybind11 ^
                         pytest ^
+                        pytest-xdist ^
                         python=%PYTHON_VERSION% ^
                         qcelemental ^
                         qcengine
@@ -209,7 +210,7 @@ jobs:
       - script: |
           set PATH=$(Build.BinariesDirectory)\install\bin;%PATH%
           set PYTHONPATH=$(Build.BinariesDirectory)\install\lib;%PYTHONPATH%
-          psi4 --test %PYTEST_TYPE%
+          psi4 --test %PYTEST_TYPE% -n %NUMBER_OF_PROCESSORS%
         displayName: "Test Psi4 (pytest $(pytest.type))"
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/doc/sphinxman/source/psiapi.ipynb
+++ b/doc/sphinxman/source/psiapi.ipynb
@@ -9,12 +9,12 @@
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Note:** Psithon and PsiAPI refer to two modes of interacting with Psi4. In Psithon mode, you write an input file in our domain-specific language (not quite Python) where commands don't have ``psi4.`` in front, then submit it to the executable ``psi4`` which processes the Psithon into pure Python and runs it internally. In PsiAPI mode, you write a pure Python script with ``import psi4`` at the top and commands are behind the ``psi4.`` namespace, then submit it to the ``python`` interpreter. Both modes are equally powerful. This tutorial covers the PsiAPI mode.\n",
+    "**Note:** Psithon and PsiAPI refer to two modes of interacting with Psi4. In Psithon mode, you write an input file in our domain-specific language (not quite Python) where commands don't have ``psi4.`` in front, then submit it to the executable ``psi4`` which processes the Psithon into pure Python and runs it internally. In PsiAPI mode, you write a pure Python script with ``import psi4`` at the top, and commands are behind the ``psi4.`` namespace, then submit it to the ``python`` interpreter. Both modes are equally powerful. This tutorial covers the PsiAPI mode.\n",
     "\n",
     "</div>\n",
     "<div class=\"alert alert-warning\">\n",
     "\n",
-    "**Warning:** Although the developers have been using PsiAPI mode stably for months before the 1.1 release and while we believe we've gotten everything nicely arranged within the ``psi4.`` namespace, the API should not be considered completely stable. Most importantly, as we someday deprecate the last of the global variables, options will be added to the method calls (*e.g.*, ``energy('scf', molecule=mol, options=opt)``)\n",
+    "**Note:** PsiAPI mode has been available since late 2016 and the v1.1 release. While we aim to provide deprecation warnings and upgrade helpers, the API should not be considered completely stable, as with a library API. Most importantly, as we someday deprecate the last of the global variables, options will be added to the method calls (*e.g.*, ``energy('scf', molecule=mol, options=opt)``)\n",
     "\n",
     "**Note:** Consult [How to run Psi4 as Python module after compilation](http://psicode.org/psi4manual/master/build_planning.html#faq-runordinarymodule) or [How to run Psi4 as a Python module from conda installation](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-psi4-as-executable-or-python-module-from-conda-installation) for assistance in setting up Psi4.\n",
     "\n",
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unlike in the past, where Psi4 was executable software which could only be called via input files like `input.dat`, it is now *interactive*, able to be loaded directly as a Python module. Here, we will explore the basics of using Psi4 in this new style by reproducing the section [A Psi4 Tutorial](http://psicode.org/psi4manual/master/tutorial.html \"Go to Psi4 Manual\") from the Psi4 manual in an interactive Jupyter Notebook.\n",
+    "Here, we will explore the basics of using Psi4 in the interactive PsiAPI style where it is loaded directly as a Python module by reproducing the section [A Psi4 Tutorial](http://psicode.org/psi4manual/master/tutorial.html \"Go to Psi4 Manual\") from the Psi4 manual in an interactive Jupyter Notebook.\n",
     "\n",
     "Note: If the newest version of Psi4 (v.1.1a2dev42 or newer) is in your path, feel free to execute each cell as you read along by pressing `Shift+Enter` when the cell is selected."
    ]
@@ -47,12 +47,14 @@
    },
    "outputs": [],
    "source": [
+    "# Ignore this block -- it's for the documentation build\n",
     "try:\n",
     "    import os, sys\n",
     "    sys.path.insert(1, os.path.abspath('@psi4_BINARY_DIR@/stage/@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@@PYMOD_INSTALL_LIBDIR@'))\n",
     "except ImportError:\n",
     "    pass\n",
     "\n",
+    "# This is the important part\n",
     "import psi4"
    ]
   },

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: p4env37
+channels:
+  - psi4/label/dev
+  - defaults
+dependencies:
+  - python=3.7
+  - psi4
+  - dftd3

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${ENABLE_ambit})
         ExternalProject_Add(ambit_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/jturney/ambit/archive/9c7049a.tar.gz  # v0.2 + 37
+            URL https://github.com/jturney/ambit/archive/v0.3.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -29,6 +29,6 @@ else()
         INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
                                                       --record=record.txt
                                                       --single-version-externally-managed
-                                                      --install-bin=${_install_bin}
+                                                      --install-scripts=${_install_bin}
                                                       --install-lib=${_install_lib})
 endif()

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -16,6 +16,7 @@ else()
     message(STATUS "Suitable qcengine could not be located, ${Magenta}Building qcengine${ColourReset} instead.")
 
     file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}" _install_lib)
+    file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" _install_bin)
 
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
@@ -28,5 +29,6 @@ else()
         INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
                                                       --record=record.txt
                                                       --single-version-externally-managed
+                                                      --install-bin=${_install_bin}
                                                       --install-lib=${_install_lib})
 endif()

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -26,4 +26,7 @@ def tear_down():
     for pat in patterns:
         pytest_scratches.extend(glob.glob(pat))
     for fl in pytest_scratches:
-        os.unlink(fl)
+        try:
+            os.unlink(fl)
+        except (OSError, PermissionError):
+            pass


### PR DESCRIPTION
## Todos
- [x] bump ambit to v0.3
- [x] enable parallel pytest for CI
- [x] `environment.yaml` to build binder from
- [x] install qcng scripts to the right place

## Status
- [x] Ready for review
- [x] Ready for merge
