### PR TITLE
Set gradient with set_gradient

### DIFF
--- a/psi4/src/psi4/dfocc/dfgrad.cc
+++ b/psi4/src/psi4/dfocc/dfgrad.cc
@@ -125,7 +125,7 @@ void DFOCC::dfgrad() {
         gradients["Total"]->print_atom_vector();
     }
 
-    gradient_ = total;
+    set_gradient(total);
 
     // outfile->Printf("\tdfgrad is done. \n");
 }  // end dfgrad


### PR DESCRIPTION
The title is pleasantly self-explanatory.

The `set_gradient` call will automatically set the `gradient_` variable. With the old way of setting the gradient, the gradient wouldn't be picked up by serialization, meaning my attempt at an optking3 IRC (of course) was failing.

I'll also take this opportunity to soapbox about why we (read: I) need to centralize our DF gradient code.