### PR TITLE
get dftd3 and mp2d into PSI_SCRATCH

### DIFF
--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -206,7 +206,8 @@ class EmpiricalDispersion(object):
                     'molecule': molecule.to_schema(dtype=2),
                     'provenance': p4util.provenance_stamp(__name__),
                 })
-            jobrec = qcng.compute(resi, self.engine, raise_error=True)
+            jobrec = qcng.compute(resi, self.engine, raise_error=True,
+                                  local_options={"scratch_directory": core.IOManager.shared_object().get_default_path()})
 
             dashd_part = float(jobrec.extras['qcvars']['DISPERSION CORRECTION ENERGY'])
             if wfn is not None:
@@ -261,7 +262,8 @@ class EmpiricalDispersion(object):
                     'molecule': molecule.to_schema(dtype=2),
                     'provenance': p4util.provenance_stamp(__name__),
                 })
-            jobrec = qcng.compute(resi, self.engine, raise_error=True)
+            jobrec = qcng.compute(resi, self.engine, raise_error=True,
+                                  local_options={"scratch_directory": core.IOManager.shared_object().get_default_path()})
 
             dashd_part = core.Matrix.from_array(
                 np.array(jobrec.extras['qcvars']['DISPERSION CORRECTION GRADIENT']).reshape(-1, 3))


### PR DESCRIPTION
## Description
Addresses #1724 by telling QCEngine to parent the scratch of dftd3 and mp2d into `$PSI_SCRATCH`. Contrary to what I said in that issue, the dftd3 parameters are written to local working dir (that is, scratch), not to $HOME. There's one other qcng call. It's `qcdb.Molecule.run_dftd3`. I really don't want to be calling `core` there, and it only runs in tests, so leaving that for now.

## Status
- [x] Ready for review
- [ ] Ready for merge
