### PR TITLE
dcft LGTM: Pt. I

### DIFF
--- a/psi4/src/psi4/dcft/dcft.cc
+++ b/psi4/src/psi4/dcft/dcft.cc
@@ -114,7 +114,12 @@ void DCFTSolver::dpd_buf4_add(dpdbuf4 *A, dpdbuf4 *B, double alpha) {
     }
 }
 
-DCFTSolver::~DCFTSolver() {}
+DCFTSolver::~DCFTSolver() {
+    delete []aocc_off_;
+    delete []avir_off_;
+    delete []bocc_off_;
+    delete []bvir_off_;
+}
 
 }  // namespace dcft
 }  // namespace psi

--- a/psi4/src/psi4/dcft/dcft_df_tensor.cc
+++ b/psi4/src/psi4/dcft/dcft_df_tensor.cc
@@ -220,7 +220,7 @@ void DCFTSolver::formb_ao(std::shared_ptr<BasisSet> primary, std::shared_ptr<Bas
 
     auto sieve = std::make_shared<ERISieve>(primary, 1.0E-20);
     const std::vector<std::pair<int, int>>& shell_pairs = sieve->shell_pairs();
-    int npairs = shell_pairs.size();
+    size_t npairs = shell_pairs.size();
 
     // => Memory Constraints <= //
     int max_rows;
@@ -312,7 +312,7 @@ void DCFTSolver::df_memory() {
 #endif
 
     outfile->Printf("\t => Sizing <=\n\n");
-    outfile->Printf("\t  Memory   = %11d MB\n", long(memory) / (1024L * 1024L));
+    outfile->Printf("\t  Memory   = %11ld MB\n", long(memory) / (1024L * 1024L));
     outfile->Printf("\t  Threads  = %11d\n", nthreads);
     outfile->Printf("\t  nn       = %11d\n", nn_);
     outfile->Printf("\t  nQ       = %11d\n\n", nQ_);

--- a/psi4/src/psi4/dcft/dcft_memory.cc
+++ b/psi4/src/psi4/dcft/dcft_memory.cc
@@ -108,8 +108,8 @@ void DCFTSolver::init() {
     bvir_tau_ = std::make_shared<Matrix>("MO basis Tau (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
 
     // Compute MO offsets
-    aocc_off_ = init_int_array(nirrep_);
-    avir_off_ = init_int_array(nirrep_);
+    aocc_off_ = new int[nirrep_];
+    avir_off_ = new int[nirrep_];
     double ocount = naoccpi_[0];
     double vcount = navirpi_[0];
     for (int h = 1; h < nirrep_; h++) {
@@ -119,8 +119,8 @@ void DCFTSolver::init() {
         vcount += navirpi_[h];
     }
 
-    bocc_off_ = init_int_array(nirrep_);
-    bvir_off_ = init_int_array(nirrep_);
+    bocc_off_ = new int[nirrep_];
+    bvir_off_ = new int[nirrep_];
     ocount = nboccpi_[0];
     vcount = nbvirpi_[0];
     for (int h = 1; h < nirrep_; h++) {

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -238,8 +238,8 @@ void DCFTSolver::print_orbital_energies() {
     std::sort(aPairs.begin(), aPairs.end());
     std::sort(bPairs.begin(), bPairs.end());
 
-    int *aIrrepCount = init_int_array(nirrep_);
-    int *bIrrepCount = init_int_array(nirrep_);
+    auto aIrrepCount = std::vector<int>(nirrep_, 0);
+    auto bIrrepCount = std::vector<int>(nirrep_, 0);
     std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
     outfile->Printf("\n\tOrbital energies (a.u.):\n\t\tAlpha occupied orbitals\n\t\t");
@@ -290,8 +290,6 @@ void DCFTSolver::print_orbital_energies() {
         Ca_->print();
         Cb_->print();
     }
-    free(aIrrepCount);
-    free(bIrrepCount);
 }
 
 /**

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -290,8 +290,8 @@ void DCFTSolver::print_orbital_energies() {
         Ca_->print();
         Cb_->print();
     }
-    delete[] aIrrepCount;
-    delete[] bIrrepCount;
+    free(aIrrepCount);
+    free(bIrrepCount);
 }
 
 /**

--- a/psi4/src/psi4/dcft/dcft_tau_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_tau_RHF.cc
@@ -332,16 +332,12 @@ void DCFTSolver::print_opdm_RHF() {
             aPairs.push_back(std::make_pair(T_VV.matrix[h][row][row], h));
     }
 
-    std::vector<std::pair<double, int> > bPairs(aPairs);
-
     global_dpd_->file2_close(&T_OO);
     global_dpd_->file2_close(&T_VV);
 
     sort(aPairs.begin(), aPairs.end(), std::greater<std::pair<double, int> >());
-    sort(bPairs.begin(), bPairs.end(), std::greater<std::pair<double, int> >());
 
-    int *aIrrepCount = init_int_array(nirrep_);
-    int *bIrrepCount = init_int_array(nirrep_);
+    auto aIrrepCount = std::vector<int>(nirrep_, 0);
     std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
     outfile->Printf("\n\tOrbital occupations:\n\t\tDoubly occupied orbitals\n\t\t");
@@ -357,8 +353,6 @@ void DCFTSolver::print_opdm_RHF() {
         if (count % 4 == 3 && i != nmo_) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n");
-    free(aIrrepCount);
-    free(bIrrepCount);
 }
 }  // namespace dcft
 }  // namespace psi

--- a/psi4/src/psi4/dcft/dcft_tau_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_tau_UHF.cc
@@ -734,8 +734,8 @@ void DCFTSolver::print_opdm() {
     sort(aPairs.begin(), aPairs.end(), std::greater<std::pair<double, int> >());
     sort(bPairs.begin(), bPairs.end(), std::greater<std::pair<double, int> >());
 
-    int *aIrrepCount = init_int_array(nirrep_);
-    int *bIrrepCount = init_int_array(nirrep_);
+    auto aIrrepCount = std::vector<int>(nirrep_, 0);
+    auto bIrrepCount = std::vector<int>(nirrep_, 0);
     std::vector<std::string> irrepLabels = molecule_->irrep_labels();
 
     outfile->Printf("\n\tOrbital occupations:\n\t\tAlpha occupied orbitals\n\t\t");
@@ -763,8 +763,6 @@ void DCFTSolver::print_opdm() {
         if (count % 4 == 3 && i != nmo_) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n");
-    free(aIrrepCount);
-    free(bIrrepCount);
 }
 
 void DCFTSolver::refine_tau() {


### PR DESCRIPTION
Part 1 of the dcft segment of #1615. `ctest -R dcft -j4` passes. Most of the LGTM issues in `dcft` are _not_ addressed in this PR, as the fixes belong elsewhere:
* Changing the type of basisset.nbf and wavefunction.nso from ints to size_t
* Changing Dimension from std::vector<int> to std::vector<size_t>
* Changing rowtot and coltot in dpd.h to be arrays of size_t instead of ints. This one may be more controversial.