### PR TITLE
Fix SCF plugin python file

### DIFF
--- a/psi4/share/psi4/plugin/scf/pymodule.py.template
+++ b/psi4/share/psi4/plugin/scf/pymodule.py.template
@@ -57,7 +57,7 @@ def run_@plugin@(name, **kwargs):
     new_wfn = psi4.core.Wavefunction.build(@plugin@_molecule, psi4.core.get_global_option('BASIS'))
 
     @plugin@_wfn = psi4.core.plugin('@plugin@.so', new_wfn)
-    psi4.set_scalar_variable('CURRENT ENERGY', @plugin@_wfn.energy())
+    psi4.set_variable('CURRENT ENERGY', @plugin@_wfn.energy())
 
     if kwargs.get('ref_wfn', False):
         return (@plugin@_wfn, @plugin@_wfn.energy())


### PR DESCRIPTION
## Description
Simple fix for the SCF plugin template, to work with the new `set_variable` syntax.

## Questions
- [x] What about [these](https://github.com/psi4/psi4/blob/master/psi4/driver/driver_nbody.py#L295-L298)?  I only discovered them by grepping the codebase so I have no evidence to suggest they should be changed - it's probably the difference between the `wfn` or `core` namespaces, vs. the `psi4` namespace being used in the plugin snippet.


## Status
- [x] Ready for review
- [x] Ready for merge
