### PR TITLE
Enable interoperability via The MolSSI Driver Interface

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -96,7 +96,6 @@ jobs:
         qcelemental \
         qcengine \
         pybind11 \
-        pymdi \
         -c conda-forge
       conda install adcc -c adcc -c conda-forge
       conda list

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -96,6 +96,7 @@ jobs:
         qcelemental \
         qcengine \
         pybind11 \
+        pymdi \
         -c conda-forge
       conda install adcc -c adcc -c conda-forge
       conda list

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -116,6 +116,7 @@ jobs:
                         numpy ^
                         pint ^
                         pybind11 ^
+                        pymdi ^
                         pytest ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -116,7 +116,6 @@ jobs:
                         numpy ^
                         pint ^
                         pybind11 ^
-                        pymdi ^
                         pytest ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ ExternalProject_Add(psi4-core
            qcengine_external
            simint_external
            libxc_external
+	   mdi_external
    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/psi4
    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ ExternalProject_Add(psi4-core
            qcengine_external
            simint_external
            libxc_external
-	   mdi_external
+           mdi_external
    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/psi4
    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/CMakeLists.txt
+++ b/external/upstream/CMakeLists.txt
@@ -16,6 +16,7 @@ foreach(dir
   qcengine
   simint
   libxc
+  mdi
   )
   add_subdirectory(${dir})
 endforeach()

--- a/external/upstream/CMakeLists.txt
+++ b/external/upstream/CMakeLists.txt
@@ -10,13 +10,13 @@ foreach(dir
   gau2grid
   gdma
   libint
+  mdi
   pcmsolver
   pylibefp
   qcelemental
   qcengine
   simint
   libxc
-  mdi
   )
   add_subdirectory(${dir})
 endforeach()

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,0 +1,39 @@
+##if(${ENABLE_mdi})
+    find_package(mdi CONFIG QUIET)
+
+    if(${mdi_FOUND})
+        get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
+        message(STATUS "${Cyan}Found mdi${ColourReset}: ${_loc} (found version ${mdi_VERSION})")
+        add_library(mdi_external INTERFACE)  # dummy
+    else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_mdi})
+            message(FATAL_ERROR "Suitable mdi could not be externally located as user insists")
+        endif()
+
+        include(ExternalProject)
+        message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
+        ExternalProject_Add(mdi_external
+            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.1.tar.gz
+            UPDATE_COMMAND ""
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                       -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+                       -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+                       -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                       -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
+                       -DENABLE_XHOST=${ENABLE_XHOST}
+                       -DBUILD_FPIC=${BUILD_FPIC}
+                       -DENABLE_GENERIC=${ENABLE_GENERIC}
+                       -DLIBC_INTERJECT=${LIBC_INTERJECT}
+		       -Dlanguage=Python
+            CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
+                             -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
+
+        set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)
+    endif()
+##else()
+##    add_library(mdi_external INTERFACE)  # dummy
+##endif()
+

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -13,7 +13,7 @@
         include(ExternalProject)
         message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
         ExternalProject_Add(mdi_external
-            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.3.tar.gz
+            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.4.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -18,7 +18,6 @@ else()
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
                    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                    -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
@@ -28,8 +27,7 @@ else()
                    -DENABLE_GENERIC=${ENABLE_GENERIC}
                    -DLIBC_INTERJECT=${LIBC_INTERJECT}
                    -Dlanguage=Python
-        CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-                         -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+        CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
 
     set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,41 +1,36 @@
-##if(${ENABLE_mdi})
-    find_package(mdi CONFIG QUIET)
+find_package(mdi CONFIG QUIET)
 
-    if(${mdi_FOUND})
-        get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
-        message(STATUS "${Cyan}Found mdi${ColourReset}: ${_loc} (found version ${mdi_VERSION})")
-        add_library(mdi_external INTERFACE)  # dummy
-    else()
-        if(${CMAKE_INSIST_FIND_PACKAGE_mdi})
-            message(FATAL_ERROR "Suitable mdi could not be externally located as user insists")
-        endif()
-
-        include(ExternalProject)
-        message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
-        ExternalProject_Add(mdi_external
-            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.4.tar.gz
-            UPDATE_COMMAND ""
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
-                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                       -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
-                       -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
-                       -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
-                       -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                       -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
-                       -DENABLE_XHOST=${ENABLE_XHOST}
-                       -DBUILD_FPIC=${BUILD_FPIC}
-                       -DENABLE_GENERIC=${ENABLE_GENERIC}
-                       -DLIBC_INTERJECT=${LIBC_INTERJECT}
-		       -Dlanguage=Python
-            CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-                             -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-                             -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
-
-        set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)
+if(${mdi_FOUND})
+    get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
+    message(STATUS "${Cyan}Found mdi${ColourReset}: ${_loc} (found version ${mdi_VERSION})")
+    add_library(mdi_external INTERFACE)  # dummy
+else()
+    if(${CMAKE_INSIST_FIND_PACKAGE_mdi})
+        message(FATAL_ERROR "Suitable mdi could not be externally located as user insists")
     endif()
-##else()
-##    add_library(mdi_external INTERFACE)  # dummy
-##endif()
 
+    include(ExternalProject)
+    message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
+    ExternalProject_Add(mdi_external
+        URL https://github.com/MolSSI/MDI_Library/archive/v0.6.4.tar.gz
+        UPDATE_COMMAND ""
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                   -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+                   -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+                   -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant for thread safety
+                   -DENABLE_XHOST=${ENABLE_XHOST}
+                   -DBUILD_FPIC=${BUILD_FPIC}
+                   -DENABLE_GENERIC=${ENABLE_GENERIC}
+                   -DLIBC_INTERJECT=${LIBC_INTERJECT}
+                   -Dlanguage=Python
+        CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
+                         -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                         -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
+
+    set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)
+endif()

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -13,7 +13,7 @@
         include(ExternalProject)
         message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
         ExternalProject_Add(mdi_external
-            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.1.tar.gz
+            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.2.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(mdi 1.1.4 CONFIG QUIET)
+find_package(mdi 1.1.5 CONFIG QUIET)
 
 if(${mdi_FOUND})
     get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(mdi CONFIG QUIET)
+find_package(mdi 0.6.5 CONFIG QUIET)
 
 if(${mdi_FOUND})
     get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
@@ -12,7 +12,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
     ExternalProject_Add(mdi_external
-        URL https://github.com/MolSSI/MDI_Library/archive/v0.6.4.tar.gz
+        URL https://github.com/MolSSI/MDI_Library/archive/v0.6.5.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -13,7 +13,7 @@
         include(ExternalProject)
         message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
         ExternalProject_Add(mdi_external
-            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.2.tar.gz
+            URL https://github.com/MolSSI/MDI_Library/archive/v0.6.3.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(mdi 0.6.5 CONFIG QUIET)
+find_package(mdi 1.1.3 CONFIG QUIET)
 
 if(${mdi_FOUND})
     get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
@@ -12,7 +12,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
     ExternalProject_Add(mdi_external
-        URL https://github.com/MolSSI/MDI_Library/archive/v0.6.5.tar.gz
+        URL https://github.com/MolSSI/MDI_Library/archive/v1.1.3.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(mdi 1.1.5 CONFIG QUIET)
+find_package(mdi 1.1.6 CONFIG QUIET)
 
 if(${mdi_FOUND})
     get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
@@ -12,7 +12,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
     ExternalProject_Add(mdi_external
-        URL https://github.com/MolSSI-MDI/MDI_Library/archive/v1.1.5.tar.gz
+        URL https://github.com/MolSSI-MDI/MDI_Library/archive/v1.1.6.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
     ExternalProject_Add(mdi_external
-        URL https://github.com/MolSSI/MDI_Library/archive/v1.1.4.tar.gz
+        URL https://github.com/MolSSI-MDI/MDI_Library/archive/v1.1.5.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(mdi 1.1.3 CONFIG QUIET)
+find_package(mdi 1.1.4 CONFIG QUIET)
 
 if(${mdi_FOUND})
     get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
@@ -12,7 +12,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
     ExternalProject_Add(mdi_external
-        URL https://github.com/MolSSI/MDI_Library/archive/v1.1.3.tar.gz
+        URL https://github.com/MolSSI/MDI_Library/archive/v1.1.4.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -18,6 +18,7 @@
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                        -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
@@ -29,7 +30,8 @@
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
 		       -Dlanguage=Python
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
-                             -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
+                             -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                             -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
 
         set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)
     endif()

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -28,7 +28,8 @@ else()
                    -DLIBC_INTERJECT=${LIBC_INTERJECT}
                    -Dlanguage=Python
         CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-                         -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
+                         -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+                         -DTargetOpenMP_FIND_COMPONENTS:STRING=C;CXX)
 
     set(mdi_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/mdi CACHE PATH "path to internally built mdiConfig.cmake" FORCE)
 endif()

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -134,7 +134,7 @@ get_property(_loc TARGET Libint::int PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
-find_package(mdi 1.1.5 CONFIG REQUIRED)
+find_package(mdi 1.1.6 CONFIG REQUIRED)
 get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using mdi${ColourReset}: ${_loc} (version ${mdi_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -134,7 +134,7 @@ get_property(_loc TARGET Libint::int PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
-find_package(mdi 0.6.5 CONFIG REQUIRED)
+find_package(mdi 1.1.4 CONFIG REQUIRED)
 get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using mdi${ColourReset}: ${_loc} (version ${mdi_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -134,6 +134,11 @@ get_property(_loc TARGET Libint::int PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
+find_package(mdi 0.6.5 CONFIG REQUIRED)
+get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
+list(APPEND _addons ${_loc})
+message(STATUS "${Cyan}Using mdi${ColourReset}: ${_loc} (version ${mdi_VERSION})")
+
 if(${ENABLE_PCMSolver})
     find_package(PCMSolver 1.2.1 CONFIG REQUIRED)
     get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -134,7 +134,7 @@ get_property(_loc TARGET Libint::int PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint ${Libint_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint_VERSION})")
 
-find_package(mdi 1.1.4 CONFIG REQUIRED)
+find_package(mdi 1.1.5 CONFIG REQUIRED)
 get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using mdi${ColourReset}: ${_loc} (version ${mdi_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -268,6 +268,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/standard_suite_runner.py
               ../tests/pytests/test_detci_opdm.py
               ../tests/pytests/test_gradients.py
+              ../tests/pytests/test_mdi.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 
     # <<<  install psi4 share/ & include/  >>>

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -33,6 +33,7 @@ from . import dependency_check
 from qcelemental import constants
 from psi4.driver import psifiles as psif
 
+from psi4.driver.mdi_engine import mdi_run
 from psi4.driver.molutil import *
 from psi4.driver.inputparser import process_input
 from psi4.driver.p4util.util import *

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -33,7 +33,7 @@ from . import dependency_check
 from qcelemental import constants
 from psi4.driver import psifiles as psif
 
-from psi4.driver.mdi_engine import mdi_run
+from psi4.driver.mdi_engine import mdi
 from psi4.driver.molutil import *
 from psi4.driver.inputparser import process_input
 from psi4.driver.p4util.util import *

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -33,7 +33,6 @@ from . import dependency_check
 from qcelemental import constants
 from psi4.driver import psifiles as psif
 
-from psi4.driver.mdi_engine import mdi
 from psi4.driver.molutil import *
 from psi4.driver.inputparser import process_input
 from psi4.driver.p4util.util import *

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -48,6 +48,7 @@ from psi4.driver import p4util
 from psi4.driver import qcdb
 from psi4.driver.procrouting import *
 from psi4.driver.p4util.exceptions import *
+from psi4.driver.mdi_engine import mdi_run
 
 # never import wrappers or aliases into this file
 
@@ -498,6 +499,11 @@ def energy(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
+
+    # Bounce to MDI if mdi kwarg
+    use_mdi = kwargs.pop('mdi', False)
+    if use_mdi:
+        return mdi_run(name, **kwargs)
 
     core.print_out("\nScratch directory: %s\n" % core.IOManager.shared_object().get_default_path())
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -250,7 +250,7 @@ class MDIEngine():
             else:
                 command = None
             if use_mpi4py:
-                command = mpi_world.bcast(command, root=0)
+                command = self.mpi_world.bcast(command, root=0)
             if self.world_rank == 0:
                 core.print_out('\nMDI command received: ' + str(command) + ' \n')
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -81,6 +81,7 @@ class MDIEngine():
         self.molecule.reset_point_group('c1')
         self.molecule.fix_orientation(True)
         self.molecule.fix_com(True)
+        self.molecule.reinterpret_coordentry(False)
         self.molecule.update_geometry()
 
     def length_conversion(self):

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -34,17 +34,9 @@ import psi4
 import numpy as np
 import qcelemental as qcel
 
-try:
-    # Attempt to use an internal build of MDI
-    from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
-        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
-        MDI_Register_Node, MDI_Register_Command
-except ImportError:
-    # Attempt to use an installed MDI package
-    from mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
-        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
-        MDI_Register_Node, MDI_Register_Command
-
+from mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
+    MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
+    MDI_Register_Node, MDI_Register_Command
 
 try:
     from mpi4py import MPI

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -44,9 +44,9 @@ try:
 except ImportError:
     use_mpi4py = False
 
-class MDIEngine():
 
-    def __init__(self, scf_method, molecule = None):
+class MDIEngine():
+    def __init__(self, scf_method, molecule=None):
         """ Initialize an MDIEngine object for communication with MDI
 
         Arguments:
@@ -66,10 +66,10 @@ class MDIEngine():
         self.energy = 0.0
 
         # Variables used when MDI sets a lattice of point charges
-        self.nlattice = 0 # number of lattice point charges
-        self.clattice = [] # list of lattice coordinates
-        self.lattice = [] # list of lattice charges
-        self.lattice_field = psi4.QMMM() # Psi4 chargefield
+        self.nlattice = 0  # number of lattice point charges
+        self.clattice = []  # list of lattice coordinates
+        self.lattice = []  # list of lattice charges
+        self.lattice_field = psi4.QMMM()  # Psi4 chargefield
 
         # MPI variables
         self.mpi_world = None
@@ -95,26 +95,26 @@ class MDIEngine():
 
         # Dictionary of all supported MDI commands
         self.commands = {
-            "<NATOMS": self.send_natoms, 
-            "<COORDS": self.send_coords, 
-            "<CHARGES": self.send_charges, 
-            "<ELEMENTS": self.send_elements, 
-            "<MASSES": self.send_masses, 
-            "<ENERGY": self.send_energy, 
-            "<FORCES": self.send_forces, 
-            ">COORDS": self.recv_coords, 
-            ">NLATTICE": self.recv_nlattice, 
-            ">CLATTICE": self.recv_clattice, 
-            ">LATTICE": self.recv_lattice, 
-            ">MASSES": self.recv_masses, 
-            "SCF": self.run_scf, 
-            "<DIMENSIONS": self.send_dimensions, 
-            "<NCOMMANDS": self.send_ncommands, 
-            "<COMMANDS": self.send_commands, 
-            "<TOTCHARGE": self.send_total_charge, 
-            ">TOTCHARGE": self.recv_total_charge, 
-            "<ELEC_MULT": self.send_multiplicity, 
-            ">ELEC_MULT": self.recv_multiplicity, 
+            "<NATOMS": self.send_natoms,
+            "<COORDS": self.send_coords,
+            "<CHARGES": self.send_charges,
+            "<ELEMENTS": self.send_elements,
+            "<MASSES": self.send_masses,
+            "<ENERGY": self.send_energy,
+            "<FORCES": self.send_forces,
+            ">COORDS": self.recv_coords,
+            ">NLATTICE": self.recv_nlattice,
+            ">CLATTICE": self.recv_clattice,
+            ">LATTICE": self.recv_lattice,
+            ">MASSES": self.recv_masses,
+            "SCF": self.run_scf,
+            "<DIMENSIONS": self.send_dimensions,
+            "<NCOMMANDS": self.send_ncommands,
+            "<COMMANDS": self.send_commands,
+            "<TOTCHARGE": self.send_total_charge,
+            ">TOTCHARGE": self.recv_total_charge,
+            "<ELEC_MULT": self.send_multiplicity,
+            ">ELEC_MULT": self.recv_multiplicity,
             "EXIT": self.exit
         }
 
@@ -123,7 +123,7 @@ class MDIEngine():
         """
         unit_name = self.molecule.units()
         if unit_name == "Angstrom":
-            unit_conv = MDI_Conversion_Factor("bohr","angstrom")
+            unit_conv = MDI_Conversion_Factor("bohr", "angstrom")
         elif unit_name == "Bohr":
             unit_conv = 1.0
         else:
@@ -152,7 +152,7 @@ class MDIEngine():
         """ Send the nuclear charges through MDI
         """
         natom = self.molecule.natom()
-        charges = [ self.molecule.charge(iatom) for iatom in range(natom) ]
+        charges = [self.molecule.charge(iatom) for iatom in range(natom)]
         MDI_Send(charges, natom, MDI_DOUBLE, self.comm)
         return charges
 
@@ -161,7 +161,7 @@ class MDIEngine():
         """ Send the nuclear masses through MDI
         """
         natom = self.molecule.natom()
-        masses = [ self.molecule.mass(iatom) for iatom in range(natom) ]
+        masses = [self.molecule.mass(iatom) for iatom in range(natom)]
         MDI_Send(masses, natom, MDI_DOUBLE, self.comm)
         return masses
 
@@ -170,7 +170,7 @@ class MDIEngine():
         """ Send the atomic number of each nucleus through MDI
         """
         natom = self.molecule.natom()
-        elements = [ self.molecule.true_atomic_number(iatom) for iatom in range(natom) ]
+        elements = [self.molecule.true_atomic_number(iatom) for iatom in range(natom)]
         MDI_Send(elements, natom, MDI_INT, self.comm)
         return elements
 
@@ -191,7 +191,7 @@ class MDIEngine():
         return forces
 
     # respond to >CHARGES command
-    def recv_charges(self, charges = None):
+    def recv_charges(self, charges=None):
         """ Receive a set of nuclear charges through MDI and assign them to the atoms in the current molecule
 
         Arguments:
@@ -204,7 +204,7 @@ class MDIEngine():
             self.molecule.set_nuclear_charge(iatom, charges[iatom])
 
     # respond to >COORDS command
-    def recv_coords(self, coords = None):
+    def recv_coords(self, coords=None):
         """ Receive a set of nuclear coordinates through MDI and assign them to the atoms in the current molecule
 
         Arguments:
@@ -212,12 +212,12 @@ class MDIEngine():
         """
         natom = self.molecule.natom()
         if coords is None:
-            coords = MDI_Recv(3*natom, MDI_DOUBLE, self.comm)
+            coords = MDI_Recv(3 * natom, MDI_DOUBLE, self.comm)
         matrix = psi4.core.Matrix.from_array(np.array(coords).reshape(-1, 3))
         self.molecule.set_geometry(matrix)
 
     # respond to the >MASSES command
-    def recv_masses(self, masses = None):
+    def recv_masses(self, masses=None):
         """ Receive a set of nuclear masses through MDI and assign them to the atoms in the current molecule
 
         Arguments:
@@ -244,14 +244,14 @@ class MDIEngine():
         self.lattice_field = psi4.QMMM()
         unit_conv = self.length_conversion()
         for ilat in range(self.nlattice):
-            latx = self.clattice[3*ilat+0] * unit_conv
-            laty = self.clattice[3*ilat+1] * unit_conv
-            latz = self.clattice[3*ilat+2] * unit_conv
+            latx = self.clattice[3 * ilat + 0] * unit_conv
+            laty = self.clattice[3 * ilat + 1] * unit_conv
+            latz = self.clattice[3 * ilat + 2] * unit_conv
             self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
         psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
 
     # respond to >NLATTICE command
-    def recv_nlattice(self, nlattice = None):
+    def recv_nlattice(self, nlattice=None):
         """ Receive the number of lattice point charges through MDI
 
         Arguments:
@@ -261,25 +261,25 @@ class MDIEngine():
             self.nlattice = MDI_Recv(1, MDI_INT, self.comm)
         else:
             self.nlattice = nlattice
-        self.clattice = [ 0.0 for ilat in range(3*self.nlattice) ]
-        self.lattice = [ 0.0 for ilat in range(self.nlattice) ]
+        self.clattice = [0.0 for ilat in range(3 * self.nlattice)]
+        self.lattice = [0.0 for ilat in range(self.nlattice)]
         self.set_lattice_field()
 
     # respond to >CLATTICE command
-    def recv_clattice(self, clattice = None):
+    def recv_clattice(self, clattice=None):
         """ Receive the coordinates of a set of lattice point charges through MDI
 
         Arguments:
             clattice: New coordinates of the lattice of point charges. If None, receive through MDI.
         """
         if clattice is None:
-            self.clattice = MDI_Recv(3*self.nlattice, MDI_DOUBLE, self.comm)
+            self.clattice = MDI_Recv(3 * self.nlattice, MDI_DOUBLE, self.comm)
         else:
             self.clattice = clattice
         self.set_lattice_field()
 
     # respond to >LATTICE command
-    def recv_lattice(self, lattice = None):
+    def recv_lattice(self, lattice=None):
         """ Receive the charges of a set of lattice point charges through MDI
 
         Arguments:
@@ -302,7 +302,7 @@ class MDIEngine():
         """ Send the dimensionality of the system through MDI
         """
         dimensions = [1, 1, 1]
-        MDI_Send( dimensions, 3, MDI_INT, self.comm )
+        MDI_Send(dimensions, 3, MDI_INT, self.comm)
         return dimensions
 
     # respond to <NCOMMANDS command
@@ -334,7 +334,7 @@ class MDIEngine():
         return charge
 
     # respond to the >TOTCHARGE command
-    def recv_total_charge(self, charge = None):
+    def recv_total_charge(self, charge=None):
         """ Receive the total system charge through MDI
 
         Arguments:
@@ -342,7 +342,7 @@ class MDIEngine():
         """
         if charge is None:
             charge = MDI_Recv(1, MDI_DOUBLE, self.comm)
-        self.molecule.set_molecular_charge( int(round(charge)) )
+        self.molecule.set_molecular_charge(int(round(charge)))
 
     # respond to the <ELEC_MULT command
     def send_multiplicity(self):
@@ -353,7 +353,7 @@ class MDIEngine():
         return multiplicity
 
     # respond to the >ELEC_MULT command
-    def recv_multiplicity(self, multiplicity = None):
+    def recv_multiplicity(self, multiplicity=None):
         """ Receive the electronic multiplicity through MDI
 
         Arguments:
@@ -361,7 +361,7 @@ class MDIEngine():
         """
         if multiplicity is None:
             multiplicity = MDI_Recv(1, MDI_INT, self.comm)
-        self.molecule.set_multiplicity( multiplicity )
+        self.molecule.set_multiplicity(multiplicity)
 
     # respond to the EXIT command
     def exit(self):
@@ -395,8 +395,6 @@ class MDIEngine():
                 raise Exception('Unrecognized command: ' + str(command))
 
 
-
-
 def mdi_init(mdi_arguments):
     """ Initialize the MDI Library
 
@@ -407,6 +405,7 @@ def mdi_init(mdi_arguments):
     if use_mpi4py:
         mpi_world = MPI.COMM_WORLD
     MDI_Init(mdi_arguments, mpi_world)
+
 
 def mdi(scf_method):
     """ Begin functioning as an MDI engine

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -36,7 +36,7 @@ import qcelemental as qcel
 
 from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
 from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command
-from MDI_Library.mdi import MDI_INT, MDI_DOUBLE, MDI_CHAR, MDI_COMMAND_LENGTH
+from MDI_Library.mdi import MDI_INT, MDI_DOUBLE
 from MDI_Library.mdi import MDI_Register_Node, MDI_Register_Command
 
 try:

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -44,10 +44,7 @@ except ImportError:
 
 class MDIEngine():
 
-    def __init__(self, mdi_arguments, scf_method):
-
-        # Argument to the -mdi command line option
-        self.mdi_arguments = mdi_arguments
+    def __init__(self, scf_method):
 
         # Method used when the SCF command is received
         self.scf_method = scf_method
@@ -65,13 +62,10 @@ class MDIEngine():
         self.mpi_world = None
         self.world_rank = 0
 
-        # initialize MDI
-        if use_mpi4py:
-            mpi_world = MPI.COMM_WORLD
-        MDI_Init(self.mdi_arguments,self.mpi_world)
+        # Get correct intra-code MPI communicator
         if use_mpi4py:
             self.mpi_world = MDI_Get_Intra_Code_MPI_Comm()
-            self.world_rank = mpi_world.Get_rank()
+            self.world_rank = self.mpi_world.Get_rank()
 
         # Accept a communicator to the driver code
         self.comm = MDI_Accept_Communicator()
@@ -249,6 +243,11 @@ class MDIEngine():
 
 
 
+def mdi_init(mdi_arguments):
+    mpi_world = None
+    if use_mpi4py:
+        mpi_world = MPI.COMM_WORLD
+    MDI_Init(mdi_arguments, mpi_world)
 
 def mdi(scf_method):
     """ Begin functioning as an MDI engine
@@ -260,8 +259,7 @@ def mdi(scf_method):
     """
     core.print_out("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n")
 
-    mdi_arguments = "-role ENGINE -name QM -method TCP -port 8021 -hostname localhost"
-    engine = MDIEngine(mdi_arguments, scf_method)
+    engine = MDIEngine(scf_method)
     engine.listen_for_commands()
 
     pass

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -77,6 +77,9 @@ class MDIEngine():
         self.mpi_world = None
         self.world_rank = 0
 
+        # Flag for if a lattice of point charges has been set
+        self.set_lattice = False
+
         # Get correct intra-code MPI communicator
         if use_mpi4py:
             self.mpi_world = MDI_Get_Intra_Code_MPI_Comm()
@@ -262,6 +265,7 @@ class MDIEngine():
             latz = self.clattice[3 * ilat + 2] * unit_conv
             self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
         psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
+        self.set_lattice = True
 
     # Respond to the >NLATTICE command
     def recv_nlattice(self, nlattice=None):
@@ -381,6 +385,11 @@ class MDIEngine():
         """ Stop listening for MDI commands
         """
         self.stop_listening = True
+
+        # If a lattice of point charges was set, unset it now
+        if self.set_lattice:
+            psi4.core.set_global_option_python('EXTERN', None)
+            
 
     # Enter server mode, listening for commands from the driver
     def listen_for_commands(self):

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -131,7 +131,7 @@ class MDIEngine():
 
         return unit_conv
 
-    # respond to <NATOMS command
+    # Respond to the <NATOMS command
     def send_natoms(self):
         """ Send the number of atoms through MDI
         """
@@ -139,7 +139,7 @@ class MDIEngine():
         MDI_Send(natom, 1, MDI_INT, self.comm)
         return natom
 
-    # respond to <COORDS command
+    # Respond to the <COORDS command
     def send_coords(self):
         """ Send the nuclear coordinates through MDI
         """
@@ -147,7 +147,7 @@ class MDIEngine():
         MDI_Send(coords, len(coords), MDI_DOUBLE_NUMPY, self.comm)
         return coords
 
-    # respond to <CHARGES command
+    # Respond to the <CHARGES command
     def send_charges(self):
         """ Send the nuclear charges through MDI
         """
@@ -156,7 +156,7 @@ class MDIEngine():
         MDI_Send(charges, natom, MDI_DOUBLE, self.comm)
         return charges
 
-    # respond to <MASSES command
+    # Respond to the <MASSES command
     def send_masses(self):
         """ Send the nuclear masses through MDI
         """
@@ -165,7 +165,7 @@ class MDIEngine():
         MDI_Send(masses, natom, MDI_DOUBLE, self.comm)
         return masses
 
-    # respond to <ELEMENTS command
+    # Respond to the <ELEMENTS command
     def send_elements(self):
         """ Send the atomic number of each nucleus through MDI
         """
@@ -174,14 +174,14 @@ class MDIEngine():
         MDI_Send(elements, natom, MDI_INT, self.comm)
         return elements
 
-    # respond to <ENERGY command
+    # Respond to the <ENERGY command
     def send_energy(self):
         """ Send the total energy through MDI
         """
         MDI_Send(self.energy, 1, MDI_DOUBLE, self.comm)
         return self.energy
 
-    # respond to <FORCES command
+    # Respond to the <FORCES command
     def send_forces(self):
         """ Send the nuclear forces through MDI
         """
@@ -190,7 +190,7 @@ class MDIEngine():
         MDI_Send(forces, len(forces), MDI_DOUBLE_NUMPY, self.comm)
         return forces
 
-    # respond to >CHARGES command
+    # Respond to the >CHARGES command
     def recv_charges(self, charges=None):
         """ Receive a set of nuclear charges through MDI and assign them to the atoms in the current molecule
 
@@ -203,7 +203,7 @@ class MDIEngine():
         for iatom in range(natom):
             self.molecule.set_nuclear_charge(iatom, charges[iatom])
 
-    # respond to >COORDS command
+    # Respond to the >COORDS command
     def recv_coords(self, coords=None):
         """ Receive a set of nuclear coordinates through MDI and assign them to the atoms in the current molecule
 
@@ -216,7 +216,7 @@ class MDIEngine():
         matrix = psi4.core.Matrix.from_array(np.array(coords).reshape(-1, 3))
         self.molecule.set_geometry(matrix)
 
-    # respond to the >MASSES command
+    # Respond to the >MASSES command
     def recv_masses(self, masses=None):
         """ Receive a set of nuclear masses through MDI and assign them to the atoms in the current molecule
 
@@ -227,7 +227,7 @@ class MDIEngine():
         if masses is None:
             masses = MDI_Recv(natom, MDI_DOUBLE, self.comm)
 
-        # assign the mass of all atoms, taking care to avoid ghost atoms
+        # Assign the mass of all atoms, taking care to avoid ghost atoms
         jatom = 0
         for iatom in range(natom):
             while self.molecule.fcharge(jatom) == 0.0 and jatom < self.molecule.nallatom():
@@ -237,7 +237,7 @@ class MDIEngine():
             self.molecule.set_mass(iatom, masses[jatom])
             jatom = jatom + 1
 
-    # set a lattice of point charges
+    # Set a lattice of point charges
     def set_lattice_field(self):
         """ Set a field of lattice point charges using information received through MDI
         """
@@ -250,7 +250,7 @@ class MDIEngine():
             self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
         psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
 
-    # respond to >NLATTICE command
+    # Respond to the >NLATTICE command
     def recv_nlattice(self, nlattice=None):
         """ Receive the number of lattice point charges through MDI
 
@@ -265,7 +265,7 @@ class MDIEngine():
         self.lattice = [0.0 for ilat in range(self.nlattice)]
         self.set_lattice_field()
 
-    # respond to >CLATTICE command
+    # Respond to the >CLATTICE command
     def recv_clattice(self, clattice=None):
         """ Receive the coordinates of a set of lattice point charges through MDI
 
@@ -278,7 +278,7 @@ class MDIEngine():
             self.clattice = clattice
         self.set_lattice_field()
 
-    # respond to >LATTICE command
+    # Respond to the >LATTICE command
     def recv_lattice(self, lattice=None):
         """ Receive the charges of a set of lattice point charges through MDI
 
@@ -291,13 +291,13 @@ class MDIEngine():
             self.lattice = lattice
         self.set_lattice_field()
 
-    # respond to SCF command
+    # Respond to the SCF command
     def run_scf(self):
         """ Run an energy calculation
         """
         self.energy = psi4.energy(self.scf_method, molecule=self.molecule)
 
-    # respond to the <DIMENSIONS command
+    # Respond to the <DIMENSIONS command
     def send_dimensions(self):
         """ Send the dimensionality of the system through MDI
         """
@@ -305,14 +305,14 @@ class MDIEngine():
         MDI_Send(dimensions, 3, MDI_INT, self.comm)
         return dimensions
 
-    # respond to <NCOMMANDS command
+    # Respond to the <NCOMMANDS command
     def send_ncommands(self):
         """ Send the number of supported MDI commands through MDI
         """
         MDI_Send(len(self.commands), 1, MDI_INT, self.comm)
         return len(self.commands)
 
-    # respond to the <COMMANDS command
+    # Respond to the <COMMANDS command
     def send_commands(self):
         """ Send the supported MDI commands through MDI
         """
@@ -325,7 +325,7 @@ class MDIEngine():
         MDI_Send(command_string, len(command_string), MDI_CHAR, self.comm)
         return command_string
 
-    # respond to the <TOTCHARGE command
+    # Respond to the <TOTCHARGE command
     def send_total_charge(self):
         """ Send the total system charge through MDI
         """
@@ -333,7 +333,7 @@ class MDIEngine():
         MDI_Send(charge, 1, MDI_DOUBLE, self.comm)
         return charge
 
-    # respond to the >TOTCHARGE command
+    # Respond to the >TOTCHARGE command
     def recv_total_charge(self, charge=None):
         """ Receive the total system charge through MDI
 
@@ -344,7 +344,7 @@ class MDIEngine():
             charge = MDI_Recv(1, MDI_DOUBLE, self.comm)
         self.molecule.set_molecular_charge(int(round(charge)))
 
-    # respond to the <ELEC_MULT command
+    # Respond to the <ELEC_MULT command
     def send_multiplicity(self):
         """ Send the electronic multiplicity through MDI
         """
@@ -352,7 +352,7 @@ class MDIEngine():
         MDI_Send(multiplicity, 1, MDI_INT, self.comm)
         return multiplicity
 
-    # respond to the >ELEC_MULT command
+    # Respond to the >ELEC_MULT command
     def recv_multiplicity(self, multiplicity=None):
         """ Receive the electronic multiplicity through MDI
 
@@ -363,13 +363,13 @@ class MDIEngine():
             multiplicity = MDI_Recv(1, MDI_INT, self.comm)
         self.molecule.set_multiplicity(multiplicity)
 
-    # respond to the EXIT command
+    # Respond to the EXIT command
     def exit(self):
         """ Stop listening for MDI commands
         """
         self.stop_listening = True
 
-    # enter server mode, listening for commands from the driver
+    # Enter server mode, listening for commands from the driver
     def listen_for_commands(self):
         """ Receive commands through MDI and respond to them as defined by the MDI Standard
         """
@@ -384,11 +384,11 @@ class MDIEngine():
             if self.world_rank == 0:
                 psi4.core.print_out('\nMDI command received: ' + str(command) + ' \n')
 
-            # search for this command in self.commands
+            # Search for this command in self.commands
             found_command = False
             for supported_command in self.commands:
                 if not found_command and command == supported_command:
-                    # run the function corresponding to this command
+                    # Run the function corresponding to this command
                     self.commands[supported_command]()
                     found_command = True
             if not found_command:

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -131,7 +131,6 @@ class MDIEngine():
         """
         natom = self.molecule.natom()
         MDI_Send(natom, 1, MDI_INT, self.comm)
-        print("Natoms: " + str(natom))
         return natom
 
     # respond to <COORDS command
@@ -141,7 +140,6 @@ class MDIEngine():
         natom = self.molecule.natom()
         coords = [ self.molecule.xyz(iatom)[icoord] for iatom in range(natom) for icoord in range(3) ]
         MDI_Send(coords, 3*natom, MDI_DOUBLE, self.comm)
-        print("Coords: " + str(coords))
         return coords
 
     # respond to <CHARGES command
@@ -151,7 +149,6 @@ class MDIEngine():
         natom = self.molecule.natom()
         charges = [ self.molecule.charge(iatom) for iatom in range(natom) ]
         MDI_Send(charges, natom, MDI_DOUBLE, self.comm)
-        print("Charges: " + str(charges))
         return charges
 
     # respond to <MASSES command
@@ -161,7 +158,6 @@ class MDIEngine():
         natom = self.molecule.natom()
         masses = [ self.molecule.mass(iatom) for iatom in range(natom) ]
         MDI_Send(masses, natom, MDI_DOUBLE, self.comm)
-        print("Masses: " + str(masses))
         return masses
 
     # respond to <ELEMENTS command
@@ -171,7 +167,6 @@ class MDIEngine():
         natom = self.molecule.natom()
         elements = [ self.molecule.true_atomic_number(iatom) for iatom in range(natom) ]
         MDI_Send(elements, natom, MDI_INT, self.comm)
-        print("Elements: " + str(elements))
         return elements
 
     # respond to <ENERGY command
@@ -179,7 +174,6 @@ class MDIEngine():
         """ Send the total energy through MDI
         """
         MDI_Send(self.energy, 1, MDI_DOUBLE, self.comm)
-        print("Energy: " + str(self.energy))
         return self.energy
 
     # respond to <FORCES command
@@ -191,7 +185,6 @@ class MDIEngine():
         unit_conv = 1.0
         forces = [ force_matrix.get(iatom,icoord)*unit_conv for iatom in range(natom) for icoord in range(3) ]
         MDI_Send(forces, 3*natom, MDI_DOUBLE, self.comm)
-        print("Forces: " + str(forces))
         return forces
 
     # respond to >CHARGES command
@@ -330,7 +323,6 @@ class MDIEngine():
             for i in range(len(command), MDI_COMMAND_LENGTH):
                 command_string += " "
 
-        print("COMMANDS: " + str(len(command_string)) + " " + str(command_string))
         MDI_Send(command_string, len(command_string), MDI_CHAR, self.comm)
         return command_string
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -84,6 +84,10 @@ class MDIEngine():
             self.mpi_world = MDI_Get_Intra_Code_MPI_Comm()
             self.world_rank = self.mpi_world.Get_rank()
 
+            # Psi4 does not currently support multiple MPI ranks
+            if self.mpi_world.Get_size() != 1:
+                MPI.COMM_WORLD.Abort()
+
         # Accept a communicator to the driver code
         self.comm = MDI_Accept_Communicator()
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -88,27 +88,28 @@ class MDIEngine():
         self.stop_listening = False
 
         # List of all supported MDI commands
-        self.commands = [ ( "<NATOMS", self.send_natoms ), 
-                          ( "<COORDS", self.send_coords ), 
-                          ( "<CHARGES", self.send_charges ), 
-                          ( "<ELEMENTS", self.send_elements ), 
-                          ( "<MASSES", self.send_masses ), 
-                          ( "<ENERGY", self.send_energy ), 
-                          ( "<FORCES", self.send_forces ), 
-                          ( ">COORDS", self.recv_coords ), 
-                          ( ">NLATTICE", self.recv_nlattice ), 
-                          ( ">CLATTICE", self.recv_clattice ), 
-                          ( ">LATTICE", self.recv_lattice ), 
-                          ( ">MASSES", self.recv_masses ), 
-                          ( "SCF", self.run_scf ), 
-                          ( "<DIMENSIONS", self.send_dimensions ), 
-                          ( "<NCOMMANDS", self.send_ncommands ), 
-                          ( "<COMMANDS", self.send_commands ), 
-                          ( "<TOTCHARGE", self.send_total_charge ), 
-                          ( ">TOTCHARGE", self.recv_total_charge ), 
-                          ( "<ELEC_MULT", self.send_multiplicity ), 
-                          ( ">ELEC_MULT", self.recv_multiplicity ), 
-                          ( "EXIT", self.exit ) ]
+        self.commands = { }
+        self.commands["<NATOMS"] = self.send_natoms
+        self.commands["<COORDS"] = self.send_coords
+        self.commands["<CHARGES"] = self.send_charges
+        self.commands["<ELEMENTS"] = self.send_elements
+        self.commands["<MASSES"] = self.send_masses
+        self.commands["<ENERGY"] = self.send_energy
+        self.commands["<FORCES"] = self.send_forces
+        self.commands[">COORDS"] = self.recv_coords
+        self.commands[">NLATTICE"] = self.recv_nlattice
+        self.commands[">CLATTICE"] = self.recv_clattice
+        self.commands[">LATTICE"] = self.recv_lattice
+        self.commands[">MASSES"] = self.recv_masses
+        self.commands["SCF"] = self.run_scf
+        self.commands["<DIMENSIONS"] = self.send_dimensions
+        self.commands["<NCOMMANDS"] = self.send_ncommands
+        self.commands["<COMMANDS"] = self.send_commands
+        self.commands["<TOTCHARGE"] = self.send_total_charge
+        self.commands[">TOTCHARGE"] = self.recv_total_charge
+        self.commands["<ELEC_MULT"] = self.send_multiplicity
+        self.commands[">ELEC_MULT"] = self.recv_multiplicity
+        self.commands["EXIT"] = self.exit
 
     def length_conversion(self):
         """ Obtain the conversion factor between the geometry specification units and bohr
@@ -306,8 +307,8 @@ class MDIEngine():
         """
         command_string = ""
         for command in self.commands:
-            command_string += command[0]
-            for i in range(len(command[0]), MDI_COMMAND_LENGTH):
+            command_string += command
+            for i in range(len(command), MDI_COMMAND_LENGTH):
                 command_string += " "
 
         print("COMMANDS: " + str(len(command_string)) + " " + str(command_string))
@@ -370,9 +371,9 @@ class MDIEngine():
             # search for this command in self.commands
             found_command = False
             for supported_command in self.commands:
-                if not found_command and command == supported_command[0]:
+                if not found_command and command == supported_command:
                     # run the function corresponding to this command
-                    supported_command[1]()
+                    self.commands[supported_command]()
                     found_command = True
             if not found_command:
                 raise Exception('Unrecognized command: ' + str(command))

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -128,6 +128,8 @@ class MDIEngine():
 
     def length_conversion(self):
         """ Obtain the conversion factor between the geometry specification units and bohr
+
+        :returns: *unit_conv* Conversion factor between the geometry specification units and bohr
         """
         unit_name = self.molecule.units()
         if unit_name == "Angstrom":
@@ -158,6 +160,8 @@ class MDIEngine():
     # Respond to the <CHARGES command
     def send_charges(self):
         """ Send the nuclear charges through MDI
+
+        :returns: *charges* Atomic charges
         """
         natom = self.molecule.natom()
         charges = [self.molecule.charge(iatom) for iatom in range(natom)]
@@ -167,6 +171,8 @@ class MDIEngine():
     # Respond to the <MASSES command
     def send_masses(self):
         """ Send the nuclear masses through MDI
+
+        :returns: *masses* Atomic masses
         """
         natom = self.molecule.natom()
         molecule_dict = self.molecule.to_dict()
@@ -177,6 +183,8 @@ class MDIEngine():
     # Respond to the <ELEMENTS command
     def send_elements(self):
         """ Send the atomic number of each nucleus through MDI
+
+        :returns: *elements* Element of each atom
         """
         natom = self.molecule.natom()
         elements = [self.molecule.true_atomic_number(iatom) for iatom in range(natom)]
@@ -186,6 +194,8 @@ class MDIEngine():
     # Respond to the <ENERGY command
     def send_energy(self):
         """ Send the total energy through MDI
+
+        :returns: *energy* Energy of the system
         """
         self.run_scf()
         MDI_Send(self.energy, 1, MDI_DOUBLE, self.comm)
@@ -194,6 +204,8 @@ class MDIEngine():
     # Respond to the <FORCES command
     def send_forces(self):
         """ Send the nuclear forces through MDI
+
+        :returns: *forces* Atomic forces
         """
         force_matrix = psi4.driver.gradient(self.scf_method, molecule=self.molecule)
         forces = force_matrix.np.ravel()
@@ -320,6 +332,8 @@ class MDIEngine():
     # Respond to the <DIMENSIONS command
     def send_dimensions(self):
         """ Send the dimensionality of the system through MDI
+
+        :returns: *dimensions* Dimensionality of the system
         """
         dimensions = [1, 1, 1]
         MDI_Send(dimensions, 3, MDI_INT, self.comm)
@@ -328,13 +342,18 @@ class MDIEngine():
     # Respond to the <NCOMMANDS command
     def send_ncommands(self):
         """ Send the number of supported MDI commands through MDI
+
+        :returns: *ncommands* Number of supported commands
         """
-        MDI_Send(len(self.commands), 1, MDI_INT, self.comm)
-        return len(self.commands)
+        ncommands = len(self.commands)
+        MDI_Send(ncommands, 1, MDI_INT, self.comm)
+        return ncommands
 
     # Respond to the <COMMANDS command
     def send_commands(self):
         """ Send the supported MDI commands through MDI
+
+        :returns: *command_string* String containing the name of each supported command
         """
         command_string = ""
         for command in self.commands:
@@ -348,6 +367,8 @@ class MDIEngine():
     # Respond to the <TOTCHARGE command
     def send_total_charge(self):
         """ Send the total system charge through MDI
+
+        :returns: *charge* Total charge of the system
         """
         charge = self.molecule.molecular_charge()
         MDI_Send(charge, 1, MDI_DOUBLE, self.comm)
@@ -367,6 +388,8 @@ class MDIEngine():
     # Respond to the <ELEC_MULT command
     def send_multiplicity(self):
         """ Send the electronic multiplicity through MDI
+
+        :returns: *multiplicity* Multiplicity of the system
         """
         multiplicity = self.molecule.multiplicity()
         MDI_Send(multiplicity, 1, MDI_INT, self.comm)

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -197,6 +197,9 @@ class MDIEngine():
     # respond to >CHARGES command
     def recv_charges(self, charges = None):
         """ Receive a set of nuclear charges through MDI and assign them to the atoms in the current molecule
+
+        Arguments:
+            charges: New nuclear charges. If None, receive through MDI.
         """
         natom = self.molecule.natom()
         if charges is None:
@@ -207,6 +210,9 @@ class MDIEngine():
     # respond to >COORDS command
     def recv_coords(self, coords = None):
         """ Receive a set of nuclear coordinates through MDI and assign them to the atoms in the current molecule
+
+        Arguments:
+            coords: New nuclear coordinates. If None, receive through MDI.
         """
         natom = self.molecule.natom()
         if coords is None:
@@ -221,6 +227,9 @@ class MDIEngine():
     # respond to the >MASSES command
     def recv_masses(self, masses = None):
         """ Receive a set of nuclear masses through MDI and assign them to the atoms in the current molecule
+
+        Arguments:
+            masses: New nuclear masses. If None, receive through MDI.
         """
         natom = self.molecule.natom()
         if masses is None:
@@ -252,6 +261,9 @@ class MDIEngine():
     # respond to >NLATTICE command
     def recv_nlattice(self, nlattice = None):
         """ Receive the number of lattice point charges through MDI
+
+        Arguments:
+            nlattice: New number of point charges. If None, receive through MDI.
         """
         if nlattice is None:
             self.nlattice = MDI_Recv(1, MDI_INT, self.comm)
@@ -264,6 +276,9 @@ class MDIEngine():
     # respond to >CLATTICE command
     def recv_clattice(self, clattice = None):
         """ Receive the coordinates of a set of lattice point charges through MDI
+
+        Arguments:
+            clattice: New coordinates of the lattice of point charges. If None, receive through MDI.
         """
         if clattice is None:
             self.clattice = MDI_Recv(3*self.nlattice, MDI_DOUBLE, self.comm)
@@ -274,6 +289,9 @@ class MDIEngine():
     # respond to >LATTICE command
     def recv_lattice(self, lattice = None):
         """ Receive the charges of a set of lattice point charges through MDI
+
+        Arguments:
+            lattice: New charges of the lattice of point charges. If None, receive through MDI.
         """
         if lattice is None:
             self.lattice = MDI_Recv(self.nlattice, MDI_DOUBLE, self.comm)
@@ -327,6 +345,9 @@ class MDIEngine():
     # respond to the >TOTCHARGE command
     def recv_total_charge(self, charge = None):
         """ Receive the total system charge through MDI
+
+        Arguments:
+            charge: New charge of the system. If None, receive through MDI.
         """
         if charge is None:
             charge = MDI_Recv(1, MDI_DOUBLE, self.comm)
@@ -343,6 +364,9 @@ class MDIEngine():
     # respond to the >ELEC_MULT command
     def recv_multiplicity(self, multiplicity = None):
         """ Receive the electronic multiplicity through MDI
+
+        Arguments:
+            multiplicity: New multiplicity of the system. If None, receive through MDI.
         """
         if multiplicity is None:
             multiplicity = MDI_Recv(1, MDI_INT, self.comm)

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -36,9 +36,21 @@ from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Co
 from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_Conversion_Factor
 from MDI_Library.mdi import MDI_INT, MDI_DOUBLE, MDI_CHAR
 
+try:
+    from mpi4py import MPI
+    use_mpi4py = True
+except ImportError:
+    use_mpi4py = False
+
 class MDIEngine():
 
-    def __init__(self):
+    def __init__(self, mdi_arguments, scf_method):
+
+        # Argument to the -mdi command line option
+        self.mdi_arguments = mdi_arguments
+
+        # Method used when the SCF command is received
+        self.scf_method = scf_method
 
         self.molecule = psi4.core.get_active_molecule()
         self.energy = 0.0
@@ -49,10 +61,196 @@ class MDIEngine():
         self.lattice = [] # list of lattice charges
         self.lattice_field = psi4.QMMM() # Psi4 chargefield
 
+        # MPI variables
+        self.mpi_world = None
+        self.world_rank = 0
+
+        # initialize MDI
+        if use_mpi4py:
+            mpi_world = MPI.COMM_WORLD
+        MDI_Init(self.mdi_arguments,self.mpi_world)
+        if use_mpi4py:
+            self.mpi_world = MDI_Get_Intra_Code_MPI_Comm()
+            self.world_rank = mpi_world.Get_rank()
+
+        # Accept a communicator to the driver code
+        self.comm = MDI_Accept_Communicator()
+
+
+    def length_conversion(self):
+        unit_name = self.molecule.units()
+        unit_conv = 1.0
+        if unit_name == "Angstrom":
+            unit_conv = MDI_Conversion_Factor("bohr","angstrom")
+        elif unit_name == "Bohr":
+            unit_conv = 1.0
+        else:
+            raise Exception('Unrecognized unit type: ' + str(unit_name))
+
+        return unit_conv
+
+    # respond to <NATOMS command
+    def send_natoms(self):
+        natom = self.molecule.natom()
+        MDI_Send(natom, 1, MDI_INT, self.comm)
+        print("Natoms: " + str(natom))
+
+    # respond to <COORDS command
+    def send_coords(self):
+        natom = self.molecule.natom()
+        coords = [ self.molecule.xyz(iatom)[icoord] for iatom in range(natom) for icoord in range(3) ]
+        MDI_Send(coords, 3*natom, MDI_DOUBLE, self.comm)
+        print("Coords: " + str(coords))
+
+    # respond to <CHARGES command
+    def send_charges(self):
+        natom = self.molecule.natom()
+        charges = [ self.molecule.charge(iatom) for iatom in range(natom) ]
+        MDI_Send(charges, natom, MDI_DOUBLE, self.comm)
+        print("Charges: " + str(charges))
+
+    # respond to <MASSES command
+    def send_masses(self):
+        natom = self.molecule.natom()
+        masses = [ self.molecule.mass(iatom) for iatom in range(natom) ]
+        MDI_Send(masses, natom, MDI_DOUBLE, self.comm)
+        print("Masses: " + str(masses))
+
+    # respond to <ELEMENTS command
+    def send_elements(self):
+        natom = self.molecule.natom()
+        elements = [ self.molecule.true_atomic_number(iatom) for iatom in range(natom) ]
+        MDI_Send(elements, natom, MDI_INT, self.comm)
+        print("Elements: " + str(elements))
+
+    # respond to <ENERGY command
+    def send_energy(self):
+        MDI_Send(self.energy, 1, MDI_DOUBLE, self.comm)
+        print("Energy: " + str(self.energy))
+
+    # respond to <FORCES command
+    def send_forces(self):
+        natom = self.molecule.natom()
+        force_matrix = psi4.driver.gradient(self.scf_method)
+        unit_conv = 1.0
+        forces = [ force_matrix.get(iatom,icoord)*unit_conv for iatom in range(natom) for icoord in range(3) ]
+        MDI_Send(forces, 3*natom, MDI_DOUBLE, self.comm)
+        print("Forces: " + str(forces))
+
+    # respond to >CHARGES command
+    def recv_charges(self):
+        natom = self.molecule.natom()
+        charges = MDI_Recv(natom, MDI_DOUBLE, self.comm)
+        for iatom in range(natom):
+            self.molecule.set_nuclear_charge(iatom, charges[iatom])
+
+    # respond to >COORDS command
+    def recv_coords(self):
+        natom = self.molecule.natom()
+        coords = MDI_Recv(3*natom, MDI_DOUBLE, self.comm)
+        matrix = psi4.core.Matrix(natom, 3)
+        for iatom in range(natom):
+            matrix.set(iatom,0,coords[3*iatom+0])
+            matrix.set(iatom,1,coords[3*iatom+1])
+            matrix.set(iatom,2,coords[3*iatom+2])
+        self.molecule.set_geometry(matrix)
+
+    # respond to the >MASSES command
+    def recv_masses(self):
+        natom = self.molecule.natom()
+        masses = MDI_Recv(natom, MDI_DOUBLE, self.comm)
+
+        # assign the mass of all atoms, taking care to avoid ghost atoms
+        jatom = 0
+        for iatom in range(natom):
+            while self.molecule.fcharge(jatom) == 0.0 and jatom < self.molecule.nallatom():
+                jatom = jatom + 1
+                if jatom >= self.molecule.nallatom():
+                    raise Exception('Unexpected number of ghost atoms when receiving masses: ')
+            self.molecule.set_mass(iatom, masses[jatom])
+            jatom = jatom + 1
+
+    # set a lattice of point charges
+    def set_lattice_field(self):
+        self.lattice_field = psi4.QMMM()
+        for ilat in range(self.nlattice):
+            latx = self.clattice[3*ilat+0]
+            laty = self.clattice[3*ilat+1]
+            latz = self.clattice[3*ilat+2]
+            self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
+        psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
+
+    # respond to >NLATTICE command
+    def recv_nlattice(self):
+        self.nlattice = MDI_Recv(1, MDI_INT, self.comm)
+        self.clattice = [ 0.0 for ilat in range(3*self.nlattice) ]
+        self.lattice = [ 0.0 for ilat in range(self.nlattice) ]
+        set_lattice_field(self.molecule)
+
+    # respond to >CLATTICE command
+    def recv_clattice(self):
+        self.clattice = MDI_Recv(3*self.nlattice, MDI_DOUBLE, self.comm)
+        set_lattice_field(self.molecule)
+
+    # respond to >LATTICE command
+    def recv_lattice(self):
+        self.lattice = MDI_Recv(self.nlattice, MDI_DOUBLE, self.comm)
+        set_lattice_field(self.molecule)
+
+    # respond to SCF command
+    def run_scf(self):
+        self.energy = psi4.energy(self.scf_method)
+
+    # enter server mode, listening for commands from the driver
+    def listen_for_commands(self):
+
+        while True:
+            print("--- FIRST COMMAND")
+            if self.world_rank == 0:
+                command = MDI_Recv_Command(self.comm)
+            else:
+                command = None
+            if use_mpi4py:
+                command = mpi_world.bcast(command, root=0)
+            print("   COMMAND: " + str(command))
+
+            # respond to commands
+            if command == "<NATOMS":
+                self.send_natoms()
+            elif command == "<COORDS":
+                self.send_coords()
+            elif command == "<CHARGES":
+                self.send_charges()
+            elif command == "<ELEMENTS":
+                self.send_elements()
+            elif command == "<MASSES":
+                self.send_masses()
+            elif command == "<ENERGY":
+                self.send_energy()
+            elif command == "<FORCES":
+                self.send_forces()
+            elif command == ">COORDS":
+                self.recv_coords()
+            elif command == ">NLATTICE":
+                self.recv_nlattice()
+            elif command == ">CLATTICE":
+                self.recv_clattice()
+            elif command == ">LATTICE":
+                self.recv_lattice()
+            elif command == ">MASSES":
+                self.recv_masses()
+            elif command == "SCF":
+                self.run_scf()
+            elif command == "EXIT":
+                break
+            else:
+                raise Exception('Unrecognized command: ' + str(command))
 
 
 
-def mdi():
+
+
+def mdi(scf_method):
     """ Begin functioning as an MDI engine
 
 #    Arguments:
@@ -61,4 +259,9 @@ def mdi():
 #        options: LOT, multiplicity and charge
     """
     core.print_out("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n")
+
+    mdi_arguments = "-role ENGINE -name QM -method TCP -port 8021 -hostname localhost"
+    engine = MDIEngine(mdi_arguments, scf_method)
+    engine.listen_for_commands()
+
     pass

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -357,6 +357,10 @@ class MDIEngine():
         """
         command_string = "".join([f"{c:{MDI_COMMAND_LENGTH}}" for c in self.commands.keys()])
 
+        # confirm that command_string is the correct length
+        if len(command_string) != len(self.commands) * MDI_COMMAND_LENGTH:
+            raise Exception('Programming error: MDI command_string is incorrect length')
+
         MDI_Send(command_string, len(command_string), MDI_CHAR, self.comm)
         return command_string
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -1,0 +1,40 @@
+#
+# @BEGIN LICENSE
+#
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2019 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
+#
+# This file is part of Psi4.
+#
+# Psi4 is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# Psi4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Psi4; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# @END LICENSE
+#
+
+from psi4 import core
+from psi4.driver import p4util
+from psi4.driver import driver
+from psi4.driver.p4util.exceptions import *
+
+#from mdi.MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
+from MDI_Library import *
+
+
+def mdi_run():
+    psi4.core.print_out("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n")
+    pass

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -26,15 +26,39 @@
 # @END LICENSE
 #
 
-from psi4 import core
+#from psi4 import core
+import psi4
 from psi4.driver import p4util
 from psi4.driver import driver
 from psi4.driver.p4util.exceptions import *
 
-#from mdi.MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
-from MDI_Library import *
+from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
+from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_Conversion_Factor
+from MDI_Library.mdi import MDI_INT, MDI_DOUBLE, MDI_CHAR
+
+class MDIEngine():
+
+    def __init__(self):
+
+        self.molecule = psi4.core.get_active_molecule()
+        self.energy = 0.0
+
+        # lattice variables
+        self.nlattice = 0 # number of lattice point charges
+        self.clattice = [] # list of lattice coordinates
+        self.lattice = [] # list of lattice charges
+        self.lattice_field = psi4.QMMM() # Psi4 chargefield
 
 
-def mdi_run():
-    psi4.core.print_out("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n")
+
+
+def mdi():
+    """ Begin functioning as an MDI engine
+
+#    Arguments:
+#        molecule: Initial molecule
+#        serverdata: Configuration where to connect to ipi
+#        options: LOT, multiplicity and charge
+    """
+    core.print_out("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n")
     pass

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -34,10 +34,17 @@ import psi4
 import numpy as np
 import qcelemental as qcel
 
-from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
-from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command
-from MDI_Library.mdi import MDI_INT, MDI_DOUBLE
-from MDI_Library.mdi import MDI_Register_Node, MDI_Register_Command
+try:
+    # Attempt to use an internal build of MDI
+    from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
+        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
+        MDI_Register_Node, MDI_Register_Command
+except ImportError:
+    # Attempt to use an installed MDI package
+    from mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
+        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
+        MDI_Register_Node, MDI_Register_Command
+
 
 try:
     from mpi4py import MPI

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -35,9 +35,8 @@ import numpy as np
 import qcelemental as qcel
 
 from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
-from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_Conversion_Factor
+from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_DOUBLE_NUMPY
 from MDI_Library.mdi import MDI_INT, MDI_DOUBLE, MDI_CHAR, MDI_COMMAND_LENGTH
-from MDI_Library.mdi import MDI_DOUBLE_NUMPY
 
 try:
     from mpi4py import MPI

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -355,11 +355,7 @@ class MDIEngine():
 
         :returns: *command_string* String containing the name of each supported command
         """
-        command_string = ""
-        for command in self.commands:
-            command_string += command
-            for i in range(len(command), MDI_COMMAND_LENGTH):
-                command_string += " "
+        command_string = "".join([f"{c:{MDI_COMMAND_LENGTH}}" for c in self.commands.keys()])
 
         MDI_Send(command_string, len(command_string), MDI_CHAR, self.comm)
         return command_string

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -103,7 +103,11 @@ class MDIEngine():
                           ( "SCF", self.run_scf ), 
                           ( "<DIMENSIONS", self.send_dimensions ), 
                           ( "<NCOMMANDS", self.send_ncommands ), 
-                          ( "<COMMANDS", self.send_commands ),
+                          ( "<COMMANDS", self.send_commands ), 
+                          ( "<TOTCHARGE", self.send_total_charge ), 
+                          ( ">TOTCHARGE", self.recv_total_charge ), 
+                          ( "<ELEC_MULT", self.send_multiplicity ), 
+                          ( ">ELEC_MULT", self.recv_multiplicity ), 
                           ( "EXIT", self.exit ) ]
 
     def length_conversion(self):
@@ -286,6 +290,34 @@ class MDIEngine():
 
         print("COMMANDS: " + str(len(command_string)) + " " + str(command_string))
         MDI_Send(command_string, len(command_string), MDI_CHAR, self.comm)
+
+    # respond to the <TOTCHARGE command
+    def send_total_charge(self):
+        """ Send the total system charge through MDI
+        """
+        charge = self.molecule.molecular_charge()
+        MDI_Send(charge, 1, MDI_DOUBLE, self.comm)
+
+    # respond to the >TOTCHARGE command
+    def recv_total_charge(self):
+        """ Receive the total system charge through MDI
+        """
+        charge = MDI_Recv(1, MDI_DOUBLE, self.comm)
+        self.molecule.set_molecular_charge( int(round(charge)) )
+
+    # respond to the <ELEC_MULT command
+    def send_multiplicity(self):
+        """ Send the electronic multiplicity through MDI
+        """
+        multiplicity = self.molecule.multiplicity()
+        MDI_Send(multiplicity, 1, MDI_INT, self.comm)
+
+    # respond to the >ELEC_MULT command
+    def recv_multiplicity(self):
+        """ Receive the electronic multiplicity through MDI
+        """
+        multiplicity = MDI_Recv(1, MDI_INT, self.comm)
+        self.molecule.set_multiplicity( multiplicity )
 
     # respond to the EXIT command
     def exit(self):

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -30,9 +30,6 @@ For details regarding MDI, see https://molssi.github.io/MDI_Library/html/index.h
 
 """
 import psi4
-from psi4.driver import p4util
-from psi4.driver import driver
-from psi4.driver.p4util.exceptions import *
 
 from MDI_Library.mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator
 from MDI_Library.mdi import MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_Conversion_Factor
@@ -115,7 +112,6 @@ class MDIEngine():
         """ Obtain the conversion factor between the geometry specification units and bohr
         """
         unit_name = self.molecule.units()
-        unit_conv = 1.0
         if unit_name == "Angstrom":
             unit_conv = MDI_Conversion_Factor("bohr","angstrom")
         elif unit_name == "Bohr":
@@ -383,7 +379,7 @@ class MDIEngine():
             if use_mpi4py:
                 command = self.mpi_world.bcast(command, root=0)
             if self.world_rank == 0:
-                core.print_out('\nMDI command received: ' + str(command) + ' \n')
+                psi4.core.print_out('\nMDI command received: ' + str(command) + ' \n')
 
             # search for this command in self.commands
             found_command = False

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -241,10 +241,11 @@ class MDIEngine():
         """ Set a field of lattice point charges using information received through MDI
         """
         self.lattice_field = psi4.QMMM()
+        unit_conv = self.length_conversion()
         for ilat in range(self.nlattice):
-            latx = self.clattice[3*ilat+0]
-            laty = self.clattice[3*ilat+1]
-            latz = self.clattice[3*ilat+2]
+            latx = self.clattice[3*ilat+0] * unit_conv
+            laty = self.clattice[3*ilat+1] * unit_conv
+            latz = self.clattice[3*ilat+2] * unit_conv
             self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
         psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
 

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -79,6 +79,8 @@ parser.add_argument("--json", action='store_true',
                     help="Runs a JSON input file. !Warning! depcrated option in 1.4, use --qcschema instead.")
 parser.add_argument("-t", "--test", nargs='?', const='smoke', default=None,
                     help="Runs pytest tests. If `pytest-xdist` installed, parallel with `--nthread`.")
+parser.add_argument("--mdi", default=None,
+                    help="Sets MDI configuration options")
 
 # For plugins
 parser.add_argument("--plugin-name", help="""\
@@ -234,6 +236,10 @@ psi4.extras._input_dir_ = os.path.dirname(os.path.abspath(args["input"]))
 if args["qcschema"] is False:
     psi4.print_header()
 start_time = datetime.datetime.now()
+
+# Initialize MDI
+if args["mdi"] is not None:
+    psi4.mdi_engine.mdi_init(args["mdi"])
 
 # Prepare scratch for inputparser
 if args["scratch"] is not None:

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -3,6 +3,7 @@ from qcelemental.testing import compare, compare_recursive, compare_values, tnm
 
 import psi4
 
+
 def test_mdi_water():
 
     psi4.geometry("""
@@ -13,9 +14,9 @@ def test_mdi_water():
     """)
 
     psi4.set_options({
-            'reference': 'uhf',
-            'scf_type': 'direct',
-            'e_convergence': 1e-12,
+        'reference': 'uhf',
+        'scf_type': 'direct',
+        'e_convergence': 1e-12,
     })
 
     scf_method = "scf/cc-pVDZ"
@@ -29,29 +30,35 @@ def test_mdi_water():
 
     # Test the <COORDS command
     coords = engine.send_coords()
-    expected = [0.0, 0.0, -0.12947688966627896, 0.0, -1.4941867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
-    assert compare_values( expected, coords, atol=1.e-7 )
+    expected = [
+        0.0, 0.0, -0.12947688966627896, 0.0, -1.4941867446308548, 1.027446098871551, 0.0, 1.4941867446308548,
+        1.027446098871551
+    ]
+    assert compare_values(expected, coords, atol=1.e-7)
 
     # Test the >COORDS command
-    expected = [0.1, 0.0, -0.12947688966627896, 0.0, -1.4341867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
+    expected = [
+        0.1, 0.0, -0.12947688966627896, 0.0, -1.4341867446308548, 1.027446098871551, 0.0, 1.4941867446308548,
+        1.027446098871551
+    ]
     engine.recv_coords(expected)
     coords = engine.send_coords()
-    assert compare_values( expected, coords, atol=1.e-7 )
+    assert compare_values(expected, coords, atol=1.e-7)
 
     # Test the <CHARGES command
     charges = engine.send_charges()
     expected = [8.0, 1.0, 1.0]
-    assert compare_values( expected, charges, atol=1.e-7 )
+    assert compare_values(expected, charges, atol=1.e-7)
 
     # Test the <ELEMENTS command
     elements = engine.send_elements()
     expected = [8.0, 1.0, 1.0]
-    assert compare_values( expected, elements, atol=1.e-7 )
+    assert compare_values(expected, elements, atol=1.e-7)
 
     # Test the <MASSES command
     masses = engine.send_masses()
     expected = [15.99491461957, 1.00782503223, 1.00782503223]
-    assert compare_values( expected, masses, atol=1.e-7 )
+    assert compare_values(expected, masses, atol=1.e-7)
 
     # Test the SCF command
     engine.run_scf()
@@ -59,25 +66,26 @@ def test_mdi_water():
     # Test the <ENERGY command
     energy = engine.send_energy()
     expected = -76.02320201768676
-    assert compare_values( expected, energy, atol=1.e-7 )
+    assert compare_values(expected, energy, atol=1.e-7)
 
     # Test the <FORCES command
     forces = engine.send_forces()
-    expected = [0.004473733542292732, -0.01775852359379196, -0.051757651796320636, 
-                -0.0016762687719661835, -0.024093270269019917, 0.019393138772564877, 
-                -0.0027974647702799747, 0.04185179386282589, 0.03236451302360538]
-    assert compare_values( expected, forces, atol=1.e-7 )
+    expected = [
+        0.004473733542292732, -0.01775852359379196, -0.051757651796320636, -0.0016762687719661835,
+        -0.024093270269019917, 0.019393138772564877, -0.0027974647702799747, 0.04185179386282589, 0.03236451302360538
+    ]
+    assert compare_values(expected, forces, atol=1.e-7)
 
     # Test the >MASSES command
     expected = [15.99491461957, 3.0, 2.0]
     engine.recv_masses(expected)
     masses = engine.send_masses()
-    assert compare_values( expected, masses, atol=1.e-7 )
+    assert compare_values(expected, masses, atol=1.e-7)
 
     # Test the <DIMENSIONS command
     expected = [1, 1, 1]
     dimensions = engine.send_dimensions()
-    assert compare_values( expected, dimensions, atol=1.e-7 )
+    assert compare_values(expected, dimensions, atol=1.e-7)
 
     # Test the <NCOMMANDS command
     ncommands = engine.send_ncommands()
@@ -88,29 +96,29 @@ def test_mdi_water():
     # Test the <TOTCHARGE command
     totcharge = engine.send_total_charge()
     expected = 0.0
-    assert compare_values( expected, totcharge, atol=1.e-7 )
+    assert compare_values(expected, totcharge, atol=1.e-7)
 
     # Test the >TOTCHARGE command
     expected = 1.0
     engine.recv_total_charge(expected)
     totcharge = engine.send_total_charge()
-    assert compare_values( expected, totcharge, atol=1.e-7 )
+    assert compare_values(expected, totcharge, atol=1.e-7)
 
     # Test the <ELEC_MULT command
     multiplicity = engine.send_multiplicity()
     expected = 1
-    assert compare_values( expected, multiplicity, atol=1.e-7 )
+    assert compare_values(expected, multiplicity, atol=1.e-7)
 
     # Test the >ELEC_MULT command
     expected = 2
     engine.recv_multiplicity(expected)
     multiplicity = engine.send_multiplicity()
-    assert compare_values( expected, multiplicity, atol=1.e-7 )
+    assert compare_values(expected, multiplicity, atol=1.e-7)
 
     # Test the >NLATTICE, >CLATTICE, and >LATTICE commands
     nlattice = 2
-    clattice = [ -3.0, 1.0, 0.0, 4.0, 3.0, 0.0 ]
-    lattice = [ -1.0, -0.5 ]
+    clattice = [-3.0, 1.0, 0.0, 4.0, 3.0, 0.0]
+    lattice = [-1.0, -0.5]
     engine.recv_nlattice(nlattice)
     engine.recv_clattice(clattice)
     engine.recv_lattice(lattice)
@@ -119,12 +127,13 @@ def test_mdi_water():
     engine.run_scf()
     energy = engine.send_energy()
     expected = -76.032853528
-    assert compare_values( expected, energy, atol=1.e-7 )
+    assert compare_values(expected, energy, atol=1.e-7)
     forces = engine.send_forces()
-    expected = [0.032658205591954814, -0.027256446310611037, -0.02211229050834887, 
-                0.01582812526594022, -0.009687716838968852, 0.011685251062047874, 
-                0.02635302048909935, 0.00831403427972563, 0.033873999955958245]
-    assert compare_values( expected, forces, atol=1.e-7 )
+    expected = [
+        0.032658205591954814, -0.027256446310611037, -0.02211229050834887, 0.01582812526594022, -0.009687716838968852,
+        0.011685251062047874, 0.02635302048909935, 0.00831403427972563, 0.033873999955958245
+    ]
+    assert compare_values(expected, forces, atol=1.e-7)
 
     # Test the EXIT command
     engine.exit()

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -1,0 +1,132 @@
+import pytest
+from qcelemental.testing import compare, compare_recursive, compare_values, tnm
+
+import psi4
+
+def test_mdi_water():
+
+    psi4.geometry("""
+    0 1
+    O
+    H 1 1.0
+    H 1 1.0 2 104.5
+    """)
+
+    psi4.set_options({
+            'reference': 'uhf',
+            'scf_type': 'direct',
+    })
+
+    scf_method = "scf/cc-pVDZ"
+
+    psi4.mdi_engine.mdi_init("-role DRIVER -name Psi4 -method TEST")
+    engine = psi4.mdi_engine.MDIEngine(scf_method)
+
+    # Test the <NATOMS command
+    natom = engine.send_natoms()
+    assert natom == 3
+
+    # Test the <COORDS command
+    coords = engine.send_coords()
+    expected = [0.0, 0.0, -0.12947688966627896, 0.0, -1.4941867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
+    assert compare_values( expected, coords, atol=1.e-7 )
+
+    # Test the >COORDS command
+    expected = [0.1, 0.0, -0.12947688966627896, 0.0, -1.4341867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
+    engine.recv_coords(expected)
+    coords = engine.send_coords()
+    assert compare_values( expected, coords, atol=1.e-7 )
+
+    # Test the <CHARGES command
+    charges = engine.send_charges()
+    expected = [8.0, 1.0, 1.0]
+    assert compare_values( expected, charges, atol=1.e-7 )
+
+    # Test the <ELEMENTS command
+    elements = engine.send_elements()
+    expected = [8.0, 1.0, 1.0]
+    assert compare_values( expected, elements, atol=1.e-7 )
+
+    # Test the <MASSES command
+    masses = engine.send_masses()
+    expected = [15.99491461957, 1.00782503223, 1.00782503223]
+    assert compare_values( expected, masses, atol=1.e-7 )
+
+    # Test the SCF command
+    engine.run_scf()
+
+    # Test the <ENERGY command
+    energy = engine.send_energy()
+    expected = -76.02320201768676
+    assert compare_values( expected, energy, atol=1.e-7 )
+
+    # Test the <FORCES command
+    forces = engine.send_forces()
+    expected = [0.004473733542292732, -0.01775852359379196, -0.051757651796320636, 
+                -0.0016762687719661835, -0.024093270269019917, 0.019393138772564877, 
+                -0.0027974647702799747, 0.04185179386282589, 0.03236451302360538]
+    assert compare_values( expected, forces, atol=1.e-7 )
+
+    # Test the >MASSES command
+    expected = [15.99491461957, 3.0, 2.0]
+    engine.recv_masses(expected)
+    masses = engine.send_masses()
+    assert compare_values( expected, masses, atol=1.e-7 )
+
+    # Test the <DIMENSIONS command
+    expected = [1, 1, 1]
+    dimensions = engine.send_dimensions()
+    assert compare_values( expected, dimensions, atol=1.e-7 )
+
+    # Test the <NCOMMANDS command
+    ncommands = engine.send_ncommands()
+
+    # Test the <COMMANDS command
+    commands = engine.send_commands()
+
+    # Test the <TOTCHARGE command
+    totcharge = engine.send_total_charge()
+    expected = 0.0
+    assert compare_values( expected, totcharge, atol=1.e-7 )
+
+    # Test the >TOTCHARGE command
+    expected = 1.0
+    engine.recv_total_charge(expected)
+    totcharge = engine.send_total_charge()
+    assert compare_values( expected, totcharge, atol=1.e-7 )
+
+    # Test the <ELEC_MULT command
+    multiplicity = engine.send_multiplicity()
+    expected = 1
+    assert compare_values( expected, multiplicity, atol=1.e-7 )
+
+    # Test the >ELEC_MULT command
+    expected = 2
+    engine.recv_multiplicity(expected)
+    multiplicity = engine.send_multiplicity()
+    assert compare_values( expected, multiplicity, atol=1.e-7 )
+
+    # Test the >NLATTICE, >CLATTICE, and >LATTICE commands
+    nlattice = 2
+    expected = [0.1, 0.0, -0.12947688966627896, 0.0, -1.4341867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
+    clattice = [ -3.0, 1.0, 0.0, 4.0, 3.0, 0.0 ]
+    lattice = [ -1.0, -0.5 ]
+    engine.recv_nlattice(nlattice)
+    engine.recv_clattice(clattice)
+    engine.recv_lattice(lattice)
+
+    # Test the final energy
+    engine.run_scf()
+    energy = engine.send_energy()
+    expected = -75.849720155
+    assert compare_values( expected, energy, atol=1.e-7 )
+    forces = engine.send_forces()
+    expected = [0.0035613224585257022, -0.016598297018046902, -0.017280423215642285, 
+                0.007362641893430897, 0.006549235194699597, 0.004369283420143519, 
+                0.010069470231969673, -0.0001476166993489153, 0.01776306875176103]
+    assert compare_values( expected, forces, atol=1.e-7 )
+
+    # Test the EXIT command
+    engine.exit()
+
+    return 0

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -15,6 +15,7 @@ def test_mdi_water():
     psi4.set_options({
             'reference': 'uhf',
             'scf_type': 'direct',
+            'e_convergence': 1e-12,
     })
 
     scf_method = "scf/cc-pVDZ"
@@ -108,7 +109,6 @@ def test_mdi_water():
 
     # Test the >NLATTICE, >CLATTICE, and >LATTICE commands
     nlattice = 2
-    expected = [0.1, 0.0, -0.12947688966627896, 0.0, -1.4341867446308548, 1.027446098871551, 0.0, 1.4941867446308548, 1.027446098871551]
     clattice = [ -3.0, 1.0, 0.0, 4.0, 3.0, 0.0 ]
     lattice = [ -1.0, -0.5 ]
     engine.recv_nlattice(nlattice)
@@ -118,12 +118,12 @@ def test_mdi_water():
     # Test the final energy
     engine.run_scf()
     energy = engine.send_energy()
-    expected = -75.849720155
+    expected = -76.032853528
     assert compare_values( expected, energy, atol=1.e-7 )
     forces = engine.send_forces()
-    expected = [0.0035613224585257022, -0.016598297018046902, -0.017280423215642285, 
-                0.007362641893430897, 0.006549235194699597, 0.004369283420143519, 
-                0.010069470231969673, -0.0001476166993489153, 0.01776306875176103]
+    expected = [0.032658205591954814, -0.027256446310611037, -0.02211229050834887, 
+                0.01582812526594022, -0.009687716838968852, 0.011685251062047874, 
+                0.02635302048909935, 0.00831403427972563, 0.033873999955958245]
     assert compare_values( expected, forces, atol=1.e-7 )
 
     # Test the EXIT command

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -3,6 +3,7 @@ from qcelemental.testing import compare, compare_recursive, compare_values, tnm
 
 import psi4
 
+pytestmark = [pytest.mark.quick, pytest.mark.mdi]
 
 def test_mdi_water():
 
@@ -126,12 +127,12 @@ def test_mdi_water():
     # Test the final energy
     engine.run_scf()
     energy = engine.send_energy()
-    expected = -76.032853528
+    expected = -76.03284774075954
     assert compare_values(expected, energy, atol=1.e-6)
     forces = engine.send_forces()
     expected = [
-        0.032658205591954814, -0.027256446310611037, -0.02211229050834887, 0.01582812526594022, -0.009687716838968852,
-        0.011685251062047874, 0.02635302048909935, 0.00831403427972563, 0.033873999955958245
+        0.032656171616, -0.027255620629, -0.02211206073, 0.015827924001, -0.009687198705,
+        0.011685024025, 0.026352703866, 0.008313469614, 0.033873286169,
     ]
     assert compare_values(expected, forces, atol=1.e-6)
 

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -88,12 +88,6 @@ def test_mdi_water():
     dimensions = engine.send_dimensions()
     assert compare_values(expected, dimensions, atol=1.e-7)
 
-    # Test the <NCOMMANDS command
-    ncommands = engine.send_ncommands()
-
-    # Test the <COMMANDS command
-    commands = engine.send_commands()
-
     # Test the <TOTCHARGE command
     totcharge = engine.send_total_charge()
     expected = 0.0

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -58,7 +58,7 @@ def test_mdi_water():
     # Test the <MASSES command
     masses = engine.send_masses()
     expected = [15.99491461957, 1.00782503223, 1.00782503223]
-    assert compare_values(expected, masses, atol=1.e-7)
+    assert compare_values(expected, masses, atol=1.e-6)
 
     # Test the SCF command
     engine.run_scf()
@@ -66,7 +66,7 @@ def test_mdi_water():
     # Test the <ENERGY command
     energy = engine.send_energy()
     expected = -76.02320201768676
-    assert compare_values(expected, energy, atol=1.e-7)
+    assert compare_values(expected, energy, atol=1.e-6)
 
     # Test the <FORCES command
     forces = engine.send_forces()
@@ -74,7 +74,7 @@ def test_mdi_water():
         0.004473733542292732, -0.01775852359379196, -0.051757651796320636, -0.0016762687719661835,
         -0.024093270269019917, 0.019393138772564877, -0.0027974647702799747, 0.04185179386282589, 0.03236451302360538
     ]
-    assert compare_values(expected, forces, atol=1.e-7)
+    assert compare_values(expected, forces, atol=1.e-6)
 
     # Test the >MASSES command
     expected = [15.99491461957, 3.0, 2.0]
@@ -127,13 +127,13 @@ def test_mdi_water():
     engine.run_scf()
     energy = engine.send_energy()
     expected = -76.032853528
-    assert compare_values(expected, energy, atol=1.e-7)
+    assert compare_values(expected, energy, atol=1.e-6)
     forces = engine.send_forces()
     expected = [
         0.032658205591954814, -0.027256446310611037, -0.02211229050834887, 0.01582812526594022, -0.009687716838968852,
         0.011685251062047874, 0.02635302048909935, 0.00831403427972563, 0.033873999955958245
     ]
-    assert compare_values(expected, forces, atol=1.e-7)
+    assert compare_values(expected, forces, atol=1.e-6)
 
     # Test the EXIT command
     engine.exit()


### PR DESCRIPTION
## Description
This PR enables Psi4 to interoperate on-the-fly with other codes via [The MolSSI Driver Interface (MDI)](https://github.com/MolSSI/MDI_Library).  MDI is an effort of [The MolSSI](https://molssi.org/) to improve and standardize the process of interoperating codes within the computational molecular sciences domain.

In particular, MDI supports interoperability within a driver-engine paradigm, in which a driver code controls the high-level operations of one or more engine codes, orchestrating complex calculations like QM/MM or advanced sampling.  This PR provides all functionality required for Psi4 to act as an MDI engine.  This makes it possible for external codes to exercise control over Psi4 in a manner similar to what is possible using Psi4’s existing API (albeit with a much smaller subset of the functionality), but with the advantage of cross-code generality (all MDI commands are defined by [The MDI Standard](https://molssi.github.io/MDI_Library/html/mdi_standard.html)) and the option of fast inter-code communication via the MPI or TCP/IP methods (selected by the user at runtime).

The PR adds [The MDI Library](https://molssi.github.io/MDI_Library/html/index.html), which handles the details of inter-code communication, as an external dependency.  The MDI Library compiles with CMake and has no additional requirements, although it will link to an MPI library if one is found.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Include the MDI Library as an external dependency
- [x] Add functionality for Psi4 to respond to MDI commands as defined by [The MDI Standard](https://molssi.github.io/MDI_Library/html/mdi_standard.html)
- [x] Add the --mdi command-line option, which causes Psi4 to run as an MDI engine.
- [ ] Document the use of Psi4 as an MDI Engine.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
