### PR TITLE
IRC: Displace from initial geom correctly

### DIFF
--- a/psi4/src/psi4/optking/molecule_irc_step.cc
+++ b/psi4/src/psi4/optking/molecule_irc_step.cc
@@ -290,7 +290,7 @@ void MOLECULE::irc_step()
       double *v_m = lowest_evector(H_m, Nintco);
       v = init_array(Nintco);
 
-      // Transform the gradient to internals
+      // Transform the displacement to pivot point to internals
       for(int i=0; i<Nintco; i++)
           v[i] = array_dot(rootG_inv[i], v_m, Nintco);
 

--- a/psi4/src/psi4/optking/molecule_irc_step.cc
+++ b/psi4/src/psi4/optking/molecule_irc_step.cc
@@ -283,12 +283,16 @@ void MOLECULE::irc_step()
   //Pivot Point and Initial Working Geometry:
   //step along along normalized, mass-weighted v
   if(at_FS) {
-    // If starting from TS, follow lowest-eigenvalued eigenvector.
+    // If starting from TS, follow lowest-eigenvalued eigenvector of mass-weighted Hessian.
     // Otherwise, follow the gradient (negative of the force vector).
     double *v;
     if (at_TS) {
-      //v = lowest_evector(H_m, Nintco);
-      v = lowest_evector(H, Nintco);
+      double *v_m = lowest_evector(H_m, Nintco);
+      v = init_array(Nintco);
+
+      // Transform the gradient to internals
+      for(int i=0; i<Nintco; i++)
+          v[i] = array_dot(rootG_inv[i], v_m, Nintco);
 
       if(Opt_params.IRC_direction == OPT_PARAMS::FORWARD)
         oprintf_out( "  Stepping in forward direction from TS.\n");

--- a/tests/opt-irc-2/input.dat
+++ b/tests/opt-irc-2/input.dat
@@ -45,4 +45,4 @@ set {
 
 energy = optimize('scf')
 
-compare_values(-92.8743625872132, energy, 4, "Energy of last IRC point")  #TEST
+compare_values(-92.874466547129, energy, 4, "Energy of last IRC point")  #TEST


### PR DESCRIPTION
## Description
Last summer, I discovered that the energy _increased_ along the IRC for my complex formation coordinate. I eventually tracked this down to a bug where the molecule did not displace the initial geometry correctly, which this PR fixes. Since that time, those of us at UGA have found this fix essential to follow modes <200i. I discuss this in more detail [here](https://github.com/psi-rking/optking/issues/19).

I updated a test to reflect the fact that the IRC can go a bit further when it displaces correctly. I didn't bother updating the reference files, as I expect it'll be invalidated soon anyways. The whole reason I'm submitting this PR now is to eliminate this bug from consideration when I send @psi-rking the _latest_ IRC bug I found.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fix IRCs

## Checklist
- [x] All IRC tests run

## Status
- [x] Ready for review
- [x] Ready for merge
