### PR TITLE
relax grid point checking near machine epsilon

### DIFF
--- a/tests/dft-pruning/input.dat
+++ b/tests/dft-pruning/input.dat
@@ -33,9 +33,8 @@ for scheme in SCHEMES:
 
 # screening based on small weights
 set DFT_PRUNING_SCHEME ROBUST
-screening = {1e-12: 45198, 1e-14: 45429, 1e-16: 45679}
-for val in screening:
+for val, points, error in [(1e-12, 45198, 0), (1e-14, 45429, 0), (1e-16, 45679, 5)]:
     set DFT_WEIGHTS_TOLERANCE $val
     energy('pbe/sto-3g')
-    compare_integers(screening[val], int(variable('XC GRID TOTAL POINTS')),
+    compare_integers(True, abs(points - int(variable('XC GRID TOTAL POINTS'))) <= error,
                      'grid points for weights_tolerance: ' + str(val))  #TEST


### PR DESCRIPTION
## Description
I was getting an error of off one grid point count on local box for 1.e-16 tolerance. So relaxed the count.

## Questions
- [ ] Is this a good way to handle this?

## Status
- [x] Ready for review
- [x] Ready for merge
