### PR TITLE
Close input file in basis set parser once it's not needed anymore

### DIFF
--- a/psi4/driver/qcdb/libmintsbasissetparser.py
+++ b/psi4/driver/qcdb/libmintsbasissetparser.py
@@ -64,13 +64,14 @@ class Gaussian94BasisSetParser(object):
         basis_separator = re.compile(r'^\s*\[\s*(.*?)\s*\]\s*$')
 
         # Loads an entire file.
-        if os.stat(filename).st_size == 0:
-            raise ValidationError("""BasisSetParser::parse: given filename '%s' is blank.""" % (filename))
         try:
-            with open(filename, 'r') as infile:
-                contents = infile.readlines()
+            infile = open(filename, 'r')
         except IOError:
             raise BasisSetFileNotFound("""BasisSetParser::parse: Unable to open basis set file: %s""" % (filename))
+        if os.stat(filename).st_size == 0:
+            raise ValidationError("""BasisSetParser::parse: given filename '%s' is blank.""" % (filename))
+        contents = infile.readlines()
+        infile.close()
 
         lines = []
         for text in contents:

--- a/psi4/driver/qcdb/libmintsbasissetparser.py
+++ b/psi4/driver/qcdb/libmintsbasissetparser.py
@@ -64,14 +64,13 @@ class Gaussian94BasisSetParser(object):
         basis_separator = re.compile(r'^\s*\[\s*(.*?)\s*\]\s*$')
 
         # Loads an entire file.
-        try:
-            infile = open(filename, 'r')
-        except IOError:
-            raise BasisSetFileNotFound("""BasisSetParser::parse: Unable to open basis set file: %s""" % (filename))
         if os.stat(filename).st_size == 0:
             raise ValidationError("""BasisSetParser::parse: given filename '%s' is blank.""" % (filename))
-        contents = infile.readlines()
-        infile.close()
+        try:
+            with open(filename, 'r') as infile:
+                contents = infile.readlines()
+        except IOError:
+            raise BasisSetFileNotFound("""BasisSetParser::parse: Unable to open basis set file: %s""" % (filename))
 
         lines = []
         for text in contents:

--- a/psi4/driver/qcdb/libmintsbasissetparser.py
+++ b/psi4/driver/qcdb/libmintsbasissetparser.py
@@ -71,6 +71,7 @@ class Gaussian94BasisSetParser(object):
         if os.stat(filename).st_size == 0:
             raise ValidationError("""BasisSetParser::parse: given filename '%s' is blank.""" % (filename))
         contents = infile.readlines()
+        infile.close()
 
         lines = []
         for text in contents:


### PR DESCRIPTION
# Description
Fixes warning message described on slack by iwatobipen:
```
/home/user/anaconda3/envs/chemo37/lib/python3.7/site-packages/psi4/driver/qcdb/libmintsbasisset.py:854: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/anaconda3/envs/chemo37/share/psi4/basis/aug-cc-pvdz.gbs' mode='r' encoding='UTF-8'>
  names[index] = parser.load_file(fullfilename)
```
as suggested by @loriab 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
