### PR TITLE
Gradient Refactor

### DIFF
--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -4803,6 +4803,37 @@ void DCTSolver::compute_ewdm_odc() {
         offset += nmopi_[h];
     }
 
+    // Here be example code of the new interface.
+    // auto a_opdm_oo = std::make_shared<Matrix>("MO-basis Alpha OPDM <O|O>", nirrep_, naoccpi_, naoccpi_);
+    // a_opdm_oo->identity();  // The kappa term
+    // a_opdm_oo->add(aocc_tau_);
+    // auto a_opdm_vv = avir_tau_->clone();
+    // a_opdm_vv->set_name("MO-basis Alpha OPDM <V|V>");
+    // std::map<std::array<char, 2>, SharedMatrix> alpha_density = {{{'O', 'O'}, a_opdm_oo}, {{'V', 'V'}, a_opdm_vv}};
+    // Da_ = _ints->backtransform_two_index(alpha_density, "SO-basis Alpha OPDM");
+
+    // auto b_opdm_oo = std::make_shared<Matrix>("MO-basis Beta OPDM <O|O>", nirrep_, nboccpi_, nboccpi_);
+    // b_opdm_oo->identity();  // The kappa term
+    // b_opdm_oo->add(bocc_tau_);
+    // auto b_opdm_vv = bvir_tau_->clone();
+    // b_opdm_vv->set_name("MO-basis Beta OPDM <V|V>");
+    // std::map<std::array<char, 2>, SharedMatrix> beta_density = {{{'o', 'o'}, b_opdm_oo}, {{'v', 'v'}, b_opdm_vv}};
+    // Db_ = _ints->backtransform_two_index(beta_density, "SO-basis Beta OPDM");
+
+    //// Rather than send over the Lagrangian, 0.5(X_pq+X_qp), let's send X_pq and leave the symmetrizing to libtrans.
+    // const std::vector<std::array<char, 2>> lagrangian_labels = {{'O', 'O'}, {'O', 'V'}, {'V', 'O'}, {'V', 'V'},
+    //                                                            {'o', 'o'}, {'o', 'v'}, {'v', 'o'}, {'v', 'v'}};
+    // auto *label = new char[10];
+    // std::map<std::array<char, 2>, SharedMatrix> lagrangian_terms;
+    // for (const auto k : lagrangian_labels) {
+    //    sprintf(label, "X <%c|%c>", k[0], k[1]);
+    //    global_dpd_->file2_init(&X_OV, PSIF_DCT_DPD, 0, ID(k[0]), ID(k[1]), label);
+    //    lagrangian_terms[k] = std::make_shared<Matrix>(&X_OV);
+    //    global_dpd_->file2_close(&X_OV);
+    //}
+
+    // Lagrangian_ = _ints->backtransform_two_index(lagrangian_terms, "SO-basis Lagrangian");
+
     dpdbuf4 G;
 
     struct iwlbuf AA, AB, BB;

--- a/psi4/src/psi4/libtrans/CMakeLists.txt
+++ b/psi4/src/psi4/libtrans/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND sources
   integraltransform_dpd_id.cc
   integraltransform_moinfo.cc
   integraltransform_oei.cc
