### PR TITLE
F-/ISAPT-D

### DIFF
--- a/psi4/driver/procrouting/sapt/fisapt_proc.py
+++ b/psi4/driver/procrouting/sapt/fisapt_proc.py
@@ -213,7 +213,7 @@ def fisapt_fdrop(self):
             Ntot = self.molecule().natom()
             NA = self.molecule().extract_subsets(1).natom()
             NB = self.molecule().extract_subsets(2).natom()
-            
+
             Disp_AB = np.zeros((NA, NB))
             for a in range(NA):
                A = a + 1
@@ -262,39 +262,6 @@ def _drop(array, filepath):
     filename = filepath + os.sep + array.name + '.dat'
     with open(filename, 'wb') as handle:
         np.savetxt(handle, array.to_array(), fmt="%24.16E", delimiter=' ', newline='\n')
-
-def fisapt_d3ie(d3pairs, NA=0, Ntot=0):
-    """Helper function to compute the D3 dispersion interaction energy from
-    DFTD3 pairwise analysis.
-
-    Parameters
-    ----------
-    d3pairs : dict
-        Parsed atom-pairwise interaction info from DFTD3 output
-    NA : int
-        Integer number of atoms in monomer A
-    Ntot : int
-        Integer number of atoms in the total dimer
-
-    Returns
-    -------
-    Edisp : float64
-        Total -D dispersion interaction energy [kcal/mol]
-    """
-    Edisp = 0.0
-
-    AxB = [(i, j) for i in range(1, NA + 1) for j in range(NA+1, Ntot+1)]
-    for pair, Pdisp in d3pairs.items():
-        if pair in AxB:
-            Edisp += Pdisp
-
-    #else:
-    #    for i in range(1,NA+1):
-    #        for j in range(NA+1, Ntot+1):
-    #            #print(i,j)
-    #            Edisp += pairdf.loc[idx[i,j], idx['Edisp']]
-                
-    return Edisp
 
 core.FISAPT.compute_energy = fisapt_compute_energy
 core.FISAPT.fdrop = fisapt_fdrop

--- a/psi4/driver/procrouting/sapt/fisapt_proc.py
+++ b/psi4/driver/procrouting/sapt/fisapt_proc.py
@@ -162,24 +162,33 @@ def fisapt_fdrop(self):
     _drop(matrices["IndAB_AB"], filepath)
     _drop(matrices["IndBA_AB"], filepath)
 
+    # Drop disp matrix if it's computed
     if core.get_option("FISAPT", "FISAPT_DO_FSAPT_DISP"):
         matrices["Disp_AB"].name = "Disp"
         _drop(matrices["Disp_AB"], filepath)
-    else:
+
+    # Drop D3 disp matrix if it's computed
+    if core.get_option("FISAPT", "FISAPT_DO_EMPIRICAL_DISP"):
         # Populate (NA, NB) chunk of Disp_AB
+        core.variables()['PAIRWISE DISPERSION CORRECTION ANALYSIS'].print_out()
         d3pairs = core.variables()['PAIRWISE DISPERSION CORRECTION ANALYSIS'].to_array()
         Ntot = self.molecule().natom()
         NA = self.molecule().extract_subsets(1).natom()
         NB = self.molecule().extract_subsets(2).natom()
 
-        Disp_AB = np.zeros((NA, NB))
+        # Empirical disp doesn't preclude exact disp, test for both
+        try:
+            Disp_AB = matrices["Disp_AB"].to_array()
+        except KeyError:
+            Disp_AB = np.zeros((NA, NB))
+
         for a in range(NA):
            for b in range(NB):
-                B = b + NA - 1
+                B = b + NA
                 Disp_AB[a,b] = d3pairs[a,B]
 
         matrices["Disp_AB"] = core.Matrix.from_array(Disp_AB)
-        matrices["Disp_AB"].name = 'D3Disp'
+        matrices["Disp_AB"].name = "Disp"
         _drop(matrices["Disp_AB"], filepath)
 
     if core.get_option("FISAPT", "SSAPT0_SCALE"):
@@ -204,25 +213,32 @@ def fisapt_fdrop(self):
         _drop(matrices["sIndAB_AB"], ssapt_filepath)
         _drop(matrices["sIndBA_AB"], ssapt_filepath)
 
+        # Drop disp matrix if it's computed
         if core.get_option("FISAPT", "FISAPT_DO_FSAPT_DISP"):
-            matrices["sDisp_AB"].name = "Disp"
-            _drop(matrices["Disp_AB"], ssapt_filepath)
-        else:
+            matrices["sDisp_AB"].name = "sDisp"
+            _drop(matrices["sDisp_AB"], ssapt_filepath)
+
+        # Drop D3 disp matrix if it's computed
+        if core.get_option("FISAPT", "FISAPT_DO_EMPIRICAL_DISP"):
             # Populate (NA, NB) chunk of Disp_AB
             d3pairs = core.variables()['PAIRWISE DISPERSION CORRECTION ANALYSIS'].to_array()
             Ntot = self.molecule().natom()
             NA = self.molecule().extract_subsets(1).natom()
             NB = self.molecule().extract_subsets(2).natom()
 
