### PR TITLE
QCSchema Wavefunction Quantities

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1411,7 +1411,7 @@ void export_mints(py::module& m) {
     typedef int (BasisSet::*ncore_no_args)() const;
     typedef int (BasisSet::*ncore_one_arg)(const std::string&) const;
 
-    py::class_<BasisSet, std::shared_ptr<BasisSet>>(m, "BasisSet", "Contains basis set information")
+    py::class_<BasisSet, std::shared_ptr<BasisSet>>(m, "BasisSet", "Contains basis set information", py::dynamic_attr())
         .def(py::init<const std::string&, std::shared_ptr<Molecule>,
                       std::map<std::string, std::map<std::string, std::vector<ShellInfo>>>&,
                       std::map<std::string, std::map<std::string, std::vector<ShellInfo>>>&>())
@@ -1434,6 +1434,8 @@ void export_mints(py::module& m) {
         .def("nshell", &BasisSet::nshell, "Returns number of shells")
         .def("shell", no_center_version(&BasisSet::shell), py::return_value_policy::copy,
              "Return the si'th Gaussian shell", "si"_a)
+        .def("ecp_shell", &BasisSet::ecp_shell, py::return_value_policy::copy,
+             "Return the si'th ECP shell", "si"_a)
         .def("shell", center_version(&BasisSet::shell), py::return_value_policy::copy,
              "Return the si'th Gaussian shell on center", "center"_a, "si"_a)
         .def("n_frozen_core", &BasisSet::n_frozen_core,
@@ -1457,6 +1459,10 @@ void export_mints(py::module& m) {
              "Given a function number what shell does it correspond to", "i"_a)
         .def("function_to_center", &BasisSet::function_to_center, "The atomic center for the i'th function", "i"_a)
         .def("nshell_on_center", &BasisSet::nshell_on_center, "Return the number of shells on a given center", "i"_a)
+        .def("shell_on_center", &BasisSet::shell_on_center, "Return the i'th shell on center.", "c"_a, "i"_a)
+        .def("n_ecp_shell_on_center", &BasisSet::n_ecp_shell_on_center, "Return the number of ECP shells on a given center", "i"_a)
+        .def("ecp_shell_on_center", &BasisSet::ecp_shell_on_center, "Return the i'th ECP shell on center.", "c"_a, "i"_a)
+
         //            def("decontract", &BasisSet::decontract, "docstring").
         .def("ao_to_shell", &BasisSet::ao_to_shell,
              "Given a cartesian function (AO) number what shell does it correspond to", "i"_a)

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -10,31 +10,32 @@ from .utils import *
 
 pytestmark = pytest.mark.quick
 
-data_blob = {
-    "molecule": {
-        "geometry": [
-            0.0, 0.0, -0.1294769411935893,
-            0.0, -1.494187339479985, 1.0274465079245698,
-            0.0, 1.494187339479985, 1.0274465079245698
-        ],
-        "symbols": ["O", "H", "H"],
-        "connectivity": [(0, 1, 1.0), (0, 2, 1.0)]
-    },
-    "driver": "energy",
-    "model": {
-        "method": "MP2",
-        "basis": "cc-pVDZ"
-    },
-    "keywords": {
-        "scf_type": "df",
-        "mp2_type": "df",
-        "scf_properties": ["mayer_indices"]
+@pytest.fixture(scope="function")
+def result_data_fixture():
+    return {
+        "molecule": {
+            "geometry": [
+                0.0, 0.0, -0.1294769411935893,
+                0.0, -1.494187339479985, 1.0274465079245698,
+                0.0, 1.494187339479985, 1.0274465079245698
+            ],
+            "symbols": ["O", "H", "H"],
+            "connectivity": [(0, 1, 1.0), (0, 2, 1.0)]
+        },
+        "driver": "energy",
+        "model": {
+            "method": "MP2",
+            "basis": "cc-pVDZ"
+        },
+        "keywords": {
+            "scf_type": "df",
+            "mp2_type": "df",
+            "scf_properties": ["mayer_indices"]
+        }
     }
-} # yapf: disable
 
-def test_qcschema_energy():
-    inp = data_blob.copy()
-    ret = psi4.schema_wrapper.run_qcschema(inp)
+def test_qcschema_energy(result_data_fixture):
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
 
     expected_return_result = -76.22831410222477
     assert compare_integers(True, ret.success, "Computation Status")
@@ -52,10 +53,9 @@ def test_qcschema_energy():
     assert compare_integers(True, ret.provenance.routine == "psi4.schema_runner.run_qcschema", "Provenance: Routine")
 
 
-def test_qcschema_gradient():
-    inp = data_blob.copy()
-    inp["driver"] = "gradient"
-    ret = psi4.schema_wrapper.run_qcschema(inp)
+def test_qcschema_gradient(result_data_fixture):
+    result_data_fixture["driver"] = "gradient"
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
 
     bench_grad = np.array([[0.00000000e+00, 0.00000000e+00, -3.14003710e-02],
                            [0.00000000e+00, -3.02856483e-02, 1.57001855e-02],
@@ -67,25 +67,24 @@ def test_qcschema_gradient():
     assert compare_values(-122.44529682915068, ret.properties.scf_one_electron_energy, 5, "SCF One-Electron Energy")
 
 
-def test_qcschema_keyword_error():
-    inp = data_blob.copy()
-    inp["keywords"] = {"unicorn": "bad option"}
-    ret = psi4.schema_wrapper.run_qcschema(inp)
+def test_qcschema_keyword_error(result_data_fixture):
+    result_data_fixture["keywords"] = {"unicorn": "bad option"}
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
 
     assert compare_integers(False, ret.success, "Computation Status")
     assert compare_integers(True, "unicorn" in ret.error.error_message, "Error Message")
 
 
 @pytest.mark.parametrize("input_enc, input_fn, output_enc, output_fn, ", [
-  ("json", "input.json", "json", None),
-  ("msgpack-ext", "input.msgpack", "msgpack-ext", None),
-  ("json", "input.json", "msgpack-ext", "output.msgpack"),
-  ("msgpack-ext", "input.msgpack", "json", "output.json"),
-  ("msgpack-ext", "input.msgpack", "msgpack-ext", "output.something"),
+    ("json", "input.json", "json", None),
+    ("msgpack-ext", "input.msgpack", "msgpack-ext", None),
+    ("json", "input.json", "msgpack-ext", "output.msgpack"),
+    ("msgpack-ext", "input.msgpack", "json", "output.json"),
+    ("msgpack-ext", "input.msgpack", "msgpack-ext", "output.something"),
 ])
-def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn):
+def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn, result_data_fixture):
 
-    data = qcel.models.ResultInput(**data_blob)
+    data = qcel.models.ResultInput(**result_data_fixture)
 
     if (input_enc == "msgpack-ext") or (output_enc == "msgpack-ext"):
         try:
@@ -94,7 +93,6 @@ def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn):
             pytest.skip("Msgpack could not be found, skipping.")
 
     inputs = {input_fn: data.serialize(input_enc)}
-
 
     cmds = ["--qcschema"]
     if output_fn:
@@ -110,7 +108,6 @@ def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn):
     if output_enc == "msgpack-ext":
         as_binary.append(output_fn)
 
-
     success, ret = run_psi4_cli(inputs, outfiles, cmds, as_binary=as_binary)
     assert compare_integers(True, success, "Computation Status")
     assert compare_integers(True, ret['stdout'] == '', "Empty stdout")
@@ -124,3 +121,6 @@ def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn):
 
     assert compare_integers(True, parsed, "Result Model Parsed")
     assert compare_integers(-76.22831410207938, ret.return_result, "Return")
+
+def test_qcschema_wavefunction():
+    pass

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -132,3 +132,11 @@ def test_qcschema_wavefunction_basis(result_data_fixture):
     assert wfn.basis.atom_map[1] == wfn.basis.atom_map[2]
     assert wfn.basis.nbf == 24
     assert wfn.restricted
+
+def test_qcschema_wavefunction_scf_orbitals(result_data_fixture):
+    result_data_fixture["protocols"] = {"wavefunction": "orbitals_and_eigenvalues"}
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
+    wfn = ret.wavefunction
+
+    expected_keys = {'basis', 'restricted', 'scf_orbitals_a', 'scf_eigenvalues_a', 'orbitals_a', 'eigenvalues_a'}
+    assert wfn.dict().keys() == expected_keys

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -122,5 +122,13 @@ def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn, result_data_fi
     assert compare_integers(True, parsed, "Result Model Parsed")
     assert compare_integers(-76.22831410207938, ret.return_result, "Return")
 
-def test_qcschema_wavefunction():
-    pass
+def test_qcschema_wavefunction_basis(result_data_fixture):
+    result_data_fixture["protocols"] = {"wavefunction": "orbitals_and_eigenvalues"}
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
+    wfn = ret.wavefunction
+
+    assert len(wfn.basis.center_data) == 2
+    assert len(wfn.basis.atom_map) == 3
+    assert wfn.basis.atom_map[1] == wfn.basis.atom_map[2]
+    assert wfn.basis.nbf == 24
+    assert wfn.restricted


### PR DESCRIPTION
## Description
Adds the new QCSchema Wavefunction properties to the Psi4 schema runner.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Creates a schema BasisSet object
- [ ] ECP Basis quantities
- [x] Maps Psi4 arrays to schema `return_result` quantities
- [x] Reorders Psi4 arrays to CCA ordering for both spherical and cartesian basis functions.
- [ ] Provides support for post-SCF `return_result`s

Not entirely sure how we can correctly map post-SCF quantities. It becomes difficult to understand when new orbitals/densities are created. Thinking through a few options here, but if anyone has suggestions let me know!

## Status
- [ ] Ready for review
- [ ] Ready for merge
