### PR TITLE
printout of initial orbital occupations

### DIFF
--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1000,7 +1000,7 @@ void HF::guess() {
         guess_E = compute_initial_E();
 
     } else if (guess_type == "SAD") {
-        if (print_) outfile->Printf("  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.\n\n");
+        if (print_) outfile->Printf("  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).\n\n");
 
         // Superposition of Atomic Density. Modified by Susi Lehtola
         // 2018-12-15 to work also for ROHF, as well as to allow using


### PR DESCRIPTION
## Description
Suggestion for #1711
Moves the `nmo` table to a place after the orbital guess, so that it actual contains all the information. Adds a reduced `nmo` table for SAD together with a note that no occupations are available.

_Formatting details up to debate_. Perhaps especially the placement of the `Pre-Iterations` line.

Edit: See updated examples in thread below

## Status
- [x] Ready for review
- [x] Ready for merge
