### PR TITLE
Add simple print statements for scratch directory

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -499,6 +499,8 @@ def energy(name, **kwargs):
     """
     kwargs = p4util.kwargs_lower(kwargs)
 
+    core.print_out("\nScratch directory: %s\n" % core.IOManager.shared_object().get_default_path())
+
     # Bounce to CP if bsse kwarg
     if kwargs.get('bsse_type', None) is not None:
         return driver_nbody.nbody_gufunc(energy, name, ptype='energy', **kwargs)
@@ -605,6 +607,8 @@ def gradient(name, **kwargs):
 
     """
     kwargs = p4util.kwargs_lower(kwargs)
+    
+    core.print_out("\nScratch directory: %s\n" % core.IOManager.shared_object().get_default_path())
 
     # Figure out what kind of gradient this is
     if hasattr(name, '__call__'):


### PR DESCRIPTION
## Description
Couldn't (I think) go in the header, but this PR prints the correct scratch directory at the beginning of energy() and gradient() calls. This is particularly useful if the user simultaneously specifies scratch directories in different ways.

## Checklist
- [X] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
