### PR TITLE
orthog test fixes

### DIFF
--- a/psi4/src/psi4/libmints/orthog.cc
+++ b/psi4/src/psi4/libmints/orthog.cc
@@ -137,7 +137,7 @@ void OverlapOrthog::compute_canonical_orthog() {
 void OverlapOrthog::compute_orthog_trans() {
     compute_overlap_eig();
     if (orthog_method_ == Automatic) {
-        orthog_method_ = (min_S < lindep_tol_) ? Symmetric : Canonical;
+        orthog_method_ = (min_S > lindep_tol_) ? Symmetric : Canonical;
     }
 
     switch (orthog_method_) {

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -120,7 +120,7 @@ def test_qcschema_cli(input_enc, input_fn, output_enc, output_fn, result_data_fi
         print(e)
 
     assert compare_integers(True, parsed, "Result Model Parsed")
-    assert compare_integers(-76.22831410207938, ret.return_result, "Return")
+    assert compare_values(-76.22831410207938, ret.return_result, "Return")
 
 def test_qcschema_wavefunction_basis(result_data_fixture):
     result_data_fixture["protocols"] = {"wavefunction": "orbitals_and_eigenvalues"}


### PR DESCRIPTION
## Description
This is consistent to [what HF orthog was doing](https://github.com/psi4/psi4/pull/1759/files?utf8=%E2%9C%93&diff=split&w=1#diff-542034e7ed85da9a795544399b295be6L743) pre #1759 . Fixes the cookbook/rohf and scf-guess-read2 tests, both of which involve ROHF. Look sensible, @susilehtola?

## Checklist
- [ ] ~Tests added for any new features~
- [x] All or relevant fraction of full tests run -- full ctest now passes at 1759

## Status
- [x] Ready for review
- [x] Ready for merge
