### PR TITLE
Clean manager.cc Variables: OCC's Open-Heart Surgery II

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1967,112 +1967,94 @@ def run_occ(name, **kwargs):
         ['OCC', 'WFN_TYPE'])
 
     if name == 'mp2':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'FALSE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'omp2':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'scs-omp2':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCS')
     elif name == 'scs(n)-omp2':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCSN')
     elif name == 'scs-omp2-vdw':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCSVDW')
     elif name == 'sos-omp2':
-        vars_on_wfn = True
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SOS', 'TRUE')
         core.set_local_option('OCC', 'SOS_TYPE', 'SOS')
     elif name == 'sos-pi-omp2':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SOS', 'TRUE')
         core.set_local_option('OCC', 'SOS_TYPE', 'SOSPI')
 
     elif name == 'mp2.5':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2.5')
         core.set_local_option('OCC', 'ORB_OPT', 'FALSE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'omp2.5':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP2.5')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
 
     elif name == 'mp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'FALSE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'omp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'scs-omp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCS')
     elif name == 'scs(n)-omp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCSN')
     elif name == 'scs-omp3-vdw':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'TRUE')
         core.set_local_option('OCC', 'SCS_TYPE', 'SCSVDW')
     elif name == 'sos-omp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SOS', 'TRUE')
         core.set_local_option('OCC', 'SOS_TYPE', 'SOS')
     elif name == 'sos-pi-omp3':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OMP3')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SOS', 'TRUE')
         core.set_local_option('OCC', 'SOS_TYPE', 'SOSPI')
 
     elif name == 'lccd':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OCEPA')
         core.set_local_option('OCC', 'ORB_OPT', 'FALSE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
         core.set_local_option('OCC', 'DO_SOS', 'FALSE')
     elif name == 'olccd':
-        vars_on_wfn = False
         core.set_local_option('OCC', 'WFN_TYPE', 'OCEPA')
         core.set_local_option('OCC', 'ORB_OPT', 'TRUE')
         core.set_local_option('OCC', 'DO_SCS', 'FALSE')
@@ -2094,9 +2076,8 @@ def run_occ(name, **kwargs):
     occ_wfn = core.occ(ref_wfn)
 
     # Shove variables into global space
-    if vars_on_wfn:
-        for k, v in occ_wfn.variables().items():
-            core.set_variable(k, v)
+    for k, v in occ_wfn.variables().items():
+        core.set_variable(k, v)
 
     optstash.restore()
     return occ_wfn
@@ -2170,9 +2151,8 @@ def run_occ_gradient(name, **kwargs):
     occ_wfn.set_gradient(grad)
 
     # Shove variables into global space
-    if name in ['mp2', 'omp2']:
-        for k, v in occ_wfn.variables().items():
-            core.set_variable(k, v)
+    for k, v in occ_wfn.variables().items():
+        core.set_variable(k, v)
 
     optstash.restore()
     return occ_wfn

--- a/psi4/src/psi4/occ/CMakeLists.txt
+++ b/psi4/src/psi4/occ/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND sources
   omp3_response_pdms.cc
   omp3_t2_1st_general.cc
   omp3_t2_1st_sc.cc
+  postprocessing.cc
   semi_canonic.cc
   t1_1st.cc
   t2_2nd_general.cc

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -264,7 +264,7 @@ void OCCWave::mp2_manager() {
     if (ip_poles == "TRUE") omp2_ip_poles();
     if (ep_ip_poles == "TRUE") ep2_ip();
 
-    mp2_postprocessing();
+    mp2_postprocessing(reference == "ROHF");
 
     // Why is the below line commented?
     // if (reference == "ROHF") Process::environment.globals["MP2 SINGLES ENERGY"] = Emp2_t1;

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -1040,23 +1040,7 @@ void OCCWave::omp2_5_manager() {
     Emp3L_old = Emp3;
     if (ip_poles == "TRUE") omp3_ip_poles();
 
-    outfile->Printf("\n");
-    outfile->Printf("\tComputing MP2.5 energy using SCF MOs (Canonical MP2.5)... \n");
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-    outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
-    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
-    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\n");
-
-    Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
-    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
+    mp2p5_postprocessing();
 
     omp3_response_pdms();
     gfock();
@@ -1222,24 +1206,7 @@ void OCCWave::mp2_5_manager() {
     Emp3L_old = Emp3;
     if (ip_poles == "TRUE") omp3_ip_poles();
 
-    outfile->Printf("\n");
-    outfile->Printf("\tComputing MP2.5 energy using SCF MOs (Canonical MP2.5)... \n");
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-    outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
-    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
-    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\n");
-
-    Process::environment.globals["MP2.5 TOTAL ENERGY"] = Emp3;
-    Process::environment.globals["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
-    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
+    mp2p5_postprocessing();
     Process::environment.globals["CURRENT ENERGY"] = Emp3L;
     Process::environment.globals["CURRENT REFERENCE ENERGY"] = Eref;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -481,24 +481,24 @@ void OCCWave::omp3_manager() {
         variables_["CURRENT REFERENCE ENERGY"] = Escf;
         if (do_scs == "TRUE") {
             if (scs_type_ == "SCS") {
-                Process::environment.globals["CURRENT ENERGY"] = Escsmp3;
+                variables_["CURRENT ENERGY"] = Escsmp3;
             }
 
             else if (scs_type_ == "SCSN") {
-                Process::environment.globals["CURRENT ENERGY"] = Escsnmp3;
+                variables_["CURRENT ENERGY"] = Escsnmp3;
             }
 
             else if (scs_type_ == "SCSVDW") {
-                Process::environment.globals["CURRENT ENERGY"] = Escsmp3vdw;
+                variables_["CURRENT ENERGY"] = Escsmp3vdw;
             }
         }
         else if (do_sos == "TRUE") {
             if (sos_type_ == "SOS") {
-                Process::environment.globals["CURRENT ENERGY"] = Esosmp3;
+                variables_["CURRENT ENERGY"] = Esosmp3;
             }
 
             else if (sos_type_ == "SOSPI") {
-                Process::environment.globals["CURRENT ENERGY"] = Esospimp3;
+                variables_["CURRENT ENERGY"] = Esospimp3;
             }
         } else {
             variables_["CURRENT ENERGY"] = Emp3;
@@ -557,24 +557,24 @@ void OCCWave::mp3_manager() {
     variables_["CURRENT REFERENCE ENERGY"] = Escf;
     if (do_scs == "TRUE") {
         if (scs_type_ == "SCS") {
-            Process::environment.globals["CURRENT ENERGY"] = Escsmp3;
+            variables_["CURRENT ENERGY"] = Escsmp3;
         }
 
         else if (scs_type_ == "SCSN") {
-            Process::environment.globals["CURRENT ENERGY"] = Escsnmp3;
+            variables_["CURRENT ENERGY"] = Escsnmp3;
         }
 
         else if (scs_type_ == "SCSVDW") {
-            Process::environment.globals["CURRENT ENERGY"] = Escsmp3vdw;
+            variables_["CURRENT ENERGY"] = Escsmp3vdw;
         }
     }
     else if (do_sos == "TRUE") {
         if (sos_type_ == "SOS") {
-            Process::environment.globals["CURRENT ENERGY"] = Esosmp3;
+            variables_["CURRENT ENERGY"] = Esosmp3;
         }
 
         else if (sos_type_ == "SOSPI") {
-            Process::environment.globals["CURRENT ENERGY"] = Esospimp3;
+            variables_["CURRENT ENERGY"] = Esospimp3;
         }
     } else {
         variables_["CURRENT ENERGY"] = Emp3;
@@ -717,26 +717,21 @@ void OCCWave::ocepa_manager() {
         variables_["OLCCD TOTAL ENERGY"] = EcepaL;
         Process::environment.globals["SCS-OLCCD TOTAL ENERGY"] = Escscepa;
         Process::environment.globals["SOS-OLCCD TOTAL ENERGY"] = Esoscepa;
-        variables_["CURRENT ENERGY"] = EcepaL;
         variables_["CURRENT REFERENCE ENERGY"] = Escf;
-        variables_["CURRENT CORRELATION ENERGY"] = EcepaL - Escf;
 
         variables_["OLCCD CORRELATION ENERGY"] = EcepaL - Escf;
         Process::environment.globals["SCS-OLCCD CORRELATION ENERGY"] = Escscepa - Escf;
         Process::environment.globals["SOS-OLCCD CORRELATION ENERGY"] = Esoscepa - Escf;
 
-        // if scs on
         if (do_scs == "TRUE") {
-            Process::environment.globals["CURRENT ENERGY"] = Escscepa;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escscepa - Escf;
-
+            variables_["CURRENT ENERGY"] = Escscepa;
         }
-
-        // else if sos on
         else if (do_sos == "TRUE") {
-            Process::environment.globals["CURRENT ENERGY"] = Esoscepa;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Esoscepa - Escf;
+            variables_["CURRENT ENERGY"] = Esoscepa;
+        } else {
+            variables_["CURRENT ENERGY"] = EcepaL;
         }
+        variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
 
         if (natorb == "TRUE") nbo();
         if (occ_orb_energy == "TRUE") semi_canonic();

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -140,25 +140,7 @@ void OCCWave::omp2_manager() {
             if (ekt_ea_ == "TRUE") ekt_ea();
         }
 
-        outfile->Printf("\n");
-        outfile->Printf("\tComputing MP2 energy using optimized MOs... \n");
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-        outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-        outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp2AA);
-        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp2AB);
-        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp2BB);
-        outfile->Printf("\tScaled_SS Correlation Energy (a.u.): %20.14f\n", Escsmp2AA + Escsmp2BB);
-        outfile->Printf("\tScaled_OS Correlation Energy (a.u.): %20.14f\n", Escsmp2AB);
-        outfile->Printf("\tSCS-MP2 Total Energy (a.u.)        : %20.14f\n", Escsmp2);
-        outfile->Printf("\tSOS-MP2 Total Energy (a.u.)        : %20.14f\n", Esosmp2);
-        outfile->Printf("\tSCSN-MP2 Total Energy (a.u.)       : %20.14f\n", Escsnmp2);
-        outfile->Printf("\tSCS-MP2-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp2vdw);
-        outfile->Printf("\tSOS-PI-MP2 Total Energy (a.u.)     : %20.14f\n", Esospimp2);
-        outfile->Printf("\tMP2 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-        outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
-        outfile->Printf("\t============================================================================== \n");
+        mp2_printing();
 
         outfile->Printf("\n");
         outfile->Printf("\t============================================================================== \n");
@@ -519,26 +501,7 @@ void OCCWave::omp3_manager() {
             if (ekt_ea_ == "TRUE") ekt_ea();
         }
 
-        outfile->Printf("\n");
-        outfile->Printf("\tComputing MP2 energy using optimized MOs... \n");
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-        outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-        outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp2AA);
-        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp2AB);
-        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp2BB);
-        outfile->Printf("\tScaled_SS Correlation Energy (a.u.): %20.14f\n", Escsmp2AA + Escsmp2BB);
-        outfile->Printf("\tScaled_OS Correlation Energy (a.u.): %20.14f\n", Escsmp2AB);
-        outfile->Printf("\tSCS-MP2 Total Energy (a.u.)        : %20.14f\n", Escsmp2);
-        outfile->Printf("\tSOS-MP2 Total Energy (a.u.)        : %20.14f\n", Esosmp2);
-        outfile->Printf("\tSCSN-MP2 Total Energy (a.u.)       : %20.14f\n", Escsnmp2);
-        outfile->Printf("\tSCS-MP2-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp2vdw);
-        outfile->Printf("\tSOS-PI-MP2 Total Energy (a.u.)     : %20.14f\n", Esospimp2);
-        outfile->Printf("\tMP2 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-        outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\n");
+        mp2_printing();
 
         outfile->Printf("\n");
         outfile->Printf("\tComputing MP3 energy using optimized MOs... \n");
@@ -1103,26 +1066,7 @@ void OCCWave::omp2_5_manager() {
             if (ekt_ea_ == "TRUE") ekt_ea();
         }
 
-        outfile->Printf("\n");
-        outfile->Printf("\tComputing MP2 energy using optimized MOs... \n");
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-        outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-        outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp2AA);
-        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp2AB);
-        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp2BB);
-        outfile->Printf("\tScaled_SS Correlation Energy (a.u.): %20.14f\n", Escsmp2AA + Escsmp2BB);
-        outfile->Printf("\tScaled_OS Correlation Energy (a.u.): %20.14f\n", Escsmp2AB);
-        outfile->Printf("\tSCS-MP2 Total Energy (a.u.)        : %20.14f\n", Escsmp2);
-        outfile->Printf("\tSOS-MP2 Total Energy (a.u.)        : %20.14f\n", Esosmp2);
-        outfile->Printf("\tSCSN-MP2 Total Energy (a.u.)       : %20.14f\n", Escsnmp2);
-        outfile->Printf("\tSCS-MP2-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp2vdw);
-        outfile->Printf("\tSOS-PI-MP2 Total Energy (a.u.)     : %20.14f\n", Esospimp2);
-        outfile->Printf("\tMP2 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-        outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\n");
+        mp2_printing();
 
         outfile->Printf("\n");
         outfile->Printf("\tComputing MP2.5 energy using optimized MOs... \n");

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -975,21 +975,7 @@ void OCCWave::omp2_5_manager() {
         }
 
         mp2_printing();
-
-        outfile->Printf("\n");
-        outfile->Printf("\tComputing MP2.5 energy using optimized MOs... \n");
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-        outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-        outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-        outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
-        outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
-        outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\n");
+        mp2p5_printing();
 
         outfile->Printf("\n");
         outfile->Printf("\t============================================================================== \n");

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -403,43 +403,7 @@ void OCCWave::omp3_manager() {
     Emp3L_old = Emp3;
     if (ip_poles == "TRUE") omp3_ip_poles();
 
-    outfile->Printf("\n");
-    outfile->Printf("\tComputing MP3 energy using SCF MOs (Canonical MP3)... \n");
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", (Emp2 - Escf) + 0.5 * (Emp3 - Emp2));
-    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", 0.5 * (Emp3 + Emp2));
-    outfile->Printf("\tSCS-MP3 Total Energy (a.u.)        : %20.14f\n", Escsmp3);
-    outfile->Printf("\tSOS-MP3 Total Energy (a.u.)        : %20.14f\n", Esosmp3);
-    outfile->Printf("\tSCSN-MP3 Total Energy (a.u.)       : %20.14f\n", Escsnmp3);
-    outfile->Printf("\tSCS-MP3-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp3vdw);
-    outfile->Printf("\tSOS-PI-MP3 Total Energy (a.u.)     : %20.14f\n", Esospimp3);
-    outfile->Printf("\t3rd Order Energy (a.u.)            : %20.14f\n", Emp3 - Emp2);
-    outfile->Printf("\tMP3 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-    outfile->Printf("\tMP3 Total Energy (a.u.)            : %20.14f\n", Emp3);
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\n");
-
-    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp3;
-    Process::environment.globals["SCS-MP3 TOTAL ENERGY"] = Escsmp3;
-    Process::environment.globals["SOS-MP3 TOTAL ENERGY"] = Esosmp3;
-    Process::environment.globals["SCSN-MP3 TOTAL ENERGY"] = Escsnmp3;
-    Process::environment.globals["SCS-MP3-VDW TOTAL ENERGY"] = Escsmp3vdw;
-    Process::environment.globals["SOS-PI-MP3 TOTAL ENERGY"] = Esospimp3;
-
-    Process::environment.globals["MP2.5 CORRELATION ENERGY"] = (Emp2 - Escf) + 0.5 * (Emp3 - Emp2);
-    Process::environment.globals["MP2.5 TOTAL ENERGY"] = 0.5 * (Emp3 + Emp2);
-    Process::environment.globals["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
-    Process::environment.globals["SCS-MP3 CORRELATION ENERGY"] = Escsmp3 - Escf;
-    Process::environment.globals["SOS-MP3 CORRELATION ENERGY"] = Esosmp3 - Escf;
-    Process::environment.globals["SCSN-MP3 CORRELATION ENERGY"] = Escsnmp3 - Escf;
-    Process::environment.globals["SCS-MP3-VDW CORRELATION ENERGY"] = Escsmp3vdw - Escf;
-    Process::environment.globals["SOS-PI-MP3 CORRELATION ENERGY"] = Esospimp3 - Escf;
+    mp3_postprocessing();
 
     omp3_response_pdms();
     gfock();
@@ -503,27 +467,7 @@ void OCCWave::omp3_manager() {
 
         mp2_printing();
 
-        outfile->Printf("\n");
-        outfile->Printf("\tComputing MP3 energy using optimized MOs... \n");
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-        outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-        outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-        outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", (Emp2 - Escf) + 0.5 * (Emp3 - Emp2));
-        outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", 0.5 * (Emp3 + Emp2));
-        outfile->Printf("\tSCS-MP3 Total Energy (a.u.)        : %20.14f\n", Escsmp3);
-        outfile->Printf("\tSOS-MP3 Total Energy (a.u.)        : %20.14f\n", Esosmp3);
-        outfile->Printf("\tSCSN-MP3 Total Energy (a.u.)       : %20.14f\n", Escsnmp3);
-        outfile->Printf("\tSCS-MP3-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp3vdw);
-        outfile->Printf("\tSOS-PI-MP3 Total Energy (a.u.)     : %20.14f\n", Esospimp3);
-        outfile->Printf("\t3rd Order Energy (a.u.)            : %20.14f\n", Emp3 - Emp2);
-        outfile->Printf("\tMP3 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-        outfile->Printf("\tMP3 Total Energy (a.u.)            : %20.14f\n", Emp3);
-        outfile->Printf("\t============================================================================== \n");
-        outfile->Printf("\n");
+        mp3_printing();
 
         outfile->Printf("\n");
         outfile->Printf("\t============================================================================== \n");
@@ -639,47 +583,11 @@ void OCCWave::mp3_manager() {
     Emp3L_old = Emp3;
     if (ip_poles == "TRUE") omp3_ip_poles();
 
-    outfile->Printf("\n");
-    outfile->Printf("\tComputing MP3 energy using SCF MOs (Canonical MP3)... \n");
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", (Emp2 - Escf) + 0.5 * (Emp3 - Emp2));
-    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", 0.5 * (Emp3 + Emp2));
-    outfile->Printf("\tSCS-MP3 Total Energy (a.u.)        : %20.14f\n", Escsmp3);
-    outfile->Printf("\tSOS-MP3 Total Energy (a.u.)        : %20.14f\n", Esosmp3);
-    outfile->Printf("\tSCSN-MP3 Total Energy (a.u.)       : %20.14f\n", Escsnmp3);
-    outfile->Printf("\tSCS-MP3-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp3vdw);
-    outfile->Printf("\tSOS-PI-MP3 Total Energy (a.u.)     : %20.14f\n", Esospimp3);
-    outfile->Printf("\t3rd Order Energy (a.u.)            : %20.14f\n", Emp3 - Emp2);
-    outfile->Printf("\tMP3 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
-    outfile->Printf("\tMP3 Total Energy (a.u.)            : %20.14f\n", Emp3);
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\n");
+    mp3_postprocessing();
 
     Process::environment.globals["CURRENT ENERGY"] = Emp3;
     Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3 - Escf;
     Process::environment.globals["CURRENT REFERENCE ENERGY"] = Escf;
-
-    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp3;
-    Process::environment.globals["SCS-MP3 TOTAL ENERGY"] = Escsmp3;
-    Process::environment.globals["SOS-MP3 TOTAL ENERGY"] = Esosmp3;
-    Process::environment.globals["SCSN-MP3 TOTAL ENERGY"] = Escsnmp3;
-    Process::environment.globals["SCS-MP3-VDW TOTAL ENERGY"] = Escsmp3vdw;
-    Process::environment.globals["SOS-PI-MP3 TOTAL ENERGY"] = Esospimp3;
-
-    Process::environment.globals["MP2.5 CORRELATION ENERGY"] = (Emp2 - Escf) + 0.5 * (Emp3 - Emp2);
-    Process::environment.globals["MP2.5 TOTAL ENERGY"] = 0.5 * (Emp3 + Emp2);
-    Process::environment.globals["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
-    Process::environment.globals["SCS-MP3 CORRELATION ENERGY"] = Escsmp3 - Escf;
-    Process::environment.globals["SOS-MP3 CORRELATION ENERGY"] = Esosmp3 - Escf;
-    Process::environment.globals["SCSN-MP3 CORRELATION ENERGY"] = Escsnmp3 - Escf;
-    Process::environment.globals["SCS-MP3-VDW CORRELATION ENERGY"] = Escsmp3vdw - Escf;
-    Process::environment.globals["SOS-PI-MP3 CORRELATION ENERGY"] = Esospimp3 - Escf;
 
     // if scs on
     if (do_scs == "TRUE") {

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -172,10 +172,7 @@ void OCCWave::omp2_manager() {
         // LAB: variables_ and energy_ here are what I vouch for and test.
         //      The P::e.globals will diminish and go into the West and be
         //      replaced by qcvar formulas computed py-side from wfn vars.
-        energy_ = Emp2L;
-        variables_["CURRENT ENERGY"] = Emp2L;
         variables_["CURRENT REFERENCE ENERGY"] = Escf;
-        variables_["CURRENT CORRELATION ENERGY"] = Emp2L - Escf;
 
         variables_["OMP2 CORRELATION ENERGY"] = Emp2L - Escf;
         Process::environment.globals["SCS-OMP2 CORRELATION ENERGY"] = Escsmp2 - Escf;
@@ -187,38 +184,32 @@ void OCCWave::omp2_manager() {
         // if scs on
         if (do_scs == "TRUE") {
             if (scs_type_ == "SCS") {
-                energy_ = Escsmp2;
                 variables_["CURRENT ENERGY"] = Escsmp2;
-                variables_["CURRENT CORRELATION ENERGY"] = Escsmp2 - Escf;
             }
 
             else if (scs_type_ == "SCSN") {
-                energy_ = Escsnmp2;
                 variables_["CURRENT ENERGY"] = Escsnmp2;
-                variables_["CURRENT CORRELATION ENERGY"] = Escsnmp2 - Escf;
             }
 
             else if (scs_type_ == "SCSVDW") {
-                energy_ = Escsmp2vdw;
                 variables_["CURRENT ENERGY"] = Escsmp2vdw;
-                variables_["CURRENT CORRELATION ENERGY"] = Escsmp2vdw - Escf;
             }
         }
 
         // else if sos on
         else if (do_sos == "TRUE") {
             if (sos_type_ == "SOS") {
-                energy_ = Esosmp2;
                 variables_["CURRENT ENERGY"] = Esosmp2;
-                variables_["CURRENT CORRELATION ENERGY"] = Esosmp2 - Escf;
             }
 
             else if (sos_type_ == "SOSPI") {
-                energy_ = Esospimp2;
                 variables_["CURRENT ENERGY"] = Esospimp2;
-                variables_["CURRENT CORRELATION ENERGY"] = Esospimp2 - Escf;
             }
+        } else {
+            variables_["CURRENT ENERGY"] = Emp2L;
         }
+        energy_ = variables_["CURRENT ENERGY"];
+        variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
 
         if (natorb == "TRUE") nbo();
         if (occ_orb_energy == "TRUE") semi_canonic();
@@ -275,49 +266,34 @@ void OCCWave::mp2_manager() {
 
     mp2_postprocessing();
 
-    variables_["CURRENT REFERENCE ENERGY"] = Escf;
-    variables_["CURRENT CORRELATION ENERGY"] = Emp2 - Escf;
-    variables_["CURRENT ENERGY"] = Emp2;
-    energy_ = Emp2;
-
     // Why is the below line commented?
     // if (reference == "ROHF") Process::environment.globals["MP2 SINGLES ENERGY"] = Emp2_t1;
 
-    // if scs on
+    variables_["CURRENT REFERENCE ENERGY"] = Escf;
     if (do_scs == "TRUE") {
         if (scs_type_ == "SCS") {
-            energy_ = Escsmp2;
             variables_["CURRENT ENERGY"] = Escsmp2;
-            variables_["CURRENT CORRELATION ENERGY"] = Escsmp2 - Escf;
         }
-
         else if (scs_type_ == "SCSN") {
-            energy_ = Escsnmp2;
             variables_["CURRENT ENERGY"] = Escsnmp2;
-            variables_["CURRENT CORRELATION ENERGY"] = Escsnmp2 - Escf;
         }
-
         else if (scs_type_ == "SCSVDW") {
-            energy_ = Escsmp2vdw;
             variables_["CURRENT ENERGY"] = Escsmp2vdw;
-            variables_["CURRENT CORRELATION ENERGY"] = Escsmp2vdw - Escf;
         }
     }
-
-    // else if sos on
     else if (do_sos == "TRUE") {
         if (sos_type_ == "SOS") {
-            energy_ = Esosmp2;
             variables_["CURRENT ENERGY"] = Esosmp2;
-            variables_["CURRENT CORRELATION ENERGY"] = Esosmp2 - Escf;
         }
-
         else if (sos_type_ == "SOSPI") {
-            energy_ = Esospimp2;
             variables_["CURRENT ENERGY"] = Esospimp2;
-            variables_["CURRENT CORRELATION ENERGY"] = Esospimp2 - Escf;
         }
+    } else {
+        variables_["CURRENT ENERGY"] = Emp2;
     }
+    energy_ = variables_["CURRENT ENERGY"];
+    variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
+
 
     /* updates the wavefunction for checkpointing */
     name_ = "MP2";
@@ -488,53 +464,46 @@ void OCCWave::omp3_manager() {
         outfile->Printf("\n");
 
         // Set the global variables with the energies
-        Process::environment.globals["OMP3 TOTAL ENERGY"] = Emp3L;
+        variables_["OMP3 TOTAL ENERGY"] = Emp3L;
         Process::environment.globals["SCS-OMP3 TOTAL ENERGY"] = Escsmp3;
         Process::environment.globals["SOS-OMP3 TOTAL ENERGY"] = Esosmp3;
         Process::environment.globals["SCSN-OMP3 TOTAL ENERGY"] = Escsnmp3;
         Process::environment.globals["SCS-OMP3-VDW TOTAL ENERGY"] = Escsmp3vdw;
         Process::environment.globals["SOS-PI-OMP3 TOTAL ENERGY"] = Esospimp3;
-        Process::environment.globals["CURRENT ENERGY"] = Emp3L;
-        Process::environment.globals["CURRENT REFERENCE ENERGY"] = Escf;
-        Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
 
-        Process::environment.globals["OMP3 CORRELATION ENERGY"] = Emp3L - Escf;
+        variables_["OMP3 CORRELATION ENERGY"] = Emp3L - Escf;
         Process::environment.globals["SCS-OMP3 CORRELATION ENERGY"] = Escsmp3 - Escf;
         Process::environment.globals["SOS-OMP3 CORRELATION ENERGY"] = Esosmp3 - Escf;
         Process::environment.globals["SCSN-OMP3 CORRELATION ENERGY"] = Escsnmp3 - Escf;
         Process::environment.globals["SCS-OMP3-VDW CORRELATION ENERGY"] = Escsmp3vdw - Escf;
         Process::environment.globals["SOS-PI-OMP3 CORRELATION ENERGY"] = Esospimp3 - Escf;
 
-        // if scs on
+        variables_["CURRENT REFERENCE ENERGY"] = Escf;
         if (do_scs == "TRUE") {
             if (scs_type_ == "SCS") {
                 Process::environment.globals["CURRENT ENERGY"] = Escsmp3;
-                Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsmp3 - Escf;
             }
 
             else if (scs_type_ == "SCSN") {
                 Process::environment.globals["CURRENT ENERGY"] = Escsnmp3;
-                Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsnmp3 - Escf;
             }
 
             else if (scs_type_ == "SCSVDW") {
                 Process::environment.globals["CURRENT ENERGY"] = Escsmp3vdw;
-                Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsmp3vdw - Escf;
             }
         }
-
-        // else if sos on
         else if (do_sos == "TRUE") {
             if (sos_type_ == "SOS") {
                 Process::environment.globals["CURRENT ENERGY"] = Esosmp3;
-                Process::environment.globals["CURRENT CORRELATION ENERGY"] = Esosmp3 - Escf;
             }
 
             else if (sos_type_ == "SOSPI") {
                 Process::environment.globals["CURRENT ENERGY"] = Esospimp3;
-                Process::environment.globals["CURRENT CORRELATION ENERGY"] = Esospimp3 - Escf;
             }
+        } else {
+            variables_["CURRENT ENERGY"] = Emp3;
         }
+        variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
 
         if (natorb == "TRUE") nbo();
         if (occ_orb_energy == "TRUE") semi_canonic();
@@ -585,40 +554,32 @@ void OCCWave::mp3_manager() {
 
     mp3_postprocessing();
 
-    Process::environment.globals["CURRENT ENERGY"] = Emp3;
-    Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3 - Escf;
-    Process::environment.globals["CURRENT REFERENCE ENERGY"] = Escf;
-
-    // if scs on
+    variables_["CURRENT REFERENCE ENERGY"] = Escf;
     if (do_scs == "TRUE") {
         if (scs_type_ == "SCS") {
             Process::environment.globals["CURRENT ENERGY"] = Escsmp3;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsmp3 - Escf;
         }
 
         else if (scs_type_ == "SCSN") {
             Process::environment.globals["CURRENT ENERGY"] = Escsnmp3;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsnmp3 - Escf;
         }
 
         else if (scs_type_ == "SCSVDW") {
             Process::environment.globals["CURRENT ENERGY"] = Escsmp3vdw;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Escsmp3vdw - Escf;
         }
     }
-
-    // else if sos on
     else if (do_sos == "TRUE") {
         if (sos_type_ == "SOS") {
             Process::environment.globals["CURRENT ENERGY"] = Esosmp3;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Esosmp3 - Escf;
         }
 
         else if (sos_type_ == "SOSPI") {
             Process::environment.globals["CURRENT ENERGY"] = Esospimp3;
-            Process::environment.globals["CURRENT CORRELATION ENERGY"] = Esospimp3 - Escf;
         }
+    } else {
+        variables_["CURRENT ENERGY"] = Emp3;
     }
+    variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
 
     // Compute Analytic Gradients
     if (dertype == "FIRST" || ekt_ip_ == "TRUE" || ekt_ea_ == "TRUE") {
@@ -753,14 +714,14 @@ void OCCWave::ocepa_manager() {
         outfile->Printf("\n");
 
         // Set the global variables with the energies
-        Process::environment.globals["OLCCD TOTAL ENERGY"] = EcepaL;
+        variables_["OLCCD TOTAL ENERGY"] = EcepaL;
         Process::environment.globals["SCS-OLCCD TOTAL ENERGY"] = Escscepa;
         Process::environment.globals["SOS-OLCCD TOTAL ENERGY"] = Esoscepa;
-        Process::environment.globals["CURRENT ENERGY"] = EcepaL;
-        Process::environment.globals["CURRENT REFERENCE ENERGY"] = Escf;
-        Process::environment.globals["CURRENT CORRELATION ENERGY"] = EcepaL - Escf;
+        variables_["CURRENT ENERGY"] = EcepaL;
+        variables_["CURRENT REFERENCE ENERGY"] = Escf;
+        variables_["CURRENT CORRELATION ENERGY"] = EcepaL - Escf;
 
-        Process::environment.globals["OLCCD CORRELATION ENERGY"] = EcepaL - Escf;
+        variables_["OLCCD CORRELATION ENERGY"] = EcepaL - Escf;
         Process::environment.globals["SCS-OLCCD CORRELATION ENERGY"] = Escscepa - Escf;
         Process::environment.globals["SOS-OLCCD CORRELATION ENERGY"] = Esoscepa - Escf;
 
@@ -830,11 +791,11 @@ void OCCWave::cepa_manager() {
     outfile->Printf("\n");
 
     // Set the global variables with the energies
-    Process::environment.globals["LCCD TOTAL ENERGY"] = Ecepa;
-    Process::environment.globals["LCCD CORRELATION ENERGY"] = Ecorr;
-    Process::environment.globals["CURRENT ENERGY"] = Ecepa;
-    Process::environment.globals["CURRENT REFERENCE ENERGY"] = Eref;
-    Process::environment.globals["CURRENT CORRELATION ENERGY"] = Ecorr;
+    variables_["LCCD TOTAL ENERGY"] = Ecepa;
+    variables_["LCCD CORRELATION ENERGY"] = Ecorr;
+    variables_["CURRENT ENERGY"] = Ecepa;
+    variables_["CURRENT REFERENCE ENERGY"] = Eref;
+    variables_["CURRENT CORRELATION ENERGY"] = Ecorr;
     // EcepaL = Ecepa;
 
     // Compute Analytic Gradients
@@ -991,11 +952,11 @@ void OCCWave::omp2_5_manager() {
         outfile->Printf("\n");
 
         // Set the global variables with the energies
-        Process::environment.globals["OMP2.5 TOTAL ENERGY"] = Emp3L;
-        Process::environment.globals["OMP2.5 CORRELATION ENERGY"] = Emp3L - Escf;
-        Process::environment.globals["CURRENT ENERGY"] = Emp3L;
-        Process::environment.globals["CURRENT REFERENCE ENERGY"] = Escf;
-        Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
+        variables_["OMP2.5 TOTAL ENERGY"] = Emp3L;
+        variables_["OMP2.5 CORRELATION ENERGY"] = Emp3L - Escf;
+        variables_["CURRENT ENERGY"] = Emp3L;
+        variables_["CURRENT REFERENCE ENERGY"] = Escf;
+        variables_["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
 
         if (natorb == "TRUE") nbo();
         if (occ_orb_energy == "TRUE") semi_canonic();
@@ -1045,9 +1006,9 @@ void OCCWave::mp2_5_manager() {
     if (ip_poles == "TRUE") omp3_ip_poles();
 
     mp2p5_postprocessing();
-    Process::environment.globals["CURRENT ENERGY"] = Emp3L;
-    Process::environment.globals["CURRENT REFERENCE ENERGY"] = Eref;
-    Process::environment.globals["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
+    variables_["CURRENT ENERGY"] = Emp3L;
+    variables_["CURRENT REFERENCE ENERGY"] = Eref;
+    variables_["CURRENT CORRELATION ENERGY"] = Emp3L - Escf;
 
     // Compute Analytic Gradients
     if (dertype == "FIRST" || ekt_ip_ == "TRUE" || ekt_ea_ == "TRUE") {

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -105,6 +105,9 @@ class OCCWave : public Wavefunction {
     void s2_response();
     void s2_lagrangian();
 
+    // Processing functions - print output, save variables
+    void mp2_postprocessing(bool include_singles = false);
+
     // OMP2
     void omp2_manager();
     void mp2_manager();

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -107,8 +107,10 @@ class OCCWave : public Wavefunction {
 
     // Processing functions - print output, save variables
     void mp2_printing(bool scf = false, bool include_singles = false);
+    void mp3_printing(bool scf = false);
     void mp2_postprocessing(bool include_singles = false);
     void mp2p5_postprocessing();
+    void mp3_postprocessing();
 
     // OMP2
     void omp2_manager();

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -107,6 +107,7 @@ class OCCWave : public Wavefunction {
 
     // Processing functions - print output, save variables
     void mp2_postprocessing(bool include_singles = false);
+    void mp2p5_postprocessing();
 
     // OMP2
     void omp2_manager();

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -107,6 +107,7 @@ class OCCWave : public Wavefunction {
 
     // Processing functions - print output, save variables
     void mp2_printing(bool scf = false, bool include_singles = false);
+    void mp2p5_printing(bool scf = false);
     void mp3_printing(bool scf = false);
     void mp2_postprocessing(bool include_singles = false);
     void mp2p5_postprocessing();

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -106,6 +106,7 @@ class OCCWave : public Wavefunction {
     void s2_lagrangian();
 
     // Processing functions - print output, save variables
+    void mp2_printing(bool scf = false, bool include_singles = false);
     void mp2_postprocessing(bool include_singles = false);
     void mp2p5_postprocessing();
 

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -62,6 +62,25 @@ void OCCWave::mp2_printing(bool scf, bool include_singles) {
     outfile->Printf("\n");
 }
 
+void OCCWave::mp2p5_printing(bool scf) {
+    outfile->Printf("\n");
+    std::string which_mos = scf ? "SCF" : "optimized";
+    std::string parenthetical = scf ? " (Canonical MP2.5)" : "";
+    outfile->Printf("\tComputing MP2.5 energy using %s MOs%s... \n", which_mos.c_str(), parenthetical.c_str());
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
+    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
+    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
+    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
+    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
+    outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
+    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
+    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\n");
+}
+
 void OCCWave::mp3_printing(bool scf) {
     outfile->Printf("\n");
     std::string which_mos = scf ? "SCF" : "optimized";
@@ -135,20 +154,7 @@ void OCCWave::mp3_postprocessing() {
 }
 
 void OCCWave::mp2p5_postprocessing() {
-    outfile->Printf("\n");
-    outfile->Printf("\tComputing MP2.5 energy using SCF MOs (Canonical MP2.5)... \n");
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
-    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
-    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
-    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
-    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
-    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
-    outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
-    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
-    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
-    outfile->Printf("\t============================================================================== \n");
-    outfile->Printf("\n");
+    mp2p5_printing(true);
 
     variables_["MP2.5 TOTAL ENERGY"] = Emp3;
     variables_["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -81,5 +81,26 @@ void OCCWave::mp2_postprocessing(bool include_singles) {
     variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = Emp2AB;
     variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = Emp2AA + Emp2BB;
 }
+
+void OCCWave::mp2p5_postprocessing() {
+    outfile->Printf("\n");
+    outfile->Printf("\tComputing MP2.5 energy using SCF MOs (Canonical MP2.5)... \n");
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
+    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
+    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
+    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
+    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
+    outfile->Printf("\t0.5 Energy Correction (a.u.)       : %20.14f\n", Emp3 - Emp2);
+    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", Ecorr);
+    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", Emp3);
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\n");
+
+    variables_["MP2.5 TOTAL ENERGY"] = Emp3;
+    variables_["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
+    variables_["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
+}
 }
 }

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -1,0 +1,85 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2019 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "psi4/libpsi4util/process.h"
+
+#include "occwave.h"
+
+namespace psi {
+namespace occwave {
+
+void OCCWave::mp2_postprocessing(bool include_singles) {
+    outfile->Printf("\n");
+    outfile->Printf("\tComputing MP2 energy using SCF MOs (%sMP2)... \n", include_singles ? "ROHF-" : "Canonical ");
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
+    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
+    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp2AA);
+    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp2AB);
+    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp2BB);
+    outfile->Printf("\tScaled_SS Correlation Energy (a.u.): %20.14f\n", Escsmp2AA + Escsmp2BB);
+    outfile->Printf("\tScaled_OS Correlation Energy (a.u.): %20.14f\n", Escsmp2AB);
+    outfile->Printf("\tSCS-MP2 Total Energy (a.u.)        : %20.14f\n", Escsmp2);
+    outfile->Printf("\tSOS-MP2 Total Energy (a.u.)        : %20.14f\n", Esosmp2);
+    outfile->Printf("\tSCSN-MP2 Total Energy (a.u.)       : %20.14f\n", Escsnmp2);
+    outfile->Printf("\tSCS-MP2-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp2vdw);
+    outfile->Printf("\tSOS-PI-MP2 Total Energy (a.u.)     : %20.14f\n", Esospimp2);
+    if (include_singles) {
+        outfile->Printf("\tMP2 Singles Energy (a.u.)          : %20.14f\n", Emp2_t1);
+        outfile->Printf("\tMP2 Doubles Energy (a.u.)          : %20.14f\n", Ecorr - Emp2_t1);
+    }
+    outfile->Printf("\tMP2 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
+    outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\n");
+
+    // Wavefunctions saved to variables are set on the wavefunction Py-side.
+    // Other variables will be set Py-side via QCDB formulas, per a future Lori project.
+    variables_["MP2 CORRELATION ENERGY"] = Emp2 - Escf;
+    variables_["SCS-MP2 CORRELATION ENERGY"] = 6.0/5.0 * Emp2AB + 1.0/3.0 * (Emp2AA + Emp2BB) + Emp2_t1;
+    variables_["CUSTOM SCS-MP2 CORRELATION ENERGY"] = os_scale * Emp2AB + ss_scale * (Emp2AA + Emp2BB) + Emp2_t1;
+    Process::environment.globals["SOS-MP2 CORRELATION ENERGY"] = Esosmp2 - Escf;
+    Process::environment.globals["SCSN-MP2 CORRELATION ENERGY"] = Escsnmp2 - Escf;
+    Process::environment.globals["SCS-MP2-VDW CORRELATION ENERGY"] = Escsmp2vdw - Escf;
+    Process::environment.globals["SOS-PI-MP2 CORRELATION ENERGY"] = Esospimp2 - Escf;
+
+    variables_["MP2 TOTAL ENERGY"] = Emp2;
+    variables_["SCS-MP2 TOTAL ENERGY"] =  Escf + variables_["SCS-MP2 CORRELATION ENERGY"];
+    variables_["CUSTOM SCS-MP2 TOTAL ENERGY"] =  Escf + variables_["CUSTOM SCS-MP2 CORRELATION ENERGY"];
+    Process::environment.globals["SOS-MP2 TOTAL ENERGY"] = Esosmp2;
+    Process::environment.globals["SCSN-MP2 TOTAL ENERGY"] = Escsnmp2;
+    Process::environment.globals["SCS-MP2-VDW TOTAL ENERGY"] = Escsmp2vdw;
+    Process::environment.globals["SOS-PI-MP2 TOTAL ENERGY"] = Esospimp2;
+
+
+    variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = Emp2AB;
+    variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = Emp2AA + Emp2BB;
+}
+}
+}

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -136,16 +136,16 @@ void OCCWave::mp2_postprocessing(bool include_singles) {
 void OCCWave::mp3_postprocessing() {
     mp3_printing(true);
 
-    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp3;
+    variables_["MP3 TOTAL ENERGY"] = Emp3;
     Process::environment.globals["SCS-MP3 TOTAL ENERGY"] = Escsmp3;
     Process::environment.globals["SOS-MP3 TOTAL ENERGY"] = Esosmp3;
     Process::environment.globals["SCSN-MP3 TOTAL ENERGY"] = Escsnmp3;
     Process::environment.globals["SCS-MP3-VDW TOTAL ENERGY"] = Escsmp3vdw;
     Process::environment.globals["SOS-PI-MP3 TOTAL ENERGY"] = Esospimp3;
 
-    Process::environment.globals["MP2.5 CORRELATION ENERGY"] = (Emp2 - Escf) + 0.5 * (Emp3 - Emp2);
-    Process::environment.globals["MP2.5 TOTAL ENERGY"] = 0.5 * (Emp3 + Emp2);
-    Process::environment.globals["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
+    variables_["MP2.5 CORRELATION ENERGY"] = (Emp2 - Escf) + 0.5 * (Emp3 - Emp2);
+    variables_["MP2.5 TOTAL ENERGY"] = 0.5 * (Emp3 + Emp2);
+    variables_["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
     Process::environment.globals["SCS-MP3 CORRELATION ENERGY"] = Escsmp3 - Escf;
     Process::environment.globals["SOS-MP3 CORRELATION ENERGY"] = Esosmp3 - Escf;
     Process::environment.globals["SCSN-MP3 CORRELATION ENERGY"] = Escsnmp3 - Escf;

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -35,9 +35,9 @@ namespace occwave {
 
 void OCCWave::mp2_printing(bool scf, bool include_singles) {
     outfile->Printf("\n");
-    std::string which_mos = scf ? "SCF" % "optimized";
+    std::string which_mos = scf ? "SCF" : "optimized";
     std::string parenthetical = scf ? (include_singles ? " (ROHF-MP2)" : " (Canonical MP2)") : "";
-    outfile->Printf("\tComputing MP2 energy using %s MOs%s... \n", which_mos, parenthetical);
+    outfile->Printf("\tComputing MP2 energy using %s MOs%s... \n", which_mos.c_str(), parenthetical.c_str());
     outfile->Printf("\t============================================================================== \n");
     outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
     outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
@@ -58,6 +58,32 @@ void OCCWave::mp2_printing(bool scf, bool include_singles) {
     }
     outfile->Printf("\tMP2 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
     outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\n");
+}
+
+void OCCWave::mp3_printing(bool scf) {
+    outfile->Printf("\n");
+    std::string which_mos = scf ? "SCF" : "optimized";
+    std::string parenthetical = scf ? " (Canonical MP2)" : "";
+    outfile->Printf("\tComputing MP3 energy using %s MOs%s... \n", which_mos.c_str(), parenthetical.c_str());
+    outfile->Printf("\t============================================================================== \n");
+    outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
+    outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
+    outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", Emp3AA);
+    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", Emp3AB);
+    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", Emp3BB);
+    outfile->Printf("\tMP2.5 Correlation Energy (a.u.)    : %20.14f\n", (Emp2 - Escf) + 0.5 * (Emp3 - Emp2));
+    outfile->Printf("\tMP2.5 Total Energy (a.u.)          : %20.14f\n", 0.5 * (Emp3 + Emp2));
+    outfile->Printf("\tSCS-MP3 Total Energy (a.u.)        : %20.14f\n", Escsmp3);
+    outfile->Printf("\tSOS-MP3 Total Energy (a.u.)        : %20.14f\n", Esosmp3);
+    outfile->Printf("\tSCSN-MP3 Total Energy (a.u.)       : %20.14f\n", Escsnmp3);
+    outfile->Printf("\tSCS-MP3-VDW Total Energy (a.u.)    : %20.14f\n", Escsmp3vdw);
+    outfile->Printf("\tSOS-PI-MP3 Total Energy (a.u.)     : %20.14f\n", Esospimp3);
+    outfile->Printf("\t3rd Order Energy (a.u.)            : %20.14f\n", Emp3 - Emp2);
+    outfile->Printf("\tMP3 Correlation Energy (a.u.)      : %20.14f\n", Ecorr);
+    outfile->Printf("\tMP3 Total Energy (a.u.)            : %20.14f\n", Emp3);
     outfile->Printf("\t============================================================================== \n");
     outfile->Printf("\n");
 }
@@ -86,6 +112,26 @@ void OCCWave::mp2_postprocessing(bool include_singles) {
 
     variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = Emp2AB;
     variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = Emp2AA + Emp2BB;
+}
+
+void OCCWave::mp3_postprocessing() {
+    mp3_printing(true);
+
+    Process::environment.globals["MP3 TOTAL ENERGY"] = Emp3;
+    Process::environment.globals["SCS-MP3 TOTAL ENERGY"] = Escsmp3;
+    Process::environment.globals["SOS-MP3 TOTAL ENERGY"] = Esosmp3;
+    Process::environment.globals["SCSN-MP3 TOTAL ENERGY"] = Escsnmp3;
+    Process::environment.globals["SCS-MP3-VDW TOTAL ENERGY"] = Escsmp3vdw;
+    Process::environment.globals["SOS-PI-MP3 TOTAL ENERGY"] = Esospimp3;
+
+    Process::environment.globals["MP2.5 CORRELATION ENERGY"] = (Emp2 - Escf) + 0.5 * (Emp3 - Emp2);
+    Process::environment.globals["MP2.5 TOTAL ENERGY"] = 0.5 * (Emp3 + Emp2);
+    Process::environment.globals["MP3 CORRELATION ENERGY"] = Emp3 - Escf;
+    Process::environment.globals["SCS-MP3 CORRELATION ENERGY"] = Escsmp3 - Escf;
+    Process::environment.globals["SOS-MP3 CORRELATION ENERGY"] = Esosmp3 - Escf;
+    Process::environment.globals["SCSN-MP3 CORRELATION ENERGY"] = Escsnmp3 - Escf;
+    Process::environment.globals["SCS-MP3-VDW CORRELATION ENERGY"] = Escsmp3vdw - Escf;
+    Process::environment.globals["SOS-PI-MP3 CORRELATION ENERGY"] = Esospimp3 - Escf;
 }
 
 void OCCWave::mp2p5_postprocessing() {

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -84,7 +84,7 @@ void OCCWave::mp2p5_printing(bool scf) {
 void OCCWave::mp3_printing(bool scf) {
     outfile->Printf("\n");
     std::string which_mos = scf ? "SCF" : "optimized";
-    std::string parenthetical = scf ? " (Canonical MP2)" : "";
+    std::string parenthetical = scf ? " (Canonical MP3)" : "";
     outfile->Printf("\tComputing MP3 energy using %s MOs%s... \n", which_mos.c_str(), parenthetical.c_str());
     outfile->Printf("\t============================================================================== \n");
     outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);

--- a/psi4/src/psi4/occ/postprocessing.cc
+++ b/psi4/src/psi4/occ/postprocessing.cc
@@ -33,9 +33,11 @@
 namespace psi {
 namespace occwave {
 
-void OCCWave::mp2_postprocessing(bool include_singles) {
+void OCCWave::mp2_printing(bool scf, bool include_singles) {
     outfile->Printf("\n");
-    outfile->Printf("\tComputing MP2 energy using SCF MOs (%sMP2)... \n", include_singles ? "ROHF-" : "Canonical ");
+    std::string which_mos = scf ? "SCF" % "optimized";
+    std::string parenthetical = scf ? (include_singles ? " (ROHF-MP2)" : " (Canonical MP2)") : "";
+    outfile->Printf("\tComputing MP2 energy using %s MOs%s... \n", which_mos, parenthetical);
     outfile->Printf("\t============================================================================== \n");
     outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
     outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
@@ -58,6 +60,10 @@ void OCCWave::mp2_postprocessing(bool include_singles) {
     outfile->Printf("\tMP2 Total Energy (a.u.)            : %20.14f\n", Emp2);
     outfile->Printf("\t============================================================================== \n");
     outfile->Printf("\n");
+}
+
+void OCCWave::mp2_postprocessing(bool include_singles) {
+    mp2_printing(true, include_singles);
 
     // Wavefunctions saved to variables are set on the wavefunction Py-side.
     // Other variables will be set Py-side via QCDB formulas, per a future Lori project.
@@ -102,5 +108,6 @@ void OCCWave::mp2p5_postprocessing() {
     variables_["MP2.5 CORRELATION ENERGY"] = Emp3 - Escf;
     variables_["MP3 TOTAL ENERGY"] = Emp2 + 2.0 * (Emp3 - Emp2);
 }
+
 }
 }

--- a/tests/pytests/occ_methods.txt
+++ b/tests/pytests/occ_methods.txt
@@ -1,0 +1,9 @@
+Candidate Structure for other method-tests
+
+_ref_module = {scftype: {ref: {frz: {mp2type: {} for mp2type in ['conv', 'df', 'cd']} for frz in ['true', 'false']} for ref in ['rhf', 'uhf']} for scftype in ['pk', 'df']}
+
+* The above will work for mp2, mp2.5, mp3, cepa, and the orbital-optimized variants thereof. MP2 has ROHF, but that's special.
+* The dct module can also supply non-FC, conventional integral cepa.
+* At present, occ has no frozen core energies for orbital optimized methods or frozen core gradients for anything. dfocc does. Jonathon will be changing this in a future
+  project, as well as adding some frozen virtual. ETA is Spring 2021, because that depends on the Gradient Rewrite.
+* dfocc has all DF gradients and CD energies for all options.


### PR DESCRIPTION
## Big Picture of the Project
See #1783. tl;dr: The goal is to improve orbital convergence in `occ`, but I need the module cleaned up to make it easier to think about the code I'm needing to mess with. I'm breaking a monolith PR into several.

## Description of the PR
The objective of the current PR is to clean up `occ/manager.cc`. All duplicated printing and variable setting code is now located in `postprocessing.cc`.

## Infrastructure Changes
* Less code duplication and less code!
* The important `occ` variables are now set in `variables_` C-side so they can be set Py-side.
* A new file has been created, `postprocessing.cc`, for all `occ`'s repetitive printng and Psi variable-setting needs

## Questions
* @loriab, please check that there's nothing obvious missing. In particular, there is no `test_omp.py`, so I just made a .txt file for you.

## Checklist
- [x] [Quick tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
