### PR TITLE
allow_pickle=True in np.save

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -300,7 +300,7 @@ def _core_wavefunction_to_file(wfn, filename=None):
 
     if filename is not None:
         if not filename.endswith('.npy'): filename += '.npy'
-        np.save(filename, wfn_data)
+        np.save(filename, wfn_data, allow_pickle=True)
 
     return wfn_data
 


### PR DESCRIPTION
## Description
EDIT: Sorry for no providing the re-producible example
I encountered a crash while using Psi4 python API with the following minimal code example
```python
import psi4

geo_str = """
He  0.000 0.000 -1.48169297
--
He  0.000 0.000  1.48169297
"""

dimer = psi4.geometry(geo_str)
rt_options = {
    "basis": "jun-cc-pvdz",
    "scf_type": "mem_df",
    "reference": "uhf",
    "basis_guess": "3-21G",
    "guess": "sad",
    "e_convergence": 1e-12,
    "d_convergence": 1e-12,
}
psi4.set_options(rt_options)

dimer.reset_point_group("c1")

# no ghost
subset_A = [2]
subset_B = [1]

# mon geometries
monomerA = dimer.extract_subsets(1, subset_A)
monomerA.set_name("Monomer A")

monomerB = dimer.extract_subsets(2, subset_B)
monomerB.set_name("Monomer B")

scf_e_A, wfnA = psi4.energy("SCF", return_wfn=True, molecule=monomerA)
scf_e_B, wfnB = psi4.energy("SCF", return_wfn=True, molecule=monomerB)

```
Runned as
```bash
python minimal.py
```
the output is
```python
Properties computed using the SCF density matrix

  Nuclear Dipole Moment: [e a0]
     X:     0.0000      Y:     0.0000      Z:    -5.6000

  Electronic Dipole Moment: [e a0]
     X:    -0.0000      Y:    -0.0000      Z:     5.5998

  Dipole Moment: [e a0]
     X:    -0.0000      Y:    -0.0000      Z:    -0.0002     Total:     0.0002

  Dipole Moment: [D]
     X:    -0.0000      Y:    -0.0000      Z:    -0.0005     Total:     0.0005

/home/filip/software/intel-parallel/intelpython3/lib/python3.6/site-packages/numpy/lib/npyio.py:538: FutureWarning: Object arrays will not be saved by default in the future because `allow_pickle` will default to False. You should add `allow_pickle=True` explicitly to elminate this warning.
  pickle_kwargs=pickle_kwargs)
Traceback (most recent call last):
  File "minimal.py", line 34, in <module>
    scf_e_A, wfnA = psi4.energy("SCF", return_wfn=True, molecule=monomerA)
  File "/home/filip/software/psi4-1.4rc-opt/lib/psi4/driver/driver.py", line 561, in energy
    wfn = procedures['energy'][lowername](lowername, molecule=molecule, **kwargs)
  File "/home/filip/software/psi4-1.4rc-opt/lib/psi4/driver/procrouting/proc.py", line 2058, in run_scf
    scf_wfn = scf_helper(name, post_scf=False, **kwargs)
  File "/home/filip/software/psi4-1.4rc-opt/lib/psi4/driver/procrouting/proc.py", line 1423, in scf_helper
    scf_wfn.to_file(write_filename)
  File "/home/filip/software/psi4-1.4rc-opt/lib/psi4/driver/p4util/python_helpers.py", line 303, in _core_wavefunction_to_file
    np.save(filename, wfn_data)
  File "/home/filip/software/intel-parallel/intelpython3/lib/python3.6/site-packages/numpy/lib/npyio.py", line 538, in save
    pickle_kwargs=pickle_kwargs)
  File "/home/filip/software/intel-parallel/intelpython3/lib/python3.6/site-packages/numpy/lib/format.py", line 637, in write_array
    raise ValueError("Object arrays cannot be saved when "
ValueError: Object arrays cannot be saved when allow_pickle=False
```
```python
> You should add allow_pickle=True explicitly to elminate this warning
```

Related to #1607 
NumPy version 1.6.2 provided with latest intel's python distro
After the proposed change the minimal.py passes through

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Patch the only np.save() with allow_pickle=True

## Status
- [x] Ready for review
- [x] Ready for merge
