### PR TITLE
Fix Windows building and packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   - 1.3.x
 
 variables:
+  llvm.version: '7.0.1' # Note: LLVM 8.0.0 fails to build the optimized libint
   mkl.version: '2019.1'
 
 jobs:
@@ -133,7 +134,7 @@ jobs:
       # Install LLVM
       # Note: LLVM distributed by conda is too old
       - script: |
-          choco install llvm --yes
+          choco install llvm --version %LLVM_VERSION% --yes
           set PATH=C:\Program Files\LLVM\bin;%PATH%
           echo '##vso[task.setvariable variable=PATH]%PATH%'
           clang-cl --version

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -21,8 +21,8 @@ requirements:
 build:
   string: py{{ environ['PY_VER'].replace('.', '') }}_{{ 'debug' if environ['CMAKE_BUILD_TYPE'] == 'Debug' else '0' }}
   script:
-    - copy /y {{ INSTALL_DIR }}\bin\psi4     {{ PREFIX }}\Scripts
-    - copy /y {{ INSTALL_DIR }}\bin\psi4.bat {{ PREFIX }}\Scripts
+    - md {{ PREFIX }}\Scripts
+    - copy /y {{ INSTALL_DIR }}\bin\psi4 {{ PREFIX }}\Scripts
     - echo __pycache__ > exclude.txt
     - xcopy /f /i /s /exclude:exclude.txt {{ INSTALL_DIR }}\lib\psi4 {{ SP_DIR }}\psi4
     - xcopy /f /i /s {{ INSTALL_DIR }}\share\psi4\basis       {{ PREFIX }}\Lib\share\psi4\basis


### PR DESCRIPTION
## Description
This is part of *Psi4* porting to Windows (#933).

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Create `%PREFIX%\Scripts` -- `conda` stopped doing it automatically.
- [x] Don't package `bin\psi4.bat` -- `conda` learnt to recognize *Python* scripts and generate wrappers for them, i.e. `%PREFIX%\Scripts\psi4.exe`, but it is still needed for local testing.
- [x] Pin LLVM 7.0.1 -- 8.0.0 fails to build the optimized libint.

## Checklist
- [x] ~~Tests added for any new features~~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests) -- https://github.com/psi4/psi4/issues/933#issuecomment-494354023

## Status
- [x] Ready for review
- [ ] Ready for merge
