### PR TITLE
fixes bug in df-cc when reading wave functions with scf_type cd.

### DIFF
--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -537,10 +537,10 @@ void DFFrozenNO::ThreeIndexIntegrals() {
 
         nQ_scf = auxiliary->nbf();
         Process::environment.globals["NAUX (SCF)"] = nQ_scf;
-    }else if ( options_.get_str("SCF_TYPE") == "CD" ) {
-        psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
+    } else if (options_.get_str("SCF_TYPE") == "CD") {
+        psio->open(PSIF_DFSCF_BJ, PSIO_OPEN_OLD);
         psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ_scf, sizeof(long int));
-        psio->close(PSIF_DFSCF_BJ,1);
+        psio->close(PSIF_DFSCF_BJ, 1);
         Process::environment.globals["NAUX (SCF)"] = nQ_scf;
     }
 
@@ -592,9 +592,9 @@ void DFFrozenNO::ThreeIndexIntegrals() {
         if (options_.get_str("SCF_TYPE") == "CD") {
             outfile->Printf("        Reading Cholesky vectors from disk ...\n");
 
-            psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
+            psio->open(PSIF_DFSCF_BJ, PSIO_OPEN_OLD);
             psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ, sizeof(long int));
-            psio->close(PSIF_DFSCF_BJ,1);
+            psio->close(PSIF_DFSCF_BJ, 1);
 
             outfile->Printf("        Cholesky decomposition threshold: %8.2le\n",
                             options_.get_double("CHOLESKY_TOLERANCE"));

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -527,6 +527,8 @@ void DFFrozenNO::ThreeIndexIntegrals() {
     const std::vector<std::pair<int, int> >& function_pairs = sieve->function_pairs();
     long int ntri = function_pairs.size();
 
+    auto psio = std::make_shared<PSIO>();
+
     // read integrals that were written to disk in the scf
     long int nQ_scf = Process::environment.globals["NAUX (SCF)"];
     if (options_.get_str("SCF_TYPE").find("DF") != std::string::npos) {
@@ -535,11 +537,16 @@ void DFFrozenNO::ThreeIndexIntegrals() {
 
         nQ_scf = auxiliary->nbf();
         Process::environment.globals["NAUX (SCF)"] = nQ_scf;
+    }else if ( options_.get_str("SCF_TYPE") == "CD" ) {
+        psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
+        psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ_scf, sizeof(long int));
+        psio->close(PSIF_DFSCF_BJ,1);
+        Process::environment.globals["NAUX (SCF)"] = nQ_scf;
     }
 
     auto Qmn = std::make_shared<Matrix>("Qmn Integrals", nQ_scf, ntri);
     double** Qmnp = Qmn->pointer();
-    auto psio = std::make_shared<PSIO>();
+
     psio->open(PSIF_DFSCF_BJ, PSIO_OPEN_OLD);
     psio->read_entry(PSIF_DFSCF_BJ, "(Q|mn) Integrals", (char*)Qmnp[0], sizeof(double) * ntri * nQ_scf);
     psio->close(PSIF_DFSCF_BJ, 1);
@@ -584,7 +591,11 @@ void DFFrozenNO::ThreeIndexIntegrals() {
         // read integrals from disk if they were generated in the SCF
         if (options_.get_str("SCF_TYPE") == "CD") {
             outfile->Printf("        Reading Cholesky vectors from disk ...\n");
-            nQ = Process::environment.globals["NAUX (SCF)"];
+
+            psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
+            psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ, sizeof(long int));
+            psio->close(PSIF_DFSCF_BJ,1);
+
             outfile->Printf("        Cholesky decomposition threshold: %8.2le\n",
                             options_.get_double("CHOLESKY_TOLERANCE"));
             outfile->Printf("        Number of Cholesky vectors:          %5li\n", nQ);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   fcidump
                   fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
-                  fnocc3 fnocc4 frac frac-ip-fitting frac-traverse ghosts gibbs matrix1
+                  fnocc3 fnocc4 fnocc5 frac frac-ip-fitting frac-traverse ghosts gibbs matrix1
                   mcscf1 mcscf2 mcscf3
                   mints1 mints2 mints3 mints4 mints5 mints6 mints8 mints-benchmark mints-helper
                   mints9 mints10 molden1 molden2 mom mp2-1 mp2-def2 mp2-grad1 mp2-grad2

--- a/tests/fnocc5/CMakeLists.txt
+++ b/tests/fnocc5/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(fnocc5 "psi;quicktests;fnocc")

--- a/tests/fnocc5/input.dat
+++ b/tests/fnocc5/input.dat
@@ -1,0 +1,34 @@
+#! Test FNO-DF-CCSD(T) energy
+molecule h2o {
+0 1
+O
+H 1 1.0 
+H 1 1.0 2 104.5
+symmetry c1
+}
+
+set {
+  basis aug-cc-pvdz
+  freeze_core         true
+  e_convergence      1e-12
+  d_convergence      1e-12
+  r_convergence      1e-12
+  cholesky_tolerance 1e-12
+  nat_orbs            true
+  occ_tolerance       1e-4
+  scf_type              cd
+  cc_type               cd
+  df_ints_io          save
+}
+en,wfn = energy('scf',return_wfn=True)
+energy('ccsd(t)',ref_wfn=wfn)
+edfccsd  = variable("CCSD CORRELATION ENERGY")
+edfccsdt = variable("CCSD(T) CORRELATION ENERGY")
+
+refccsd  = -0.230820828839    #TEST
+refccsdt = -0.236177474967    #TEST
+
+compare_values(refccsd, edfccsd, 8, "DF-CCSD correlation energy")          #TEST 
+compare_values(refccsdt, edfccsdt, 8, "DF-CCSD(T) correlation energy")     #TEST 
+
+clean()

--- a/tests/fnocc5/output.ref
+++ b/tests/fnocc5/output.ref
@@ -1,0 +1,456 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {fnocc_update} b66402c dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 17 December 2019 08:39AM
+
+    Process ID: 48976
+    Host:       illegally-used-at.fsu
+    PSIDATADIR: /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Test FNO-DF-CCSD(T) energy
+molecule h2o {
+0 1
+O
+H 1 1.0 
+H 1 1.0 2 104.5
+symmetry c1
+}
+
+set {
+  basis aug-cc-pvdz
+  freeze_core         true
+  e_convergence      1e-12
+  d_convergence      1e-12
+  r_convergence      1e-12
+  cholesky_tolerance 1e-12
+  nat_orbs            true
+  occ_tolerance       1e-4
+  scf_type              cd
+  cc_type               cd
+  df_ints_io          save
+}
+en,wfn = energy('scf',return_wfn=True)
+energy('ccsd(t)',ref_wfn=wfn)
+edfccsd  = variable("CCSD CORRELATION ENERGY")
+edfccsdt = variable("CCSD(T) CORRELATION ENERGY")
+
+refccsd  = -0.230820828839    #TEST
+refccsdt = -0.236177474967    #TEST
+
+compare_values(refccsd, edfccsd, 8, "DF-CCSD correlation energy")          #TEST 
+compare_values(refccsdt, edfccsdt, 8, "DF-CCSD(T) correlation energy")     #TEST 
+
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+
+*** tstart() called on illegally-used-at.fsu
+*** at Tue Dec 17 08:39:45 2019
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   254 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 19
+    Number of basis function: 41
+    Number of Cartesian functions: 43
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         41      41       0       0       0       0
+   -------------------------------------------------------
+    Total      41      41       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 1
+    Integrals threads:              1
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-12
+    No. Cholesky vectors:         644
+
+  Minimum eigenvalue in the overlap matrix is 3.1766171140E-03.
+    Using symmetric orthogonalization.
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.41489747543585   -7.54149e+01   0.00000e+00 
+   @RHF iter   1:   -75.94941361511187   -5.34516e-01   1.10059e-02 DIIS
+   @RHF iter   2:   -76.00127152392369   -5.18579e-02   7.53959e-03 DIIS
+   @RHF iter   3:   -76.03522111001719   -3.39496e-02   5.38540e-04 DIIS
+   @RHF iter   4:   -76.03565662491918   -4.35515e-04   1.32730e-04 DIIS
+   @RHF iter   5:   -76.03568680185251   -3.01769e-05   3.11102e-05 DIIS
+   @RHF iter   6:   -76.03568934279326   -2.54094e-06   6.17642e-06 DIIS
+   @RHF iter   7:   -76.03568944583049   -1.03037e-07   1.01141e-06 DIIS
+   @RHF iter   8:   -76.03568944832215   -2.49166e-09   1.70972e-07 DIIS
+   @RHF iter   9:   -76.03568944838770   -6.55547e-11   4.73489e-08 DIIS
+   @RHF iter  10:   -76.03568944839274   -5.04485e-12   6.19808e-09 DIIS
+   @RHF iter  11:   -76.03568944839283   -8.52651e-14   9.52489e-10 DIIS
+   @RHF iter  12:   -76.03568944839286   -2.84217e-14   1.39968e-10 DIIS
+   @RHF iter  13:   -76.03568944839276    9.94760e-14   2.04012e-11 DIIS
+   @RHF iter  14:   -76.03568944839284   -8.52651e-14   1.53121e-12 DIIS
+   @RHF iter  15:   -76.03568944839289   -4.26326e-14   2.94843e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.584242     2A     -1.335644     3A     -0.696478  
+       4A     -0.577441     5A     -0.506115  
+
+    Virtual:                                                              
+
+       6A      0.034638     7A      0.057685     8A      0.174873  
+       9A      0.198741    10A      0.218991    11A      0.232717  
+      12A      0.278530    13A      0.326042    14A      0.382596  
+      15A      0.397838    16A      0.427440    17A      0.532830  
+      18A      0.636757    19A      0.654113    20A      0.794630  
+      21A      0.917421    22A      1.105329    23A      1.117326  
+      24A      1.145003    25A      1.291882    26A      1.454162  
+      27A      1.469924    28A      1.572034    29A      1.970895  
+      30A      1.987693    31A      2.082183    32A      2.345806  
+      33A      2.398639    34A      2.533727    35A      2.701071  
+      36A      2.959052    37A      3.670709    38A      3.682736  
+      39A      3.693890    40A      3.973957    41A      4.218940  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.03568944839289
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.2744713714050704
+    Two-Electron Energy =                  37.4373163584447965
+    Total Energy =                        -76.0356894483929011
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.2197
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.7994     Total:     0.7994
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0319     Total:     2.0319
+
+
+*** tstop() called on illegally-used-at.fsu at Tue Dec 17 08:39:46 2019
+Module time:
+	user time   =       0.89 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.89 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+Scratch directory: /tmp/
+  Constructing Basis Sets for FNOCC...
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   270 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   204 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /Users/deprince/edeprince3/psi4/fnocc_update/install/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+
+*** tstart() called on illegally-used-at.fsu
+*** at Tue Dec 17 08:39:46 2019
+
+
+
+        *******************************************************
+        *                                                     *
+        *                       DF-CCSD                       *
+        *                 Density-fitted CCSD                 *
+        *                                                     *
+        *                   Eugene DePrince                   *
+        *                                                     *
+        *******************************************************
+
+
+  ==> 3-index integrals <==
+
+        Reading Cholesky vectors from disk ...
+        Cholesky decomposition threshold: 1.00e-12
+        Number of Cholesky vectors:            644
+
+  ==> Frozen Natural Orbitals <==
+
+        Doubles contribution to MP2 energy in full space:      -0.223147493714
+
+        Cutoff for significant NO occupancy: 1.000e-04
+
+        Number of virtual orbitals in original space:     36
+        Number of virtual orbitals in truncated space:    24
+
+  ==> Memory <==
+
+        Total memory available:             500.00 mb
+
+        CCSD memory requirements:            12.28 mb
+            3-index integrals:                3.38 mb
+            CCSD intermediates:               8.90 mb
+
+        (T) part (regular algorithm):         0.47 mb
+
+  ==> Input parameters <==
+
+        Freeze core orbitals?                 yes
+        Use frozen natural orbitals?          yes
+        r_convergence:                  1.000e-12
+        e_convergence:                  1.000e-12
+        Number of DIIS vectors:                 8
+        Number of frozen core orbitals:         1
+        Number of active occupied orbitals:     4
+        Number of active virtual orbitals:     24
+        Number of frozen virtual orbitals:     12
+
+
+  Begin singles and doubles coupled cluster iterations
+
+   Iter  DIIS          Energy       d(Energy)          |d(T)|     time
+      0   0 1   -0.2222360992   -0.2222360992    0.2140313908        0
+      1   1 1   -0.2238158923   -0.0015797931    0.0394025560        0
+      2   2 1   -0.2286675149   -0.0048516226    0.0131759018        0
+      3   3 1   -0.2299703820   -0.0013028672    0.0054372059        0
+      4   4 1   -0.2298859697    0.0000844124    0.0009504376        0
+      5   5 1   -0.2299119130   -0.0000259434    0.0002842777        0
+      6   6 1   -0.2299098139    0.0000020991    0.0000585554        1
+      7   7 1   -0.2299095997    0.0000002142    0.0000125873        0
+      8   8 1   -0.2299095213    0.0000000784    0.0000030938        0
+      9   8 2   -0.2299094265    0.0000000948    0.0000007140        0
+     10   8 3   -0.2299094325   -0.0000000060    0.0000001711        0
+     11   8 4   -0.2299094322    0.0000000003    0.0000000463        0
+     12   8 5   -0.2299094342   -0.0000000020    0.0000000133        0
+     13   8 6   -0.2299094341    0.0000000001    0.0000000037        0
+     14   8 7   -0.2299094340    0.0000000000    0.0000000011        0
+     15   8 8   -0.2299094340    0.0000000000    0.0000000003        0
+     16   8 1   -0.2299094340   -0.0000000000    0.0000000001        1
+     17   8 2   -0.2299094340    0.0000000000    0.0000000000        0
+     18   8 3   -0.2299094340    0.0000000000    0.0000000000        0
+     19   8 4   -0.2299094340    0.0000000000    0.0000000000        0
+
+  CCSD iterations converged!
+
+        T1 diagnostic:                        0.012604416091
+        D1 diagnostic:                        0.027705590195
+
+        OS MP2 FNO correction:               -0.000819116331
+        SS MP2 FNO correction:               -0.000092278158
+        MP2 FNO correction:                  -0.000911394489
+
+        OS MP2 correlation energy:           -0.166478413966
+        SS MP2 correlation energy:           -0.056669079748
+        MP2 correlation energy:              -0.223147493714
+      * MP2 total energy:                   -76.258836942107
+
+        OS CCSD correlation energy:          -0.181187220464
+        SS CCSD correlation energy:          -0.049633608039
+        CCSD correlation energy:             -0.230820828503
+      * CCSD total energy:                  -76.266510276896
+
+  Total time for CCSD iterations:       0.94 s (user)
+                                        1.01 s (system)
+                                           2 s (total)
+
+  Time per iteration:                   0.05 s (user)
+                                        0.05 s (system)
+                                        0.11 s (total)
+
+*** tstop() called on illegally-used-at.fsu at Tue Dec 17 08:39:48 2019
+Module time:
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       1.07 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       1.98 seconds =       0.03 minutes
+	system time =       1.11 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on illegally-used-at.fsu
+*** at Tue Dec 17 08:39:48 2019
+
+
+        *******************************************************
+        *                                                     *
+        *                      CCSD(T)                        *
+        *                                                     *
+        *******************************************************
+
+        num_threads:                      1
+        available memory:         500.00 mb
+        memory requirements:        0.47 mb
+
+        Number of ijk combinations: 20
+
+        Computing (T) correction...
+
+        % complete  total time
+              10.0         0 s
+              20.0         0 s
+              30.0         0 s
+              40.0         0 s
+              50.0         0 s
+              60.0         0 s
+              70.0         0 s
+              80.0         0 s
+              90.0         0 s
+
+        (T) energy                            -0.005356646097
+
+        CCSD(T) correlation energy            -0.236177474601
+      * CCSD(T) total energy                 -76.271866922993
+
+
+*** tstop() called on illegally-used-at.fsu at Tue Dec 17 08:39:48 2019
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       1.27 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstop() called on illegally-used-at.fsu at Tue Dec 17 08:39:48 2019
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       1.27 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
+    DF-CCSD correlation energy........................................PASSED
+    DF-CCSD(T) correlation energy.....................................PASSED
+
+    Psi4 stopped on: Tuesday, 17 December 2019 08:39AM
+    Psi4 wall time for execution: 0:00:03.70
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
My DFCC code was relying on Process::environment.globals() for the number of auxiliary functions in the case of scf_type = cd, which failed to work correctly when passing wavefunctions into the energy call.  This PR fixes that bug.

## Checklist
- [x] Quicktests pass. 

## Status
- [x] Ready for review
- [x] Ready for merge
