### PR TITLE
Issue cleanup: fix various crashes.

### DIFF
--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -235,6 +235,8 @@ def nbody_gufunc(func, method_string, **kwargs):
             raise ValidationError("N-Body GUFunc: bsse_type '%s' is not recognized" % btype.lower())
 
     metadata['max_nbody'] = kwargs.get('max_nbody', -1)
+    if metadata['molecule'].nfragments() == 1:
+        raise ValidationError("N-Body requires active molecule to have more than 1 fragment.")
     metadata['max_frag'] = metadata['molecule'].nfragments()
     if metadata['max_nbody'] == -1:
         metadata['max_nbody'] = metadata['molecule'].nfragments()

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -795,11 +795,11 @@ class BasisSet(object):
                     raise BasisSetNotDefined("""BasisSet::construct: No basis set specified for %s and %s.""" %
                         (symbol, key))
                 else:
-                    # No auxiliary basis set for atom, so try darnedest to find one.
+                    # No auxiliary / decon basis set for atom, so try darnedest to find one.
                     #   This involves querying the BasisFamily for default and
                     #   default-default and finally the universal default (defined
                     #   in this function). Since user hasn't indicated any specifics,
-                    #   look only in Psi4's library and for symbol only, not label.
+                    #   look for symbol only, not label.
                     tmp = []
                     tmp.append(corresponding_basis(basdict['BASIS'], deffit))
                     #NYI#tmp.append(corresponding_basis(basdict['BASIS'], deffit + '-DEFAULT'))
@@ -808,7 +808,7 @@ class BasisSet(object):
                         tmp.append(univdef[deffit])
                     seek['basis'] = [item for item in tmp if item != (None, None, None)]
                     seek['entry'] = [symbol]
-                    seek['path'] = libraryPath
+                    seek['path'] = basisPath
                     seek['strings'] = ''
             else:
                 # User (I hope ... dratted has_changed) has set basis for atom,

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2221,100 +2221,109 @@ std::vector<std::string> Molecule::irrep_labels() {
     return irreplabel;
 }
 
-Vector3 Molecule::xyz(int atom) const { 
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
-    return input_units_to_au_ * atoms_[atom]->compute(); 
+void Molecule::check_atom_(int atom, bool full) const  {
+    if (full && atom >= full_atoms_.size()) {
+        throw std::runtime_error("Requested atom doesn't exist in full atoms list.");
+    }
+    if (not full && atom >= atoms_.size()) {
+        throw std::runtime_error("Requested atom doesn't exist in atoms list.");
+    }
+}
+
+Vector3 Molecule::xyz(int atom) const {
+    check_atom_(atom, false);
+    return input_units_to_au_ * atoms_[atom]->compute();
 }
 
 Vector3 Molecule::fxyz(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return input_units_to_au_ * full_atoms_[atom]->compute();
 }
 
 double Molecule::xyz(int atom, int _xyz) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return input_units_to_au_ * atoms_[atom]->compute()[_xyz];
 }
 
 const double &Molecule::Z(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
-    return atoms_[atom]->Z(); 
+    check_atom_(atom, false);
+    return atoms_[atom]->Z();
 }
 
 double Molecule::fZ(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return full_atoms_[atom]->Z();
 }
 
 double Molecule::x(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return input_units_to_au_ * atoms_[atom]->compute()[0];
 }
 
 double Molecule::y(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return input_units_to_au_ * atoms_[atom]->compute()[1];
 }
 
 double Molecule::z(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return input_units_to_au_ * atoms_[atom]->compute()[2];
 }
 
 double Molecule::fx(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return input_units_to_au_ * full_atoms_[atom]->compute()[0];
 }
 
 double Molecule::fy(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
-    return input_units_to_au_ * full_atoms_[atom]->compute()[1]; 
+    check_atom_(atom, true);
+    return input_units_to_au_ * full_atoms_[atom]->compute()[1];
 }
 
 double Molecule::fz(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return input_units_to_au_ * full_atoms_[atom]->compute()[2];
 }
 
 double Molecule::charge(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return atoms_[atom]->charge();
 }
 
 double Molecule::fcharge(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return full_atoms_[atom]->charge();
 }
 
 int Molecule::mass_number(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return atoms_[atom]->A();
 }
 
 int Molecule::fmass_number(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return full_atoms_[atom]->A();
 }
 
 void Molecule::set_nuclear_charge(int atom, double newZ) {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     atoms_[atom]->set_nuclear_charge(newZ);
 }
 
 const std::string &Molecule::basis_on_atom(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return atoms_[atom]->basisset();
 }
 
 int Molecule::true_atomic_number(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     Element_to_Z Z;
     Z.load_values();
     return (int)Z[atoms_[atom]->symbol()];
 }
 
 int Molecule::ftrue_atomic_number(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     Element_to_Z Z;
     Z.load_values();
     return (int)Z[full_atoms_[atom]->symbol()];
@@ -2355,17 +2364,17 @@ void Molecule::set_shell_by_label(const std::string &label, const std::string &n
 }
 
 const std::shared_ptr<CoordEntry> &Molecule::atom_entry(int atom) const {
-    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, false);
     return atoms_[atom];
 }
 
 double Molecule::fmass(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return full_atoms_[atom]->mass();
 }
 
 std::string Molecule::flabel(int atom) const {
-    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    check_atom_(atom, true);
     return full_atoms_[atom]->label();
 }
 

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2221,7 +2221,7 @@ std::vector<std::string> Molecule::irrep_labels() {
     return irreplabel;
 }
 