-            Disp_AB = np.zeros((NA, NB))
+            # Empirical disp doesn't preclude exact disp, test for both
+            try:
+                Disp_AB = matrices["sDisp_AB"].to_array()
+            except KeyError:
+                Disp_AB = np.zeros((NA, NB))
+
             for a in range(NA):
-               A = a + 1
                for b in range(NB):
-                   B = b + NA + 1
-                   Disp_AB[a,b] = d3pairs[A,B]
+                    B = b + NA
+                    Disp_AB[a,b] = d3pairs[a,B]
 
             matrices["sDisp_AB"] = core.Matrix.from_array(Disp_AB)
-            matrices["sDisp_AB"].name = 'D3Disp'
+            matrices["sDisp_AB"].name = "sDisp"
             _drop(matrices["sDisp_AB"], ssapt_filepath)
 
 def fisapt_plot(self):

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1314,7 +1314,12 @@ class Molecule(LibmintsMolecule):
         # hack as not checking type GRAD
         for k, qca in jobrec['extras']['qcvars'].items():
             if isinstance(qca, (list, np.ndarray)):
-                jobrec['extras']['qcvars'][k] = np.array(qca).reshape(-1, 3)
+                # Coerce gradient into proper shape
+                try:
+                    jobrec['extras']['qcvars'][k] = np.array(qca).reshape(-1, 3)
+                # Not working? It's a DFTD3 pairwise array.  Pass on directly
+                except ValueError:
+                    jobrec['extras']['qcvars'][k] = qca
 
         if isinstance(self, Molecule):
             pass

--- a/psi4/share/psi4/fsapt/fsapt.py
+++ b/psi4/share/psi4/fsapt/fsapt.py
@@ -30,6 +30,7 @@
 
 from __future__ import print_function
 import sys, os, re, math, copy
+import numpy as np
 
 # => Global Data <= #
 
@@ -332,7 +333,11 @@ def extractOsaptData(filepath):
     vals['Exch']  = readBlock('%s/Exch.dat'  % filepath, H_to_kcal_)
     vals['IndAB'] = readBlock('%s/IndAB.dat' % filepath, H_to_kcal_)
     vals['IndBA'] = readBlock('%s/IndBA.dat' % filepath, H_to_kcal_)
-    vals['Disp']  = readBlock('%s/Disp.dat'  % filepath, H_to_kcal_)
+    try:
+        vals['Disp'] = readBlock('%s/Disp.dat'  % filepath, H_to_kcal_)
+    except FileNotFoundError:
+        vals['Disp'] = np.zeros_like(np.array(readBlock('%s/Elst.dat'  % filepath, H_to_kcal_)))
+
     vals['Total'] = [[0.0 for x in vals['Elst'][0]] for x2 in vals['Elst']]
     for key in ['Elst', 'Exch', 'IndAB', 'IndBA', 'Disp']:
         for k in range(len(vals['Total'])):

--- a/psi4/share/psi4/fsapt/fsapt.py
+++ b/psi4/share/psi4/fsapt/fsapt.py
@@ -32,12 +32,12 @@ from __future__ import print_function
 import sys, os, re, math, copy
 import numpy as np
 from typing import Dict, List, Any, Optional, Tuple
-#import psi4
+import psi4
 
 # => Global Data <= #
 
 # H to kcal constant
