### PR TITLE
Fix CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -191,7 +191,8 @@ jobs:
       # Spot Test
       - script: |
           setlocal EnableDelayedExpansion
-          stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
+          set PATH=$(Build.BinariesDirectory)\install\bin;%PATH%
+          psi4 $(Build.BinariesDirectory)\tests\tu1-h2o-energy\input.dat
         displayName: 'Spot Test'
         workingDirectory: $(Build.BinariesDirectory)/build
 

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -192,7 +192,7 @@ jobs:
       - script: |
           setlocal EnableDelayedExpansion
           set PATH=$(Build.BinariesDirectory)\install\bin;%PATH%
-          psi4 $(Build.BinariesDirectory)\tests\tu1-h2o-energy\input.dat
+          psi4 $(Build.SourcesDirectory)\tests\tu1-h2o-energy\input.dat
         displayName: 'Spot Test'
         workingDirectory: $(Build.BinariesDirectory)/build
 

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -188,6 +188,13 @@ jobs:
         displayName: "Test Psi4 (OpenMP)"
         workingDirectory: $(Build.BinariesDirectory)/install/lib
 
+      # Spot Test
+      - script: |
+          setlocal EnableDelayedExpansion
+          stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
+        displayName: 'Spot Test'
+        workingDirectory: $(Build.BinariesDirectory)/build
+
       # Test (ctest)
       - script: |
           setlocal EnableDelayedExpansion

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental ATLEAST 0.11.0 QUIET)
+    find_python_module(qcelemental ATLEAST 0.12.0 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -19,7 +19,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.11.0.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.12.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcengine}))
     include(FindPythonModule)
-    find_python_module(qcengine ATLEAST 0.11.0 QUIET)
+    find_python_module(qcengine ATLEAST 0.13.0 QUIET)
 endif()
 
 if(${qcengine_FOUND})
@@ -21,7 +21,7 @@ else()
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCEngine/archive/v0.10.0.tar.gz
+        URL https://github.com/MolSSI/QCEngine/archive/v0.13.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/tests/pytests/addons.py
+++ b/tests/pytests/addons.py
@@ -1,7 +1,20 @@
-import subprocess
-
 import pytest
+
 from qcelemental.util import parse_version, which, which_import
+from qcengine.testing import using
+
+__all__ = [
+    'hardware_nvidia_gpu',
+    'using_cppe',
+    'using_dftd3',
+    'using_dftd3_321',
+    'using_gcp',
+    'using_mp2d',
+    'using_memory_profiler',
+    'using_networkx',
+    'using_psi4',
+    'using_qcdb',
+]
 
 
 def is_psi4_new_enough(version_feature_introduced):
@@ -9,24 +22,6 @@ def is_psi4_new_enough(version_feature_introduced):
         return False
     import psi4
     return parse_version(psi4.__version__) >= parse_version(version_feature_introduced)
-
-
-def is_numpy_new_enough(version_feature_introduced):
-    if not which_import('numpy', return_bool=True):
-        return False
-    import numpy
-    return parse_version(numpy.version.version) >= parse_version(version_feature_introduced)
-
-
-def is_dftd3_new_enough(version_feature_introduced):
-    if not which('dftd3', return_bool=True):
-        return False
-    # Note: anything below v3.2.1 will return the help menu here. but that's fine as version compare evals to False.
-    command = [which('dftd3'), '-version']
-    proc = subprocess.run(command, stdout=subprocess.PIPE)
-    candidate_version = proc.stdout.decode('utf-8').strip()
-
-    return parse_version(candidate_version) >= parse_version(version_feature_introduced)
 
 
 def is_nvidia_gpu_present():
@@ -50,7 +45,7 @@ def is_nvidia_gpu_present():
             return ngpu > 0
 
 
