### PR TITLE
Renamed instances of property function to properties in docs

### DIFF
--- a/doc/sphinxman/source/cc.rst
+++ b/doc/sphinxman/source/cc.rst
@@ -156,8 +156,8 @@ to functions like :py:func:`~psi4.energy`: ``'ccsd'``, ``'ccsd(t)'``, ``'ccsd(at
 ``'cc3'``, ``'bccd'`` (CCD with Brueckner orbitals), ``'bccd(t)'`` (CCD(T) with
 Brueckner orbitals), ``'eom-ccsd'``, ``'eom-cc2'`` (CC2 for excited states),
 ``'eom-cc3'`` (CC3 for excited states).  Response properties can be obtained
-by calling the function :py:func:`~psi4.property` (instead of, for example, :py:func:`~psi4.energy`,
-*e.g.*, ``property('ccsd')``.  There are many sample
+by calling the function :py:func:`~psi4.properties` (instead of, for example, :py:func:`~psi4.energy`,
+*e.g.*, ``properties('ccsd')``.  There are many sample
 coupled cluster inputs provided in :source:`samples`.
 
 Basic Keywords
@@ -219,8 +219,8 @@ The most important keywords associated with EOM-CC calculations are:
 Linear Response (CCLR) Calculations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Linear response computations are invoked like ``property('ccsd')``
-or ``property('cc2')``, along with a list of requested properties.
+Linear response computations are invoked like ``properties('ccsd')``
+or ``properties('cc2')``, along with a list of requested properties.
 A complete list of keywords related to
 coupled cluster linear response is provided in Appendix :ref:`apdx:ccresponse`.
 

--- a/doc/sphinxman/source/cfour.rst
+++ b/doc/sphinxman/source/cfour.rst
@@ -681,7 +681,7 @@ into |PSIfour| data objects.
   stowed in PSI Variables.
 
 * Property calls that required extra computation not yet translated into
-  :py:func:`~psi4.property` computation command
+  :py:func:`~psi4.properties` computation command
 
 * Frequencies
 

--- a/doc/sphinxman/source/oeprop.rst
+++ b/doc/sphinxman/source/oeprop.rst
@@ -97,12 +97,12 @@ properties to compute.  The available properties are shown in the table above.
 The syntax above works well for computing properties using the SCF
 wavefunction, however, may be difficult (or impossible) to use for some of the
 correlated levels of theory. Alternatively, one-electron properties can be
-computed using the built-in property() function, e.g.::
+computed using the built-in properties() function, e.g.::
 
-  property('ccsd', properties=['dipole'])
+  properties('ccsd', properties=['dipole'])
 
-The :py:func:`~psi4.property` function provides limited functionality, but is a lot easier to
-use for correlated methods. For capabilities of :py:func:`~psi4.property` see the
+The :py:func:`~psi4.properties` function provides limited functionality, but is a lot easier to
+use for correlated methods. For capabilities of :py:func:`~psi4.properties` see the
 corresponding section of the manual.
 
 

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -881,7 +881,7 @@ Convergence and Algorithm Defaults
    that use an alternate starting point, like MCSCF. SAPT computations, too,
    set tighter values.
 
-.. [#f2] This applies to properties computed through the :py:func:`~psi4.property` function.
+.. [#f2] This applies to properties computed through the :py:func:`~psi4.properties` function.
 
 .. [#f3] Post-HF methods that do not rely upon the usual 4-index AO integrals use a
    density-fitted SCF reference. That is, for DF-MP2 and SAPT, the default |globals__scf_type| is DF.


### PR DESCRIPTION
## Description
Fix occurrences of `psi4.property` in the documentation and replace by `psi4.properties`.

## Checklist
- [-] Tests added for any new features
- [-] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
