### PR TITLE
Validate DOCC/SOCC; Cleanup Occupation Code in HF

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -670,6 +670,25 @@ def scf_print_energies(self):
     self.set_variable('SCF ITERATIONS', self.iteration_)
 
 
+def scf_print_preiterations(self):
+    ct = self.molecule().point_group().char_table()
+
+    core.print_out("   -------------------------------------------------------\n")
+    core.print_out("    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc\n")
+    core.print_out("   -------------------------------------------------------\n")
+
+    for h in range(self.nirrep()):
+        core.print_out(
+            f"     {ct.gamma(h).symbol():<3s}   {self.nsopi()[h]:6d}  {self.nmopi()[h]:6d}  {self.nalphapi()[h]:6d}  {self.nbetapi()[h]:6d}  {self.doccpi()[h]:6d}  {self.soccpi()[h]:6d}\n"
+        )
+
+    core.print_out("   -------------------------------------------------------\n")
+    core.print_out(
+        f"    Total  {self.nso():6d}  {self.nmo():6d}  {self.nalpha():6d}  {self.nbeta():6d}  {self.nbeta():6d}  {self.nalpha() - self.nbeta():6d}\n"
+    )
+    core.print_out("   -------------------------------------------------------\n\n")
+
+
 # Bind functions to core.HF class
 core.HF.initialize = scf_initialize
 core.HF.initialize_jk = initialize_jk
@@ -677,6 +696,7 @@ core.HF.iterations = scf_iterate
 core.HF.compute_energy = scf_compute_energy
 core.HF.finalize_energy = scf_finalize_energy
 core.HF.print_energies = scf_print_energies
+core.HF.print_preiterations = scf_print_preiterations
 
 
 def _converged(e_delta, d_rms, e_conv=None, d_conv=None):

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -25,7 +25,6 @@
 #
 # @END LICENSE
 #
-
 """
 The SCF iteration functions
 """
@@ -100,13 +99,14 @@ def scf_compute_energy(self):
     scf_energy = self.finalize_energy()
     return scf_energy
 
+
 def _build_jk(wfn, memory):
-    jk = core.JK.build(
-        wfn.get_basisset("ORBITAL"),
-        aux=wfn.get_basisset("DF_BASIS_SCF"),
-        do_wK=wfn.functional().is_x_lrc(),
-        memory=memory)
+    jk = core.JK.build(wfn.get_basisset("ORBITAL"),
+                       aux=wfn.get_basisset("DF_BASIS_SCF"),
+                       do_wK=wfn.functional().is_x_lrc(),
+                       memory=memory)
     return jk
+
 
 def initialize_jk(self, memory, jk=None):
 
@@ -139,9 +139,9 @@ def scf_initialize(self):
     if vbase:
         collocation_size = vbase.grid().collocation_size()
         if vbase.functional().ansatz() == 1:
-            collocation_size *= 4 # First derivs
+            collocation_size *= 4  # First derivs
         elif vbase.functional().ansatz() == 2:
-            collocation_size *= 10 # Second derivs
+            collocation_size *= 10  # Second derivs
     else:
         collocation_size = 0
 
@@ -207,7 +207,7 @@ def scf_initialize(self):
             # EFP: Add in permanent moment contribution and cache
             core.timer_on("HF: Form Vefp")
             verbose = core.get_option('SCF', "PRINT")
-            Vefp = modify_Fock_permanent(self.molecule(), mints, verbose=verbose-1)
+            Vefp = modify_Fock_permanent(self.molecule(), mints, verbose=verbose - 1)
             Vefp = core.Matrix.from_array(Vefp)
             self.H().add(Vefp)
             Horig = self.H().clone()
@@ -228,14 +228,12 @@ def scf_initialize(self):
         self.form_D()
         self.set_energies("Total Energy", self.compute_initial_E())
 
-
     # turn off VV10 for iterations
     if core.get_option('SCF', "DFT_VV10_POSTSCF") and self.functional().vv10_b() > 0.0:
         core.print_out("  VV10: post-SCF option active \n \n")
         self.functional().set_lock(False)
         self.functional().set_do_vv10(False)
         self.functional().set_lock(True)
