### PR TITLE
Fix libxc download location

### DIFF
--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -15,9 +15,9 @@ else()
         # Default: use a stable release tarball of libxc. To use the
         # development version of libxc, instead, comment the URL line,
         # and uncomment the GIT lines.
-        URL http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.4/libxc-4.3.4.tar.gz
-        #GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
-        #GIT_TAG master
+        #URL http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.4/libxc-4.3.4.tar.gz
+        GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
+        GIT_TAG 4.3.4
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -16,8 +16,9 @@ else()
         # development version of libxc, instead, comment the URL line,
         # and uncomment the GIT lines.
         #URL http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.4/libxc-4.3.4.tar.gz
-        GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
-        GIT_TAG 4.3.4
+        URL https://gitlab.com/libxc/libxc/-/archive/4.3.4/libxc-4.3.4.tar.gz
+        #GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
+        #GIT_TAG 4.3.4
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
## Description
Modify the download location away from the (temporarily?) defunct tddft.org, back to gitlab.

## Status
- [x] Ready for review
- [x] Ready for merge
