### PR TITLE
Fix cmake changes causing plugin link problems on Mac

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ### >> Create core target, so we may link modules to it directly <<
 ### >> This allow to propagate dependencies upwards sanely
-pybind11_add_module(core MODULE NO_EXTRAS core.cc)
+pybind11_add_module(core SHARED NO_EXTRAS core.cc)
 
 ### >> Go into psi4 subdirectory to compile libraries and modules <<
 add_subdirectory(psi4)


### PR DESCRIPTION
## Description
Alternative solution to problem at #1640 

## Checklist
- [x] v2rdm compiles against this on Mac and runs a test

## Status
- [x] Ready for review
- [x] Ready for merge
