### PR TITLE
Crash program if electrons outside of RAS spaces.

### DIFF
--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -950,9 +950,10 @@ void CIWavefunction::set_ras_parameters() {
         }
         if (j > 0) nras2alp += j;
         if (j > CalcInfo_->ras_opi[1][i]) {
-            outfile->Printf("(set_ras_parms): detecting %d electrons ", j - CalcInfo_->ras_opi[1][i]);
+            outfile->Printf("(set_ras_parms): detecting %d alpha electrons ", j - CalcInfo_->ras_opi[1][i]);
             outfile->Printf("in RAS III for irrep %d.\n", i);
             outfile->Printf("Some parts of DETCI assume all elec in I and II\n");
+            throw PSIEXCEPTION("DETCI: electrons detected outside of active space.\n");
         }
     }
     /* beta electrons */
@@ -968,9 +969,10 @@ void CIWavefunction::set_ras_parameters() {
         }
         if (j > 0) nras2bet += j;
         if (j > CalcInfo_->ras_opi[1][i]) {
-            outfile->Printf("(set_ras_parms): detecting %d electrons ", j - CalcInfo_->ras_opi[1][i]);
+            outfile->Printf("(set_ras_parms): detecting %d beta electrons ", j - CalcInfo_->ras_opi[1][i]);
             outfile->Printf("in RAS III for irrep %d.\n", i);
             outfile->Printf("Some parts of DETCI assume all elec in I and II\n");
+            throw PSIEXCEPTION("DETCI: electrons detected outside of active space.\n");
         }
     }
 


### PR DESCRIPTION
## Description
At present the program prints a warning if electrons are outside the active space, and then later on crashes. This PR changes behavior so that the program terminates at once.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
