### PR TITLE
Dfh wk

### DIFF
--- a/psi4/driver/procrouting/dft/superfunctionals.py
+++ b/psi4/driver/procrouting/dft/superfunctionals.py
@@ -126,7 +126,7 @@ def build_superfunctional(name, restricted, npoints=None, deriv=1):
         raise ValidationError("SCF: Decide between NL_DISPERSION_PARAMETERS and DFT_VV10_B !!")
 
     # Check SCF_TYPE
-    if sup[0].is_x_lrc() and (core.get_global_option("SCF_TYPE") not in ["DIRECT", "DF", "OUT_OF_CORE", "PK"]):
+    if sup[0].is_x_lrc() and (core.get_global_option("SCF_TYPE") not in ["DISK_DF", "MEM_DF" ,"DIRECT", "DF", "OUT_OF_CORE", "PK"]):
         raise ValidationError(
             "SCF: SCF_TYPE (%s) not supported for range-separated functionals, plese use SCF_TYPE = 'DF' to automatically select the correct JK build." % core.get_global_option("SCF_TYPE"))
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -167,6 +167,11 @@ void DFHelper::initialize() {
     // if metric power is not zero, prepare it
     if (!(std::fabs(mpower_ - 0.0) < 1e-13)) (hold_met_ ? prepare_metric_core() : prepare_metric());
 
+    // if metric power for omega integrals, prepare its metric
+    if (do_wK_) {
+        if (!(std::fabs(wmpower_ - 0.0) < 1e-13)) (hold_met_ ? prepare_metric_core() : prepare_metric());
+    }
+
     // prepare sparsity masks
     prepare_sparsity();
 
@@ -182,10 +187,9 @@ void DFHelper::initialize() {
     if (AO_core_) {
         prepare_AO_core();
         if (do_wK_) {
-            std::stringstream error;
-            error << "DFHelper: not equipped to do wK";
-            throw PSIEXCEPTION(error.str().c_str());
-            // TODO prepare_AO_wK_core();
+            prepare_AO_wK_core();
+        } else {
+            //			prepare_AO_core();
         }
     } else if (!direct_ && !direct_iaQ_) {
         prepare_AO();
@@ -193,7 +197,9 @@ void DFHelper::initialize() {
             std::stringstream error;
             error << "DFHelper: not equipped to do wK";
             throw PSIEXCEPTION(error.str().c_str());
-            // TODO prepare_AO_wK();
+            prepare_AO_wK();
+        } else {
+            //        	prepare_AO();
         }
     }
 
@@ -212,7 +218,7 @@ void DFHelper::AO_core() {
         // if do_wK added to code, the following will need to be changed to match
         required_core_size_ = naux_ * nbf_ * nbf_;
     } else {
-        // total size of sparse AOs
+        // total size of sparse AOs. beautiful
         required_core_size_ = (do_wK_ ? 3 * big_skips_[nbf_] : big_skips_[nbf_]);
     }
 
@@ -451,7 +457,24 @@ void DFHelper::prepare_AO() {
         count += size;
     }
 }
+void DFHelper::prepare_AO_wK() {
+    // prepare eris
+    std::shared_ptr<BasisSet> zero = BasisSet::zero_ao_basis_set();
+    auto rifactory = std::make_shared<IntegralFactory>(aux_, zero, primary_, primary_);
+    std::vector<std::shared_ptr<TwoBodyAOInt>> eri(nthreads_);
+#pragma omp parallel num_threads(nthreads_)
+    {
+        int rank = 0;
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+        eri[rank] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
+    }
 
+    // gather blocking info
+    std::vector<std::pair<size_t, size_t>> psteps;
+    std::pair<size_t, size_t> plargest = pshell_blocks_for_AO_build(memory_, 0, psteps);
+}
 void DFHelper::prepare_AO_core() {
     // get each thread an eri object
     std::shared_ptr<BasisSet> zero = BasisSet::zero_ao_basis_set();
@@ -476,6 +499,8 @@ void DFHelper::prepare_AO_core() {
     } else {
         Ppq_ = std::unique_ptr<double[]>(new double[big_skips_[nbf_]]);
     }
+
+    double* ppq = Ppq_.get();
 
     // outfile->Printf("\n    ==> Begin AO Blocked Construction <==\n\n");
     if (direct_iaQ_ || direct_) {
@@ -515,13 +540,108 @@ void DFHelper::prepare_AO_core() {
 
             // contract metric
             timer_on("DFH: AO-Met. Contraction");
-            contract_metric_AO_core_symm(Mp, metp, begin, end);
+            contract_metric_AO_core_symm(Mp, ppq, metp, begin, end);
             timer_off("DFH: AO-Met. Contraction");
         }
         // no more need for metrics
         if (hold_met_) metrics_.clear();
     }
     // outfile->Printf("\n    ==> End AO Blocked Construction <==");
+}
+void DFHelper::prepare_AO_wK_core() {
+    // get each thread an eri object
+    std::shared_ptr<BasisSet> zero = BasisSet::zero_ao_basis_set();
+    auto rifactory = std::make_shared<IntegralFactory>(aux_, zero, primary_, primary_);
+    std::vector<std::shared_ptr<TwoBodyAOInt>> eri(nthreads_);
+    std::vector<std::shared_ptr<TwoBodyAOInt>> weri(nthreads_);
+
+#pragma omp parallel num_threads(nthreads_)
+    {
+        int rank = 0;
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+        eri[rank] = std::shared_ptr<TwoBodyAOInt>(rifactory->eri());
+        weri[rank] = std::shared_ptr<TwoBodyAOInt>(rifactory->erf_eri(omega_));
+    }
+
+    // use blocking as for prepare_AO_core
+    std::vector<std::pair<size_t, size_t>> psteps;
+    std::pair<size_t, size_t> plargest = pshell_blocks_for_AO_build(memory_, 1, psteps);
+
+    wPpq_ = std::unique_ptr<double[]>(new double[big_skips_[nbf_]]);
+    m1Ppq_ = std::unique_ptr<double[]>(new double[big_skips_[nbf_]]);
+
+    double* wppq = wPpq_.get();
+    double* m1ppq = m1Ppq_.get();
+
+    std::unique_ptr<double[]> Qpq(new double[std::get<0>(plargest)]);
+    double* M1p = Qpq.get();
+    std::unique_ptr<double[]> metric;
+    double* met1p;
+
+    if (!hold_met_) {
+        metric = std::unique_ptr<double[]>(new double[naux_ * naux_]);
+        met1p = metric.get();
+        std::string filename = return_metfile(wmpower_);
+        get_tensor_(std::get<0>(files_[filename]), met1p, 0, naux_ - 1, 0, naux_ - 1);
+    } else {
+        met1p = metric_prep_core(wmpower_);
+        // met1p = metric_prep_core(1.0);
+        /*		auto Jinv = std::make_shared<FittingMetric>(aux_, true);
+                        Jinv->form_full_eig_inverse(condition_);
+                        met1p = Jinv->get_metric()->pointer()[0]; */
+    }
+
+    for (size_t i = 0; i < psteps.size(); i++) {
+        size_t start = std::get<0>(psteps[i]);
+        size_t stop = std::get<1>(psteps[i]);
+        size_t begin = pshell_aggs_[start];
+        size_t end = pshell_aggs_[stop + 1] - 1;
+
+        // compute (A|mn)
+        timer_on("DFH: AO Construction");
+        compute_sparse_pQq_blocking_p_symm(start, stop, M1p, eri);
+        timer_off("DFH: AO Construction");
+
+        // contract metric
+        timer_on("DFH: AO-Met. Contraction");
+        contract_metric_AO_core_symm(M1p, m1ppq, met1p, begin, end);
+        timer_off("DFH: AO-Met. Contraction");
+
+        // compute (A|w|mn)
+        timer_on("DFH: wAO Construction");
+        compute_sparse_pQq_blocking_p_symm(start, stop, M1p, weri);
+        timer_off("DFH: wAO Construction");
+
+        timer_on("DFH: wAO Copy");
+        copy_upper_lower_wAO_core_symm(M1p, wppq, begin, end);
+        timer_off("DFH: wAO Copy");
+    }
+
+    //    FILE * eri_ints = fopen("/theoryfs2/ds/obrien/Debug/Psi4/dfh_wk/dfheri_ints.txt", "w");
+    //    FILE * eriwints = fopen("/theoryfs2/ds/obrien/Debug/Psi4/dfh_wk/dfheriwints.txt", "w");
+    //
+    //	for (int i = 0; i < nbf_; i++) {
+    //		fprintf(eri_ints, "%d\n", i); fprintf(eriwints,"%d\n", i);
+    //		for (int j = 0; j < naux_; j++) {
+    //			for (int k = 0; k < small_skips_[i]; k++){
+    //				fprintf(eriwints," %f",  wppq[ big_skips_[i] + j * small_skips_[i] + k] );
+    //				fprintf(eri_ints," %f", m1ppq[ big_skips_[i] + j * small_skips_[i] + k] );
+    //			}
+    //			fprintf(eriwints,"\n");
+    //			fprintf(eri_ints,"\n");
+    //		}
+    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
+    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
+    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
+    //	}
+    //
+    //    fclose(eri_ints);
+    //    fclose(eriwints);
+
+    // no more need for metrics
+    if (hold_met_) metrics_.clear();
 }
 std::pair<size_t, size_t> DFHelper::pshell_blocks_for_AO_build(const size_t mem, size_t symm,
                                                                std::vector<std::pair<size_t, size_t>>& b) {
@@ -539,12 +659,18 @@ std::pair<size_t, size_t> DFHelper::pshell_blocks_for_AO_build(const size_t mem,
             // get current cost of this block of AOs and add it to the total
             // the second buffer is accounted for with full AO_core
             current = symm_big_skips_[end + 1] - symm_big_skips_[begin];
+            if (do_wK_) {
+                current *= 3;
+            }
             total += current;
         } else {
             // on-disk
             // get current cost of this block of AOs and add it to the total
             // count current twice, for both pre and post contracted buffers
             current = big_skips_[end + 1] - big_skips_[begin];
+            if (do_wK_) {
+                current *= 3;
+            }
             total += 2 * current;
         }
 
@@ -577,7 +703,6 @@ std::pair<size_t, size_t> DFHelper::pshell_blocks_for_AO_build(const size_t mem,
     // returns pair(largest buffer size, largest block size)
     return std::make_pair(largest, block_size);
 }
-
 std::pair<size_t, size_t> DFHelper::Qshell_blocks_for_transform(const size_t mem, size_t wtmp, size_t wfinal,
                                                                 std::vector<std::pair<size_t, size_t>>& b) {
     size_t extra = (hold_met_ ? naux_ * naux_ : 0);
@@ -1189,14 +1314,18 @@ double* DFHelper::metric_prep_core(double pow) {
             break;
         }
     }
+    timer_on("DFH: metric power");
     if (!on) {
         power = pow;
-        timer_on("DFH: metric power");
         SharedMatrix J = metrics_[1.0];
-        J->power(power, condition_);
+        if (fabs(pow + 1.0) < 1e-13) {
+            J->invert();
+        } else {
+            J->power(power, condition_);
+        }
         metrics_[power] = J;
-        timer_off("DFH: metric power");
     }
+    timer_off("DFH: metric power");
 
     return metrics_[power]->pointer()[0];
 }
@@ -1259,7 +1388,36 @@ std::string DFHelper::compute_metric(double pow) {
     }
     return return_metfile(pow);
 }
