### PR TITLE
fixes test: dft-pruning

### DIFF
--- a/tests/dft-pruning/input.dat
+++ b/tests/dft-pruning/input.dat
@@ -35,6 +35,7 @@ for scheme in SCHEMES:
 set DFT_PRUNING_SCHEME ROBUST
 screening = {1e-12: 45198, 1e-14: 45429, 1e-16: 45679}
 for val in screening:
+    set DFT_WEIGHTS_TOLERANCE $val
     energy('pbe/sto-3g')
     compare_integers(screening[val], int(variable('XC GRID TOTAL POINTS')),
                      'grid points for weights_tolerance: ' + str(val))  #TEST


### PR DESCRIPTION
## Description
The mandatory option setting the `DFT_WEIGHT_TOLRANCE` was missing.

## Checklist

- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
