### PR TITLE
Restore DCFT Guess

### DIFF
--- a/psi4/src/psi4/dcft/dcft_compute.cc
+++ b/psi4/src/psi4/dcft/dcft_compute.cc
@@ -49,17 +49,16 @@ double DCFTSolver::compute_energy() {
     double total_energy = 0.0;
 
     if (options_.get_str("DCFT_GUESS") == "DCFT") {
-		// We're reusing DCFT files from a previous computation. Let's check that one exists.
-		if (!((same_a_b_orbs_ == true && psio_tocentry_exists(PSIF_DCFT_DPD, "Lambda SF <OO|VV>")) ||
-			(same_a_b_orbs_ == false && psio_tocentry_exists(PSIF_DCFT_DPD, "Lambda <Oo|Vv>")))) {
-			throw PSIEXCEPTION("Could not find a previous DCFT computation as the DCFT_GUESS=DCFT guess.");
-		}
-	}
-	else {
-		// Obliviate all old DCFT files.
-		psio_->close(PSIF_DCFT_DPD, 0);
-		psio_->open(PSIF_DCFT_DPD, PSIO_OPEN_OLD);
-	}
+        // We're reusing DCFT files from a previous computation. Let's check that one exists.
+        if (!((same_a_b_orbs_ == true && psio_tocentry_exists(PSIF_DCFT_DPD, "Lambda SF <OO|VV>")) ||
+              (same_a_b_orbs_ == false && psio_tocentry_exists(PSIF_DCFT_DPD, "Lambda <Oo|Vv>")))) {
+            throw PSIEXCEPTION("Could not find a previous DCFT computation as the DCFT_GUESS=DCFT guess.");
+        }
+    } else {
+        // Obliviate all old DCFT files.
+        psio_->close(PSIF_DCFT_DPD, 0);
+        psio_->open(PSIF_DCFT_DPD, PSIO_OPEN_OLD);
+    }
 
     if ((options_.get_str("SCF_TYPE").find("DF") != std::string::npos) || options_.get_str("SCF_TYPE") == "CD" ||
         options_.get_str("SCF_TYPE") == "DIRECT") {

--- a/psi4/src/psi4/dcft/dcft_compute_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_compute_RHF.cc
@@ -152,11 +152,11 @@ void DCFTSolver::run_simult_dcft_RHF() {
 
     // DIIS on orbitals (AA and BB) and cumulants (AA, AB, BB)
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda SF <OO|VV>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda <oo|vv>");
     diisManager.set_error_vector_size(5, DIISEntry::Matrix, scf_error_a_.get(), DIISEntry::Matrix, scf_error_b_.get(),
                                       DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);

--- a/psi4/src/psi4/dcft/dcft_compute_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_compute_UHF.cc
@@ -237,11 +237,11 @@ void DCFTSolver::run_twostep_dcft() {
 int DCFTSolver::run_twostep_dcft_cumulant_updates() {
     // Set up DIIS
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     DIISManager lambdaDiisManager(maxdiis_, "DCFT DIIS Lambdas", DIISManager::LargestError, DIISManager::InCore);
     if ((nalpha_ + nbeta_) > 1) {
@@ -437,11 +437,11 @@ void DCFTSolver::run_simult_dcft() {
     // Set up the DIIS manager
     DIISManager diisManager(maxdiis_, "DCFT DIIS vectors");
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     diisManager.set_error_vector_size(5, DIISEntry::Matrix, scf_error_a_.get(), DIISEntry::Matrix, scf_error_b_.get(),
                                       DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);

--- a/psi4/src/psi4/dcft/dcft_gradient_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_gradient_UHF.cc
@@ -109,11 +109,11 @@ void DCFTSolver::compute_gradient_dc() {
         // Set up DIIS extrapolation
         dpdbuf4 Zaa, Zab, Zbb, Raa, Rab, Rbb;
         dpdfile2 zaa, zbb, raa, rbb;
-        global_dpd_->buf4_init(&Zaa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+        global_dpd_->buf4_init(&Zaa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                                "Z <OO|VV>");
-        global_dpd_->buf4_init(&Zab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+        global_dpd_->buf4_init(&Zab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                                "Z <Oo|Vv>");
-        global_dpd_->buf4_init(&Zbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+        global_dpd_->buf4_init(&Zbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                                "Z <oo|vv>");
         global_dpd_->file2_init(&zaa, PSIF_DCFT_DPD, 0, ID('O'), ID('V'), "z <O|V>");
         global_dpd_->file2_init(&zbb, PSIF_DCFT_DPD, 0, ID('o'), ID('v'), "z <o|v>");
@@ -1893,11 +1893,11 @@ void DCFTSolver::iterate_cumulant_response() {
 
     // Set up DIIS extrapolation
     dpdbuf4 Zaa, Zab, Zbb, Raa, Rab, Rbb;
-    global_dpd_->buf4_init(&Zaa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+    global_dpd_->buf4_init(&Zaa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Z <OO|VV>");
-    global_dpd_->buf4_init(&Zab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&Zab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Z <Oo|Vv>");
-    global_dpd_->buf4_init(&Zbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+    global_dpd_->buf4_init(&Zbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Z <oo|vv>");
     DIISManager ZDiisManager(maxdiis_, "DCFT DIIS Z", DIISManager::LargestError, DIISManager::InCore);
     ZDiisManager.set_error_vector_size(3, DIISEntry::DPDBuf4, &Zaa, DIISEntry::DPDBuf4, &Zab, DIISEntry::DPDBuf4, &Zbb);
@@ -1976,14 +1976,12 @@ void DCFTSolver::iterate_cumulant_response() {
 void DCFTSolver::cumulant_response_guess() {
     dpdbuf4 Z, D, dC;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * Z_ijab += dC_ijab / D_ijab
      */
 
     // Z_IJAB += dC_IJAB / D_IJAB
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");
     global_dpd_->buf4_init(&dC, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "C <OO|VV> new - old");
@@ -1995,7 +1993,7 @@ void DCFTSolver::cumulant_response_guess() {
     global_dpd_->buf4_close(&Z);
 
     // Z_IjAb += dC_IjAb / D_IjAb
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "D <Oo|Vv>");
     global_dpd_->buf4_init(&dC, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "C <Oo|Vv> new - old");
@@ -2007,7 +2005,7 @@ void DCFTSolver::cumulant_response_guess() {
     global_dpd_->buf4_close(&Z);
 
     // Z_ijab += dC_ijab / D_ijab
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                            "D <oo|vv>");
     global_dpd_->buf4_init(&dC, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "C <oo|vv> new - old");
@@ -2017,8 +2015,6 @@ void DCFTSolver::cumulant_response_guess() {
     dpd_buf4_add(&Z, &dC, 1.0);
     global_dpd_->buf4_close(&dC);
     global_dpd_->buf4_close(&Z);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::build_perturbed_tau() {
@@ -2558,7 +2554,7 @@ void DCFTSolver::compute_cumulant_response_intermediates() {
     global_dpd_->buf4_init(&Zaa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Z <OO|VV>");
     // Temp_IJAB = Z_IJCB F_AC
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Zaa, &T, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     global_dpd_->buf4_close(&Zaa);
@@ -2581,7 +2577,7 @@ void DCFTSolver::compute_cumulant_response_intermediates() {
     global_dpd_->buf4_init(&Zaa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Z <OO|VV>");
     // Temp_IJAB = -Z_KJAB F_IK
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Zaa, &T, 1, 0, 0, -1.0, 0.0);
 
     global_dpd_->file2_close(&F_OO);
@@ -2600,19 +2596,19 @@ void DCFTSolver::compute_cumulant_response_intermediates() {
     global_dpd_->buf4_init(&F, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "F <Oo|Vv>");
     global_dpd_->buf4_init(&Zab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "Z <Oo|Vv>");
     // F_IjAb += Z_IjCb F_AC
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Zab, &F, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     // F_IjAb += Z_IjAc F_bc
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract424(&Zab, &F_vv, &F, 3, 1, 0, 1.0, 1.0);
     global_dpd_->file2_close(&F_vv);
     // F_IjAb -= Z_KjAb F_IK
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Zab, &F, 1, 0, 0, -1.0, 1.0);
     global_dpd_->file2_close(&F_OO);
     // F_IjAb -= Z_IkAb F_jk
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract424(&Zab, &F_oo, &F, 1, 1, 1, -1.0, 1.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Zab);
@@ -2622,7 +2618,7 @@ void DCFTSolver::compute_cumulant_response_intermediates() {
     global_dpd_->buf4_init(&Zbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Z <oo|vv>");
     // Temp_ijab = Z_ijcb F_ac
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract244(&F_vv, &Zbb, &T, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_vv);
     global_dpd_->buf4_close(&Zbb);
@@ -2645,7 +2641,7 @@ void DCFTSolver::compute_cumulant_response_intermediates() {
     global_dpd_->buf4_init(&Zbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Z <oo|vv>");
     // Temp_ijab = -Z_kjab X_ik
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract244(&F_oo, &Zbb, &T, 1, 0, 0, -1.0, 0.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Zbb);
@@ -3039,14 +3035,12 @@ double DCFTSolver::compute_cumulant_response_residual() {
 void DCFTSolver::update_cumulant_response() {
     dpdbuf4 Z, D, R;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * Z_ijab += R_ijab / D_ijab
      */
 
     // Z_IJAB += R_IJAB / D_IJAB
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0, "R <OO|VV>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -3057,7 +3051,7 @@ void DCFTSolver::update_cumulant_response() {
     global_dpd_->buf4_close(&Z);
 
     // Z_IjAb += R_IjAb / D_IjAb
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "D <Oo|Vv>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "R <Oo|Vv>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -3068,7 +3062,7 @@ void DCFTSolver::update_cumulant_response() {
     global_dpd_->buf4_close(&Z);
 
     // Z_ijab += R_ijab / D_ijab
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                            "D <oo|vv>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0, "R <oo|vv>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -3077,8 +3071,6 @@ void DCFTSolver::update_cumulant_response() {
     dpd_buf4_add(&Z, &R, 1.0);
     global_dpd_->buf4_close(&R);
     global_dpd_->buf4_close(&Z);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::compute_lagrangian_OO() {

--- a/psi4/src/psi4/dcft/dcft_integrals_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_integrals_RHF.cc
@@ -334,7 +334,7 @@ void DCFTSolver::build_denominators_RHF() {
     // Elements of the Fock matrix
     if (!exact_tau_) {
         // Alpha occupied
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
         global_dpd_->file2_mat_init(&F);
         int offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -350,7 +350,7 @@ void DCFTSolver::build_denominators_RHF() {
         global_dpd_->file2_close(&F);
 
         // Alpha Virtual
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
         global_dpd_->file2_mat_init(&F);
         offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -366,7 +366,7 @@ void DCFTSolver::build_denominators_RHF() {
         global_dpd_->file2_close(&F);
     }
 
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");
     for (int h = 0; h < nirrep_; ++h) {
         global_dpd_->buf4_mat_irrep_init(&D, h);

--- a/psi4/src/psi4/dcft/dcft_integrals_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_integrals_UHF.cc
@@ -634,7 +634,7 @@ void DCFTSolver::build_denominators() {
     // Alpha occupied
 
     if (!exact_tau_) {
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
         global_dpd_->file2_mat_init(&F);
         int offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -650,7 +650,7 @@ void DCFTSolver::build_denominators() {
         global_dpd_->file2_close(&F);
 
         // Alpha Virtual
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
         global_dpd_->file2_mat_init(&F);
         offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -692,7 +692,7 @@ void DCFTSolver::build_denominators() {
     // Beta Occupied
 
     if (!exact_tau_) {
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
         global_dpd_->file2_mat_init(&F);
         int offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -708,7 +708,7 @@ void DCFTSolver::build_denominators() {
         global_dpd_->file2_close(&F);
 
         // Beta Virtual
-        global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+        global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
         global_dpd_->file2_mat_init(&F);
         offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
@@ -732,7 +732,7 @@ void DCFTSolver::build_denominators() {
     ///////////////////////////////
     // The alpha-alpha spin case //
     ///////////////////////////////
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");
     for (int h = 0; h < nirrep_; ++h) {
         global_dpd_->buf4_mat_irrep_init(&D, h);
@@ -754,7 +754,7 @@ void DCFTSolver::build_denominators() {
     //////////////////////////////
     // The alpha-beta spin case //
     //////////////////////////////
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "D <Oo|Vv>");
     for (int h = 0; h < nirrep_; ++h) {
         global_dpd_->buf4_mat_irrep_init(&D, h);
@@ -776,7 +776,7 @@ void DCFTSolver::build_denominators() {
     /////////////////////////////
     // The beta-beta spin case //
     /////////////////////////////
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                            "D <oo|vv>");
     for (int h = 0; h < nirrep_; ++h) {
         global_dpd_->buf4_mat_irrep_init(&D, h);

--- a/psi4/src/psi4/dcft/dcft_intermediates_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_intermediates_RHF.cc
@@ -217,8 +217,6 @@ void DCFTSolver::compute_F_intermediate_RHF() {
     dpdfile2 F_OO, F_oo, F_VV, F_vv;
     dpdbuf4 F, Lab;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * F_ijab += P(ab) F_ca lambda_ijcb - P(ij) F_ki lambda_jkab
      */
@@ -228,30 +226,26 @@ void DCFTSolver::compute_F_intermediate_RHF() {
                            "Lambda SF <OO|VV>");  // Lambda <Oo|Vv>
 
     // F_IjAb += lambda_IjCb F_AC
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Lab, &F, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     // F_IjAb += lambda_IjAc F_bc
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");  // F <v|v>
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");  // F <v|v>
     global_dpd_->contract424(&Lab, &F_vv, &F, 3, 1, 0, 1.0, 1.0);
     global_dpd_->file2_close(&F_vv);
     // F_IjAb -= lambda_KjAb F_IK
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Lab, &F, 1, 0, 0, -1.0, 1.0);
     global_dpd_->file2_close(&F_OO);
     // F_IjAb -= lambda_IkAb F_jk
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");  // F <o|o>
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");  // F <o|o>
     global_dpd_->contract424(&Lab, &F_oo, &F, 1, 1, 1, -1.0, 1.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&F);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::form_density_weighted_fock_RHF() {
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     dpdfile2 T_OO, T_VV, F_OO, F_VV;
 
     global_dpd_->file2_init(&T_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "Tau <O|O>");
@@ -333,8 +327,8 @@ void DCFTSolver::form_density_weighted_fock_RHF() {
     // Alpha spin
     nso_Fa->back_transform(a_evecs);
 
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
 
     global_dpd_->file2_mat_init(&F_OO);
     global_dpd_->file2_mat_init(&F_VV);
@@ -362,8 +356,6 @@ void DCFTSolver::form_density_weighted_fock_RHF() {
     global_dpd_->file2_mat_wrt(&F_VV);
     global_dpd_->file2_close(&F_OO);
     global_dpd_->file2_close(&F_VV);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 }  // namespace dcft
 }  // namespace psi

--- a/psi4/src/psi4/dcft/dcft_intermediates_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_intermediates_UHF.cc
@@ -398,8 +398,6 @@ void DCFTSolver::compute_F_intermediate() {
     dpdfile2 F_OO, F_oo, F_VV, F_vv;
     dpdbuf4 F, T, Laa, Lab, Lbb;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * F_ijab += P(ab) F_ca lambda_ijcb - P(ij) F_ki lambda_jkab
      */
@@ -407,7 +405,7 @@ void DCFTSolver::compute_F_intermediate() {
     global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
     // Temp_IJAB = lambda_IJCB F_AC
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Laa, &T, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     global_dpd_->buf4_close(&Laa);
@@ -430,7 +428,7 @@ void DCFTSolver::compute_F_intermediate() {
     global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
     // Temp_IJAB = -lambda_KJAB F_IK
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Laa, &T, 1, 0, 0, -1.0, 0.0);
 
     global_dpd_->file2_close(&F_OO);
@@ -450,19 +448,19 @@ void DCFTSolver::compute_F_intermediate() {
     global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
     // F_IjAb += lambda_IjCb F_AC
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Lab, &F, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     // F_IjAb += lambda_IjAc F_bc
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract424(&Lab, &F_vv, &F, 3, 1, 0, 1.0, 1.0);
     global_dpd_->file2_close(&F_vv);
     // F_IjAb -= lambda_KjAb F_IK
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Lab, &F, 1, 0, 0, -1.0, 1.0);
     global_dpd_->file2_close(&F_OO);
     // F_IjAb -= lambda_IkAb F_jk
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract424(&Lab, &F_oo, &F, 1, 1, 1, -1.0, 1.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Lab);
@@ -472,7 +470,7 @@ void DCFTSolver::compute_F_intermediate() {
     global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     // Temp_ijab = lambda_ijcb F_ac
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract244(&F_vv, &Lbb, &T, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_vv);
     global_dpd_->buf4_close(&Lbb);
@@ -495,7 +493,7 @@ void DCFTSolver::compute_F_intermediate() {
     global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     // Temp_ijab = -lambda_kjab F_ik
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract244(&F_oo, &Lbb, &T, 1, 0, 0, -1.0, 0.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Lbb);
@@ -509,13 +507,9 @@ void DCFTSolver::compute_F_intermediate() {
     dpd_buf4_add(&F, &T, -1.0);
     global_dpd_->buf4_close(&T);
     global_dpd_->buf4_close(&F);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::form_density_weighted_fock() {
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     dpdfile2 T_OO, T_oo, T_VV, T_vv, F_OO, F_oo, F_VV, F_vv;
 
     global_dpd_->file2_init(&T_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "Tau <O|O>");
@@ -650,10 +644,10 @@ void DCFTSolver::form_density_weighted_fock() {
     Ftilde_a_->copy(nso_Fa);
     Ftilde_b_->copy(nso_Fb);
 
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
 
     global_dpd_->file2_mat_init(&F_OO);
     global_dpd_->file2_mat_init(&F_oo);
@@ -703,8 +697,6 @@ void DCFTSolver::form_density_weighted_fock() {
     global_dpd_->file2_close(&F_oo);
     global_dpd_->file2_close(&F_VV);
     global_dpd_->file2_close(&F_vv);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::compute_V_intermediate() {
@@ -2300,17 +2292,15 @@ void DCFTSolver::compute_W_intermediate() {
     compute_M_intermediate();
     compute_N_intermediate();
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     global_dpd_->file2_init(&T_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "T <O|O>");
     global_dpd_->file2_init(&T_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "T <o|o>");
     global_dpd_->file2_init(&T_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "T <V|V>");
     global_dpd_->file2_init(&T_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "T <v|v>");
 
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
 
     // Precompute Temp_im = 4 (Ft_il T_lm + T_il Ft_lm) - I_ilmk Ft_kl + 2 K_idmc Ft_cd
     global_dpd_->file2_init(&Temp_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "Temp <O|O>");
@@ -3407,21 +3397,17 @@ void DCFTSolver::compute_W_intermediate() {
     global_dpd_->buf4_close(&T);
 
     global_dpd_->buf4_close(&TT);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::compute_M_intermediate() {
     dpdbuf4 M, Laa, Lab, Lbb;
     dpdfile2 F_VV, F_vv;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     // M_IJAB = F_AC Lambda_IJCB
     global_dpd_->buf4_init(&M, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0, "M <OO|V'V>");
     global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Laa, &M, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     global_dpd_->buf4_close(&Laa);
@@ -3431,7 +3417,7 @@ void DCFTSolver::compute_M_intermediate() {
     global_dpd_->buf4_init(&M, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "M <Oo|V'v>");
     global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->file2_init(&F_VV, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F_VV, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->contract244(&F_VV, &Lab, &M, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_VV);
     global_dpd_->buf4_close(&Lab);
@@ -3441,7 +3427,7 @@ void DCFTSolver::compute_M_intermediate() {
     global_dpd_->buf4_init(&M, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "M <Oo|Vv'>");
     global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract424(&Lab, &F_vv, &M, 3, 1, 0, 1.0, 0.0);
     global_dpd_->file2_close(&F_vv);
     global_dpd_->buf4_close(&Lab);
@@ -3451,26 +3437,22 @@ void DCFTSolver::compute_M_intermediate() {
     global_dpd_->buf4_init(&M, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o,o]"), ID("[v,v]"), 0, "M <oo|v'v>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
-    global_dpd_->file2_init(&F_vv, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F_vv, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->contract244(&F_vv, &Lbb, &M, 1, 2, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_vv);
     global_dpd_->buf4_close(&Lbb);
     global_dpd_->buf4_close(&M);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 
 void DCFTSolver::compute_N_intermediate() {
     dpdbuf4 N, Laa, Lab, Lbb;
     dpdfile2 F_OO, F_oo;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     // N_IJAB = F_IK lambda_KJAB
     global_dpd_->buf4_init(&N, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0, "N <O'O|VV>");
     global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Laa, &N, 1, 0, 0, 1.0, 0.0);
     global_dpd_->file2_close(&F_OO);
     global_dpd_->buf4_close(&Laa);
@@ -3480,7 +3462,7 @@ void DCFTSolver::compute_N_intermediate() {
     global_dpd_->buf4_init(&N, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "N <O'o|Vv>");
     global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->file2_init(&F_OO, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F_OO, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->contract244(&F_OO, &Lab, &N, 1, 0, 0, 1.0, 0.0);
     global_dpd_->file2_close(&F_OO);
     global_dpd_->buf4_close(&Lab);
@@ -3490,7 +3472,7 @@ void DCFTSolver::compute_N_intermediate() {
     global_dpd_->buf4_init(&N, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "N <Oo'|Vv>");
     global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract424(&Lab, &F_oo, &N, 1, 1, 1, 1.0, 0.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Lab);
@@ -3500,13 +3482,11 @@ void DCFTSolver::compute_N_intermediate() {
     global_dpd_->buf4_init(&N, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o,o]"), ID("[v,v]"), 0, "N <o'o|vv>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
-    global_dpd_->file2_init(&F_oo, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F_oo, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->contract244(&F_oo, &Lbb, &N, 1, 0, 0, 1.0, 0.0);
     global_dpd_->file2_close(&F_oo);
     global_dpd_->buf4_close(&Lbb);
     global_dpd_->buf4_close(&N);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 }
 }  // namespace dcft
 }  // namespace psi

--- a/psi4/src/psi4/dcft/dcft_lambda_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_lambda_RHF.cc
@@ -88,14 +88,12 @@ void DCFTSolver::update_cumulant_jacobi_RHF() {
 
     dpdbuf4 L, D, R;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * Lambda_ijab += R_ijab / D_ijab
      */
 
     // L_IjAb += R_IjAb / D_IjAb
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");  // D <Oo|Vv>
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "R SF <OO|VV>");  // R <Oo|Vv>
@@ -115,8 +113,6 @@ void DCFTSolver::update_cumulant_jacobi_RHF() {
     global_dpd_->buf4_copy(&L, PSIF_DCFT_DPD, "Lambda <OO|VV>");
     global_dpd_->buf4_copy(&L, PSIF_DCFT_DPD, "Lambda <oo|vv>");
     global_dpd_->buf4_close(&L);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 
     dcft_timer_off("DCFTSolver::update_lambda_from_residual()");
 }

--- a/psi4/src/psi4/dcft/dcft_lambda_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_lambda_UHF.cc
@@ -202,14 +202,12 @@ void DCFTSolver::update_cumulant_jacobi() {
 
     dpdbuf4 L, D, R;
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     /*
      * Lambda_ijab += R_ijab / D_ijab
      */
 
     // L_IJAB += R_IJAB / D_IJAB
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "D <OO|VV>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0, "R <OO|VV>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -221,7 +219,7 @@ void DCFTSolver::update_cumulant_jacobi() {
     global_dpd_->buf4_close(&L);
 
     // L_IjAb += R_IjAb / D_IjAb
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "D <Oo|Vv>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "R <Oo|Vv>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -233,7 +231,7 @@ void DCFTSolver::update_cumulant_jacobi() {
     global_dpd_->buf4_close(&L);
 
     // L_IJAB += R_ijab / D_ijab
-    global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
+    global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                            "D <oo|vv>");
     global_dpd_->buf4_init(&R, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0, "R <oo|vv>");
     global_dpd_->buf4_dirprd(&D, &R);
@@ -243,8 +241,6 @@ void DCFTSolver::update_cumulant_jacobi() {
     dpd_buf4_add(&L, &R, 1.0);
     global_dpd_->buf4_close(&R);
     global_dpd_->buf4_close(&L);
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
 
     dcft_timer_off("DCFTSolver::update_lambda_from_residual()");
 }

--- a/psi4/src/psi4/dcft/dcft_memory.cc
+++ b/psi4/src/psi4/dcft/dcft_memory.cc
@@ -206,7 +206,7 @@ void DCFTSolver::init() {
  * Frees up the memory sequestered by the init_moinfo() and read_checkpoint() routines.
  */
 void DCFTSolver::finalize() {
-    psio_->close(PSIF_DCFT_DPD, 0);
+    psio_->close(PSIF_DCFT_DPD, 1);
     delete _ints;
 
     aocc_c_.reset();

--- a/psi4/src/psi4/dcft/dcft_mp2_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_mp2_RHF.cc
@@ -85,7 +85,7 @@ void DCFTSolver::mp2_guess_RHF() {
         global_dpd_->buf4_copy(&I, PSIF_DCFT_DPD, "Lambda SF <OO|VV>");  // Lambda <Oo|Vv>
         global_dpd_->buf4_close(&I);
 
-        global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+        global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                                "D <OO|VV>");  // D <Oo|Vv>
         global_dpd_->buf4_init(&I, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                                "Lambda SF <OO|VV>");  // Lambda <Oo|Vv>

--- a/psi4/src/psi4/dcft/dcft_mp2_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_mp2_UHF.cc
@@ -83,7 +83,7 @@ void DCFTSolver::mp2_guess() {
         global_dpd_->buf4_close(&I);
         global_dpd_->buf4_init(&I, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                                "Lambda <OO|VV>");
-        global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
+        global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                                "D <OO|VV>");
         global_dpd_->buf4_dirprd(&D, &I);
         global_dpd_->buf4_close(&I);
@@ -96,7 +96,7 @@ void DCFTSolver::mp2_guess() {
         global_dpd_->buf4_close(&I);
         global_dpd_->buf4_init(&I, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                                "Lambda <Oo|Vv>");
-        global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+        global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                                "D <Oo|Vv>");
         global_dpd_->buf4_dirprd(&D, &I);
         global_dpd_->buf4_close(&I);
@@ -109,7 +109,7 @@ void DCFTSolver::mp2_guess() {
         global_dpd_->buf4_close(&I);
         global_dpd_->buf4_init(&I, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                                "Lambda <oo|vv>");
-        global_dpd_->buf4_init(&D, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
+        global_dpd_->buf4_init(&D, PSIF_DCFT_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                                "D <oo|vv>");
         global_dpd_->buf4_dirprd(&D, &I);
         global_dpd_->buf4_close(&I);

--- a/psi4/src/psi4/dcft/dcft_oo_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_oo_RHF.cc
@@ -68,11 +68,11 @@ void DCFTSolver::run_simult_dcft_oo_RHF() {
 
     // DIIS on orbitals (AA and BB) and cumulants (AA, AB, BB)
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda SF <OO|VV>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Lambda <oo|vv>");
     diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
                                       orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,

--- a/psi4/src/psi4/dcft/dcft_oo_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_oo_UHF.cc
@@ -60,11 +60,11 @@ void DCFTSolver::run_simult_dcft_oo() {
     // Set up the DIIS manager
     DIISManager diisManager(maxdiis_, "DCFT DIIS vectors");
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
                                       orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,

--- a/psi4/src/psi4/dcft/dcft_qc.cc
+++ b/psi4/src/psi4/dcft/dcft_qc.cc
@@ -76,11 +76,11 @@ void DCFTSolver::run_qc_dcft() {
     // Set up the DIIS manager
     DIISManager diisManager(maxdiis_, "DCFT DIIS vectors");
     dpdbuf4 Laa, Lab, Lbb;
-    global_dpd_->buf4_init(&Laa, PSIF_LIBTRANS_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
+    global_dpd_->buf4_init(&Laa, PSIF_DCFT_DPD, 0, ID("[O>O]-"), ID("[V>V]-"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Lambda <OO|VV>");
-    global_dpd_->buf4_init(&Lab, PSIF_LIBTRANS_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
+    global_dpd_->buf4_init(&Lab, PSIF_DCFT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                            "Lambda <Oo|Vv>");
-    global_dpd_->buf4_init(&Lbb, PSIF_LIBTRANS_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
+    global_dpd_->buf4_init(&Lbb, PSIF_DCFT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Lambda <oo|vv>");
     diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
                                       orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,
@@ -230,10 +230,9 @@ void DCFTSolver::compute_orbital_gradient() {
     moFb_->transform(Cb_);
     // Update the Fock matrix DPD file2
     dpdfile2 F;
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
 
     // Alpha Occupied
-    global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "F <O|O>");
+    global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
     global_dpd_->file2_mat_init(&F);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
@@ -246,7 +245,7 @@ void DCFTSolver::compute_orbital_gradient() {
     global_dpd_->file2_close(&F);
 
     // Alpha Virtual
-    global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "F <V|V>");
+    global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
     global_dpd_->file2_mat_init(&F);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < navirpi_[h]; ++i) {
@@ -259,7 +258,7 @@ void DCFTSolver::compute_orbital_gradient() {
     global_dpd_->file2_close(&F);
 
     // Beta Occupied
-    global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "F <o|o>");
+    global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('o'), ID('o'), "F <o|o>");
     global_dpd_->file2_mat_init(&F);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nboccpi_[h]; ++i) {
@@ -272,7 +271,7 @@ void DCFTSolver::compute_orbital_gradient() {
     global_dpd_->file2_close(&F);
 
     // Beta Virtual
-    global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "F <v|v>");
+    global_dpd_->file2_init(&F, PSIF_DCFT_DPD, 0, ID('v'), ID('v'), "F <v|v>");
     global_dpd_->file2_mat_init(&F);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nbvirpi_[h]; ++i) {
@@ -283,8 +282,6 @@ void DCFTSolver::compute_orbital_gradient() {
     }
     global_dpd_->file2_mat_wrt(&F);
     global_dpd_->file2_close(&F);
-
-    psio_->close(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
 
     // Initialize the idempotent contribution to the OPDM (Kappa)
     if (!orbital_optimized_) {

--- a/psi4/src/psi4/dcft/dcft_scf_RHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_RHF.cc
@@ -45,8 +45,8 @@ namespace psi {
 namespace dcft {
 
 /**
- * Computes the initial Hartree-Fock orbitals by either reading them from the
- * checkpoint file or computing a core Hamiltonian guess
+ * Reads the orbitals and related quantities from the reference wavefunction
+ * and reads the one-electron integrals from PSIO.
  * for RHF reference.
  */
 void DCFTSolver::scf_guess_RHF() {
@@ -63,8 +63,6 @@ void DCFTSolver::scf_guess_RHF() {
 
     so_h_->add(T);
     so_h_->add(V);
-
-    std::string guess = options_.get_str("DCFT_GUESS");  // The default DCFT_GUESS is mp2
 
     epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
     epsilon_b_->copy(epsilon_a_.get());

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -293,8 +293,8 @@ void DCFTSolver::print_orbital_energies() {
 }
 
 /**
- * Computes the initial Hartree-Fock orbitals by either reading them from the
- * checkpoint file or computing a core Hamiltonian guess.
+ * Reads the orbitals and related quantities from the reference wavefunction
+ * and reads the one-electron integrals from PSIO.
  */
 void DCFTSolver::scf_guess() {
     dcft_timer_on("DCFTSolver::scf_guess");
@@ -311,7 +311,6 @@ void DCFTSolver::scf_guess() {
     so_h_->add(T);
     so_h_->add(V);
 
-    std::string guess = options_.get_str("DCFT_GUESS");
     epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
     epsilon_b_->copy(reference_wavefunction_->epsilon_b().get());
     Ca_->copy(reference_wavefunction_->Ca());

--- a/psi4/src/psi4/dcft/dcft_scf_UHF.cc
+++ b/psi4/src/psi4/dcft/dcft_scf_UHF.cc
@@ -1018,8 +1018,6 @@ void DCFTSolver::update_fock() {
 
     // Copy MO basis GTau to the memory
 
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
     // Alpha occupied
     global_dpd_->file2_init(&Gtau, PSIF_DCFT_DPD, 0, ID('O'), ID('O'), "GTau <O|O>");
     global_dpd_->file2_mat_init(&Gtau);
@@ -1082,8 +1080,6 @@ void DCFTSolver::update_fock() {
 
     // Write the MO basis Fock operator to the DPD file and update the denominators
     build_denominators();
-
-    psio_->close(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
 
     dcft_timer_off("DCFTSolver::update_fock");
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dcft-grad1 dcft-grad2
                   dcft-grad3 dcft-grad4 dcft1 dcft2 dcft3 dcft4 dcft5 dcft6
-                  dcft7 dcft8 dcft9 ao-dfcasscf-sp dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp
+                  dcft7 dcft8 dcft9 dcft10 ao-dfcasscf-sp dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp
                   dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1 dfccsd-t-grad1
                   dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-ecp dfmp2-fc dfmp2-grad1
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfomp2-1 dfomp2-2 dfomp2-3

--- a/tests/dcft10/CMakeLists.txt
+++ b/tests/dcft10/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dcft1 "psi;dcft")
+add_regression_test(dcft10 "psi;dcft")

--- a/tests/dcft10/CMakeLists.txt
+++ b/tests/dcft10/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dcft1 "psi;dcft")

--- a/tests/dcft10/input.dat
+++ b/tests/dcft10/input.dat
@@ -1,0 +1,34 @@
+#! The multiple guesses for DCT amplitudes for ODC-12.
+
+refodc12     = -5.7749813965267096 #TEST
+
+molecule he2 {
+    He
+    He 1 3.2
+}
+
+set {
+    r_convergence 12
+    ao_basis    none
+    algorithm   simultaneous
+    basis       6-31G**
+    df_scf_guess false
+    reference   uhf
+}
+
+set dcft_functional odc-12
+energy('dcft')
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dcft_guess cc
+energy('dcft')
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dcft_guess bcc
+wfn = energy('dcft', return_wfn=True)[1]
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dcft_guess dcft
+set dcft maxiter 3 
+energy('dcft', ref_wfn = wfn)
+compare_values(refodc12, variable("DCFT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST


### PR DESCRIPTION
## Description
While working on a _different_ PR for the dcft code, I stumbled across a bug that I had accidentally introduced in #1310. DCFT previously allowed you to use the amplitudes from a previous computation as your guess for the next one by setting `dcft_guess dcft`. Key to this mechanism was the fact that the LibDPD files persisted after the computation... which is precisely what I changed in #1310 to fix #1309, where intermediate files would interfere with the amplitude guess.

The primary purpose of this PR is to both keep the guess feature working and keep issue #1309 fixed. This is accomplished by checking if `dcft_guess` is `dcft` at the time of `compute_energy` and choosing whether or not to nuke previous files. So past intermediate files will interfere only when you want them to.

There are also some related changes: adding a helpful error message to replace the PSIO error that appears when the past files don't exist, adding a test case to prevent a repeat of this little mess, removing some dead code, and per discussions with @jturney, moving some tensors from the libtrans libdpd to the dcft libdpd if they were more than integrals.

The other `dcft` PR will be coming as soon as this one is merged in: another bugfix, and (finally!) the transition from `dcft` to `dct`.

Obligatory @ssh2 notification.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Restore `dcft_guess dcft` functionality
- [x] Move tensors (DCT's amplitudes and "generalized" Fock matrix) from the `libtrans` dpd buffer to the `dcft` buffer
- [x] Add a test for `dcft_guess`
- [x] Eliminate one obnoxious PSIO_ERROR

## Checklist
- [x] Tests added for any newly working features
- [x] All 14 `dcft` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