-
 
 
 def scf_iterate(self, e_conv=None, d_conv=None):
@@ -256,8 +254,8 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
     if self.iteration_ < 2:
         core.print_out("  ==> Iterations <==\n\n")
-        core.print_out("%s                        Total Energy        Delta E     %s |[F,P]|\n\n" % ("   "
-                                                                                                     if is_dfjk else "", "RMS" if diis_rms else "MAX"))
+        core.print_out("%s                        Total Energy        Delta E     %s |[F,P]|\n\n" %
+                       ("   " if is_dfjk else "", "RMS" if diis_rms else "MAX"))
 
     # SCF iterations!
     SCFE_old = 0.0
@@ -278,7 +276,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             self.H().copy(self.Horig)
             global mints_psi4_yo
             mints_psi4_yo = core.MintsHelper(self.basisset())
-            Vefp = modify_Fock_induced(self.molecule().EFP, mints_psi4_yo, verbose=verbose-1)
+            Vefp = modify_Fock_induced(self.molecule().EFP, mints_psi4_yo, verbose=verbose - 1)
             Vefp = core.Matrix.from_array(Vefp)
             self.H().add(Vefp)
 
@@ -341,12 +339,12 @@ def scf_iterate(self, e_conv=None, d_conv=None):
                 base_name = "SOSCF, nmicro="
 
             if not _converged(Ediff, Dnorm, e_conv=e_conv, d_conv=d_conv):
-                nmicro = self.soscf_update(
-                    core.get_option('SCF', 'SOSCF_CONV'),
-                    core.get_option('SCF', 'SOSCF_MIN_ITER'),
-                    core.get_option('SCF', 'SOSCF_MAX_ITER'), core.get_option('SCF', 'SOSCF_PRINT'))
+                nmicro = self.soscf_update(core.get_option('SCF', 'SOSCF_CONV'),
+                                           core.get_option('SCF', 'SOSCF_MIN_ITER'),
+                                           core.get_option('SCF', 'SOSCF_MAX_ITER'),
+                                           core.get_option('SCF', 'SOSCF_PRINT'))
                 # if zero, the soscf call bounced for some reason
-                soscf_performed = (nmicro>0)
+                soscf_performed = (nmicro > 0)
 
                 if soscf_performed:
                     self.find_occupation()
@@ -431,8 +429,10 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             self.Db().print_out()
 
         # Print out the iteration
-        core.print_out("   @%s%s iter %3s: %20.14f   %12.5e   %-11.5e %s\n" %
-                       ("DF-" if is_dfjk else "", reference, "SAD" if ((self.iteration_ == 0) and self.sad_) else self.iteration_, SCFE, Ediff, Dnorm, '/'.join(status)))
+        core.print_out(
+            "   @%s%s iter %3s: %20.14f   %12.5e   %-11.5e %s\n" %
+            ("DF-" if is_dfjk else "", reference, "SAD" if
+             ((self.iteration_ == 0) and self.sad_) else self.iteration_, SCFE, Ediff, Dnorm, '/'.join(status)))
 
         # if a an excited MOM is requested but not started, don't stop yet
         if self.MOM_excited_ and not self.MOM_performed_:
@@ -536,7 +536,9 @@ def scf_finalize_energy(self):
         self.set_energies("Total Energy", SCFE)
         core.print_out(efpobj.energy_summary(scfefp=SCFE, label='psi'))
 
-        self.set_variable('EFP ELST ENERGY', efpene['electrostatic'] + efpene['charge_penetration'] + efpene['electrostatic_point_charges'])
+        self.set_variable(
+            'EFP ELST ENERGY',
+            efpene['electrostatic'] + efpene['charge_penetration'] + efpene['electrostatic_point_charges'])
         self.set_variable('EFP IND ENERGY', efpene['polarization'])
         self.set_variable('EFP DISP ENERGY', efpene['dispersion'])
         self.set_variable('EFP EXCH ENERGY', efpene['exchange_repulsion'])
@@ -552,16 +554,16 @@ def scf_finalize_energy(self):
 
     energy = self.get_energies("Total Energy")
 
