### PR TITLE
Move basis set orthogonalization to libmints/orthog.cc

### DIFF
--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -66,6 +66,7 @@ list(APPEND sources
   bessel.cc
   gaussquad.cc
   ecpint.cc
+  orthog.cc
   )
 
 psi4_add_module(lib mints sources)

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -44,8 +44,6 @@ Dimension::Dimension(int n, const std::string& name) : name_(name), blocks_(n, 0
 
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
-Dimension::~Dimension() {}
-
 void Dimension::init(int n, const std::string& name) {
     name_ = name;
     blocks_.assign(n, 0);

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -44,8 +44,6 @@ Dimension::Dimension(int n, const std::string& name) : name_(name), blocks_(n, 0
 
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
-Dimension::Dimension(const Dimension& other) : name_(other.name_), blocks_(other.blocks_) {}
-
 Dimension::~Dimension() {}
 
 void Dimension::init(int n, const std::string& name) {
@@ -67,12 +65,6 @@ void Dimension::print() const {
         outfile->Printf("%d  ", ni);
     }
     outfile->Printf("\n");
-}
-
-Dimension& Dimension::operator=(const Dimension& other) {
-    name_ = other.name_;
-    blocks_ = other.blocks_;
-    return *this;
 }
 
 Dimension& Dimension::operator=(const int* other) {

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -46,7 +46,6 @@ class PSI_API Dimension {
     Dimension();
     Dimension(int n, const std::string& name = "");
     Dimension(const std::vector<int>& other);
-    ~Dimension();
 
     /// Assignment operator, this one can be very dangerous
     Dimension& operator=(const int* other);

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -44,13 +44,9 @@ class PSI_API Dimension {
 
    public:
     Dimension();
-    Dimension(const Dimension& other);
     Dimension(int n, const std::string& name = "");
     Dimension(const std::vector<int>& other);
     ~Dimension();
-
-    /// Assignment operator
-    Dimension& operator=(const Dimension& other);
 
     /// Assignment operator, this one can be very dangerous
     Dimension& operator=(const int* other);

--- a/psi4/src/psi4/libmints/orthog.cc
+++ b/psi4/src/psi4/libmints/orthog.cc
@@ -29,205 +29,165 @@
 #include <cstdlib>
 #include <cmath>
 #include <iterator>
+#include <algorithm>
 
 #include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
-#include "matrix.h"
-#include "vector.h"
-#include "orthog.h"
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/vector.h"
+#include "psi4/libmints/orthog.h"
 
 namespace psi {
 
-namespace {
-
-struct max_abs {
-    bool operator()(const double& i, const double& j) { return std::abs(i) < std::abs(j); }
-};
-
-}  // namespace
-
-OverlapOrthog::OverlapOrthog(OrthogMethod method, SharedMatrix overlap, double lindep_tolerance, int debug)
-    : nlindep_(0), min_orthog_res_(0.0), max_orthog_res_(0.0) {
-    orthog_method_ = method;
-    overlap_ = overlap;
-    lindep_tol_ = lindep_tolerance;
-    debug_ = debug;
-    dim_ = overlap_->rowspi();
-    orthog_dim_.init("Orthogonal Dimension", dim_.n());
+OverlapOrthog::OverlapOrthog(OrthogMethod method, SharedMatrix overlap, double lindep_tolerance, int print)
+    : orthog_method_(method), overlap_(overlap), lindep_tol_(lindep_tolerance), print_(print) {
+    eigval_ = nullptr;
+    eigvec_ = nullptr;
 }
 
-void OverlapOrthog::compute_overlap_eig(Matrix& overlap_eigvec, Vector& isqrt_eigval, Vector& sqrt_eigval) {
-    auto U = std::make_shared<Matrix>("U", overlap_->rowspi(), overlap_->colspi());
-    auto m = std::make_shared<Vector>(overlap_->colspi());
+void OverlapOrthog::compute_overlap_eig() {
+    // Eigenvectors
+    eigvec_ = std::make_shared<Matrix>("U", overlap_->rowspi(), overlap_->colspi());
+    // Eigenvalues
+    eigval_ = std::make_shared<Vector>(overlap_->colspi());
+    overlap_->diagonalize(eigvec_, eigval_);
 
-    overlap_->diagonalize(U, m);
+    bool min_S_initialized = false;
+    for (int h = 0; h < eigval_->nirrep(); ++h) {
+        for (int i = 0; i < eigval_->dim(h); i++) {
+            double eval = eigval_->get(h, i);
 
-    double maxabs = *std::max_element(m->begin(), m->end(), max_abs());
-    double s_tol = lindep_tol_ * maxabs;
-    double minabs = maxabs;
-
-    std::vector<double> m_sqrt(dim_.sum());
-    std::vector<double> m_isqrt(dim_.sum());
-    std::vector<int> m_index(dim_.sum());
-    std::vector<int> nfunc(dim_.n());
-    int nfunctotal = 0;
-
-    nlindep_ = 0;
-    for (int h = 0; h < m->nirrep(); ++h) {
-        for (Vector::iterator iter = m->begin_irrep(h); iter != m->end_irrep(h); ++iter) {
-            if (*iter > s_tol) {
-                if (*iter < minabs) minabs = *iter;
-                m_sqrt[nfunctotal] = sqrt(*iter);
-                m_isqrt[nfunctotal] = 1.0 / m_sqrt[nfunctotal];
-                m_index[nfunctotal] = std::distance(m->begin_irrep(h), iter);
-                nfunc[h]++;
-                nfunctotal++;
-            } else if (orthog_method_ == Symmetric) {
-                m_sqrt[nfunctotal] = 0.0;
-                m_isqrt[nfunctotal] = 0.0;
-                m_index[nfunctotal] = std::distance(m->begin_irrep(h), iter);
-                ;
-                nfunc[h]++;
-                nfunctotal++;
-                nlindep_++;
-            } else
-                nlindep_++;
-        }
-    }
-
-    if (nlindep_ > 0 && orthog_method_ == Symmetric) {
-        outfile->Printf("    WARNING: %d basis function%s ignored in symmetric orthogonalization.\n", nlindep_,
-                        (dim_.sum() - orthog_dim_.sum() > 1) ? "s" : "");
-    }
-
-    if (orthog_method_ == Symmetric) {
-        orthog_dim_.init("ortho basis (symmetric)", m->nirrep());
-        orthog_dim_ = m->dimpi();
-    } else {
-        orthog_dim_.init("ortho basis (canonical)", m->nirrep());
-        orthog_dim_ = nfunc;
-    }
-
-    overlap_eigvec.init(dim_, orthog_dim_, "Overlap Eigenvectors");
-    if (orthog_method_ == Symmetric)
-        overlap_eigvec.copy(U);
-    else {
-        int jfunc = 0;
-        // Copy over the vectors we need
-        for (int h = 0; h < m->nirrep(); ++h) {
-            for (int j = 0; j < nfunc[h]; ++j) {
-                for (int i = 0; i < dim_[h]; ++i) {
-                    overlap_eigvec.set(h, i, j, U->get(h, i, m_index[jfunc]));
-                }
-                jfunc++;
+            if (!min_S_initialized) {
+                min_S = eval;
+                min_S_initialized = true;
+            } else if (min_S > eval) {
+                min_S = eval;
             }
         }
     }
+    outfile->Printf("  Minimum eigenvalue in the overlap matrix is %14.10E.\n", min_S);
+}
 
-    sqrt_eigval.init(orthog_dim_);
-    isqrt_eigval.init(orthog_dim_);
+void OverlapOrthog::compute_inverse() {
+    Xinv_ = std::make_shared<Matrix>("Orthogonal Inverse Transformation", X_->rowspi(), X_->colspi());
+    Xinv_->gemm(false, false, 1.0, overlap_, X_, 0.0);
+}
 
-    std::copy(m_sqrt.begin(), m_sqrt.end(), sqrt_eigval.begin());
-    std::copy(m_isqrt.begin(), m_isqrt.end(), isqrt_eigval.begin());
-
-    max_orthog_res_ = maxabs;
-    min_orthog_res_ = minabs;
-
-    if (debug_ > 1) {
-        overlap_->print();
-        overlap_eigvec.print();
-        isqrt_eigval.print();
-        sqrt_eigval.print();
-    }
+SharedMatrix OverlapOrthog::overlap_inverse() {
+    auto Sinv = std::make_shared<Matrix>("Inverse Transformation", X_->rowspi(), X_->rowspi());
+    Sinv->gemm(false, true, 1.0, X_, X_, 0.0);
+    return Sinv;
 }
 
 void OverlapOrthog::compute_symmetric_orthog() {
-    Matrix overlap_eigvec;
-    Vector overlap_isqrt_eigval;
-    Vector overlap_sqrt_eigval;
+    if (!eigval_) compute_overlap_eig();
+    if (min_S < lindep_tol_) {
+        outfile->Printf("WARNING: smallest overlap eigenvalue %e is smaller than S_TOLERANCE!\n", min_S);
+    }
+    const Dimension& nbf = eigval_->dimpi();
 
-    compute_overlap_eig(overlap_eigvec, overlap_isqrt_eigval, overlap_sqrt_eigval);
+    SharedVector eval(std::make_shared<Vector>(nbf));
+    eval->copy(*eigval_);
+    for (int h = 0; h < eval->nirrep(); ++h) {
+        for (int i = 0; i < eval->dim(h); i++) {
+            double val = 1.0 / sqrt(eval->get(h, i));
+            eval->set(h, i, val);
+        }
+    }
 
-    auto overlap_isqrt_eigval_mat = std::make_shared<Matrix>(orthog_dim_, orthog_dim_);
-    overlap_isqrt_eigval_mat->set_diagonal(overlap_isqrt_eigval);
-    auto overlap_sqrt_eigval_mat = std::make_shared<Matrix>(orthog_dim_, orthog_dim_);
-    overlap_sqrt_eigval_mat->set_diagonal(overlap_sqrt_eigval);
+    auto eigtemp2 = std::make_shared<Matrix>("Scratch matrix 1", nbf, nbf);
+    eigtemp2->set_diagonal(eval);
+    auto eigtemp = std::make_shared<Matrix>("Scratch matrix 2", nbf, nbf);
+    eigtemp->gemm(false, true, 1.0, eigtemp2, eigvec_, 0.0);
 
-    orthog_trans_ = std::make_shared<Matrix>("Orthogonal Transformation", dim_, dim_);
-    orthog_trans_->transform(*overlap_isqrt_eigval_mat.get(), overlap_eigvec);
-    orthog_trans_inverse_ = std::make_shared<Matrix>("Orthogonal Inverse Transformation", dim_, dim_);
-    orthog_trans_inverse_->transform(*overlap_sqrt_eigval_mat.get(), overlap_eigvec);
-
-    //    overlap_eigvec.print();
-    //    overlap_isqrt_eigval.print();
-    //    overlap_sqrt_eigval.print();
-    //    orthog_trans_->print();
-    //    orthog_trans_inverse_->print();
+    X_ = std::make_shared<Matrix>("X (Symmetric Orthogonalization)", nbf, nbf);
+    X_->gemm(false, false, 1.0, eigvec_, eigtemp, 0.0);
 }
 
 void OverlapOrthog::compute_canonical_orthog() {
-    Matrix overlap_eigvec;
-    Vector overlap_isqrt_eigval;
-    Vector overlap_sqrt_eigval;
+    if (!eigval_) compute_overlap_eig();
+    const Dimension& nbf = eigval_->dimpi();
+    int nirrep = eigval_->nirrep();
 
-    compute_overlap_eig(overlap_eigvec, overlap_isqrt_eigval, overlap_sqrt_eigval);
+    // Count number of orbitals
+    Dimension nmo(nbf);
+    for (int h = 0; h < nirrep; ++h) {
+        nmo[h] = 0;
+        for (int i = 0; i < nbf[h]; ++i) {
+            if (eigval_->get(h, i) > lindep_tol_) {
+                nmo[h]++;
+            }
+        }
+        if (print_ > 2) outfile->Printf("  Irrep %d, %d of %d possible MOs eliminated.\n", h, nbf[h] - nmo[h], nbf[h]);
+    }
 
-    auto overlap_isqrt_eigval_mat = std::make_shared<Matrix>(orthog_dim_, orthog_dim_);
-    overlap_isqrt_eigval_mat->set_diagonal(overlap_isqrt_eigval);
-    auto overlap_sqrt_eigval_mat = std::make_shared<Matrix>(orthog_dim_, orthog_dim_);
-    overlap_sqrt_eigval_mat->set_diagonal(overlap_sqrt_eigval);
-
-    orthog_trans_ = std::make_shared<Matrix>("Orthogonal Transformation", orthog_dim_, dim_);
-    orthog_trans_->gemm(false, true, 1.0, overlap_isqrt_eigval_mat, overlap_eigvec, 0.0);
-    orthog_trans_inverse_ = std::make_shared<Matrix>("Orthogonal Inverse Transformation", dim_, orthog_dim_);
-    orthog_trans_inverse_->gemm(false, false, 1.0, overlap_eigvec, overlap_sqrt_eigval_mat, 0.0);
-}
-
-void OverlapOrthog::compute_gs_orthog() { throw NOT_IMPLEMENTED_EXCEPTION(); }
-
-void OverlapOrthog::compute_orthog_trans() {
-    switch (orthog_method_) {
-        case GramSchmidt:
-            outfile->Printf("    Using Gram-Schmidt orthogonalization.\n");
-            compute_gs_orthog();
-            break;
-        case Symmetric:
-            outfile->Printf("    Using symmetric orthogonalization.\n");
-            compute_symmetric_orthog();
-            break;
-        case Canonical:
-            outfile->Printf("    Using canonical orthogonalization.\n");
-            compute_canonical_orthog();
-            break;
-        default:
-            throw PSIEXCEPTION("OverlapOrthog::compute_orthog_tarns: bad value.");
+    // Form vectors
+    X_ = std::make_shared<Matrix>("X (Canonical Orthogonalization)", nbf, nmo);
+    for (int h = 0; h < nirrep; ++h) {
+        for (int mo = 0; mo < nmo[h]; ++mo) {
+            // Columns are in increasing overlap eigenvalue
+            int col = nbf[h] - nmo[h] + mo;
+            double norm = 1.0 / sqrt(eigval_->get(h, col));
+            for (int j = 0; j < nbf[h]; j++) X_->set(h, j, mo, norm * eigvec_->get(h, j, col));
+        }
     }
 }
 
-SharedMatrix OverlapOrthog::basis_to_orthog_basis() {
-    if (!orthog_trans_) compute_orthog_trans();
+void OverlapOrthog::compute_orthog_trans() {
+    compute_overlap_eig();
+    if (orthog_method_ == Automatic) {
+        orthog_method_ = (min_S < lindep_tol_) ? Symmetric : Canonical;
+    }
 
-    return orthog_trans_;
+    switch (orthog_method_) {
+        case Symmetric:
+            if (print_) outfile->Printf("    Using symmetric orthogonalization.\n");
+            compute_symmetric_orthog();
+            break;
+        case Canonical:
+            if (print_) outfile->Printf("    Using canonical orthogonalization.\n");
+            compute_canonical_orthog();
+            break;
+        default:
+            throw PSIEXCEPTION("OverlapOrthog::compute_orthog_trans: bad value.");
+    }
+
+    // Compute inverse transformation, too.
+    compute_inverse();
+}
+
+SharedMatrix OverlapOrthog::basis_to_orthog_basis() {
+    if (!X_) compute_orthog_trans();
+
+    return X_;
 }
 
 SharedMatrix OverlapOrthog::basis_to_orthog_basis_inverse() {
-    if (!orthog_trans_inverse_) compute_orthog_trans();
+    if (!X_) compute_orthog_trans();
+    if (!Xinv_) compute_inverse();
 
-    return orthog_trans_inverse_;
+    return Xinv_;
 }
 
-Dimension OverlapOrthog::dim() { return dim_; }
+Dimension OverlapOrthog::dim() { return X_->rowdim(); }
 
 Dimension OverlapOrthog::orthog_dim() {
-    if (!orthog_trans_) compute_orthog_trans();
+    if (!X_) compute_orthog_trans();
 
-    return orthog_dim_;
+    return X_->coldim();
 }
 
 int OverlapOrthog::nlindep() {
-    if (!orthog_trans_) compute_orthog_trans();
+    if (!X_) compute_orthog_trans();
 
-    return nlindep_;
+    return X_->colspi().sum();
+}
+
+int OverlapOrthog::nlindep(int h) {
+    if (!X_) compute_orthog_trans();
+
+    return X_->coldim(h);
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/orthog.h
+++ b/psi4/src/psi4/libmints/orthog.h
@@ -37,52 +37,47 @@ namespace psi {
 class PSI_API OverlapOrthog {
    public:
     /// An enum for the types of orthogonalization.
-    enum OrthogMethod { Symmetric, Canonical, GramSchmidt };
+    enum OrthogMethod { Symmetric, Canonical, Automatic };
 
    private:
-    int debug_;
-
-    Dimension dim_;
-    Dimension orthog_dim_;
+    int print_;
 
     /** The tolerance for linearly independent basis functions.
      * The interpretation depends on the orthogonalization
      * method.
      */
     double lindep_tol_;
-    /// The number of linearly dependent functions
-    int nlindep_;
     /// The orthogonalization method
     OrthogMethod orthog_method_;
-    // The orthogonalization matrices
-    SharedMatrix orthog_trans_;
-    SharedMatrix orthog_trans_inverse_;
+    /// The orthogonalizing matrix
+    SharedMatrix X_;
+    /// ... and its inverse
+    SharedMatrix Xinv_;
 
-    /// @{
-    /** The minimum and maximum residual from the
-     * orthogonalizationprocedure. The interpretation depends
-     * on the method used. For symmetry and canonical, these
-     * are the min and max overlap eigenvalues. These are the
-     * residuals for the basis functions that actually end
-     * up being used.
-     */
-    double min_orthog_res_;
-    double max_orthog_res_;
+    /// Smallest eigenvalue
+    double min_S;
     /// @}
 
-    void compute_overlap_eig(Matrix& overlap_eigvec, Vector& isqrt_eigval, Vector& sqrt_eigval);
+    /// Given X, compute Xinv = S*X
+    void compute_inverse();
+    /// Compute eigendecomposition
+    void compute_overlap_eig();
+    /// Symmetric orthogonalization
     void compute_symmetric_orthog();
+    /// Canonical orthogonalization
     void compute_canonical_orthog();
-    void compute_gs_orthog();
+    /// Driver routine
     void compute_orthog_trans();
 
+    /// Decomposed matrix
     SharedMatrix overlap_;
+    /// Eigenvectors
+    SharedMatrix eigvec_;
+    /// Eigenvalues
+    SharedVector eigval_;
 
    public:
-    OverlapOrthog(OrthogMethod method, SharedMatrix overlap, double lindep_tolerance, int debug = 0);
-
-    double min_orthog_res() const { return min_orthog_res_; }
-    double max_orthog_res() const { return max_orthog_res_; }
+    OverlapOrthog(OrthogMethod method, SharedMatrix overlap, double lindep_tolerance, int print = 0);
 
     OrthogMethod orthog_method() const { return orthog_method_; }
 
@@ -107,10 +102,15 @@ class PSI_API OverlapOrthog {
     /// Return an $S^{-1}$.
     SharedMatrix overlap_inverse();
 
+    /// Number of basis functions
     Dimension dim();
+    /// Number of orthogonal functions
     Dimension orthog_dim();
 
+    /// Number of independent functions
     int nlindep();
+    /// Number of independent functions in symmetry block h
+    int nlindep(int h);
 };
 
 }  // namespace psi

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1272,8 +1272,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("SAVE_JK", false);
         /*- Memory safety factor for allocating JK -*/
         options.add_double("SCF_MEM_SAFETY_FACTOR", 0.75);
-        /*- SO orthogonalization: symmetric or canonical? -*/
-        options.add_str("S_ORTHOGONALIZATION", "SYMMETRIC", "SYMMETRIC CANONICAL");
+        /*- SO orthogonalization: automatic, symmetric, or canonical? -*/
+        options.add_str("S_ORTHOGONALIZATION", "AUTO", "AUTO SYMMETRIC CANONICAL");
         /*- Minimum S matrix eigenvalue to allow before linear dependencies are removed. -*/
         options.add_double("S_TOLERANCE", 1E-7);
         /*- Schwarz screening threshold. Mininum absolute value below which TEI are neglected. -*/


### PR DESCRIPTION
## Description
This PR removes duplicated code in Psi4 so that orthogonalization of the basis is handled in one place.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] No code duplication
- [x] Everything works as before

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