-void Molecule::check_atom_(int atom, bool full) const  {
+void Molecule::check_atom_(int atom, bool full) const {
     if (full && atom >= full_atoms_.size()) {
         throw std::runtime_error("Requested atom doesn't exist in full atoms list.");
     }

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -2221,47 +2221,100 @@ std::vector<std::string> Molecule::irrep_labels() {
     return irreplabel;
 }
 
-Vector3 Molecule::xyz(int atom) const { return input_units_to_au_ * atoms_[atom]->compute(); }
+Vector3 Molecule::xyz(int atom) const { 
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * atoms_[atom]->compute(); 
+}
 
-Vector3 Molecule::fxyz(int atom) const { return input_units_to_au_ * full_atoms_[atom]->compute(); }
+Vector3 Molecule::fxyz(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * full_atoms_[atom]->compute();
+}
 
-double Molecule::xyz(int atom, int _xyz) const { return input_units_to_au_ * atoms_[atom]->compute()[_xyz]; }
+double Molecule::xyz(int atom, int _xyz) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * atoms_[atom]->compute()[_xyz];
+}
 
-const double &Molecule::Z(int atom) const { return atoms_[atom]->Z(); }
+const double &Molecule::Z(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return atoms_[atom]->Z(); 
+}
 
-double Molecule::fZ(int atom) const { return full_atoms_[atom]->Z(); }
+double Molecule::fZ(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return full_atoms_[atom]->Z();
+}
 
-double Molecule::x(int atom) const { return input_units_to_au_ * atoms_[atom]->compute()[0]; }
+double Molecule::x(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * atoms_[atom]->compute()[0];
+}
 
-double Molecule::y(int atom) const { return input_units_to_au_ * atoms_[atom]->compute()[1]; }
+double Molecule::y(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * atoms_[atom]->compute()[1];
+}
 
-double Molecule::z(int atom) const { return input_units_to_au_ * atoms_[atom]->compute()[2]; }
+double Molecule::z(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * atoms_[atom]->compute()[2];
+}
 
-double Molecule::fx(int atom) const { return input_units_to_au_ * full_atoms_[atom]->compute()[0]; }
+double Molecule::fx(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * full_atoms_[atom]->compute()[0];
+}
 
-double Molecule::fy(int atom) const { return input_units_to_au_ * full_atoms_[atom]->compute()[1]; }
+double Molecule::fy(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * full_atoms_[atom]->compute()[1]; 
+}
 
-double Molecule::fz(int atom) const { return input_units_to_au_ * full_atoms_[atom]->compute()[2]; }
+double Molecule::fz(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return input_units_to_au_ * full_atoms_[atom]->compute()[2];
+}
 
-double Molecule::charge(int atom) const { return atoms_[atom]->charge(); }
+double Molecule::charge(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return atoms_[atom]->charge();
+}
 
-double Molecule::fcharge(int atom) const { return full_atoms_[atom]->charge(); }
+double Molecule::fcharge(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return full_atoms_[atom]->charge();
+}
 
-int Molecule::mass_number(int atom) const { return atoms_[atom]->A(); }
+int Molecule::mass_number(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return atoms_[atom]->A();
+}
 
-int Molecule::fmass_number(int atom) const { return full_atoms_[atom]->A(); }
+int Molecule::fmass_number(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return full_atoms_[atom]->A();
+}
 
-void Molecule::set_nuclear_charge(int atom, double newZ) { atoms_[atom]->set_nuclear_charge(newZ); }
+void Molecule::set_nuclear_charge(int atom, double newZ) {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    atoms_[atom]->set_nuclear_charge(newZ);
+}
 
-const std::string &Molecule::basis_on_atom(int atom) const { return atoms_[atom]->basisset(); }
+const std::string &Molecule::basis_on_atom(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return atoms_[atom]->basisset();
+}
 
 int Molecule::true_atomic_number(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
     Element_to_Z Z;
     Z.load_values();
     return (int)Z[atoms_[atom]->symbol()];
 }
 
 int Molecule::ftrue_atomic_number(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
     Element_to_Z Z;
     Z.load_values();
     return (int)Z[full_atoms_[atom]->symbol()];
@@ -2301,11 +2354,20 @@ void Molecule::set_shell_by_label(const std::string &label, const std::string &n
     }
 }
 
-const std::shared_ptr<CoordEntry> &Molecule::atom_entry(int atom) const { return atoms_[atom]; }
+const std::shared_ptr<CoordEntry> &Molecule::atom_entry(int atom) const {
+    if (atom >= atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return atoms_[atom];
+}
 
-double Molecule::fmass(int atom) const { return full_atoms_[atom]->mass(); }
+double Molecule::fmass(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return full_atoms_[atom]->mass();
+}
 
-std::string Molecule::flabel(int atom) const { return full_atoms_[atom]->label(); }
+std::string Molecule::flabel(int atom) const {
+    if (atom >= full_atoms_.size()) throw std::runtime_error("Requested atom doesn't exist.");
+    return full_atoms_[atom]->label();
+}
 
 int Molecule::get_anchor_atom(const std::string &str, const std::string &line) {
     if (std::regex_match(str, reMatches_, integerNumber_)) {

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -277,6 +277,8 @@ class PSI_API Molecule {
     double xyz(int atom, int _xyz) const;
     /// Returns mass atom atom
     double mass(int atom) const;
+    /// Checks whether atom is within bounds of atom_ or full_atom_
+    void check_atom_(int atom, bool full) const;
 
     /// Set the mass of a particular atom (good for isotopic substitutions)
     void set_mass(int atom, double mass);

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -188,6 +188,8 @@ class PSI_API Molecule {
     bool zmat_;
     /// Whether this molecule has at least one cartesian entry
     bool cart_;
+    /// Checks whether atom is within bounds of atom_ or full_atom_
+    void check_atom_(int atom, bool full) const;
 
    public:
     Molecule();
@@ -277,8 +279,6 @@ class PSI_API Molecule {
     double xyz(int atom, int _xyz) const;
     /// Returns mass atom atom
     double mass(int atom) const;
-    /// Checks whether atom is within bounds of atom_ or full_atom_
-    void check_atom_(int atom, bool full) const;
 
     /// Set the mass of a particular atom (good for isotopic substitutions)
     void set_mass(int atom, double mass);


### PR DESCRIPTION
## Description
Resolves #1694 by throwing an exception when active molecule has only 1 fragment.
Resolves #1675 by throwing an exception when requested atom is out of bounds.
Resolves #1613 by changing the lookup path for AUX/DECON bases from `libraryPath` to `basisPath`.

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