-#    fail_on_maxiter = core.get_option("SCF", "FAIL_ON_MAXITER")
-#    if converged or not fail_on_maxiter:
-#
-#        if print_lvl > 0:
-#            self.print_orbitals()
-#
-#        if converged:
-#            core.print_out("  Energy converged.\n\n")
-#        else:
-#            core.print_out("  Energy did not converge, but proceeding anyway.\n\n")
+    #    fail_on_maxiter = core.get_option("SCF", "FAIL_ON_MAXITER")
+    #    if converged or not fail_on_maxiter:
+    #
+    #        if print_lvl > 0:
+    #            self.print_orbitals()
+    #
+    #        if converged:
+    #            core.print_out("  Energy converged.\n\n")
+    #        else:
+    #            core.print_out("  Energy did not converge, but proceeding anyway.\n\n")
 
     if core.get_option('SCF', 'PRINT') > 0:
         self.print_orbitals()
@@ -667,6 +669,7 @@ def scf_print_energies(self):
 
     self.set_variable('SCF ITERATIONS', self.iteration_)
 
+
 # Bind functions to core.HF class
 core.HF.initialize = scf_initialize
 core.HF.initialize_jk = initialize_jk
@@ -741,8 +744,8 @@ def _validate_diis():
 
         maxvecs = core.get_option('SCF', 'DIIS_MAX_VECS')
         if maxvecs < minvecs:
-            raise ValidationError(
-                'SCF DIIS_MAX_VECS ({}) must be at least DIIS_MIN_VECS ({})'.format(maxvecs, minvecs))
+            raise ValidationError('SCF DIIS_MAX_VECS ({}) must be at least DIIS_MIN_VECS ({})'.format(
+                maxvecs, minvecs))
 
     return enabled
 
@@ -819,8 +822,8 @@ def _validate_soscf():
 
         maxiter = core.get_option('SCF', 'SOSCF_MAX_ITER')
         if maxiter < miniter:
-            raise ValidationError(
-                'SCF SOSCF_MAX_ITER ({}) must be at least SOSCF_MIN_ITER ({})'.format(maxiter, miniter))
+            raise ValidationError('SCF SOSCF_MAX_ITER ({}) must be at least SOSCF_MIN_ITER ({})'.format(
+                maxiter, miniter))
 
         conv = core.get_option('SCF', 'SOSCF_CONV')
         if conv < 1.e-10:
@@ -864,9 +867,11 @@ def field_fn(xyz):
         # get electric field integrals from Psi4
         p4_field_ints = mints_psi4_yo.electric_field(origin=points[ipt])
 