-H_to_kcal_ = 627.5095
+H_to_kcal_ = psi4.constants.hartree2kcalmol
 
 # SAPT Keys
 saptkeys_ = [
@@ -342,7 +342,7 @@ def extractOsaptData(filepath):
     try:
         vals['Disp'] = readBlock('%s/Disp.dat'  % filepath, H_to_kcal_) # Exact F-SAPT0 Dispersion
     except FileNotFoundError:
-        print('No exact dispersion present.  Copying & zeroing `Elst.dat`->`Disp.dat`')
+        print('No exact dispersion present.  Copying & zeroing `Elst.dat`->`Disp.dat`, and proceeding.\n')
         vals['Disp'] = np.zeros_like(np.array(readBlock('%s/Elst.dat'  % filepath, H_to_kcal_)))
 
     # Read empirical F-SAPT0-D dispersion data
@@ -389,9 +389,9 @@ def fragmentD3Disp(d3disp: np.ndarray, frags: Dict[str, Dict[str, List[str]]]) -
                     mask[i-1,j-1] = True
             # Add up contributions from fA@fB block
             Edisp += d3disp[mask].sum()
-            D3frags[fA][fB] = d3disp[mask].sum() * H_to_kcal_ #psi4.constants.hartree2kcalmol
+            D3frags[fA][fB] = d3disp[mask].sum() * H_to_kcal_
 
-    return Edisp * H_to_kcal_, D3frags #psi4.constants.hartree2kcalmol, D3frags
+    return Edisp * H_to_kcal_, D3frags
 
 
 def extractOrder2Fsapt(osapt, wsA, wsB, frags):

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1039,6 +1039,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("FISAPT_DO_FSAPT", true);
         /*- Do F-SAPT Dispersion? -*/
         options.add_bool("FISAPT_DO_FSAPT_DISP", true);
+        /*- Do F-SAPT Empirical Dispersion? -*/
+        options.add_bool("FISAPT_DO_EMPIRICAL_DISP", false);
+        /*- Specify F-SAPT-D Empirical Dispersion Damping Function -*/
+        options.add_str("FISAPT_EMPIRICAL_DISP", "D3MBJ", "D3M D3MBJ");
         /*- Filepath to drop F-SAPT data within input file directory -*/
         options.add_str_i("FISAPT_FSAPT_FILEPATH", "fsapt/");
         /*- Do F-SAPT exchange scaling? (ratio of S^\infty to S^2) -*/

--- a/tests/dftd3/fisapt-d/input.dat
+++ b/tests/dftd3/fisapt-d/input.dat
@@ -1,0 +1,77 @@
+#! This test case shows an example of running and analyzing a standard
+#! F-SAPT0/jun-cc-pvdz procedure for phenol dimer from the S22 database.
+
+memory 1 GB
+
+molecule mol {
+0 1
+O    -1.3885044    1.9298523   -0.4431206
+H    -0.5238121    1.9646519   -0.0064609
+C    -2.0071056    0.7638459   -0.1083509
+C    -1.4630807   -0.1519120    0.7949930
+C    -2.1475789   -1.3295094    1.0883677
+C    -3.3743208   -1.6031427    0.4895864
+C    -3.9143727   -0.6838545   -0.4091028
+C    -3.2370496    0.4929609   -0.7096126
+H    -0.5106510    0.0566569    1.2642563
+H    -1.7151135   -2.0321452    1.7878417
+H    -3.9024664   -2.5173865    0.7197947
+H    -4.8670730   -0.8822939   -0.8811319
+H    -3.6431662    1.2134345   -1.4057590
+--
+0 1
+O     1.3531168    1.9382724    0.4723133
+H     1.7842846    2.3487495    1.2297110
+C     2.0369747    0.7865043    0.1495491
+C     1.5904026    0.0696860   -0.9574153
+C     2.2417367   -1.1069765   -1.3128110
+C     3.3315674   -1.5665603   -0.5748636
+C     3.7696838   -0.8396901    0.5286439
+C     3.1224836    0.3383498    0.8960491
+H     0.7445512    0.4367983   -1.5218583
+H     1.8921463   -1.6649726   -2.1701843
+H     3.8330227   -2.4811537   -0.8566666
+H     4.6137632   -1.1850101    1.1092635
+H     3.4598854    0.9030376    1.7569489
+symmetry c1
+no_reorient
+no_com
+}
+
+set {
+basis         jun-cc-pvdz
+scf_type df
+guess sad
+freeze_core true
+fisapt_do_fsapt_disp true
+fisapt_do_empirical_disp true
+fisapt_empirical_disp d3mbj
+}
+
+energy('fisapt0')
+
+keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'D3MBJ Disp', 'Etot']  #TEST
+
+Eref = {  #TEST
+    'Enuc'        : 805.1177369,  #TEST
+    'Eelst'       :  -0.01449385168,      #TEST
+    'Eexch'       :  +0.01572480431,      #TEST
+    'Eind'        :  -0.00445604001,      #TEST
+    'Edisp'       :  -0.00815025022,      #TEST
+    'D3MBJ EDisp' : -0.00977220000,       #TEST
+    'Etot'        :  -0.01137533761,      #TEST
+    }  #TEST
+
+Epsi = {  #TEST
+    'Enuc'        : mol.nuclear_repulsion_energy(),  #TEST
+    'Eelst'       : variable("SAPT ELST ENERGY"),    #TEST
+    'Eexch'       : variable("SAPT EXCH ENERGY"),    #TEST
+    'Eind'        : variable("SAPT IND ENERGY"),     #TEST
+    'Edisp'       : variable("SAPT DISP ENERGY"),    #TEST
+    'D3MBJ EDisp' : variable("SAPT EMPIRICAL D3MBJ DISP ENERGY"),  #TEST
+    'Etot'        : variable("SAPT0 TOTAL ENERGY"),  #TEST
+   }  #TEST
+
+
+for key in keys:  #TEST
+    compare_values(Eref[key], Epsi[key], 6, key)  #TEST


### PR DESCRIPTION
## Description
Enables dispersion corrected F-/ISAPT with optimal damping parameters, calling QCEngine for pairwise DFTD3 analysis.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Toggle empirical/exact dispersion in F-/ISAPT, call relevant damping functions
- [x] Parses pairwise atomic D3 interactions from QCEngine & DFTD3
- [ ] Functional group partitioning of D3 pairwise interactions

## Questions
- [ ] Current test "fails" with 1.e-5 Eh difference between direct D3 IE and supramolecular D3 IE.  Likely due to precision of pairwise atomic contact energies from DFTD3, which may be addressed in subsequent PRs to QCEngine.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