+  integraltransform_opdm_lagrangian.cc
   integraltransform_sort_mo_tpdm.cc
   integraltransform_sort_so_tei.cc
   integraltransform_sort_so_tpdm.cc

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -161,6 +161,8 @@ class PSI_API IntegralTransform {
     void backtransform_density();
     void backtransform_tpdm_restricted();
     void backtransform_tpdm_unrestricted();
+    SharedMatrix backtransform_two_index(const std::map<std::array<char, 2>, SharedMatrix> opdm_blocks,
+                                         const std::string name);
     void print_dpd_lookup();
     std::vector<SharedMatrix> compute_fock_like_matrices(SharedMatrix Hcore, std::vector<SharedMatrix> Cmats);
 
@@ -247,6 +249,11 @@ class PSI_API IntegralTransform {
 
     void reset_so_int() { alreadyPresorted_ = false; }
 
+    // Get the MO coefficients for the alpha space corresponding to the given label
+    SharedMatrix aMOCoefficients(const char label) { return MOCoefficients_[toupper(label)]; }
+    // Get the MO coefficients for the beta space corresponding to the given label
+    SharedMatrix bMOCoefficients(const char label) { return MOCoefficients_[tolower(label)]; }
+
    protected:
     void check_initialized();
     void common_initialize();
@@ -296,10 +303,12 @@ class PSI_API IntegralTransform {
     std::map<char, int *> aOrbsPI_;
     // The beta orbitals per irrep for each space
     std::map<char, int *> bOrbsPI_;
-    // The alpha MO coefficients for all unique spaces needed
+    // The alpha MO coefficients for all unique spaces needed, using the original label
     std::map<char, SharedMatrix> aMOCoefficients_;
-    // The beta MO coefficients for all unique spaces needed
+    // The beta MO coefficients for all unique spaces needed, using the original label
     std::map<char, SharedMatrix> bMOCoefficients_;
+    // The alpha and beta MO coefficients for all unique spaces needed, case sensitive
+    std::map<char, SharedMatrix> MOCoefficients_;
     // The alpha orbital indexing arrays
     std::map<char, int *> aIndices_;
     // The beta orbital indexing arrays

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -705,8 +705,8 @@ void IntegralTransform::process_eigenvectors() {
 
         if (transformationType_ == TransformationType::Restricted) Cb = Ca;
 
-        aMOCoefficients_[moSpace->label()] = Ca;
-        bMOCoefficients_[moSpace->label()] = Cb;
+        MOCoefficients_[toupper(moSpace->label())] = Ca;
+        MOCoefficients_[tolower(moSpace->label())] = Cb;
 
         if (print_ > 5) {
             outfile->Printf("Orbitals for space %c:-\n", moSpace->label());

--- a/psi4/src/psi4/libtrans/integraltransform_opdm_lagrangian.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_opdm_lagrangian.cc
@@ -1,0 +1,73 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2019 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include <algorithm>
+#include <set>
+#include "integraltransform.h"
+#include "psi4/libmints/matrix.h"
+
+using namespace psi;
+
+/* libmints's grad_two_center_computer expects libtrans to send  G_mn = 0.5 C_pm C_qn (G_pq + G_qp).
+ * How we do this differs depending on the block. For blocks with the same label (e.g., "O", "O"), we transform
+ * 0.5 (G_pq + G_qp). For blocks with different labels (e.g., "O", "V"), we pick one block and transform (G_pq + G_qp).
+ * We account for the 0.5 by not transforming the block with the reversed labels (e.g., "V", "O").
+ * The main advantage of transforming blocks over transforming the entire matrix is that we no longer
+ * force the calling code to construct the entire matrix. They normally have blocks instead. */
+SharedMatrix IntegralTransform::backtransform_two_index(std::map<std::array<char, 2>, SharedMatrix> opdm_blocks,
+                                                        std::string name) {
+    auto backtransformed_matrix = std::make_shared<Matrix>(name, nirreps_, sopi_, sopi_);
+    // We want to skip backtransformation of any blocks whose transpose we already backtransformed, because we
+    // backtransformed those two blocks together.
+    std::set<std::array<char, 2>> labels_to_skip;
+    for (const auto& kv : opdm_blocks) {
+        auto submatrix_label = kv.first;
+        if (labels_to_skip.find(submatrix_label) != labels_to_skip.end()) continue;
+        auto label_first = submatrix_label[0];
+        auto C_first = MOCoefficients_[label_first];
+        auto label_second = submatrix_label[1];
+        auto C_second = MOCoefficients_[label_second];
+        auto opdm_submatrix = kv.second->clone();
+        auto reverse_label = submatrix_label;
+        std::reverse(reverse_label.begin(), reverse_label.end());
+        labels_to_skip.insert(reverse_label);
+        if (submatrix_label == reverse_label) {
+            opdm_submatrix->hermitivitize();
+        } else {
+            auto transpose_pair = opdm_blocks.find(reverse_label);
+            if (transpose_pair != opdm_blocks.end()) {
+                opdm_submatrix->add(transpose_pair->second->transpose());
+            } else {
+                // Assume G Hermitian. G_qp = G_pq => G_pq + G_qp = 2 G_pq
+                opdm_submatrix->scale(2);
+            }
+        }
+        backtransformed_matrix->add(linalg::triplet(C_first, opdm_submatrix, C_second, false, false, true));
+    }
+    return backtransformed_matrix;
+}

--- a/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
@@ -53,10 +53,10 @@ void IntegralTransform::transform_tei_first_half(const std::shared_ptr<MOSpace> 
     auto *label = new char[100];
 
     // Grab the transformation coefficients
-    SharedMatrix c1a = aMOCoefficients_[s1->label()];
-    SharedMatrix c1b = bMOCoefficients_[s1->label()];
-    SharedMatrix c2a = aMOCoefficients_[s2->label()];
-    SharedMatrix c2b = bMOCoefficients_[s2->label()];
+    SharedMatrix c1a = aMOCoefficients(s1->label());
+    SharedMatrix c1b = bMOCoefficients(s1->label());
+    SharedMatrix c2a = aMOCoefficients(s2->label());
+    SharedMatrix c2b = bMOCoefficients(s2->label());
     // And the number of orbitals per irrep
     int *aOrbsPI1 = aOrbsPI_[s1->label()];
     int *bOrbsPI1 = bOrbsPI_[s1->label()];

--- a/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
@@ -56,10 +56,10 @@ void IntegralTransform::transform_tei_second_half(const std::shared_ptr<MOSpace>
     auto *label = new char[100];
 
     // Grab the transformation coefficients
-    SharedMatrix c3a = aMOCoefficients_[s3->label()];
-    SharedMatrix c3b = bMOCoefficients_[s3->label()];
-    SharedMatrix c4a = aMOCoefficients_[s4->label()];
-    SharedMatrix c4b = bMOCoefficients_[s4->label()];
+    SharedMatrix c3a = aMOCoefficients(s3->label());
+    SharedMatrix c3b = bMOCoefficients(s3->label());
+    SharedMatrix c4a = aMOCoefficients(s4->label());
+    SharedMatrix c4b = bMOCoefficients(s4->label());
     // And the number of orbitals per irrep
     int *aOrbsPI3 = aOrbsPI_[s3->label()];
     int *bOrbsPI3 = bOrbsPI_[s3->label()];

--- a/psi4/src/psi4/libtrans/integraltransform_tpdm_restricted.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tpdm_restricted.cc
@@ -51,7 +51,7 @@ void IntegralTransform::backtransform_tpdm_restricted() {
     presort_mo_tpdm_restricted();
 
     // Grab the transformation coefficients
-    SharedMatrix c = aMOCoefficients_[MOSPACE_ALL];
+    SharedMatrix c = aMOCoefficients(MOSPACE_ALL);
 
     // Grab control of DPD for now, but store the active number to restore it later
     int currentActiveDPD = psi::dpd_default;

--- a/psi4/src/psi4/libtrans/integraltransform_tpdm_unrestricted.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tpdm_unrestricted.cc
@@ -50,8 +50,8 @@ void IntegralTransform::backtransform_tpdm_unrestricted() {
     // This can be safely called - it returns immediately if the MO TPDM is already sorted
     presort_mo_tpdm_unrestricted();
     // Grab the transformation coefficients
-    SharedMatrix ca = aMOCoefficients_[MOSPACE_ALL];
-    SharedMatrix cb = bMOCoefficients_[MOSPACE_ALL];
+    SharedMatrix ca = aMOCoefficients(MOSPACE_ALL);
+    SharedMatrix cb = bMOCoefficients(MOSPACE_ALL);
 
     dpdbuf4 J1, J2, K;
 


### PR DESCRIPTION
## Description
Described in great detail [here](https://github.com/psi4/psi4/issues/1736).

## Todos
I see this PR occurring in six major stages.
- [x] Introducing the OPDM/Lagrangian Tech
- [ ] Introducing the Conventional TPDM Tech
- [ ] Migrating Psi to new-style gradients
- [ ] Adding deprecation warnings for old-style gradients
- [ ] Miscellaneous revision corrections

## Technical Discussions: May be tl;dr

### Step One: OPDM/Lagrangian Tech
This PR introduces a new file, `integraltransform_opdm_lagrangian.cc`, to perform this backtransformation. This was previously done by `integraltransform_oei.cc:trans_one`. As this function has other responsibilities, `trans_one` is preserved. Compared to the previous interface, there are three key changes.
1. Callers can pass in blocks of the OPDM/Lagrangian. This gives callers flexibility to pass in `oo` and `vv` and `ov` and `vo` blocks separately if available, and to not pass in a block that is conjugate to another block already passed in. This is frequently the case.
2. Callers pass in these blocks as a map from orbital space labels to a SharedMatrix containing the relevant block and are responsible for attaching this to the wavefunction object via the `Da`, `Db`, and `X` member variables. This is the most important point for this section! All codes except `cc` already store the OPDM/Lagrangian as `SharedMatrix` objects, so this is the path of least resistance. The one holdout predates `libmints` and instead uses a `libmints` `Matrix`-like structure. (See discussion in Step Four.) Existing code had to perform many an astounding number of type conversions to ultimately convert back to the type we had originally. `dct`, for instance, went `SharedMatrix` -> `file2` -> QTOrdered Block Matrix -> PSIO Entry -> Lower Triangle -> Block Matrix -> Lower Triangle -> PSIO Entry -> `SharedMatrix`. We now stay in a `SharedMatrix` the entire time. This type change is why `integraltransform_oei.cc:trans_one` is not used in the new version. When you use a `Matrix`, the transformation reduces to a `linalg::triplet` call.
3. Lastly, prefactors. Because it's ambiguous what you call the Lagrangian, I'm going to use as a point of reference "the thing you contract against the overlap derivatives", because that is pefectly unambiguous. In the old code, you'd send -2 times that thing. Now, you send -1 times that thing. This is necessary for consistency with how the SCF code determines the value of the Lagrangian on a wavefunction object.

If you want an example for how this works, see the newly added code in `dct_gradient_UHF.cc:compute_ewdm_odc`. With these changes, 30 lines of code replaces about 230. I call this a good start.

### Step Two: Conventional TPDM Tech
I don't see a way around still using `dpdbuf4` for this, even though this isn't the most plugin-friendly. The main simplification here will be eliminating the need to dump to `libiwl`.

## Questions
- [ ] There is a goof in `libtrans`: There is a [pre-defined frozen core space `O`](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libtrans/mospace.h#L51-L57), and also a [pre-defined occupied space `o`](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libtrans/mospace.h#L58-L68), and likewise for virtual orbitals. These spaces have conflicting labels. 
[Uppercase letters mean the alpha orbitals](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libtrans/integraltransform_moinfo.cc#L306) and [lower case letters mean the beta orbitals](https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libtrans/integraltransform_moinfo.cc#L505). We need to change the labels of the frozen core and frozen virtual spaces to break the conflict. We currently have five votes (Lori, Andy, Susi, Jet, and I) for `C` for frozen core and `W` for frozen virtual. Anybody opposed? Also, how on earth do I deprecate _this_? I need this for some frozen core gradient plans, so I would appreciate being able to change this sooner rather than later. Thankfully, neither space seems to be used anywhere in Psi.
- [ ] I made some internal changes to `libtrans`. There is now a case sensitive `MOCoefficients_` map, and there are case-insensitive `aMOCoefficients` and `bMOCoefficients` functions. I'd like to remove the old `aMOCoefficients_` and `bMOCoefficients_` maps, now that we have these new functions. Do I need to formally deprecate them? These were never exposed via PyBind.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
