### PR TITLE
Fix lgtm warnings in libmoinfo

### DIFF
--- a/psi4/src/psi4/libmoinfo/model_space.cc
+++ b/psi4/src/psi4/libmoinfo/model_space.cc
@@ -53,15 +53,15 @@ void ModelSpace::print() {
     outfile->Printf("\n\n  Model space:");
     outfile->Printf("\n  ------------------------------------------------------------------------------");
     for (size_t mu = 0; mu < determinants.size(); ++mu) {
-        outfile->Printf("\n  %2d %s", mu, determinants[mu].get_label().c_str());
+        outfile->Printf("\n  %2zu %s", mu, determinants[mu].get_label().c_str());
     }
     outfile->Printf("\n\n  Closed-shell to model space mapping");
     for (size_t mu = 0; mu < closed_to_all.size(); ++mu) {
-        outfile->Printf("\n  %d -> %d", mu, closed_to_all[mu]);
+        outfile->Printf("\n  %zu -> %d", mu, closed_to_all[mu]);
     }
     outfile->Printf("\n\n  Open-shell to model space mapping");
     for (size_t mu = 0; mu < opensh_to_all.size(); ++mu) {
-        outfile->Printf("\n  %d -> %d", mu, opensh_to_all[mu]);
+        outfile->Printf("\n  %zu -> %d", mu, opensh_to_all[mu]);
     }
 }
 

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -133,7 +133,8 @@ void MOInfo::read_info() {
         scf_irrep[i] = nullptr;
         if (sopi[i] && mopi[i]) {
             scf_irrep[i] = block_matrix(sopi[i], mopi[i]);
-            ::memcpy(scf_irrep[i][0], matCa->pointer(i)[0], mopi[i] * sopi[i] * sizeof(double));
+            size_t size = static_cast<size_t>(mopi[i]) * sopi[i] * sizeof(double);
+            ::memcpy(scf_irrep[i][0], matCa->pointer(i)[0], size);
         }
     }
 

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -133,7 +133,7 @@ void MOInfo::read_info() {
         scf_irrep[i] = nullptr;
         if (sopi[i] && mopi[i]) {
             scf_irrep[i] = block_matrix(sopi[i], mopi[i]);
-            size_t size = static_cast<size_t>(mopi[i]) * sopi[i] * sizeof(double);
+            size_t size = sizeof(double) * mopi[i] * sopi[i];
             ::memcpy(scf_irrep[i][0], matCa->pointer(i)[0], size);
         }
     }

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -133,8 +133,7 @@ void MOInfo::read_info() {
         scf_irrep[i] = nullptr;
         if (sopi[i] && mopi[i]) {
             scf_irrep[i] = block_matrix(sopi[i], mopi[i]);
-            size_t size = sizeof(double) * mopi[i] * sopi[i];
-            ::memcpy(scf_irrep[i][0], matCa->pointer(i)[0], size);
+            ::memcpy(scf_irrep[i][0], matCa->pointer(i)[0], sizeof(double) * mopi[i] * sopi[i]);
         }
     }
 

--- a/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
@@ -50,7 +50,7 @@ void MOInfo::print_model_space() {
     outfile->Printf("\n  ------------------------------------------------------------------------------");
     if (references.size() <= 20) {
         for (size_t i = 0; i < references.size(); ++i) {
-            outfile->Printf("\n  %2d  %s", i, references[i].get_label().c_str());
+            outfile->Printf("\n  %2zu  %s", i, references[i].get_label().c_str());
         }
     } else {
         outfile->Printf("\n  There are %d determinants in the model space", static_cast<int>(references.size()));


### PR DESCRIPTION
## Description
Fix lgtm warnings in libmoinfo.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixed printing and casting to `size_t`

## Status
- [x] Ready for review
- [x] Ready for merge