-hardware_nvidia_gpu = pytest.mark.skipif(is_nvidia_gpu_present() is False,
+hardware_nvidia_gpu = pytest.mark.skipif(True, #is_nvidia_gpu_present() is False,
                                          reason='Psi4 not detecting Nvidia GPU via `nvidia-smi`. Install one')
 
 using_memory_profiler = pytest.mark.skipif(
@@ -63,28 +58,18 @@ using_psi4 = pytest.mark.skipif(
 using_qcdb = pytest.mark.skipif(
     True, reason='Not detecting common driver. Install package if necessary and add to envvar PYTHONPATH')
 
-using_dftd3 = pytest.mark.skipif(
-    which('dftd3', return_bool=True) is False,
-    reason='Not detecting executable dftd3. Install package if necessary and add to envvar PATH or PSIPATH')
-
-using_dftd3_321 = pytest.mark.skipif(is_dftd3_new_enough("3.2.1") is False,
-                                     reason='DFTD3 does not include 3.2.1 features. Update package and add to PATH')
-
 using_gcp = pytest.mark.skipif(
     which("gcp", return_bool=True) is False,
     reason="Not detecting executable gcp. Install package if necessary and add to envvar PATH")
-
-using_mp2d = pytest.mark.skipif(
-    which('mp2d', return_bool=True) is False,
-    reason='Not detecting executable mp2d. Install package if necessary and add to envvar PATH')
 
 using_cppe = pytest.mark.skipif(
     which_import('cppe', return_bool=True) is False,
     reason="Not detecting module cppe. Rebuild with -DENABLE_cppe")
 
-#using_psi4_libxc = pytest.mark.skipif(is_psi4_new_enough("1.2a1.dev100") is False,
-#                                reason="Psi4 does not include DFT rewrite to use Libxc. Update to development head")
-
 using_networkx = pytest.mark.skipif(
     which_import('networkx', return_bool=True) is False,
     reason='Not detecting module networkx. Install package if necessary and add to envvar PYTHONPATH')
+
+using_dftd3 = using('dftd3')
+using_dftd3_321 = using('dftd3')
+using_mp2d = using('mp2d')

--- a/tests/pytests/test_addons.py
+++ b/tests/pytests/test_addons.py
@@ -4,7 +4,7 @@ from .addons import hardware_nvidia_gpu, using_dftd3, using_gcp, using_cppe
 import json
 
 import qcengine as qcng
-from qcengine.testing import using_mp2d
+from qcengine.testing import using
 
 import psi4
 
@@ -173,7 +173,7 @@ def test_chemps2():
 
 
 @pytest.mark.smoke
-@using_mp2d
+@using('mp2d')
 def test_mp2d():
     eneyne = psi4.geometry("""
     C   0.000000  -0.667578  -2.124659

--- a/tests/pytests/test_mp2d.py
+++ b/tests/pytests/test_mp2d.py
@@ -4,7 +4,7 @@ from .utils import *
 
 import psi4
 import numpy as np
-from qcengine.testing import using_mp2d
+from qcengine.testing import using
 
 pytestmark = [pytest.mark.quick]
 
@@ -44,11 +44,11 @@ for bas in ['cc-pVDZ', 'cc-pVTZ']:
 
 @pytest.mark.parametrize("inp", [
     pytest.param({'driver': 'energy', 'name': 'Mp2', 'pv': 'MP2', 'options': {}}, id='mp2-energy'),
-    pytest.param({'driver': 'energy', 'name': 'MP2-d', 'pv': 'MP2D', 'options': {}}, id='mp2d-energy', marks=using_mp2d),
+    pytest.param({'driver': 'energy', 'name': 'MP2-d', 'pv': 'MP2D', 'options': {}}, id='mp2d-energy', marks=using('mp2d')),
     pytest.param({'driver': 'gradient', 'name': 'Mp2', 'pv': 'MP2', 'options': {}}, id='mp2-gradient'),
     pytest.param({'driver': 'gradient', 'name': 'Mp2', 'pv': 'MP2', 'dertype': 0, 'options': {}}, id='mp2-gradient-findif'),
-    pytest.param({'driver': 'gradient', 'name': 'MP2-d', 'pv': 'MP2D', 'options': {}}, id='mp2d-gradient', marks=using_mp2d),
-    pytest.param({'driver': 'gradient', 'name': 'MP2-d', 'pv': 'MP2D', 'dertype': 0, 'options': {}}, id='mp2d-gradient-findif', marks=using_mp2d),
+    pytest.param({'driver': 'gradient', 'name': 'MP2-d', 'pv': 'MP2D', 'options': {}}, id='mp2d-gradient', marks=using('mp2d')),
+    pytest.param({'driver': 'gradient', 'name': 'MP2-d', 'pv': 'MP2D', 'dertype': 0, 'options': {}}, id='mp2d-gradient-findif', marks=using('mp2d')),
 #    ('mp2mp2'),
 #    ('mp2-dmp2'),
 ])
@@ -133,7 +133,7 @@ def test_dft_mp2(inp):
 #TABLE 14259 -1.155358302362078 0.7013114524160179
 
 
-@using_mp2d
+@using('mp2d')
 def test_mp2d_opt():
 
     h2 = psi4.geometry("""

--- a/tests/pytests/test_qcng_dftd3_mp2d.py
+++ b/tests/pytests/test_qcng_dftd3_mp2d.py
@@ -7,7 +7,8 @@ from qcelemental.testing import compare, compare_recursive, compare_values, tnm
 
 import qcengine as qcng
 from qcengine.programs import empirical_dispersion_resources
-from qcengine.testing import is_program_new_enough, using_dftd3, using_dftd3_321, using_psi4, using_qcdb, using_mp2d
+from qcengine.testing import is_program_new_enough, using
+from .addons import using_psi4, using_qcdb
 
 from qcengine.programs.tests import test_dftd3_mp2d
 ref, gref = test_dftd3_mp2d.ref, test_dftd3_mp2d.gref
@@ -15,7 +16,7 @@ ref, gref = test_dftd3_mp2d.ref, test_dftd3_mp2d.gref
 
 pytestmark = [pytest.mark.quick]
 
-@using_dftd3
+@using("dftd3")
 @pytest.mark.parametrize("method", [
     "b3lyp-d3",
     "b3lyp-d3m",
@@ -261,7 +262,7 @@ def test_dftd3__from_arrays__supplement():
     assert compare_recursive(ans, res, tnm() + ' idempotent', atol=1.e-4)
 
 
-@using_dftd3
+@using("dftd3")
 def test_3():
     sys = qcel.molparse.from_string(seneyne)['qm']
 
@@ -284,7 +285,7 @@ def test_3():
     assert compare('B3LYP-D3(BJ)', _compute_key(res['extras']['local_keywords']), 'key')
 
 
-@using_dftd3
+@using("dftd3")
 @pytest.mark.parametrize(
     "subjects",
     [
@@ -306,8 +307,8 @@ def test_3():
         #({'first': 'pbe', 'second': 'atm(gr)', 'parent': 'eneyne', 'subject': 'mB', 'lbl': 'ATM'}),
         #({'first': '', 'second': 'ATMgr', 'parent': 'eneyne', 'subject': 'mAgB', 'lbl': 'ATM'}),
         # below two xfail until dftd3 that's only 2-body is out of psi4 proper
-        pytest.param({'first': 'atmgr', 'second': 'atmgr', 'parent': 'eneyne', 'subject': 'gAmB', 'lbl': 'ATM'}, marks=[using_dftd3_321, pytest.mark.xfail]),
-        pytest.param({'first': 'pbe-atmgr', 'second': None, 'parent': 'ne', 'subject': 'atom', 'lbl': 'ATM'}, marks=[using_dftd3_321, pytest.mark.xfail]),
+        pytest.param({'first': 'atmgr', 'second': 'atmgr', 'parent': 'eneyne', 'subject': 'gAmB', 'lbl': 'ATM'}, marks=[using("dftd3_321"), pytest.mark.xfail]),
+        pytest.param({'first': 'pbe-atmgr', 'second': None, 'parent': 'ne', 'subject': 'atom', 'lbl': 'ATM'}, marks=[using("dftd3_321"), pytest.mark.xfail]),
     ])  # yapf: disable
 def test_molecule__run_dftd3__23body(inp, subjects):
     subject = subjects()[inp['parent']][inp['subject']]
@@ -341,7 +342,7 @@ def test_qcdb__energy_d3():
                           jrec['qcvars']['B3LYP-D3(BJ) DISPERSION CORRECTION ENERGY'].data, 7, tnm())
 
 
-@using_mp2d
+@using("mp2d")
 @pytest.mark.parametrize(
     "subjects",
     [
@@ -394,7 +395,7 @@ def test_mp2d__run_mp2d__2body(inp, subjects, request):
     gexpected, jrec['extras']['qcvars'][inp['lbl'] + ' DISPERSION CORRECTION GRADIENT'], atol=1.e-7)
 
 
-@using_dftd3
+@using("dftd3")
 @pytest.mark.parametrize(
     "subjects",
     [
@@ -449,7 +450,7 @@ def test_dftd3__run_dftd3__2body(inp, subjects, request):
         gexpected, jrec['extras']['qcvars'][inp['lbl'] + ' DISPERSION CORRECTION GRADIENT'], atol=1.e-7)
 
 
-@using_dftd3_321
+@using("dftd3_321")
 @pytest.mark.parametrize(
     "subjects",
     [


### PR DESCRIPTION
## Todos
- [x] bump qcel and qcng
- [x] new `using('<prog>')` API instead of `using_<prog>` from `qcng.testing`
- there's still a mix of selectors right now. will do a simplification pass after some other branches where I've edited pytests are merged in.

## Status
- [x] Ready for review
- [x] Ready for merge
