### PR TITLE
fix error string checking for pytest 5

### DIFF
--- a/tests/pytests/test_dertype.py
+++ b/tests/pytests/test_dertype.py
@@ -135,4 +135,4 @@ def test_negotiate_excessive_error(inp):
     with pytest.raises(psi4.ValidationError) as e:
         negotiate_derivative_type(proc=mock_proc, return_strategy=True, *inp)
 
-    assert 'excessive for target calculation' in str(e)
+    assert 'excessive for target calculation' in str(e.value)

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -19,7 +19,7 @@ def hide_test_xtpl_fn_fn_error():
     with pytest.raises(psi4.UpgradeHelper) as e:
         psi4.energy('cbs', scf_basis='cc-pvdz', scf_scheme=psi4.driver_cbs.xtpl_highest_1)
 
-    assert 'Replace extrapolation function with function name' in str(e)
+    assert 'Replace extrapolation function with function name' in str(e.value)
 
 
 def hide_test_xtpl_cbs_fn_error():
@@ -29,7 +29,7 @@ def hide_test_xtpl_cbs_fn_error():
         psi4.energy(psi4.cbs, scf_basis='cc-pvdz')
         #psi4.energy(psi4.driver.driver_cbs.complete_basis_set, scf_basis='cc-pvdz')
 
-    assert 'Replace cbs or complete_basis_set function with cbs string' in str(e)
+    assert 'Replace cbs or complete_basis_set function with cbs string' in str(e.value)
 
 
 @pytest.mark.parametrize("inp,out", [
@@ -52,7 +52,7 @@ def test_parse_cotton_irreps_error(inp):
     with pytest.raises(psi4.ValidationError) as e:
         psi4.driver.driver_util.parse_cotton_irreps(*inp)
 
-    assert 'not valid for point group' in str(e)
+    assert 'not valid for point group' in str(e.value)
 
 
 # <<<  TODO Deprecated! Delete in Psi4 v1.5  >>>

--- a/tests/pytests/test_qcng_dftd3_mp2d.py
+++ b/tests/pytests/test_qcng_dftd3_mp2d.py
@@ -252,7 +252,7 @@ def test_dftd3__from_arrays__supplement():
     assert compare_recursive(ans, res, atol=1.e-4)
     with pytest.raises(qcng.exceptions.InputError) as e:
         empirical_dispersion_resources.from_arrays(name_hint=res['fctldash'], level_hint=res['dashlevel'], param_tweaks=res['dashparams'])
-    assert "Can't guess -D correction level" in str(e)
+    assert "Can't guess -D correction level" in str(e.value)
     res = empirical_dispersion_resources.from_arrays(
         name_hint=res['fctldash'],
         level_hint=res['dashlevel'],

--- a/tests/pytests/test_qcvars.py
+++ b/tests/pytests/test_qcvars.py
@@ -94,11 +94,11 @@ def test_set_variable_overwrite(mode, pe_wfn_qcvars):
     # not fine to shadow keys with both types
     with pytest.raises(psi4.ValidationError) as err:
         obj.set_variable('vAr D', mat)
-    assert 'already a scalar variable' in str(err)
+    assert 'already a scalar variable' in str(err.value)
 
     with pytest.raises(psi4.ValidationError) as err:
         obj.set_variable('matvAr D', val)
-    assert 'already an array variable' in str(err)
+    assert 'already an array variable' in str(err.value)
 
 
 @pytest.mark.parametrize("mode", [


### PR DESCRIPTION
## Description
At least on Mac, these tests were failing with the latest pytest (5). Happily, the fix doesn't look to break pytest 4.

## Questions
- heads-up @dgasmith that qcel, qcng may also be susceptible

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