+double* DFHelper::metric_inverse_prep_core() {
+    bool on = false;
+    double power;
+    for (auto& kv : metrics_) {
+        if (!(std::fabs(-1.0 - kv.first) > 1e-13)) {
+            on = true;
+            power = kv.first;
+            break;
+        }
+    }
+    if (!on) {
+        power = -1.0;
+        timer_on("DFH: metric power");
+        SharedMatrix J = metrics_[1.0];
+        J->invert();
+        /*		printf("ping\n");
+                        double* j = metrics_[power]->pointer()[0];
+                        printf("ping\n");
+                        std::unique_ptr<int[]> IPIV(new int[naux_]);
+                        std::unique_ptr<double[]> WORK(new double[naux_]);
+                        int * ipiv = IPIV.get();
+                        double * work = WORK.get();
+                        C_DGETRF( (int) naux_, (int) naux_, j, (int) naux_, ipiv);
+                        C_DGETRI( (int) naux_, j, (int) naux_, ipiv, work, (int) naux_); */
+        metrics_[power] = J;
+        timer_off("DFH: metric power");
+    }
 
+    return metrics_[power]->pointer()[0];
+}
 void DFHelper::metric_contraction_blocking(std::vector<std::pair<size_t, size_t>>& steps, size_t blocking_index,
                                            size_t block_sizes, size_t total_mem, size_t memory_factor,
                                            size_t memory_bump) {
@@ -1375,7 +1533,7 @@ void DFHelper::contract_metric_AO_core(double* Qpq, double* metp) {
     }
 }
 