-        field[ipt] = [np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[0])),  # Ex
-                      np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[1])),  # Ey
-                      np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[2]))]  # Ez
+        field[ipt] = [
+            np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[0])),  # Ex
+            np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[1])),  # Ey
+            np.vdot(efp_Dt_psi4_yo, np.asarray(p4_field_ints[2]))
+        ]  # Ez
 
     field = np.reshape(field, 3 * npt)
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -267,7 +267,6 @@ void export_wavefunction(py::module& m) {
         .def("clear_external_potentials", &scf::HF::clear_external_potentials, "Clear private external_potentials list")
         .def("push_back_external_potential", &scf::HF::push_back_external_potential,
              "Add an external potential to the private external_potentials list", "V"_a)
-        .def("print_preiterations", &scf::HF::print_preiterations, "docstring")
         .def_property("iteration_", &scf::HF::iteration, &scf::HF::set_iteration, "docstring")
         .def_property("diis_enabled_", &scf::HF::diis_enabled, &scf::HF::set_diis_enabled, "docstring")
         .def_property("diis_start_", &scf::HF::diis_start, &scf::HF::set_diis_start, "docstring")

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -519,21 +519,6 @@ void HF::print_header() {
     basisset_->print_by_level("outfile", print_);
 }
 
-void HF::print_preiterations() {
-    CharacterTable ct = molecule_->point_group()->char_table();
-
-    outfile->Printf("   -------------------------------------------------------\n");
-    outfile->Printf("    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc\n");
-    outfile->Printf("   -------------------------------------------------------\n");
-    for (int h = 0; h < nirrep_; h++) {
-        outfile->Printf("     %-3s   %6d  %6d  %6d  %6d  %6d  %6d\n", ct.gamma(h).symbol(), nsopi_[h], nmopi_[h],
-                        nalphapi_[h], nbetapi_[h], doccpi_[h], soccpi_[h]);
-    }
-    outfile->Printf("   -------------------------------------------------------\n");
-    outfile->Printf("    Total  %6d  %6d  %6d  %6d  %6d  %6d\n", nso_, nmo_, nalpha_, nbeta_, nbeta_, nalpha_ - nbeta_);
-    outfile->Printf("   -------------------------------------------------------\n\n");
-}
-
 void HF::form_H() {
     T_ = SharedMatrix(factory_->create_matrix(PSIF_SO_T));
     V_ = SharedMatrix(factory_->create_matrix(PSIF_SO_V));

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -178,9 +178,16 @@ void HF::common_init() {
     }
 
     if (input_socc_ || input_docc_) {
+        int alphacount = 0;
+        int betacount = 0;
         for (int h = 0; h < nirrep_; h++) {
             nalphapi_[h] = doccpi_[h] + soccpi_[h];
             nbetapi_[h] = doccpi_[h];
+            alphacount += nalphapi_[h];
+            betacount += nbetapi_[h];
+        }
+        if (alphacount != nalpha_ || betacount != nbeta_) {
+            throw PSIEXCEPTION("DOCC and SOCC must specify the occupation of all electrons or none.");
         }
     }
 

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -116,7 +116,6 @@ void HF::common_init() {
     energies_["Total Energy"] = 0.0;
 
     // Read in DOCC and SOCC from memory
-    int nirreps = factory_->nirrep();
     input_docc_ = false;
     if (options_["DOCC"].has_changed()) {
         input_docc_ = true;
@@ -137,8 +136,8 @@ void HF::common_init() {
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
-            if (options_["DOCC"].size() != nirreps) throw PSIEXCEPTION("Input DOCC array has the wrong dimensions");
-            for (int h = 0; h < nirreps; ++h) {
+            if (options_["DOCC"].size() != nirrep_) throw PSIEXCEPTION("Input DOCC array has the wrong dimensions");
+            for (int h = 0; h < nirrep_; ++h) {
                 doccpi_[h] = options_["DOCC"][h].to_integer();
             }
         }
@@ -164,15 +163,15 @@ void HF::common_init() {
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
-            if (options_["SOCC"].size() != nirreps) throw PSIEXCEPTION("Input SOCC array has the wrong dimensions");
-            for (int h = 0; h < nirreps; ++h) {
+            if (options_["SOCC"].size() != nirrep_) throw PSIEXCEPTION("Input SOCC array has the wrong dimensions");
+            for (int h = 0; h < nirrep_; ++h) {
                 soccpi_[h] = options_["SOCC"][h].to_integer();
             }
         }
     }  // else take the reference wavefunctions soccpi
 
     // Check that we have enough basis functions
-    for (int h = 0; h < nirreps; ++h) {
+    for (int h = 0; h < nirrep_; ++h) {
         if (doccpi_[h] + soccpi_[h] > nmopi_[h]) {
             throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
         }

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -275,9 +275,6 @@ class HF : public Wavefunction {
     /// Prints some opening information
     void print_header();
 
-    /// Prints some details about nsopi/nmopi, and initial occupations
-    void print_preiterations();
-
     /** Compute/print spin contamination information (if unrestricted) **/
     virtual void compute_spin_contamination();
 


### PR DESCRIPTION
## Description
Fixes #1370 and cleans up some code relating to orbital occupations. `scf_iterator.py` is yapf-ified, the occupation printing code is now Py-side, and two variables specifying the same thing (`nirreps` and `nirrep_`) in the HF initialization have been condensed into a single variable.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] An error message is now raised when the electron count from DOCC and SOCC is inconsistent with the molecule's electron count.

## Checklist
- [x] `scf` and `findif` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
