### PR TITLE
libscf_solver LGTM

### DIFF
--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -769,8 +769,7 @@ void HF::form_Shalf() {
             // descending order
             int start_index = 0;
             for (int i = 0; i < dimpi[h]; ++i) {
-                if (S_cutoff < eigval->get(h, i)) { // Include this empty block by analogy of prev. block
-                } else {
+                if (S_cutoff >= eigval->get(h, i)) {
                     start_index++;
                 }
             }

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -769,7 +769,7 @@ void HF::form_Shalf() {
             // descending order
             int start_index = 0;
             for (int i = 0; i < dimpi[h]; ++i) {
-                if (S_cutoff < eigval->get(h, i)) {
+                if (S_cutoff < eigval->get(h, i)) { // Include this empty block by analogy of prev. block
                 } else {
                     start_index++;
                 }

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -715,7 +715,7 @@ std::vector<SharedMatrix> RHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
             double alpha = rzpre[i] / p_vec[i]->vector_dot(Ap_vec[nremain]);
 
             if (std::isnan(alpha)) {
-                outfile->Printf("RHF::CPHF Warning CG alpha is zero/nan for vec %d. Stopping vec.\n", i);
+                outfile->Printf("RHF::CPHF Warning CG alpha is zero/nan for vec %lu. Stopping vec.\n", i);
                 active[i] = false;
                 alpha = 0.0;
             }

--- a/psi4/src/psi4/libscf_solver/stability.cc
+++ b/psi4/src/psi4/libscf_solver/stability.cc
@@ -196,7 +196,7 @@ double UStab::compute_energy() {
 
     if (debug_ > 1) {
         for (size_t i = 0; i < eval_temp.size(); ++i) {
-            outfile->Printf("Eigenvalue %4i: %.12f\n", i, vals_[i]);
+            outfile->Printf("Eigenvalue %4lu: %.12f\n", i, vals_[i]);
         }
     }
 

--- a/psi4/src/psi4/libscf_solver/stability.h
+++ b/psi4/src/psi4/libscf_solver/stability.h
@@ -29,8 +29,6 @@
 #ifndef STABILITY_H
 #define STABILITY_H
 
-#endif  // STABILITY_H
-
 #include "psi4/libmints/wavefunction.h"
 
 namespace psi {
@@ -123,3 +121,5 @@ class UStab {
 }  // namespace scf
 
 }  // namespace psi
+
+#endif  // STABILITY_H

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -710,7 +710,7 @@ std::vector<SharedMatrix> UHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
             double alpha = rzpre[i] / tmp_denom;
 
             if (std::isnan(alpha)) {
-                outfile->Printf("RHF::CPHF Warning CG alpha is zero/nan for vec %d. Stopping vec.\n", i);
+                outfile->Printf("RHF::CPHF Warning CG alpha is zero/nan for vec %lu. Stopping vec.\n", i);
                 active[i] = false;
                 alpha = 0.0;
             }


### PR DESCRIPTION
The libscf_solver segment of #1615 in what should be its entirety. Mostly changing format strings, but also setting a header guard back to guarding the header, rather than a blank line. Passes quicktests.