### PR TITLE
Revert changes to cmake that cause Forte compilation problems on Mac

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 ### >> Create core target, so we may link modules to it directly <<
 ### >> This allow to propagate dependencies upwards sanely
 add_library(core SHARED core.cc)
-#pybind11_add_module(core MODULE NO_EXTRAS core.cc)
 
 ### >> Go into psi4 subdirectory to compile libraries and modules <<
 add_subdirectory(psi4)

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 ### >> Create core target, so we may link modules to it directly <<
 ### >> This allow to propagate dependencies upwards sanely
-pybind11_add_module(core MODULE NO_EXTRAS core.cc)
+add_library(core SHARED core.cc)
+#pybind11_add_module(core MODULE NO_EXTRAS core.cc)
 
 ### >> Go into psi4 subdirectory to compile libraries and modules <<
 add_subdirectory(psi4)
@@ -49,6 +50,8 @@ target_link_libraries(core
     ${POST_LIBRARY_OPTION}
     ${LIBC_INTERJECT}
     tgt::lapack # OpenMP flags to core.cc
+  PUBLIC
+	    pybind11::module
   )
 
 if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)


### PR DESCRIPTION
## Description
Recent changes to the cmake build systems introduced an issue when compiling psi4 plugins and Forte on a Mac. Compilation fails at the linking stage with the error
```
ld: can't link with bundle (MH_BUNDLE) only dylibs (MH_DYLIB)
```

This PR reverts two changes.

## Questions
- [ ] Is there a better solution that still uses `pybind11_add_module(core MODULE NO_EXTRAS core.cc)`?

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge