### PR TITLE
Add df_basis_sad to input parser

### DIFF
--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -697,7 +697,7 @@ def process_input(raw_input, print_level=1):
 
     # Process "basis name? { ... }"
     basis_block = re.compile(
-        r'^(\s*?)(basis|df_basis_scf|df_basis_mp2|df_basis_cc|df_basis_sapt)[=\s]*(\w*?)\s*\{(.*?)\}',
+        r'^(\s*?)(basis|df_basis_scf|df_basis_mp2|df_basis_cc|df_basis_sapt|df_basis_sad)[=\s]*(\w*?)\s*\{(.*?)\}',
         re.MULTILINE | re.DOTALL | re.IGNORECASE)
     temp = re.sub(basis_block, process_basis_block, temp)
 


### PR DESCRIPTION
### Description
The input processor now knows to apply basis syntax to `df_basis_sad`. This PR will need to go in before I can post a problematic (read: something is probably broken) SCF case.

## Checklist
- [x] Checked that input files with `df_basis_sad` now work

## Status
- [x] Ready for review
- [x] Ready for merge