-void DFHelper::contract_metric_AO_core_symm(double* Qpq, double* metp, size_t begin, size_t end) {
+void DFHelper::contract_metric_AO_core_symm(double* Qpq, double* Ppq, double* metp, size_t begin, size_t end) {
     // loop and contract
     size_t startind = symm_big_skips_[begin];
 #pragma omp parallel for num_threads(nthreads_) schedule(guided)
@@ -1385,11 +1543,9 @@ void DFHelper::contract_metric_AO_core_symm(double* Qpq, double* metp, size_t be
         size_t jump = symm_ignored_columns_[j];
         size_t skip1 = big_skips_[j];
         size_t skip2 = symm_big_skips_[j] - startind;
-        C_DGEMM('N', 'N', naux_, mi, naux_, 1.0, metp, naux_, &Qpq[skip2], mi, 0.0, &Ppq_[skip1 + jump], si);
+        C_DGEMM('N', 'N', naux_, mi, naux_, 1.0, metp, naux_, &Qpq[skip2], mi, 0.0, &Ppq[skip1 + jump], si);
     }
-
-    // copy upper-to-lower
-    double* Ppq = Ppq_.get();
+// copy upper-to-lower
 #pragma omp parallel for num_threads(nthreads_) schedule(static)
     for (size_t omu = begin; omu <= end; omu++) {
         for (size_t Q = 0; Q < naux_; Q++) {
@@ -1403,6 +1559,34 @@ void DFHelper::contract_metric_AO_core_symm(double* Qpq, double* metp, size_t be
         }
     }
 }
+void DFHelper::copy_upper_lower_wAO_core_symm(double* Qpq, double* Ppq, size_t begin, size_t end) {
+    // copy out of symm
+    size_t startind = symm_big_skips_[begin];
+    for (size_t j = begin; j <= end; j++) {
+        size_t mi = symm_small_skips_[j];
+        size_t si = small_skips_[j];
+        size_t jump = symm_ignored_columns_[j];
+        size_t skip1 = big_skips_[j];
+        size_t skip2 = symm_big_skips_[j] - startind;
+        for (size_t j2 = 0; j2 < naux_; j2++) {
+            C_DCOPY(mi, &Qpq[skip2 + mi * j2], 1, &Ppq[skip1 + jump + si * j2], 1);
+        }
+    }
+// copy upper-to-lower
+#pragma omp parallel for num_threads(nthreads_) schedule(static)
+    for (size_t omu = begin; omu <= end; omu++) {
+        for (size_t Q = 0; Q < naux_; Q++) {
+            for (size_t onu = omu + 1; onu < nbf_; onu++) {
+                if (schwarz_fun_mask_[omu * nbf_ + onu]) {
+                    size_t ind1 = big_skips_[onu] + Q * small_skips_[onu] + schwarz_fun_mask_[onu * nbf_ + omu] - 1;
+                    size_t ind2 = big_skips_[omu] + Q * small_skips_[omu] + schwarz_fun_mask_[omu * nbf_ + onu] - 1;
+                    Ppq[ind1] = Ppq[ind2];
+                }
+            }
+        }
+    }
+}
+
 void DFHelper::add_space(std::string key, SharedMatrix M) {
     size_t a0 = M->rowspi()[0];
     size_t a1 = M->colspi()[0];
@@ -2693,19 +2877,24 @@ std::tuple<size_t, size_t, size_t> DFHelper::get_tensor_shape(std::string name) 
     return sizes_[std::get<1>(files_[name])];
 }
 void DFHelper::build_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright, std::vector<SharedMatrix> D,
-                        std::vector<SharedMatrix> J, std::vector<SharedMatrix> K, size_t max_nocc, bool do_J, bool do_K,
-                        bool do_wK, bool lr_symmetric) {
+                        std::vector<SharedMatrix> J, std::vector<SharedMatrix> K, std::vector<SharedMatrix> wK,
+                        size_t max_nocc, bool do_J, bool do_K, bool do_wK, bool lr_symmetric) {
     if (debug_) {
         outfile->Printf("Entering DFHelper::build_JK\n");
     }
+
+    // This was an if-else statement. Presumably, we could manage J construction
+    //   to more effectively manage memory, so I think that was what was going on.
 
     if (do_J || do_K) {
         timer_on("DFH: compute_JK()");
         compute_JK(Cleft, Cright, D, J, K, max_nocc, do_J, do_K, do_wK, lr_symmetric);
         timer_off("DFH: compute_JK()");
-    } else {
+    }
+
+    if (do_wK_) {
         timer_on("DFH: compute_wK()");
-        ;  // TODO compute_wK(Cleft, Cright, D, J, K, max_nocc, do_J, do_K, do_wK);
+        compute_wK(Cleft, Cright, wK, max_nocc, do_J, do_K, do_wK);
         timer_off("DFH: compute_wK()");
     }
 
@@ -2967,6 +3156,67 @@ void DFHelper::compute_K(std::vector<SharedMatrix> Cleft, std::vector<SharedMatr
         // compute K
         C_DGEMM('N', 'T', nbf_, nbf_, nocc * block_size, 1.0, T1p, nocc * block_size, T2p, nocc * block_size, 1.0, Kp,
                 nbf_);
+    }
+}
+void DFHelper::compute_wK(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright,
+                          std::vector<SharedMatrix> wK, size_t max_nocc, bool do_J, bool do_K, bool do_wK) {
+    std::vector<std::pair<size_t, size_t>> Qsteps;
+    std::tuple<size_t, size_t> info = Qshell_blocks_for_JK_build(Qsteps, max_nocc, false);
+    size_t tots = std::get<0>(info);
+    size_t totsb = std::get<1>(info);
+
+    double* wMp = wPpq_.get();
+    double* M1p = m1Ppq_.get();
+    std::vector<std::vector<double>> C_buffers(nthreads_);
+// prepare C buffers
+#pragma omp parallel num_threads(nthreads_)
+    {
+        int rank = 0;
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+        C_buffers[rank] = std::vector<double>(nbf_ * std::max(max_nocc, nbf_));
+    }
+
+    // declare bufs
+    std::unique_ptr<double[]> T1;  // Ktmp1
+    std::unique_ptr<double[]> T2;  // Ktmp2
+
+    // allocate first Ktmp
+    size_t Ktmp_size = (!max_nocc ? totsb * 1 : totsb * max_nocc);
+    Ktmp_size = std::max(Ktmp_size * nbf_, nthreads_ * naux_);  // max necessary
+    T1 = std::unique_ptr<double[]>(new double[Ktmp_size]);
+    double* T1p = T1.get();
+    T2 = std::unique_ptr<double[]>(new double[Ktmp_size]);
+    double* T2p = T2.get();
+
+    /* The rest of the file would usually be in compute_K */
+    /* */
+    for (size_t bind = 0, bcount = 0; bind < Qsteps.size(); bind++) {
+        size_t start = std::get<0>(Qsteps[bind]);
+        size_t stop = std::get<1>(Qsteps[bind]);
+        size_t begin = Qshell_aggs_[start];
+        size_t end = Qshell_aggs_[stop + 1] - 1;
+        size_t block_size = end - begin + 1;
+        for (size_t i = 0; i < wK.size(); i++) {
+            size_t nocc = Cleft[i]->colspi()[0];
+            if (!nocc) {
+                continue;
+            }
+            double* Clp = Cleft[i]->pointer()[0];
+            double* Crp = Cright[i]->pointer()[0];
+            double* wKp = wK[i]->pointer()[0];
+
+            // compute first tmp
+            first_transform_pQq(nocc, bcount, block_size, M1p, T1p, Clp, C_buffers);
+            // compute second tmp
+            first_transform_pQq(nocc, bcount, block_size, wMp, T2p, Crp, C_buffers);
+
+            // compute wK
+            C_DGEMM('N', 'T', nbf_, nbf_, nocc * block_size, 1.0, T2p, nocc * block_size, T1p, nocc * block_size, 1.0,
+                    wKp, nbf_);
+        }
+        bcount += block_size;
     }
 }
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -169,7 +169,8 @@ void DFHelper::initialize() {
 
     // if metric power for omega integrals, prepare its metric
     if (do_wK_) {
-        if (!(std::fabs(wmpower_ - 0.0) < 1e-13) && (std::fabs(mpower_ - 0.0) < 1e-13)) (hold_met_ ? prepare_metric_core() : prepare_metric());
+        if (!(std::fabs(wmpower_ - 0.0) < 1e-13) && (std::fabs(mpower_ - 0.0) < 1e-13))
+            (hold_met_ ? prepare_metric_core() : prepare_metric());
     }
 
     // prepare sparsity masks
@@ -187,10 +188,10 @@ void DFHelper::initialize() {
     if (AO_core_) {
         if (do_wK_) {
             prepare_AO_wK_core();
-        } else { // It is possible to reformulate the expression for the 
-				 //   coulomb matrix to save memory in case do_wK_ is 
-                 //   is true, but do_K_ is false. This code isn't written
-  			prepare_AO_core();
+        } else {  // It is possible to reformulate the expression for the
+            //   coulomb matrix to save memory in case do_wK_ is
+            //   is true, but do_K_ is false. This code isn't written
+            prepare_AO_core();
         }
     } else if (!direct_ && !direct_iaQ_) {
         prepare_AO();
@@ -573,7 +574,7 @@ void DFHelper::prepare_AO_wK_core() {
     m1Ppq_ = std::unique_ptr<double[]>(new double[big_skips_[nbf_]]);
 
     double* wppq = wPpq_.get();
-	double* ppq = Ppq_.get();
+    double* ppq = Ppq_.get();
     double* m1ppq = m1Ppq_.get();
 
     std::unique_ptr<double[]> Qpq(new double[std::get<0>(plargest)]);
@@ -582,7 +583,6 @@ void DFHelper::prepare_AO_wK_core() {
     double* met1p;
     std::unique_ptr<double[]> metric;
     double* metp;
-
 
     if (!hold_met_) {
         metric1 = std::unique_ptr<double[]>(new double[naux_ * naux_]);
@@ -595,7 +595,7 @@ void DFHelper::prepare_AO_wK_core() {
         get_tensor_(std::get<0>(files_[filename]), metp, 0, naux_ - 1, 0, naux_ - 1);
     } else {
         met1p = metric_prep_core(wmpower_);
-		metp = metric_prep_core(mpower_);
+        metp = metric_prep_core(mpower_);
     }
 
     for (size_t i = 0; i < psteps.size(); i++) {
@@ -614,7 +614,7 @@ void DFHelper::prepare_AO_wK_core() {
         contract_metric_AO_core_symm(M1p, m1ppq, met1p, begin, end);
         timer_off("DFH: AO-Met. Contraction");
 
-		// contract half metric inverse
+        // contract half metric inverse
         timer_on("DFH: AO-Met. Contraction");
         contract_metric_AO_core_symm(M1p, ppq, metp, begin, end);
         timer_off("DFH: AO-Met. Contraction");

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -197,9 +197,9 @@ void DFHelper::initialize() {
         prepare_AO();
         if (do_wK_) {
             std::stringstream error;
-            error << "DFHelper: not equipped to do wK";
+            error << "DFHelper: not equipped to do wK out of core. \nPlease supply more memory or remove scf_type Mem_DF from the imput file";
             throw PSIEXCEPTION(error.str().c_str());
-            prepare_AO_wK();
+            //prepare_AO_wK();
         }
     }
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -619,27 +619,6 @@ void DFHelper::prepare_AO_wK_core() {
         timer_off("DFH: wAO Copy");
     }
 
-    //    FILE * eri_ints = fopen("/theoryfs2/ds/obrien/Debug/Psi4/dfh_wk/dfheri_ints.txt", "w");
-    //    FILE * eriwints = fopen("/theoryfs2/ds/obrien/Debug/Psi4/dfh_wk/dfheriwints.txt", "w");
-    //
-    //	for (int i = 0; i < nbf_; i++) {
-    //		fprintf(eri_ints, "%d\n", i); fprintf(eriwints,"%d\n", i);
-    //		for (int j = 0; j < naux_; j++) {
-    //			for (int k = 0; k < small_skips_[i]; k++){
-    //				fprintf(eriwints," %f",  wppq[ big_skips_[i] + j * small_skips_[i] + k] );
-    //				fprintf(eri_ints," %f", m1ppq[ big_skips_[i] + j * small_skips_[i] + k] );
-    //			}
-    //			fprintf(eriwints,"\n");
-    //			fprintf(eri_ints,"\n");
-    //		}
-    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
-    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
-    //		fprintf(eri_ints, "\n"); fprintf(eriwints, "\n");
-    //	}
-    //
-    //    fclose(eri_ints);
-    //    fclose(eriwints);
-
     // no more need for metrics
     if (hold_met_) metrics_.clear();
 }
@@ -1314,7 +1293,6 @@ double* DFHelper::metric_prep_core(double pow) {
             break;
         }
     }
-    timer_on("DFH: metric power");
     if (!on) {
         power = pow;
         SharedMatrix J = metrics_[1.0];
@@ -1325,7 +1303,6 @@ double* DFHelper::metric_prep_core(double pow) {
         }
         metrics_[power] = J;
     }
-    timer_off("DFH: metric power");
 
     return metrics_[power]->pointer()[0];
 }
@@ -1392,7 +1369,7 @@ double* DFHelper::metric_inverse_prep_core() {
     bool on = false;
     double power;
     for (auto& kv : metrics_) {
-        if (!(std::fabs(-1.0 - kv.first) > 1e-13)) {
+        if ((std::fabs(-1.0 - kv.first) < 1e-13)) {
             on = true;
             power = kv.first;
             break;
@@ -1403,16 +1380,6 @@ double* DFHelper::metric_inverse_prep_core() {
         timer_on("DFH: metric power");
         SharedMatrix J = metrics_[1.0];
         J->invert();
-        /*		printf("ping\n");
-                        double* j = metrics_[power]->pointer()[0];
-                        printf("ping\n");
-                        std::unique_ptr<int[]> IPIV(new int[naux_]);
-                        std::unique_ptr<double[]> WORK(new double[naux_]);
-                        int * ipiv = IPIV.get();
-                        double * work = WORK.get();
-                        C_DGETRF( (int) naux_, (int) naux_, j, (int) naux_, ipiv);
-                        C_DGETRI( (int) naux_, j, (int) naux_, ipiv, work, (int) naux_); */
-        metrics_[power] = J;
         timer_off("DFH: metric power");
     }
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -169,7 +169,7 @@ void DFHelper::initialize() {
 
     // if metric power for omega integrals, prepare its metric
     if (do_wK_) {
-        if (!(std::fabs(wmpower_ - 0.0) < 1e-13)) (hold_met_ ? prepare_metric_core() : prepare_metric());
+        if (!(std::fabs(wmpower_ - 0.0) < 1e-13) && (std::fabs(mpower_ - 0.0) < 1e-13)) (hold_met_ ? prepare_metric_core() : prepare_metric());
     }
 
     // prepare sparsity masks
@@ -199,8 +199,6 @@ void DFHelper::initialize() {
             error << "DFHelper: not equipped to do wK";
             throw PSIEXCEPTION(error.str().c_str());
             prepare_AO_wK();
-        } else {
-            //        	prepare_AO();
         }
     }
 
@@ -219,7 +217,7 @@ void DFHelper::AO_core() {
         // if do_wK added to code, the following will need to be changed to match
         required_core_size_ = naux_ * nbf_ * nbf_;
     } else {
-        // total size of sparse AOs. beautiful
+        // total size of sparse AOs.
         required_core_size_ = (do_wK_ ? 3 * big_skips_[nbf_] : big_skips_[nbf_]);
     }
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -1326,23 +1326,23 @@ void DFHelper::prepare_metric() {
     std::string putf = std::get<0>(files_[filename]);
     put_tensor(putf, Mp, 0, naux_ - 1, 0, naux_ - 1, "wb");
 }
-std::string DFHelper::return_metfile(double m_mpow) {
+std::string DFHelper::return_metfile(double m_pow) {
     bool on = 0;
     std::string key;
     for (size_t i = 0; i < metric_keys_.size() && !on; i++) {
-        double pos = std::get<0>(metric_keys_[i]);
-        if (std::fabs(pos - m_mpow) < 1e-12) {
+        double power = std::get<0>(metric_keys_[i]);
+        if (std::fabs(power - m_pow) < 1e-12) {
             key = std::get<1>(metric_keys_[i]);
             on = 1;
         }
     }
 
-    if (!on) key = compute_metric(m_mpow);
+    if (!on) key = compute_metric(m_pow);
     return key;
 }
 std::string DFHelper::compute_metric(double m_pow) {
     // ensure J
-    if (std::fabs(pow - 1.0) < 1e-13)
+    if (std::fabs(m_pow - 1.0) < 1e-13)
         prepare_metric();
     else {
         // get metric
@@ -1352,14 +1352,14 @@ std::string DFHelper::compute_metric(double m_pow) {
 
         // get and compute
         get_tensor_(std::get<0>(files_[filename]), metp, 0, naux_ - 1, 0, naux_ - 1);
-        metric->power(pow, condition_);
+        metric->power(m_pow, condition_);
 
         // make new file
         std::string name = "metric";
         name.append(".");
         name.append(std::to_string(m_pow));
         filename_maker(name, naux_, naux_, 1);
-        metric_keys_.push_back(std::make_pair(pow, name));
+        metric_keys_.push_back(std::make_pair(m_pow, name));
 
         // store
         std::string putf = std::get<0>(files_[name]);

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -114,11 +114,13 @@ class PSI_API DFHelper {
     void set_schwarz_cutoff(double cutoff) { cutoff_ = cutoff; }
     double get_schwarz_cutoff() { return cutoff_; }
 
-    /// fitting metric power (defaults to -0.5)
+    /// fitting metric power (defaults to -0.5) to use in
+	/// K_{m n} = C_{l a}(m l|Q)(Q|R)^{-1/2}(R|P)^{-1/2}(P|n s)C_{s a}
     void set_metric_pow(double pow) { mpower_ = pow; }
     double get_metric_pow() { return mpower_; }
 
-    /// fitting metric power for w integrals (defaults to -1.0)
+    /// fitting metric power for w integrals (defaults to -1.0) to use in
+    /// wK_{m n} = C_{l a}(m l|Q)(Q|P)^-1(P|w|n s)C_{s a}
     void set_wmetric_pow(double pow) { wmpower_ = pow; }
     double get_wmetric_pow() { return wmpower_; }
 

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -116,12 +116,12 @@ class PSI_API DFHelper {
 
     /// fitting metric power (defaults to -0.5) to use in
 	/// K_{m n} = C_{l a}(m l|Q)(Q|R)^{-1/2}(R|P)^{-1/2}(P|n s)C_{s a}
-    void set_metric_pow(double pow) { mpower_ = pow; }
+    void set_metric_pow(double m_pow) { mpower_ = m_pow; }
     double get_metric_pow() { return mpower_; }
 
     /// fitting metric power for w integrals (defaults to -1.0) to use in
     /// wK_{m n} = C_{l a}(m l|Q)(Q|P)^-1(P|w|n s)C_{s a}
-    void set_wmetric_pow(double pow) { wmpower_ = pow; }
+    void set_wmetric_pow(double wm_pow) { wmpower_ = wm_pow; }
     double get_wmetric_pow() { return wmpower_; }
 
     ///

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -381,9 +381,9 @@ class PSI_API DFHelper {
     std::vector<std::pair<double, std::string>> metric_keys_;
     void prepare_metric();
     void prepare_metric_core();
-    double* metric_prep_core(double pow);
-    std::string return_metfile(double pow);
-    std::string compute_metric(double pow);
+    double* metric_prep_core(double m_pow);
+    std::string return_metfile(double m_pow);
+    std::string compute_metric(double m_pow);
 
     double* metric_inverse_prep_core();
 

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -319,7 +319,7 @@ class PSI_API DFHelper {
 
     // => in-core machinery <=
     void AO_core();
-    std::unique_ptr<double[]> Ppq_;  //
+    std::unique_ptr<double[]> Ppq_;
     std::map<double, SharedMatrix> metrics_;
 
     // => in-core wK machinery <=

--- a/psi4/src/psi4/libfock/MemDFJK.cc
+++ b/psi4/src/psi4/libfock/MemDFJK.cc
@@ -101,15 +101,6 @@ void MemDFJK::compute_JK() {
     // K_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joeK.txt", false, false, true);
     // wK_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joewK.txt", false, false, true);
 }
-void set_do_wK(bool do_wK) {
-    if (do_wK) {
-        std::stringstream message;
-        message << "MemDFJK cannot compute wK integrals. Please use DiskDFJK." << std::endl;
-        message << "  If you are not a developer or using Psi4NumPy please report this issue at github.com/psi4/psi4."
-                << std::endl;
-        throw PSIEXCEPTION(message.str());
-    }
-}
 void MemDFJK::postiterations() {}
 void MemDFJK::print_header() const {
     // dfh_->print_header();

--- a/psi4/src/psi4/libfock/MemDFJK.cc
+++ b/psi4/src/psi4/libfock/MemDFJK.cc
@@ -96,10 +96,6 @@ void MemDFJK::compute_JK() {
             }
         }
     }
-
-    // J_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joeJ.txt", false, false, true);
-    // K_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joeK.txt", false, false, true);
-    // wK_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joewK.txt", false, false, true);
 }
 void MemDFJK::postiterations() {}
 void MemDFJK::print_header() const {
@@ -129,5 +125,5 @@ int MemDFJK::max_nocc() const {
     }
     return max_nocc;
 }
-void MemDFJK::set_do_wK(bool do_wK) { do_wK_ = do_wK; dfh_->set_do_wK(do_wK); }
+void MemDFJK::set_do_wK(bool tf) { do_wK_ = tf; dfh_->set_do_wK(tf); }
 }

--- a/psi4/src/psi4/libfock/MemDFJK.cc
+++ b/psi4/src/psi4/libfock/MemDFJK.cc
@@ -84,17 +84,22 @@ void MemDFJK::preiterations() {
     // we need to prepare the AOs here, and that's it.
     // DFHelper takes care of all the housekeeping
 
-    if (do_wK_) {
-        // TODO add wK integrals.
-        // DFHelper class will throw
-        // initialize_wK()
-        throw PSIEXCEPTION("MemDFJK does not yet support wK builds.");
-    } else {
-        dfh_->initialize();
-    }
+    dfh_->initialize();
 }
 void MemDFJK::compute_JK() {
-    dfh_->build_JK(C_left_ao_, C_right_ao_, D_ao_, J_ao_, K_ao_, max_nocc(), do_J_, do_K_, do_wK_, lr_symmetric_);
+    dfh_->build_JK(C_left_ao_, C_right_ao_, D_ao_, J_ao_, K_ao_, wK_ao_, max_nocc(), do_J_, do_K_, do_wK_,
+                   lr_symmetric_);
+    if (lr_symmetric_) {
+        if (do_wK_) {
+            for (size_t N = 0; N < wK_ao_.size(); N++) {
+                wK_ao_[N]->hermitivitize();
+            }
+        }
+    }
+
+    // J_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joeJ.txt", false, false, true);
+    // K_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joeK.txt", false, false, true);
+    // wK_ao_[0]->save("/theoryfs2/ds/obrien/Practice/Psi4/joewK.txt", false, false, true);
 }
 void set_do_wK(bool do_wK) {
     if (do_wK) {
@@ -133,4 +138,5 @@ int MemDFJK::max_nocc() const {
     }
     return max_nocc;
 }
+void MemDFJK::set_do_wK(bool do_wK) { do_wK_ = do_wK; dfh_->set_do_wK(do_wK); }
 }

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -106,8 +106,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         _set_dfjk_options<MemDFJK>(jk, options);
 
         return std::shared_ptr<JK>(jk);
-
-    } else if (jk_type == "PK") {
+	} else if (jk_type == "PK") {
         PKJK* jk = new PKJK(primary, options);
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
@@ -155,15 +154,9 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
 std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,
                                  Options& options, bool do_wK, size_t doubles) {
     std::string jk_type = options.get_str("SCF_TYPE");
-    if (do_wK && jk_type == "MEM_DF") {  // throw instead of auto fallback?
-        std::stringstream error;
-        error << "Cannot do SCF_TYPE == 'MEM_DF' and do_wK (yet), please set SCF_TYPE = 'DISK_DF' ";
-        throw PSIEXCEPTION(error.str().c_str());
-    }
-
     if (jk_type == "DF") {
         // logic for MemDFJK vs DiskDFJK
-        if (do_wK || options["DF_INTS_IO"].has_changed()) {
+        if (options["DF_INTS_IO"].has_changed()) {
             return build_JK(primary, auxiliary, options, "DISK_DF");
 
         } else {
@@ -216,7 +209,6 @@ void JK::common_init() {
 }
 size_t JK::memory_overhead() const {
     size_t mem = 0L;
-
     int JKwKD_factor = 1;
     if (do_J_) JKwKD_factor++;
     if (do_K_) JKwKD_factor++;

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -162,6 +162,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         } else {
             // Build exact estimate via Schwarz metrics
             auto jk = build_JK(primary, auxiliary, options, "MEM_DF");
+			jk->set_do_wK(do_wK);
             if (jk->memory_estimate() < doubles) {
                 return jk;
             }

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -56,8 +56,8 @@ using namespace psi;
 
 namespace psi {
 
-template<class T>
-void _set_dfjk_options(T* jk, Options& options){
+template <class T>
+void _set_dfjk_options(T* jk, Options& options) {
     if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
     if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
     if (options["DEBUG"].has_changed()) jk->set_debug(options.get_int("DEBUG"));
@@ -83,7 +83,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         CDJK* jk = new CDJK(primary, options.get_double("CHOLESKY_TOLERANCE"));
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
-        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM"); 
+        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM");
         if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
         if (options["DEBUG"].has_changed()) jk->set_debug(options.get_int("DEBUG"));
         if (options["BENCH"].has_changed()) jk->set_bench(options.get_int("BENCH"));
@@ -106,11 +106,11 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         _set_dfjk_options<MemDFJK>(jk, options);
 
         return std::shared_ptr<JK>(jk);
-	} else if (jk_type == "PK") {
+    } else if (jk_type == "PK") {
         PKJK* jk = new PKJK(primary, options);
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
-        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM"); 
+        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM");
         if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
         if (options["DEBUG"].has_changed()) jk->set_debug(options.get_int("DEBUG"));
 
@@ -120,7 +120,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         DiskJK* jk = new DiskJK(primary, options);
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
-        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM"); 
+        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM");
         if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
         if (options["DEBUG"].has_changed()) jk->set_debug(options.get_int("DEBUG"));
         if (options["BENCH"].has_changed()) jk->set_bench(options.get_int("BENCH"));
@@ -131,7 +131,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         DirectJK* jk = new DirectJK(primary);
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
-        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM"); 
+        if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM");
         if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
         if (options["DEBUG"].has_changed()) jk->set_debug(options.get_int("DEBUG"));
         if (options["BENCH"].has_changed()) jk->set_bench(options.get_int("BENCH"));
@@ -162,7 +162,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         } else {
             // Build exact estimate via Schwarz metrics
             auto jk = build_JK(primary, auxiliary, options, "MEM_DF");
-			jk->set_do_wK(do_wK);
+            jk->set_do_wK(do_wK);
             if (jk->memory_estimate() < doubles) {
                 return jk;
             }

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -429,7 +429,7 @@ class PSI_API JK {
     * @param do_wK do wK matrices or not,
     *        defaults to false
     */
-    void set_do_wK(bool do_wK) { do_wK_ = do_wK; }
+    virtual void set_do_wK(bool do_wK) { do_wK_ = do_wK; }
     /**
     * Set the omega value for wK
     * @param omega range-separation parameter
@@ -1050,6 +1050,12 @@ class PSI_API MemDFJK : public JK {
      */
     void set_df_ints_num_threads(int val) { df_ints_num_threads_ = val; }
 
+    /**
+ * A set_do_wK function that affects the dfhelper object.
+ * used to control wK workflow.
+ */
+    void set_do_wK(bool do_wK) override;
+
     // => Accessors <= //
 
     /**
@@ -1063,5 +1069,8 @@ class PSI_API MemDFJK : public JK {
      */
     std::shared_ptr<DFHelper> dfh() { return dfh_; }
 };
+
 }
+
 #endif
+

--- a/tests/dft-omega/input.dat
+++ b/tests/dft-omega/input.dat
@@ -47,3 +47,53 @@ compare_values(wb97_04, E, 6, 'wB97 [omega=rev]')  #TEST
 E = energy('wb97x')
 compare_values(wb97x_03, E, 6, 'wB97x [omega=rev]')  #TEST
 
+
+set scf_type disk_df
+
+E = energy('wb97')
+compare_values(wb97_04, E, 6, 'wB97 [omega=default=0.4]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_03, E, 6, 'wB97x [omega=default=0.3]')  #TEST
+
+set dft_omega 2.0
+
+E = energy('wb97')
+compare_values(wb97_20, E, 6, 'wB97 [omega=2.0]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_20, E, 6, 'wB97x [omega=2.0]')  #TEST
+
+revoke_global_option_changed('DFT_OMEGA')
+
+E = energy('wb97')
+compare_values(wb97_04, E, 6, 'wB97 [omega=rev]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_03, E, 6, 'wB97x [omega=rev]')  #TEST
+
+
+set scf_type mem_df
+
+E = energy('wb97')
+compare_values(wb97_04, E, 6, 'wB97 [omega=default=0.4]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_03, E, 6, 'wB97x [omega=default=0.3]')  #TEST
+
+set dft_omega 2.0
+
+E = energy('wb97')
+compare_values(wb97_20, E, 6, 'wB97 [omega=2.0]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_20, E, 6, 'wB97x [omega=2.0]')  #TEST
+
+revoke_global_option_changed('DFT_OMEGA')
+
+E = energy('wb97')
+compare_values(wb97_04, E, 6, 'wB97 [omega=rev]')  #TEST
+
+E = energy('wb97x')
+compare_values(wb97x_03, E, 6, 'wB97x [omega=rev]')  #TEST
+


### PR DESCRIPTION
## Description
Adds in-core handling of range-separated functionals to MemDFJK

![dfh_wK](https://user-images.githubusercontent.com/28900775/68413784-ecd19a80-015c-11ea-9f34-95bbda23f787.png)


The blue curve shows in-core DiskDFJK time. The orange curve shows the time taken by in-core MemDFJK wK which constitutes this pull request's addition to the code.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] in core omega integrals for MemDFJK in DFHelper
- [x] improves runtime of range separated DFT calculations
- [ ] out of core omega integrals for MemDFJK

## Questions
- [ ] Should we have a way to default back to Disk_DF if user asks for Mem_DF but does not give enough memory? Currently there is a psiexcption.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
