### PR TITLE
Use Ninja on Travis

### DIFF
--- a/.scripts/ninja.sh
+++ b/.scripts/ninja.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "-- Installing Ninja"
+Ninja_VERSION="1.9.0.g99df1.kitware.dyndep-1.jobserver-1"
+Ninja_URL="https://github.com/Kitware/ninja/releases/download/v${Ninja_VERSION}/ninja-${Ninja_VERSION}_x86_64-linux-gnu.tar.gz"
+cd "$HOME"/Deps
+mkdir -p ninja
+curl -Ls $Ninja_URL | tar -xz -C ninja --strip-components=1
+cd "$TRAVIS_BUILD_DIR"
+echo "-- Done with Ninja"

--- a/.scripts/travis_build.sh
+++ b/.scripts/travis_build.sh
@@ -2,7 +2,8 @@
 
 # The return code will capture an error from ANY of the functions in the pipe
 set -o pipefail
-cmake --build . -- -j 2 VERBOSE=1 2>&1 | tee build.log | grep "Building"
+export NINJA_STATUS="[Built edge %f of %t in %e sec] "
+cmake --build . -- -j 2 -v -d stats 2>&1 | tee build.log | grep "Built"
 RESULT=$?
 
 if [ $RESULT -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,12 @@ before_install:
   - free -m
   - df -h
   - ulimit -a
-  - mkdir -p $HOME/miniconda
+  - mkdir -p $HOME/miniconda $HOME/Deps
 
 install:
+  - ./.scripts/ninja.sh
   - ./.scripts/miniconda.sh
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - export PATH="$HOME/miniconda/bin:$HOME/Deps/ninja:$PATH"
   - conda create -q -n p4env python=$PYTHON_VER psi4 --only-deps -c psi4/label/dev
   - source activate p4env
   - >
@@ -89,7 +90,7 @@ before_script:
     #   reasons, pkgs are being compiled less statically, sad for CI.
     # * can't enable trivial plugins b/c no psi4 for them to detect at start (e.g., snsmp2)
   - >
-      cmake -Bbuild -H.
+      cmake -Bbuild -H. -GNinja
       -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
       -DCMAKE_C_COMPILER=${C_COMPILER}
       -DCMAKE_BUILD_TYPE=${BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ ExternalProject_Add(psi4-core
               -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
    CMAKE_CACHE_ARGS -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
+   USES_TERMINAL_BUILD 1
    BUILD_ALWAYS 1)
 
 add_subdirectory(external/downstream)

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -50,6 +50,12 @@ macro(psi4_add_module binlib libname sources)
   endif()
 
   add_library(${libname} STATIC "${${sources}}")
+  # Always color output (even when using Ninja)
+  target_compile_options(${libname}
+    PRIVATE
+      $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
+      $<$<CXX_COMPILER_ID:Clang>:-fcolor-diagnostics>
+    )
   set_target_properties(${libname}
     PROPERTIES
       CXX_VISIBILITY_PRESET hidden

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -2,6 +2,18 @@
 ### >> This allow to propagate dependencies upwards sanely
 pybind11_add_module(core SHARED NO_EXTRAS core.cc)
 
+# See here: https://github.com/pybind/pybind11/issues/1649
+target_compile_definitions(core
+  PRIVATE
+    $<$<CXX_COMPILER_ID:Intel>:PYBIND11_CPP14>
+  )
+# Always color output (even when using Ninja)
+target_compile_options(core
+  PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
+    $<$<CXX_COMPILER_ID:Clang>:-fcolor-diagnostics>
+  )
+
 ### >> Go into psi4 subdirectory to compile libraries and modules <<
 add_subdirectory(psi4)
 


### PR DESCRIPTION
Switches from Unix Makefiles to Ninja. The Kitware-maintained version of Ninja is required to have Fortran support: https://github.com/Kitware/ninja

There is not that large of a speedup.

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
