### PR TITLE
adds missing mp3 energy variables to dfocc and occ

### DIFF
--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -2619,6 +2619,7 @@ void DFOCC::omp2_5_manager() {
 
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
     Emp3L = Emp3;
     EcorrL = Emp3L - Escf;
     Emp3L_old = Emp3;
@@ -2924,6 +2925,7 @@ void DFOCC::mp2_5_manager() {
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3 - Escf;
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
     Emp3L = Emp3;
 
     /* updates the wavefunction for checkpointing */

--- a/psi4/src/psi4/dfocc/manager_cd.cc
+++ b/psi4/src/psi4/dfocc/manager_cd.cc
@@ -2286,6 +2286,7 @@ void DFOCC::omp2_5_manager_cd() {
 
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
     Emp3L = Emp3;
     EcorrL = Emp3L - Escf;
     Emp3L_old = Emp3;
@@ -2578,6 +2579,7 @@ void DFOCC::mp2_5_manager_cd() {
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3 - Escf;
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
     Emp3L = Emp3;
 
 }  // end mp2_5_manager_cd

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -1314,6 +1314,7 @@ void OCCWave::omp2_5_manager() {
     outfile->Printf("\n");
 
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
 
     omp3_response_pdms();
     gfock();
@@ -1532,6 +1533,7 @@ void OCCWave::mp2_5_manager() {
 
     Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
     Process::environment.globals["CURRENT ENERGY"] = Emp3L;
     Process::environment.globals["CURRENT REFERENCE ENERGY"] = Eref;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;


### PR DESCRIPTION
## Description
Bug fix. Exports missing `MP3 TOTAL ENERGY` variable for `mp2.5` calculations. Expected by the `cbs` driver function.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
