### PR TITLE
dipole and quadrupole arrays and units

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -97,6 +97,7 @@ jobs:
         pybind11 \
         -c conda-forge
       conda install adcc -c adcc -c conda-forge
+      conda remove qcelemental --force
       conda list
     displayName: 'Build Environment'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -97,7 +97,6 @@ jobs:
         pybind11 \
         -c conda-forge
       conda install adcc -c adcc -c conda-forge
-      conda remove qcelemental --force
       conda list
     displayName: 'Build Environment'
 

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -121,6 +121,7 @@ jobs:
                         python=%PYTHON_VERSION% ^
                         qcelemental ^
                         qcengine
+          conda remove qcelemental --force
           conda list
         displayName: "Install conda packages"
 

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -121,7 +121,6 @@ jobs:
                         python=%PYTHON_VERSION% ^
                         qcelemental ^
                         qcengine
-          conda remove qcelemental --force
           conda list
         displayName: "Install conda packages"
 

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -19,8 +19,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        #URL https://github.com/MolSSI/QCElemental/archive/v0.14.0.tar.gz
-        URL https://github.com/MolSSI/QCElemental/archive/loriab-patch-1.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.14.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental ATLEAST 0.12.0 QUIET)
+    find_python_module(qcelemental ATLEAST 0.14.0 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -19,7 +19,8 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.12.0.tar.gz
+        #URL https://github.com/MolSSI/QCElemental/archive/v0.14.0.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/loriab-patch-1.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -604,6 +604,19 @@ core.set_global_option_python = _core_set_global_option_python
 
 ## QCvar helps
 
+def _qcvar_warnings(key):
+    if any([key.upper().endswith(" DIPOLE " + cart) for cart in ["X", "Y", "Z"]]):
+        warnings.warn(
+            f"Using scalar QCVariable `{key.upper()}` [D] instead of array `{key.upper()[:-2]}` [e a0] is deprecated, and in 1.5 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=3)
+
+    if any([key.upper().endswith(" QUADRUPOLE " + cart) for cart in ["XX", "YY", "ZZ", "XY", "XZ", "YZ"]]):
+        warnings.warn(
+            f"Using scalar QCVariable `{key.upper()}` [D A] instead of array `{key.upper()[:-3]}` [e a0^2] is deprecated, and in 1.5 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=3)
+
 
 def _core_has_variable(key):
     return core.has_scalar_variable(key) or core.has_array_variable(key)
@@ -614,6 +627,8 @@ def _core_wavefunction_has_variable(cls, key):
 
 
 def _core_variable(key):
+    _qcvar_warnings(key)
+
     if core.has_scalar_variable(key):
         return core.scalar_variable(key)
     elif core.has_array_variable(key):
@@ -623,6 +638,8 @@ def _core_variable(key):
 
 
 def _core_wavefunction_variable(cls, key):
+    _qcvar_warnings(key)
+
     if cls.has_scalar_variable(key):
         return cls.scalar_variable(key)
     elif cls.has_array_variable(key):
@@ -632,6 +649,8 @@ def _core_wavefunction_variable(cls, key):
 
 
 def _core_set_variable(key, val):
+    _qcvar_warnings(key)
+
     if isinstance(val, core.Matrix):
         if core.has_scalar_variable(key):
             raise ValidationError("psi4.core.set_variable: Target variable " + key + " already a scalar variable!")
@@ -650,6 +669,8 @@ def _core_set_variable(key, val):
 
 
 def _core_wavefunction_set_variable(cls, key, val):
+    _qcvar_warnings(key)
+
     if isinstance(val, core.Matrix):
         if cls.has_scalar_variable(key):
             raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable " + key +

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1535,8 +1535,12 @@ def scf_helper(name, post_scf=True, **kwargs):
         # Compute properties
         oeprop.compute()
         for obj in [core, scf_wfn]:
-            for xyz in 'XYZ':
-                obj.set_variable('CURRENT DIPOLE ' + xyz, obj.variable('SCF DIPOLE ' + xyz))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                # component qcvars can be retired at v1.5
+                for xyz in 'XYZ':
+                    obj.set_variable('CURRENT DIPOLE ' + xyz, obj.variable('SCF DIPOLE ' + xyz))
+            obj.set_variable('CURRENT DIPOLE', obj.variable("SCF DIPOLE"))
 
     # Write out MO's
     if core.get_option("SCF", "PRINT_MOS"):
@@ -2746,9 +2750,12 @@ def run_scf_property(name, **kwargs):
     oe.compute()
     scf_wfn.oeprop = oe
 
-    # Always must set SCF dipole
-    for cart in ["X", "Y", "Z"]:
-        core.set_variable("SCF DIPOLE " + cart, core.variable(name + " DIPOLE " + cart))
+    # Always must set SCF dipole (retire components at v1.5)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for cart in ["X", "Y", "Z"]:
+            core.set_variable("SCF DIPOLE " + cart, core.variable(name + " DIPOLE " + cart))
+    core.set_variable("SCF DIPOLE", core.variable(name + " DIPOLE"))
 
     # Run Linear Respsonse
     if len(linear_response):
@@ -2899,17 +2906,24 @@ def run_cc_property(name, **kwargs):
         # call oe prop for each ES density
         if name.startswith('eom'):
             # copy GS CC DIP/QUAD ... to CC ROOT 0 DIP/QUAD ... if we are doing multiple roots
+            # retire components at v1.5
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                if 'dipole' in one:
+                    core.set_variable("CC ROOT 0 DIPOLE X", core.variable("CC DIPOLE X"))
+                    core.set_variable("CC ROOT 0 DIPOLE Y", core.variable("CC DIPOLE Y"))
+                    core.set_variable("CC ROOT 0 DIPOLE Z", core.variable("CC DIPOLE Z"))
+                if 'quadrupole' in one:
+                    core.set_variable("CC ROOT 0 QUADRUPOLE XX", core.variable("CC QUADRUPOLE XX"))
+                    core.set_variable("CC ROOT 0 QUADRUPOLE XY", core.variable("CC QUADRUPOLE XY"))
+                    core.set_variable("CC ROOT 0 QUADRUPOLE XZ", core.variable("CC QUADRUPOLE XZ"))
+                    core.set_variable("CC ROOT 0 QUADRUPOLE YY", core.variable("CC QUADRUPOLE YY"))
+                    core.set_variable("CC ROOT 0 QUADRUPOLE YZ", core.variable("CC QUADRUPOLE YZ"))
+                    core.set_variable("CC ROOT 0 QUADRUPOLE ZZ", core.variable("CC QUADRUPOLE ZZ"))
             if 'dipole' in one:
-                core.set_variable("CC ROOT 0 DIPOLE X", core.variable("CC DIPOLE X"))
-                core.set_variable("CC ROOT 0 DIPOLE Y", core.variable("CC DIPOLE Y"))
-                core.set_variable("CC ROOT 0 DIPOLE Z", core.variable("CC DIPOLE Z"))
+                core.set_variable("CC ROOT 0 DIPOLE", core.variable("CC DIPOLE"))
             if 'quadrupole' in one:
-                core.set_variable("CC ROOT 0 QUADRUPOLE XX", core.variable("CC QUADRUPOLE XX"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE XY", core.variable("CC QUADRUPOLE XY"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE XZ", core.variable("CC QUADRUPOLE XZ"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE YY", core.variable("CC QUADRUPOLE YY"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE YZ", core.variable("CC QUADRUPOLE YZ"))
-                core.set_variable("CC ROOT 0 QUADRUPOLE ZZ", core.variable("CC QUADRUPOLE ZZ"))
+                core.set_variable("CC ROOT 0 QUADRUPOLE", core.variable("CC QUADRUPOLE"))
 
             n_root = sum(core.get_global_option("ROOTS_PER_IRREP"))
             for rn in range(n_root):
@@ -3435,9 +3449,14 @@ def run_adcc_property(name, **kwargs):
         if state.method.level > 1:
             lines += [ind + "Møller Plesset 2nd order (MP2)"]
             lines += [ind + ind + format_vector("Dipole moment (in a.u.)", mp.dipole_moment(2))]
-            for i, cart in enumerate(["X", "Y", "Z"]):
-                adc_wfn.set_variable("MP2 dipole " + cart, mp.dipole_moment(2)[i])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                for i, cart in enumerate(["X", "Y", "Z"]):
+                    # retire components at v1.5
+                    adc_wfn.set_variable("MP2 dipole " + cart, mp.dipole_moment(2)[i])
                 adc_wfn.set_variable("current dipole " + cart, mp.dipole_moment(2)[i])
+            adc_wfn.set_variable("MP2 dipole", mp.dipole_moment(2))
+            adc_wfn.set_variable("current dipole", mp.dipole_moment(2))
         lines += [""]
         core.print_out("\n".join(lines) + "\n")
 
@@ -3575,9 +3594,13 @@ def run_detci(name, **kwargs):
         oeprop.add("DIPOLE")
         oeprop.compute()
         ciwfn.oeprop = oeprop
-        core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
-        core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
-        core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
+        # retire components in v1.5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
+            core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
+            core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
+        core.set_variable("CURRENT DIPOLE", core.variable(name.upper() + " DIPOLE"))
 
     ciwfn.cleanup_ci()
     ciwfn.cleanup_dpd()
@@ -4786,9 +4809,13 @@ def run_detcas(name, **kwargs):
     oeprop.add("DIPOLE")
     oeprop.compute()
     ciwfn.oeprop = oeprop
-    core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
-    core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
-    core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
+    # retire components by v1.5
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
+        core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
+        core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
+    core.set_variable("CURRENT DIPOLE", core.variable(name.upper() + " DIPOLE"))
 
     # Shove variables into global space
     for k, v in ciwfn.variables().items():

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -87,7 +87,7 @@ _qcschema_translation = {
     "scf": {
         "scf_one_electron_energy": {"variables": "ONE-ELECTRON ENERGY"},
         "scf_two_electron_energy": {"variables": "TWO-ELECTRON ENERGY"},
-        "scf_dipole_moment": {"variables": ["SCF DIPOLE X", "SCF DIPOLE Y", "SCF DIPOLE Z"], "conversion_factor": (1 / qcel.constants.dipmom_au2debye)},
+        "scf_dipole_moment": {"variables": "SCF DIPOLE"},
         "scf_iterations": {"variables": "SCF ITERATIONS", "cast": int},
         "scf_total_energy": {"variables": "SCF TOTAL ENERGY"},
         "scf_vv10_energy": {"variables": "DFT VV10 ENERGY", "skip_zero": True},

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -175,8 +175,8 @@ def _convert_variables(data, context=None, json=False):
         # Get the actual variables
         if isinstance(var["variables"], str):
             value = data.get(var["variables"], None)
-            if value and conversion_factor:
-                if isinstance(value, (int, float)):
+            if value is not None and conversion_factor:
+                if isinstance(value, (int, float, np.ndarray)):
                     value *= conversion_factor
                 elif isinstance(value, (core.Matrix, core.Vector)):
                     value.scale(conversion_factor)
@@ -566,9 +566,9 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
 
         # Dipole/quadrupole still special case
         if "dipole" in kwargs["properties"]:
-            ret["dipole"] = [psi_props[mtd + " DIPOLE " + x] for x in ["X", "Y", "Z"]]
+            ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
         if "quadrupole" in kwargs["properties"]:
-            ret["quadrupole"] = [psi_props[mtd + " QUADRUPOLE " + x] for x in ["XX", "XY", "XZ", "YY", "YZ", "ZZ"]]
+            ret["quadrupole"] = _serial_translation(psi_props[mtd + " QUADRUPOLE"], json=json_serialization)
         ret.update(_convert_variables(wfn.variables(), context="properties", json=json_serialization))
 
         json_data["return_result"] = ret

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -390,6 +390,10 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 
         // For psivar scraper
 
+        // Process::environment.globals["CC ROOT 0 DIPOLE"] = Process::environment.globals["CC DIPOLE"];
+        // Process::environment.globals["CC ROOT 0 QUADRUPOLE"] = Process::environment.globals["CC QUADRUPOLE"];
+        // Process::environment.globals["CC ROOT n DIPOLE"]
+        // Process::environment.globals["CC ROOT n QUADRUPOLE"]
         // Process::environment.globals["CC ROOT 0 DIPOLE X"] = Process::environment.globals["CC DIPOLE X"];
         // Process::environment.globals["CC ROOT 0 DIPOLE Y"] = Process::environment.globals["CC DIPOLE Y"];
         // Process::environment.globals["CC ROOT 0 DIPOLE Z"] = Process::environment.globals["CC DIPOLE Z"];

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -628,6 +628,8 @@ void CIWavefunction::ci_nat_orbs() {
 /*- Process::environment.globals["CI ROOT n DIPOLE X"] -*/
 /*- Process::environment.globals["CI ROOT n DIPOLE Y"] -*/
 /*- Process::environment.globals["CI ROOT n DIPOLE Z"] -*/
+/*- Process::environment.globals["CI ROOT n DIPOLE"] -*/
+/*- Process::environment.globals["CI ROOT n QUADRUPOLE"] -*/
 /*- Process::environment.globals["CI ROOT n QUADRUPOLE XX"] -*/
 /*- Process::environment.globals["CI ROOT n QUADRUPOLE XY"] -*/
 /*- Process::environment.globals["CI ROOT n QUADRUPOLE XZ"] -*/

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1194,6 +1194,17 @@ void OEProp::compute_dipole(bool transition) {
     s << title_ << " DIPOLE Z";
     Process::environment.globals[s.str()] = dipole->get(2);
     wfn_->set_scalar_variable(s.str(), dipole->get(2));
+
+    // Dipole array in au
+    auto dipole_array = std::make_shared<Matrix>(1, 3);
+    dipole_array->set(0, 0, dipole->get(0) / pc_dipmom_au2debye);
+    dipole_array->set(0, 1, dipole->get(1) / pc_dipmom_au2debye);
+    dipole_array->set(0, 2, dipole->get(2) / pc_dipmom_au2debye);
+
+    s.str(std::string());
+    s << title_ << " DIPOLE";
+    Process::environment.arrays[s.str()] = dipole_array;
+    wfn_->set_array_variable(s.str(), dipole_array);
 }
 
 SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_output, bool verbose) {
@@ -1319,6 +1330,23 @@ void OEProp::compute_quadrupole(bool transition) {
     s << title_ << " QUADRUPOLE YZ";
     Process::environment.globals[s.str()] = quadrupole->get(1, 2);
     wfn_->set_scalar_variable(s.str(), quadrupole->get(1, 2));
+
+    // Quadrupole array in au
+    auto quadrupole_array = std::make_shared<Matrix>(3, 3);
+    quadrupole_array->set(0, 0, quadrupole->get(0, 0) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(1, 1, quadrupole->get(1, 1) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(2, 2, quadrupole->get(2, 2) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(0, 1, quadrupole->get(0, 1) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(0, 2, quadrupole->get(0, 2) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(1, 2, quadrupole->get(1, 2) / (pc_dipmom_au2debye * pc_bohr2angstroms));
+    quadrupole_array->set(1, 0, quadrupole_array->get(0, 1));
+    quadrupole_array->set(2, 0, quadrupole_array->get(0, 2));
+    quadrupole_array->set(2, 1, quadrupole_array->get(1, 2));
+
+    s.str(std::string());
+    s << title_ << " QUADRUPOLE";
+    Process::environment.arrays[s.str()] = quadrupole_array;
+    wfn_->set_array_variable(s.str(), quadrupole_array);
 }
 
 SharedMatrix MultipolePropCalc::compute_quadrupole(bool transition, bool print_output, bool verbose) {

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -278,7 +278,7 @@ class MultipolePropCalc : public Prop {
     /// Common initialization
     MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin);
     // Output Type of multipole function, name, elec, nuc, tot
-    typedef std::vector<std::tuple<std::string, double, double, double>> MultipoleOutputTypeBase;
+    typedef std::vector<std::tuple<std::string, double, double, double, int>> MultipoleOutputTypeBase;
     typedef std::shared_ptr<MultipoleOutputTypeBase> MultipoleOutputType;
     /// Compute arbitrary-order multipoles up to (and including) l=order. returns name, elec, nuc and tot as vector_ptr
     MultipoleOutputType compute_multipoles(int order, bool transition = false, bool print_output = false,

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -277,7 +277,7 @@ class MultipolePropCalc : public Prop {
    public:
     /// Common initialization
     MultipolePropCalc(std::shared_ptr<Wavefunction> wfn, Vector3 const& origin);
-    // Output Type of multipole function, name, elec, nuc, tot
+    // Output Type of multipole function: name, elec, nuc, tot, order
     typedef std::vector<std::tuple<std::string, double, double, double, int>> MultipoleOutputTypeBase;
     typedef std::shared_ptr<MultipoleOutputTypeBase> MultipoleOutputType;
     /// Compute arbitrary-order multipoles up to (and including) l=order. returns name, elec, nuc and tot as vector_ptr

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -39,7 +39,7 @@ gs_refs = {
         "CC QUADRUPOLE ZZ":           -9.3692
         }
 pole = [gs_refs["CC DIPOLE " + cart] for cart in "XYZ"]  #TEST
-gs_refs["CC DIPOLE"] = np.array(pole).reshape((1, 3)) * d2au  #TEST
+gs_refs["CC DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
 pole = [gs_refs["CC QUADRUPOLE " + cart] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
 gs_refs["CC QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
@@ -83,7 +83,7 @@ root_refs = {
 }
 for root in range(1, 5):
     pole = [root_refs[f"CC ROOT {root} DIPOLE {cart}"] for cart in "XYZ"]  #TEST
-    root_refs[f"CC ROOT {root} DIPOLE"] = np.array(pole).reshape((1, 3)) * d2au  #TEST
+    root_refs[f"CC ROOT {root} DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
     pole = [root_refs[f"CC ROOT {root} QUADRUPOLE {cart}"] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
     root_refs[f"CC ROOT {root} QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -1,5 +1,8 @@
 #! EOM-CC2/cc-pVDZ on H2O2 with two excited states in each irrep
 
+d2au = 1 / constants.dipmom_au2debye  #TEST
+q2au = d2au / constants.bohr2angstroms  #TEST
+
 molecule h2o2 {
   0 1
   O
@@ -35,6 +38,11 @@ gs_refs = {
         "CC QUADRUPOLE YZ":            0.0000,
         "CC QUADRUPOLE ZZ":           -9.3692
         }
+pole = [gs_refs["CC DIPOLE " + cart] for cart in "XYZ"]  #TEST
+gs_refs["CC DIPOLE"] = np.array(pole).reshape((1, 3)) * d2au  #TEST
+pole = [gs_refs["CC QUADRUPOLE " + cart] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
+gs_refs["CC QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
+
 root_refs = {
         "CC ROOT 1 DIPOLE X":          0.0000,
         "CC ROOT 1 DIPOLE Y":          0.0000,
@@ -73,18 +81,27 @@ root_refs = {
         "CC ROOT 4 QUADRUPOLE YZ":     0.0000,
         "CC ROOT 4 QUADRUPOLE ZZ":   -15.3582
 }
-
-# check ground state
-for tag,refval in gs_refs.items():
-    compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
-
-# check eom roots
-for tag,refval in root_refs.items():
-    compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
+for root in range(1, 5):
+    pole = [root_refs[f"CC ROOT {root} DIPOLE {cart}"] for cart in "XYZ"]  #TEST
+    root_refs[f"CC ROOT {root} DIPOLE"] = np.array(pole).reshape((1, 3)) * d2au  #TEST
+    pole = [root_refs[f"CC ROOT {root} QUADRUPOLE {cart}"] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
+    root_refs[f"CC ROOT {root} QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
 
-# Checking that the wfn.Da/Db have been set by ccdensity
-oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST CC")
-for tag,refval in gs_refs.items():
-    oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
-    compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+
+    # check ground state
+    for tag,refval in gs_refs.items():  #TEST
+        compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
+
+    # check eom roots
+    for tag,refval in root_refs.items():  #TEST
+        compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
+
+
+    # Checking that the wfn.Da/Db have been set by ccdensity
+    oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST CC")
+    for tag,refval in gs_refs.items():
+        oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
+        compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST

--- a/tests/cc54/input.dat
+++ b/tests/cc54/input.dat
@@ -1,5 +1,8 @@
 #! CCSD dipole with user-specified basis set
 
+ref_di_au = [[0.0, 0.0, -0.724043461736]]  #TEST
+ref_quad_au = [[-5.84669623357, 0.0, 0.0], [0.0, -3.37343584714, 0.0], [0.0, 0.0, -4.70310405195]]  #TEST
+
 molecule h2o {
   0 1
   H
@@ -100,13 +103,19 @@ D 2 1.00
 
 ccsd_e, wfn = properties('ccsd',properties=['dipole'],return_wfn=True)
 oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
+    compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
+    compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
+    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
 print_variables()
+
+# prefer array dipole/quadrupole over deprecated scalar variables in section above
+compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
+compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST

--- a/tests/cc54/input.dat
+++ b/tests/cc54/input.dat
@@ -1,6 +1,6 @@
 #! CCSD dipole with user-specified basis set
 
-ref_di_au = [[0.0, 0.0, -0.724043461736]]  #TEST
+ref_di_au = [0.0, 0.0, -0.724043461736]  #TEST
 ref_quad_au = [[-5.84669623357, 0.0, 0.0], [0.0, -3.37343584714, 0.0], [0.0, 0.0, -4.70310405195]]  #TEST
 
 molecule h2o {

--- a/tests/cepa2/input.dat
+++ b/tests/cepa2/input.dat
@@ -30,7 +30,7 @@ with warnings.catch_warnings():  #TEST
     warnings.simplefilter("ignore")  #TEST
     compare_values(refDipACPF, variable("ACPF DIPOLE Z"), 5, "ACPF Z Component of dipole")             #TEST
     compare_values(refQdpACPF, variable("ACPF QUADRUPOLE ZZ"), 5, "ACPF ZZ Component of quadrupole")   #TEST
-compare_values(refDipACPF / constants.dipmom_au2debye, variable("ACPF DIPOLE").get(0, 2), 5, "ACPF Z Component of dipole")             #TEST
-compare_values(refQdpACPF / (constants.dipmom_au2debye * constants.bohr2angstroms), variable("ACPF QUADRUPOLE").get(2, 2), 5, "ACPF ZZ Component of quadrupole")   #TEST
+compare_values(refDipACPF / constants.dipmom_au2debye, variable("ACPF DIPOLE")[2], 5, "ACPF Z Component of dipole")             #TEST
+compare_values(refQdpACPF / (constants.dipmom_au2debye * constants.bohr2angstroms), variable("ACPF QUADRUPOLE")[2][2], 5, "ACPF ZZ Component of quadrupole")   #TEST
 
 clean()

--- a/tests/cepa2/input.dat
+++ b/tests/cepa2/input.dat
@@ -26,7 +26,11 @@ refQdpACPF = -5.78358853279     #TEST
 compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy")                  #TEST 
 compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
 compare_values(refacpf, variable("ACPF CORRELATION ENERGY"), 8, "ACPF correlation energy")         #TEST
-compare_values(refDipACPF, variable("ACPF DIPOLE Z"), 5, "ACPF Z Component of dipole")             #TEST
-compare_values(refQdpACPF, variable("ACPF QUADRUPOLE ZZ"), 5, "ACPF ZZ Component of quadrupole")   #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(refDipACPF, variable("ACPF DIPOLE Z"), 5, "ACPF Z Component of dipole")             #TEST
+    compare_values(refQdpACPF, variable("ACPF QUADRUPOLE ZZ"), 5, "ACPF ZZ Component of quadrupole")   #TEST
+compare_values(refDipACPF / constants.dipmom_au2debye, variable("ACPF DIPOLE").get(0, 2), 5, "ACPF Z Component of dipole")             #TEST
+compare_values(refQdpACPF / (constants.dipmom_au2debye * constants.bohr2angstroms), variable("ACPF QUADRUPOLE").get(2, 2), 5, "ACPF ZZ Component of quadrupole")   #TEST
 
 clean()

--- a/tests/cepa3/input.dat
+++ b/tests/cepa3/input.dat
@@ -20,19 +20,19 @@ set qc_module fnocc
 energy('cisd')
 
 corr1 = variable("CISD CORRELATION ENERGY")
-dipz1 = variable("CISD DIPOLE Z")
-qzz1  = variable("CISD QUADRUPOLE ZZ")
+dipz1 = variable("CISD DIPOLE")
+qzz1  = variable("CISD QUADRUPOLE")
 
 set qc_module detci
 properties("cisd")
 
 corr2 = variable("CI CORRELATION ENERGY")
-dipz2 = variable("CI DIPOLE Z")
-qzz2  = variable("CI QUADRUPOLE ZZ")
+dipz2 = variable("CI DIPOLE")
+qzz2  = variable("CI QUADRUPOLE")
 
 print_variables()
 compare_values(corr1,corr2, 9, "DETCI vs coupled-pair CISD correlation energy")   #TEST
-compare_values(dipz1,dipz2, 5, "DETCI vs coupled-pair CISD Z component of dipole")   #TEST
-compare_values(qzz1,qzz2,   5, "DETCI vs coupled-pair CISD ZZ component of quadrupole")   #TEST
+compare_values(dipz1,dipz2, 5, "DETCI vs coupled-pair CISD dipole")   #TEST
+compare_values(qzz1,qzz2,   5, "DETCI vs coupled-pair CISD quadrupole")   #TEST
 
 clean()

--- a/tests/ci-property/input.dat
+++ b/tests/ci-property/input.dat
@@ -1,5 +1,9 @@
 #! CI/MCSCF cc-pvDZ properties for Potassium nitrate (rocket fuel!)
 
+import warnings  #TEST
+d2au = 1 / constants.dipmom_au2debye  #TEST
+q2au = 1 / (constants.dipmom_au2debye * constants.bohr2angstroms)  #TEST
+
 molecule no3 {
   -1 3
    O            0.000000000000     0.000000000000     1.352965563729
@@ -40,61 +44,84 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
 fci_energy = prop('FCI', properties=props)
 
 compare_values(fci_energy, -278.7924561878957, 6, 'FCI Energy')    #TEST
-compare_values(psi4.variable('CI DIPOLE Y'), 0.000000000000, 4, "FCI DIPOLE Y")    #TEST
-compare_values(psi4.variable('CI DIPOLE Z'), 1.908946764853, 4, "FCI DIPOLE Z")    #TEST
-compare_values(psi4.variable('CI QUADRUPOLE XX'), -22.395945512510, 4, "FCI QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CI QUADRUPOLE YY'), -27.774201286760, 4, "FCI QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CI QUADRUPOLE ZZ'), -29.166055634625, 4, "FCI QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CI QUADRUPOLE YZ'), 0.000000000000, 4, "FCI QUADRUPOLE YZ")    #TEST
-compare_values(psi4.variable('CI ROOT 0 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 0 DIPOLE Y")    #TEST
-compare_values(psi4.variable('CI ROOT 0 DIPOLE Z'), -0.483503167660, 4, "CI ROOT 0 DIPOLE Z")    #TEST
-compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE XX'), -22.419106552690, 4, "CI ROOT 0 QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YY'), -26.694665553619, 4, "CI ROOT 0 QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE ZZ'), -30.482314878839, 4, "CI ROOT 0 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 0 QUADRUPOLE YZ")    #TEST
-compare_values(psi4.variable('CI ROOT 1 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.variable('CI ROOT 1 DIPOLE Z'), 4.301396697365, 4, "CI ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE XX'), -22.372784472330, 4, "CI ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YY'), -28.853737019899, 4, "CI ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE ZZ'), -27.849796390412, 4, "CI ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 1 QUADRUPOLE YZ")    #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Y')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Y")  #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Z')), 0.425513677544, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Z")  #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE XX')), 0.016387859082, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE XX")  #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
-compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(psi4.variable('CI DIPOLE Y'), 0.000000000000, 4, "FCI DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CI DIPOLE Z'), 1.908946764853, 4, "FCI DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CI QUADRUPOLE XX'), -22.395945512510, 4, "FCI QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CI QUADRUPOLE YY'), -27.774201286760, 4, "FCI QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CI QUADRUPOLE ZZ'), -29.166055634625, 4, "FCI QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CI QUADRUPOLE YZ'), 0.000000000000, 4, "FCI QUADRUPOLE YZ")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 0 DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 DIPOLE Z'), -0.483503167660, 4, "CI ROOT 0 DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE XX'), -22.419106552690, 4, "CI ROOT 0 QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YY'), -26.694665553619, 4, "CI ROOT 0 QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE ZZ'), -30.482314878839, 4, "CI ROOT 0 QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 0 QUADRUPOLE YZ")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 1 DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 DIPOLE Z'), 4.301396697365, 4, "CI ROOT 1 DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE XX'), -22.372784472330, 4, "CI ROOT 1 QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YY'), -28.853737019899, 4, "CI ROOT 1 QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE ZZ'), -27.849796390412, 4, "CI ROOT 1 QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 1 QUADRUPOLE YZ")    #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Y')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Y")  #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Z')), 0.425513677544, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Z")  #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE XX')), 0.016387859082, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE XX")  #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
+    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
+compare_values(np.array([[0, 0, 1.908946764853]]) * d2au, variable("CI DIPOLE"), 4, "FCI DIPOLE")  #TEST
+compare_values(np.array([[-22.395945512510, 0, 0], [0, -27.774201286760, 0], [0, 0, -29.166055634625]]) * q2au, variable("CI QUADRUPOLE"), 4, "FCI QUADRUPOLE")  #TEST
+compare_values(np.array([[0, 0, -0.483503167660]]) * d2au, variable("CI ROOT 0 DIPOLE"), 4, "CI ROOT 0 DIPOLE")  #TEST
+compare_values(np.array([[-22.419106552690, 0, 0], [0, -26.694665553619, 0], [0, 0, -30.482314878839]]) * q2au, variable("CI ROOT 0 QUADRUPOLE"), 4, "CI ROOT 0 QUADRUPOLE")  #TEST
+compare_values(np.array([[0, 0, 4.301396697365]]) * d2au, variable("CI ROOT 1 DIPOLE"), 4, "CI ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([[-22.372784472330, 0, 0], [0, -28.853737019899, 0], [0, 0, -27.849796390412]]) * q2au, variable("CI ROOT 1 QUADRUPOLE"), 4, "CI ROOT 1 QUADRUPOLE")  #TEST
+compare_values(np.array([[0, 0, 0.425513677544]]) * d2au, variable("CI ROOT 0 -> ROOT 1 DIPOLE"), 4, "CI ROOT 0 -> ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([[0.016387859082, 0, 0], [0, 0.573374390021, 0], [0, 0, 0.677526505530]]) * q2au, np.absolute(np.array(variable("CI ROOT 0 -> ROOT 1 QUADRUPOLE"))), 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE")  #TEST
 
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+compare_values(np.array([[0, 0, 1.994979146421]]) * d2au, variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
+compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, variable("CASSCF QUADRUPOLE"), 2, "CASSCF QUADRUPOLE")  #TEST
+compare_values(np.array([[0, 0, 4.462471853372]]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([[-22.295623175859, 0, 0], [0, -29.286904330283, 0], [0, 0, -27.288580048926]]) * q2au, variable('CASSCF ROOT 1 QUADRUPOLE'), 2, "CASSCF ROOT 1 QUADRUPOLE")  #TEST
 
 set DETCI NAT_ORBS true
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
+    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
+compare_values(np.array([[0, 0, 1.994979146421]]) * d2au, psi4.variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
+compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, psi4.variable('CASSCF QUADRUPOLE'), 2, "CASSCF QUADRUPOLE")  #TEST
+compare_values(np.array([[0, 0, 4.462471853372]]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([[-22.295623175859, 0, 0], [0, -29.286904330283, 0], [0, 0, -27.288580048926]]) * q2au, psi4.variable('CASSCF ROOT 1 QUADRUPOLE'), 2, "CASSCF ROOT 1 QUADRUPOLE")  #TEST
+
 #name = 'CASSCF'    #TEST
 #prop_list = []    #TEST
 #for dip in ['Y', 'Z']:    #TEST

--- a/tests/ci-property/input.dat
+++ b/tests/ci-property/input.dat
@@ -70,14 +70,14 @@ with warnings.catch_warnings():  #TEST
     compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
     compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
     compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
-compare_values(np.array([[0, 0, 1.908946764853]]) * d2au, variable("CI DIPOLE"), 4, "FCI DIPOLE")  #TEST
+compare_values(np.array([0, 0, 1.908946764853]) * d2au, variable("CI DIPOLE"), 4, "FCI DIPOLE")  #TEST
 compare_values(np.array([[-22.395945512510, 0, 0], [0, -27.774201286760, 0], [0, 0, -29.166055634625]]) * q2au, variable("CI QUADRUPOLE"), 4, "FCI QUADRUPOLE")  #TEST
-compare_values(np.array([[0, 0, -0.483503167660]]) * d2au, variable("CI ROOT 0 DIPOLE"), 4, "CI ROOT 0 DIPOLE")  #TEST
+compare_values(np.array([0, 0, -0.483503167660]) * d2au, variable("CI ROOT 0 DIPOLE"), 4, "CI ROOT 0 DIPOLE")  #TEST
 compare_values(np.array([[-22.419106552690, 0, 0], [0, -26.694665553619, 0], [0, 0, -30.482314878839]]) * q2au, variable("CI ROOT 0 QUADRUPOLE"), 4, "CI ROOT 0 QUADRUPOLE")  #TEST
-compare_values(np.array([[0, 0, 4.301396697365]]) * d2au, variable("CI ROOT 1 DIPOLE"), 4, "CI ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([0, 0, 4.301396697365]) * d2au, variable("CI ROOT 1 DIPOLE"), 4, "CI ROOT 1 DIPOLE")  #TEST
 compare_values(np.array([[-22.372784472330, 0, 0], [0, -28.853737019899, 0], [0, 0, -27.849796390412]]) * q2au, variable("CI ROOT 1 QUADRUPOLE"), 4, "CI ROOT 1 QUADRUPOLE")  #TEST
-compare_values(np.array([[0, 0, 0.425513677544]]) * d2au, variable("CI ROOT 0 -> ROOT 1 DIPOLE"), 4, "CI ROOT 0 -> ROOT 1 DIPOLE")  #TEST
-compare_values(np.array([[0.016387859082, 0, 0], [0, 0.573374390021, 0], [0, 0, 0.677526505530]]) * q2au, np.absolute(np.array(variable("CI ROOT 0 -> ROOT 1 QUADRUPOLE"))), 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE")  #TEST
+compare_values(np.array([0, 0, 0.425513677544]) * d2au, np.absolute(variable("CI ROOT 0 -> ROOT 1 DIPOLE")), 4, "CI ROOT 0 -> ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([[0.016387859082, 0, 0], [0, 0.573374390021, 0], [0, 0, 0.677526505530]]) * q2au, np.absolute(variable("CI ROOT 0 -> ROOT 1 QUADRUPOLE")), 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE")  #TEST
 
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
@@ -95,9 +95,9 @@ with warnings.catch_warnings():  #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
-compare_values(np.array([[0, 0, 1.994979146421]]) * d2au, variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
+compare_values(np.array([0, 0, 1.994979146421]) * d2au, variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
 compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, variable("CASSCF QUADRUPOLE"), 2, "CASSCF QUADRUPOLE")  #TEST
-compare_values(np.array([[0, 0, 4.462471853372]]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([0, 0, 4.462471853372]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
 compare_values(np.array([[-22.295623175859, 0, 0], [0, -29.286904330283, 0], [0, 0, -27.288580048926]]) * q2au, variable('CASSCF ROOT 1 QUADRUPOLE'), 2, "CASSCF ROOT 1 QUADRUPOLE")  #TEST
 
 set DETCI NAT_ORBS true
@@ -117,9 +117,9 @@ with warnings.catch_warnings():  #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
     compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
-compare_values(np.array([[0, 0, 1.994979146421]]) * d2au, psi4.variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
+compare_values(np.array([0, 0, 1.994979146421]) * d2au, psi4.variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
 compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, psi4.variable('CASSCF QUADRUPOLE'), 2, "CASSCF QUADRUPOLE")  #TEST
-compare_values(np.array([[0, 0, 4.462471853372]]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
+compare_values(np.array([0, 0, 4.462471853372]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
 compare_values(np.array([[-22.295623175859, 0, 0], [0, -29.286904330283, 0], [0, 0, -27.288580048926]]) * q2au, psi4.variable('CASSCF ROOT 1 QUADRUPOLE'), 2, "CASSCF ROOT 1 QUADRUPOLE")  #TEST
 
 #name = 'CASSCF'    #TEST

--- a/tests/cisd-h2o+-1/input.dat
+++ b/tests/cisd-h2o+-1/input.dat
@@ -32,7 +32,7 @@ with warnings.catch_warnings():  #TEST
     warnings.simplefilter("ignore")  #TEST
     compare_values(2.68224970371, variable("CISD DIPOLE Z"), 3, "CISD Z Dipole")  #TEST
     compare_values(2.79760370969, variable("SCF DIPOLE Z"), 3, "SCF Z Dipole")  #TEST
-compare_values(2.68224970371 / constants.dipmom_au2debye, variable("CISD DIPOLE").get(0, 2), 3, "CISD Z Dipole")  #TEST
-compare_values(2.79760370969 / constants.dipmom_au2debye, variable("SCF DIPOLE").get(0, 2), 3, "SCF Z Dipole")  #TEST
+compare_values(2.68224970371 / constants.dipmom_au2debye, variable("CISD DIPOLE")[2], 3, "CISD Z Dipole")  #TEST
+compare_values(2.79760370969 / constants.dipmom_au2debye, variable("SCF DIPOLE")[2], 3, "SCF Z Dipole")  #TEST
 
 

--- a/tests/cisd-h2o+-1/input.dat
+++ b/tests/cisd-h2o+-1/input.dat
@@ -28,7 +28,11 @@ compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation en
 compare_values(refcorr, variable("CISD CORRELATION ENERGY"), 7, "CI correlation energy") #TEST
 #compare_values(refcorr, variable("CISD ROOT 0 CORRELATION ENERGY"), 7, "CI correlation energy") #TEST  # waiting for qcvars
 
-compare_values(2.68224970371, variable("CISD DIPOLE Z"), 3, "CISD Z Dipole")
-compare_values(2.79760370969, variable("SCF DIPOLE Z"), 3, "SCF Z Dipole")
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(2.68224970371, variable("CISD DIPOLE Z"), 3, "CISD Z Dipole")  #TEST
+    compare_values(2.79760370969, variable("SCF DIPOLE Z"), 3, "SCF Z Dipole")  #TEST
+compare_values(2.68224970371 / constants.dipmom_au2debye, variable("CISD DIPOLE").get(0, 2), 3, "CISD Z Dipole")  #TEST
+compare_values(2.79760370969 / constants.dipmom_au2debye, variable("SCF DIPOLE").get(0, 2), 3, "SCF Z Dipole")  #TEST
 
 

--- a/tests/fci-dipole/input.dat
+++ b/tests/fci-dipole/input.dat
@@ -27,6 +27,12 @@ compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion ene
 compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
 compare_values(refci, thisenergy,                      7, "CI energy")                                 #TEST
 compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy")             #TEST
-compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
-compare_values(refDipCI, variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
-compare_values(refQdpCI, variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
+    compare_values(refDipCI, variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
+    compare_values(refQdpCI, variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST
+compare_values(refDipHF, variable("SCF DIPOLE").get(0, 2) * constants.dipmom_au2debye, 3, "SCF Z Component of dipole")                 #TEST
+compare_values(refDipCI, variable("CI DIPOLE").get(0, 2) * constants.dipmom_au2debye, 3, "CI Z Component of dipole")                   #TEST
+compare_values(refQdpCI, variable("CI QUADRUPOLE").get(2, 2) * constants.dipmom_au2debye * constants.bohr2angstroms, 3, "CI ZZ Component of quadrupole")  #TEST
+

--- a/tests/fci-dipole/input.dat
+++ b/tests/fci-dipole/input.dat
@@ -32,7 +32,7 @@ with warnings.catch_warnings():  #TEST
     compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
     compare_values(refDipCI, variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
     compare_values(refQdpCI, variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST
-compare_values(refDipHF, variable("SCF DIPOLE").get(0, 2) * constants.dipmom_au2debye, 3, "SCF Z Component of dipole")                 #TEST
-compare_values(refDipCI, variable("CI DIPOLE").get(0, 2) * constants.dipmom_au2debye, 3, "CI Z Component of dipole")                   #TEST
-compare_values(refQdpCI, variable("CI QUADRUPOLE").get(2, 2) * constants.dipmom_au2debye * constants.bohr2angstroms, 3, "CI ZZ Component of quadrupole")  #TEST
+compare_values(refDipHF, variable("SCF DIPOLE")[2] * constants.dipmom_au2debye, 3, "SCF Z Component of dipole")                 #TEST
+compare_values(refDipCI, variable("CI DIPOLE")[2] * constants.dipmom_au2debye, 3, "CI Z Component of dipole")                   #TEST
+compare_values(refQdpCI, variable("CI QUADRUPOLE")[2][2] * constants.dipmom_au2debye * constants.bohr2angstroms, 3, "CI ZZ Component of quadrupole")  #TEST
 

--- a/tests/fci-tdm-2/input.dat
+++ b/tests/fci-tdm-2/input.dat
@@ -1,5 +1,7 @@
 #! BH-H2+ FCI/cc-pVDZ Transition Dipole Moment
 
+d2au = 1 / constants.dipmom_au2debye  #TEST
+
 refnuc   =   4.9195382069     #TEST
 refscf   = -25.94361431841737 #TEST
 refci1   = -26.0272269243438  #TEST
@@ -40,7 +42,13 @@ compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #
 compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
 compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
 compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")      #TEST
+    compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
+    compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
+    compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
+compare_values(refDipHF * d2au, variable("SCF DIPOLE").get(0, 2), 3, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1 * d2au, variable("CI ROOT 0 DIPOLE").get(0, 2), 3, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2 * d2au, variable("CI ROOT 1 DIPOLE").get(0, 2), 3, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(refTDM * d2au, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE").get(0, 2)), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST

--- a/tests/fci-tdm-2/input.dat
+++ b/tests/fci-tdm-2/input.dat
@@ -48,7 +48,7 @@ with warnings.catch_warnings():  #TEST
     compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
     compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
     compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
-compare_values(refDipHF * d2au, variable("SCF DIPOLE").get(0, 2), 3, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1 * d2au, variable("CI ROOT 0 DIPOLE").get(0, 2), 3, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2 * d2au, variable("CI ROOT 1 DIPOLE").get(0, 2), 3, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(refTDM * d2au, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE").get(0, 2)), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
+compare_values(refDipHF * d2au, variable("SCF DIPOLE")[2], 3, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1 * d2au, variable("CI ROOT 0 DIPOLE")[2], 3, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2 * d2au, variable("CI ROOT 1 DIPOLE")[2], 3, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(refTDM * d2au, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE")[2]), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST

--- a/tests/fci-tdm/input.dat
+++ b/tests/fci-tdm/input.dat
@@ -36,7 +36,13 @@ compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #
 compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
 compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
 compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-compare_values(refDipHF, variable("SCF DIPOLE Z"), 5, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(refDipHF, variable("SCF DIPOLE Z"), 5, "SCF Z Component of dipole")      #TEST
+    compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
+    compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
+    compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
+compare_values(refDipHF, variable("SCF DIPOLE").get(0, 2), 5, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE").get(0, 2), 5, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE").get(0, 2), 5, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(refTDM / constants.dipmom_au2debye, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE").get(0, 2)), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST

--- a/tests/fci-tdm/input.dat
+++ b/tests/fci-tdm/input.dat
@@ -42,7 +42,7 @@ with warnings.catch_warnings():  #TEST
     compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
     compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
     compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
-compare_values(refDipHF, variable("SCF DIPOLE").get(0, 2), 5, "SCF Z Component of dipole")      #TEST
-compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE").get(0, 2), 5, "CI ROOT 0 Z Component of dipole")        #TEST
-compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE").get(0, 2), 5, "CI ROOT 1 Z Component of dipole")        #TEST
-compare_values(refTDM / constants.dipmom_au2debye, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE").get(0, 2)), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
+compare_values(refDipHF, variable("SCF DIPOLE")[2], 5, "SCF Z Component of dipole")      #TEST
+compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE")[2], 5, "CI ROOT 0 Z Component of dipole")        #TEST
+compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE")[2], 5, "CI ROOT 1 Z Component of dipole")        #TEST
+compare_values(refTDM / constants.dipmom_au2debye, abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE")[2]), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -36,6 +36,6 @@ with warnings.catch_warnings():
     compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XY'), 4, "MP2 QUADRUPOLE XY") #TEST
     compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XZ'), 4, "MP2 QUADRUPOLE XZ") #TEST
     compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE YZ'), 4, "MP2 QUADRUPOLE YZ") #TEST
-compare_values(np.array([[0, 0, 0.234000203994]]) / constants.dipmom_au2debye, variable("MP2 DIPOLE"), 4, "MP2 DIPOLE")  #TEST
+compare_values(np.array([0, 0, 0.234000203994]) / constants.dipmom_au2debye, variable("MP2 DIPOLE"), 4, "MP2 DIPOLE")  #TEST
 compare_values(np.array([[-14.731131601691, 0, 0], [0, -14.731131601691, 0], [0, 0, -19.287283345539]]) / (constants.dipmom_au2debye * constants.bohr2angstroms),  #TEST
     variable("MP2 QUADRUPOLE"), 4, "MP2 QUADRUPOLE")  #TEST

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -22,13 +22,20 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
          'MULTIPOLE(3)', 'NO_OCCUPATIONS']
 
 mp2_e, mp2_wfn = prop('MP2', properties = props, return_wfn=True)
-compare_values(-184.1840201594929454, psi4.variable('CURRENT ENERGY'), 6, "MP2 Energy") #TEST
-compare_values(0.000000000000, psi4.variable('MP2 DIPOLE X'), 4, "MP2 DIPOLE X") #TEST
-compare_values(0.000000000000, psi4.variable('MP2 DIPOLE Y'), 4, "MP2 DIPOLE Y") #TEST
-compare_values(0.234000203994, psi4.variable('MP2 DIPOLE Z'), 4, "MP2 DIPOLE Z") #TEST
-compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE XX'), 4, "MP2 QUADRUPOLE XX") #TEST
-compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE YY'), 4, "MP2 QUADRUPOLE YY") #TEST
-compare_values(-19.287283345539, psi4.variable('MP2 QUADRUPOLE ZZ'), 4, "MP2 QUADRUPOLE ZZ") #TEST
-compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XY'), 4, "MP2 QUADRUPOLE XY") #TEST
-compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XZ'), 4, "MP2 QUADRUPOLE XZ") #TEST
-compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE YZ'), 4, "MP2 QUADRUPOLE YZ") #TEST
+
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(-184.1840201594929454, psi4.variable('CURRENT ENERGY'), 6, "MP2 Energy") #TEST
+    compare_values(0.000000000000, psi4.variable('MP2 DIPOLE X'), 4, "MP2 DIPOLE X") #TEST
+    compare_values(0.000000000000, psi4.variable('MP2 DIPOLE Y'), 4, "MP2 DIPOLE Y") #TEST
+    compare_values(0.234000203994, psi4.variable('MP2 DIPOLE Z'), 4, "MP2 DIPOLE Z") #TEST
+    compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE XX'), 4, "MP2 QUADRUPOLE XX") #TEST
+    compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE YY'), 4, "MP2 QUADRUPOLE YY") #TEST
+    compare_values(-19.287283345539, psi4.variable('MP2 QUADRUPOLE ZZ'), 4, "MP2 QUADRUPOLE ZZ") #TEST
+    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XY'), 4, "MP2 QUADRUPOLE XY") #TEST
+    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XZ'), 4, "MP2 QUADRUPOLE XZ") #TEST
+    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE YZ'), 4, "MP2 QUADRUPOLE YZ") #TEST
+compare_values(np.array([[0, 0, 0.234000203994]]) / constants.dipmom_au2debye, variable("MP2 DIPOLE"), 4, "MP2 DIPOLE")  #TEST
+compare_values(np.array([[-14.731131601691, 0, 0], [0, -14.731131601691, 0], [0, 0, -19.287283345539]]) / (constants.dipmom_au2debye * constants.bohr2angstroms),  #TEST
+    variable("MP2 QUADRUPOLE"), 4, "MP2 QUADRUPOLE")  #TEST

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -39,3 +39,5 @@ with warnings.catch_warnings():
 compare_values(np.array([0, 0, 0.234000203994]) / constants.dipmom_au2debye, variable("MP2 DIPOLE"), 4, "MP2 DIPOLE")  #TEST
 compare_values(np.array([[-14.731131601691, 0, 0], [0, -14.731131601691, 0], [0, 0, -19.287283345539]]) / (constants.dipmom_au2debye * constants.bohr2angstroms),  #TEST
     variable("MP2 QUADRUPOLE"), 4, "MP2 QUADRUPOLE")  #TEST
+compare_values(np.array([0, 0, -0.9526489, 0, 0, 0, -0.9526489, 0, 0, 0, 0, 0, 0, 0, -0.9526489, 0, -0.9526489, 0, -0.9526489, 0, 0, 0, -0.9526489, 0, 0, 0, -6.8644462]).reshape((3, 3, 3)),
+    variable("MP2 OCTUPOLE"), 4, "MP2 OCTUPOLE")  #TEST

--- a/tests/pcmsolver/dipole/input.dat
+++ b/tests/pcmsolver/dipole/input.dat
@@ -70,8 +70,8 @@ for m in ['HF', 'B3LYP']:
     set perturb_h false
     e, wfn = energy(m, return_wfn=True)
     oeprop(wfn, 'MULTIPOLES(1)')
-    analytic = variable('SCF DIPOLE Z')
+    analytic = variable('SCF DIPOLE')
 
     compare_values(ref_3pt[m], dm_z_3point, 8, 'Z dipole moment, using 3-point stencil %s' % m) # TEST
     compare_values(ref_5pt[m], dm_z_5point, 8, 'Z dipole moment, using 5-point stencil %s' % m) # TEST
-    compare_values(ref_5pt[m]*psi_dipmom_au2debye, analytic, 5, 'Z dipole moment, analytic result %s' % m) # TEST
+    compare_values([0, 0, ref_5pt[m]], analytic, 5, 'Z dipole moment, analytic result %s' % m) # TEST

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -3,6 +3,7 @@
 #! atoms, fixed parameters, updated parameters, and separate charge/multiplicity
 #! specifiers for each monomer. One-electron properties computed for dimer and one monomer.
  
+import warnings  #TEST
 refENuc   = [ 268.6171792624, 13.021346350778909,  #TEST
               258.850942303987608, 13.0213463507789093 ] #TEST
 refESCF   = [ -303.20625701463621, -75.32040649282145,  #TEST
@@ -71,9 +72,15 @@ for R in Rvals:
     compare_values(refENuc[count], dimer.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
+    with warnings.catch_warnings():  #TEST
+        warnings.simplefilter("ignore")  #TEST
+        compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
+                          5, "Y Component of Dipole %d" % count)                                     #TEST
+        compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
+                          5, "YY Component of Quadrupole %d" % count)                                #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE").get(0, 1) * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
+    compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE").get(1, 1) * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()
@@ -90,9 +97,15 @@ for R in Rvals:
     compare_values(refENuc[count], monoB.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
+    with warnings.catch_warnings():  #TEST
+        warnings.simplefilter("ignore")  #TEST
+        compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
+                          5, "Y Component of Dipole %d" % count)                                     #TEST
+        compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
+                          5, "YY Component of Quadrupole %d" % count)                                #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE").get(0, 1) * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
+    compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE").get(1, 1) * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -78,9 +78,9 @@ for R in Rvals:
                           5, "Y Component of Dipole %d" % count)                                     #TEST
         compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
                           5, "YY Component of Quadrupole %d" % count)                                #TEST
-    compare_values(refDipY[count], variable("SCF DIPOLE").get(0, 1) * constants.dipmom_au2debye,     #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE")[1] * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE").get(1, 1) * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
+    compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE")[1][1] * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()
@@ -103,9 +103,9 @@ for R in Rvals:
                           5, "Y Component of Dipole %d" % count)                                     #TEST
         compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
                           5, "YY Component of Quadrupole %d" % count)                                #TEST
-    compare_values(refDipY[count], variable("SCF DIPOLE").get(0, 1) * constants.dipmom_au2debye,     #TEST
+    compare_values(refDipY[count], variable("SCF DIPOLE")[1] * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
-    compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE").get(1, 1) * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
+    compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE")[1][1] * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
                       5, "YY Component of Quadrupole %d" % count)                                    #TEST
 
     clean()

--- a/tests/props3/input.dat
+++ b/tests/props3/input.dat
@@ -54,9 +54,18 @@ scf_e, scf_wfn = energy('scf', return_wfn=True)
 
 oeprop(scf_wfn, "MULTIPOLES(7)", "ESP_AT_NUCLEI")
 
+subs = {"X": 0, "Y": 1, "Z": 2}  #TEST
 for mpole,val in reversed(sorted(refs.items())):        #TEST
     compare_values(val, variable(mpole),  4, mpole) #TEST
     compare_values(val, scf_wfn.variable(mpole),  4, mpole + " wfn") #TEST
+
+    sorder, cart = mpole.split()  #TEST
+    np_index = tuple([subs[x] for x in cart])  #TEST
+    compare_values(val, variable(sorder)[np_index], 4, mpole + " array")  #TEST
+
+
+# make sure non-compressed elements accessible
+compare_values(refs["64-pole XXYYYY"], variable("64-pole")[(0, 1, 1, 1, 1, 0)], 4, "64-pole XYYYYX symmetry element")  #TEST
 
 for n in range(1,13):                                   #TEST
     st = "ESP AT CENTER %d" % n                         #TEST
@@ -64,4 +73,3 @@ for n in range(1,13):                                   #TEST
     compare_values(esps[n-1], scf_wfn.variable(st),  4, st + " wfn") #TEST
     
 clean()
-

--- a/tests/pytests/test_dipoles.py
+++ b/tests/pytests/test_dipoles.py
@@ -33,7 +33,7 @@ def test_dipole(inp):
     for l in [1, -1, 2, -2]:
         psi4.set_options({'perturb_dipole': [0, 0, l * perturbation_strength]})
         energies[l] = psi4.energy(inp['name'])
-    findif_dipole = [[0, 0, (8 * energies[1] - 8 * energies[-1] - energies[2] + energies[-2]) / (12 * perturbation_strength)]]
+    findif_dipole = [0, 0, (8 * energies[1] - 8 * energies[-1] - energies[2] + energies[-2]) / (12 * perturbation_strength)]
 
     psi4.set_options({'perturb_h': False})
     wfn = psi4.properties(inp['name'], properties=['dipole'], return_wfn=True)[1]

--- a/tests/pytests/test_dipoles.py
+++ b/tests/pytests/test_dipoles.py
@@ -33,10 +33,10 @@ def test_dipole(inp):
     for l in [1, -1, 2, -2]:
         psi4.set_options({'perturb_dipole': [0, 0, l * perturbation_strength]})
         energies[l] = psi4.energy(inp['name'])
-    findif_dipole = (8 * energies[1] - 8 * energies[-1] - energies[2] + energies[-2]) / (12 * perturbation_strength) * qcel.constants.dipmom_au2debye
+    findif_dipole = [[0, 0, (8 * energies[1] - 8 * energies[-1] - energies[2] + energies[-2]) / (12 * perturbation_strength)]]
 
     psi4.set_options({'perturb_h': False})
     wfn = psi4.properties(inp['name'], properties=['dipole'], return_wfn=True)[1]
-    analytic_dipole = wfn.variable(inp['varname'] + " DIPOLE Z")
+    analytic_dipole = wfn.variable(inp['varname'] + " DIPOLE")
 
     assert compare_values(findif_dipole, analytic_dipole, 5, "analytic vs. findif dipole")

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -119,3 +119,14 @@ def test_deprecated_dcft_calls():
         psi4.set_module_options('dct', {'dcft_functional': 'odc-06'})
 
     assert err_substr in str(e.value)
+
+
+def test_deprecated_component_dipole():
+
+    with pytest.warns(FutureWarning) as e:
+        psi4.set_variable("current dipole x", 5)
+
+    with pytest.warns(FutureWarning) as e:
+        ans = psi4.variable("current dipole x")
+
+    assert ans == 5

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -123,8 +123,8 @@ def test_deprecated_dcft_calls():
 
 def test_deprecated_component_dipole():
 
-    with pytest.warns(FutureWarning) as e:
-        psi4.set_variable("current dipole x", 5)
+    #with pytest.warns(FutureWarning) as e:
+    psi4.set_variable("current dipole x", 5)
 
     with pytest.warns(FutureWarning) as e:
         ans = psi4.variable("current dipole x")

--- a/tests/pytests/test_psi4.py
+++ b/tests/pytests/test_psi4.py
@@ -187,9 +187,9 @@ def test_psi4_scfproperty():
     """scf-property"""
     #! UFH and B3LYP cc-pVQZ properties for the CH2 molecule.
 
-    ref_hf_di_au = np.array([[0.0, 0.0, 0.22531665104559076]])
+    ref_hf_di_au = np.array([0.0, 0.0, 0.22531665104559076])
     ref_hf_quad_au = np.array([[-5.69804565317, 0.0, 0.0], [0.0, -4.53353128969, 0.0], [0.0, 0.0, -5.25978856037]])
-    ref_b3lyp_di_au = np.array([[0.0, 0.0, 0.252480541747]])
+    ref_b3lyp_di_au = np.array([0.0, 0.0, 0.252480541747])
     ref_b3lyp_quad_au = np.array([[-5.66266837697, 0.0, 0.0], [0.0, -4.46523692003, 0.0], [0.0, 0.0, -5.22054902407]])
 
     with open('grid.dat', 'w') as handle:

--- a/tests/pytests/test_psi4.py
+++ b/tests/pytests/test_psi4.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import psi4
@@ -186,6 +187,11 @@ def test_psi4_scfproperty():
     """scf-property"""
     #! UFH and B3LYP cc-pVQZ properties for the CH2 molecule.
 
+    ref_hf_di_au = np.array([[0.0, 0.0, 0.22531665104559076]])
+    ref_hf_quad_au = np.array([[-5.69804565317, 0.0, 0.0], [0.0, -4.53353128969, 0.0], [0.0, 0.0, -5.25978856037]])
+    ref_b3lyp_di_au = np.array([[0.0, 0.0, 0.252480541747]])
+    ref_b3lyp_quad_au = np.array([[-5.66266837697, 0.0, 0.0], [0.0, -4.46523692003, 0.0], [0.0, 0.0, -5.22054902407]])
+
     with open('grid.dat', 'w') as handle:
         handle.write("""\
 0.0  0.0  0.0
@@ -221,26 +227,12 @@ def test_psi4_scfproperty():
 
     psi4.properties('scf', properties=props)
 
-    assert psi4.compare_values(psi4.variable("CURRENT ENERGY"), -38.91591819679808, 6, "SCF energy")
-    assert psi4.compare_values(psi4.variable('SCF DIPOLE X'), 0.000000000000, 4, "SCF DIPOLE X")
-    assert psi4.compare_values(psi4.variable('SCF DIPOLE Y'), 0.000000000000, 4, "SCF DIPOLE Y")
-    assert psi4.compare_values(psi4.variable('SCF DIPOLE Z'), 0.572697798348, 4, "SCF DIPOLE Z")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XX'), -7.664066833060, 4, "SCF QUADRUPOLE XX")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE YY'), -6.097755074075, 4, "SCF QUADRUPOLE YY")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE ZZ'), -7.074596012050, 4, "SCF QUADRUPOLE ZZ")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XY'), 0.000000000000, 4, "SCF QUADRUPOLE XY")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE XZ'), 0.000000000000, 4, "SCF QUADRUPOLE XZ")
-    assert psi4.compare_values(psi4.variable('SCF QUADRUPOLE YZ'), 0.000000000000, 4, "SCF QUADRUPOLE YZ")
+    assert psi4.compare_values(-38.91591819679808, psi4.variable("CURRENT ENERGY"), 6, "SCF energy")
+    assert psi4.compare_values(ref_hf_di_au, psi4.variable('SCF DIPOLE'), 4, "SCF DIPOLE")
+    assert psi4.compare_values(ref_hf_quad_au, psi4.variable('SCF QUADRUPOLE'), 4, "SCF QUADRUPOLE")
 
     psi4.properties('B3LYP', properties=props)
 
     assert psi4.compare_values(psi4.variable('CURRENT ENERGY'), -39.14134740550916, 6, "B3LYP energy")
-    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE X'), 0.000000000000, 4, "B3LYP DIPOLE X")
-    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE Y'), -0.000000000000, 4, "B3LYP DIPOLE Y")
-    assert psi4.compare_values(psi4.variable('B3LYP DIPOLE Z'), 0.641741521158, 4, "B3LYP DIPOLE Z")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XX'), -7.616483183211, 4, "B3LYP QUADRUPOLE XX")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE YY'), -6.005896804551, 4, "B3LYP QUADRUPOLE YY")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE ZZ'), -7.021817489904, 4, "B3LYP QUADRUPOLE ZZ")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XY'), 0.000000000000, 4, "B3LYP QUADRUPOLE XY")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE XZ'), 0.000000000000, 4, "B3LYP QUADRUPOLE XZ")
-    assert psi4.compare_values(psi4.variable('B3LYP QUADRUPOLE YZ'), -0.000000000000, 4, "B3LYP QUADRUPOLE YZ")
+    assert psi4.compare_values(ref_b3lyp_di_au, psi4.variable('B3LYP DIPOLE'), 4, "B3LYP DIPOLE")
+    assert psi4.compare_values(ref_b3lyp_quad_au, psi4.variable('B3LYP QUADRUPOLE'), 4, "B3LYP QUADRUPOLE")

--- a/tests/python/cc54/input.py
+++ b/tests/python/cc54/input.py
@@ -101,13 +101,16 @@ D 2 1.00
 
 ccsd_e, wfn = psi4.properties('ccsd',properties=['dipole'],return_wfn=True)
 psi4.oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
+import warnings  #TEST
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
+    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
 psi4.core.print_variables()

--- a/tests/scf-property/input.dat
+++ b/tests/scf-property/input.dat
@@ -1,5 +1,18 @@
 #! UFH and B3LYP cc-pVQZ properties for the CH2 molecule.
 
+import warnings  #TEST
+import numpy as np  #TEST
+from psi4.driver import constants  #TEST
+ref_hf_di_au = np.array([[0.0, 0.0, 0.22531665104559076]])  #TEST
+ref_hf_quad_au = np.array([[-5.69804565317, 0.0, 0.0], [0.0, -4.53353128969, 0.0], [0.0, 0.0, -5.25978856037]])  #TEST
+ref_b3lyp_di_au = np.array([[0.0, 0.0, 0.252480541747]])  #TEST
+ref_b3lyp_quad_au = np.array([[-5.66266837697, 0.0, 0.0], [0.0, -4.46523692003, 0.0], [0.0, 0.0, -5.22054902407]])  #TEST
+
+ref_hf_di_debye = ref_hf_di_au * constants.dipmom_au2debye  #TEST
+ref_hf_quad_debye = ref_hf_quad_au * constants.dipmom_au2debye * constants.bohr2angstroms  #TEST
+ref_b3lyp_di_debye = ref_b3lyp_di_au * constants.dipmom_au2debye  #TEST
+ref_b3lyp_quad_debye = ref_b3lyp_quad_au * constants.dipmom_au2debye * constants.bohr2angstroms  #TEST
+
 molecule ch2 {
     0 3
     c
@@ -32,26 +45,40 @@ properties('scf', properties=props)
 
 compare_values(-38.91591819679808, psi4.variable("CURRENT ENERGY"), 6, "SCF energy")         #TEST
 compare_values(-38.91591819679808, psi4.variable("HF TOTAL ENERGY"), 6, "SCF energy")         #TEST
-compare_values(0.000000000000, psi4.variable('SCF DIPOLE X'), 4, "SCF DIPOLE X")    #TEST
-compare_values(0.000000000000, psi4.variable('SCF DIPOLE Y'), 4, "SCF DIPOLE Y")    #TEST
-compare_values(0.572697798348, psi4.variable('SCF DIPOLE Z'), 4, "SCF DIPOLE Z")    #TEST
-compare_values(-7.664066833060, psi4.variable('SCF QUADRUPOLE XX'), 4, "SCF QUADRUPOLE XX")    #TEST
-compare_values(-6.097755074075, psi4.variable('SCF QUADRUPOLE YY'), 4, "SCF QUADRUPOLE YY")    #TEST
-compare_values(-7.074596012050, psi4.variable('SCF QUADRUPOLE ZZ'), 4, "SCF QUADRUPOLE ZZ")    #TEST
-compare_values(0.000000000000, psi4.variable('SCF QUADRUPOLE XY'), 4, "SCF QUADRUPOLE XY")    #TEST
-compare_values(0.000000000000, psi4.variable('SCF QUADRUPOLE XZ'), 4, "SCF QUADRUPOLE XZ")    #TEST
-compare_values(0.000000000000, psi4.variable('SCF QUADRUPOLE YZ'), 4, "SCF QUADRUPOLE YZ")    #TEST
+
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(ref_hf_di_debye[0][0], psi4.variable('SCF DIPOLE X'), 4, "SCF DIPOLE X")    #TEST
+    compare_values(ref_hf_di_debye[0][1], psi4.variable('SCF DIPOLE Y'), 4, "SCF DIPOLE Y")    #TEST
+    compare_values(ref_hf_di_debye[0][2], psi4.variable('SCF DIPOLE Z'), 4, "SCF DIPOLE Z")    #TEST
+    compare_values(ref_hf_quad_debye[0][0], psi4.variable('SCF QUADRUPOLE XX'), 4, "SCF QUADRUPOLE XX")    #TEST
+    compare_values(ref_hf_quad_debye[1][1], psi4.variable('SCF QUADRUPOLE YY'), 4, "SCF QUADRUPOLE YY")    #TEST
+    compare_values(ref_hf_quad_debye[2][2], psi4.variable('SCF QUADRUPOLE ZZ'), 4, "SCF QUADRUPOLE ZZ")    #TEST
+    compare_values(ref_hf_quad_debye[0][1], psi4.variable('SCF QUADRUPOLE XY'), 4, "SCF QUADRUPOLE XY")    #TEST
+    compare_values(ref_hf_quad_debye[0][2], psi4.variable('SCF QUADRUPOLE XZ'), 4, "SCF QUADRUPOLE XZ")    #TEST
+    compare_values(ref_hf_quad_debye[1][2], psi4.variable('SCF QUADRUPOLE YZ'), 4, "SCF QUADRUPOLE YZ")    #TEST
+
+# prefer array dipole/quadrupole over deprecated scalar variables in section above
+compare_values(ref_hf_di_au, psi4.variable('SCF DIPOLE'), 4, "SCF DIPOLE")  #TEST
+compare_values(ref_hf_quad_au, psi4.variable('SCF QUADRUPOLE'), 4, "SCF QUADRUPOLE")  #TEST
 
 properties('B3LYP', properties=props)
 
 compare_values(-39.14134740550916, variable('CURRENT ENERGY'), 6, "B3LYP energy")    #TEST
 #compare_values(-39.14134740550916, variable('B3LYP TOTaL ENERGY'), 6, "B3LYP energy")    #TEST  # waiting for dft fctl psivars
-compare_values(0.000000000000, psi4.variable('B3LYP DIPOLE X'), 4, "B3LYP DIPOLE X")    #TEST
-compare_values(-0.000000000000, psi4.variable('B3LYP DIPOLE Y'), 4, "B3LYP DIPOLE Y")    #TEST
-compare_values(0.641741521158, psi4.variable('B3LYP DIPOLE Z'), 4, "B3LYP DIPOLE Z")    #TEST
-compare_values(-7.616483183211, psi4.variable('B3LYP QUADRUPOLE XX'), 4, "B3LYP QUADRUPOLE XX")    #TEST
-compare_values(-6.005896804551, psi4.variable('B3LYP QUADRUPOLE YY'), 4, "B3LYP QUADRUPOLE YY")    #TEST
-compare_values(-7.021817489904, psi4.variable('B3LYP QUADRUPOLE ZZ'), 4, "B3LYP QUADRUPOLE ZZ")    #TEST
-compare_values(0.000000000000, psi4.variable('B3LYP QUADRUPOLE XY'), 4, "B3LYP QUADRUPOLE XY")    #TEST
-compare_values(0.000000000000, psi4.variable('B3LYP QUADRUPOLE XZ'), 4, "B3LYP QUADRUPOLE XZ")    #TEST
-compare_values(-0.000000000000, psi4.variable('B3LYP QUADRUPOLE YZ'), 4, "B3LYP QUADRUPOLE YZ")    #TEST
+
+with warnings.catch_warnings():  #TEST
+    warnings.simplefilter("ignore")  #TEST
+    compare_values(ref_b3lyp_di_debye[0][0], psi4.variable('B3LYP DIPOLE X'), 4, "B3LYP DIPOLE X")    #TEST
+    compare_values(ref_b3lyp_di_debye[0][1], psi4.variable('B3LYP DIPOLE Y'), 4, "B3LYP DIPOLE Y")    #TEST
+    compare_values(ref_b3lyp_di_debye[0][2], psi4.variable('B3LYP DIPOLE Z'), 4, "B3LYP DIPOLE Z")    #TEST
+    compare_values(ref_b3lyp_quad_debye[0][0], psi4.variable('B3LYP QUADRUPOLE XX'), 4, "B3LYP QUADRUPOLE XX")    #TEST
+    compare_values(ref_b3lyp_quad_debye[1][1], psi4.variable('B3LYP QUADRUPOLE YY'), 4, "B3LYP QUADRUPOLE YY")    #TEST
+    compare_values(ref_b3lyp_quad_debye[2][2], psi4.variable('B3LYP QUADRUPOLE ZZ'), 4, "B3LYP QUADRUPOLE ZZ")    #TEST
+    compare_values(ref_b3lyp_quad_debye[0][1], psi4.variable('B3LYP QUADRUPOLE XY'), 4, "B3LYP QUADRUPOLE XY")    #TEST
+    compare_values(ref_b3lyp_quad_debye[0][2], psi4.variable('B3LYP QUADRUPOLE XZ'), 4, "B3LYP QUADRUPOLE XZ")    #TEST
+    compare_values(ref_b3lyp_quad_debye[1][2], psi4.variable('B3LYP QUADRUPOLE YZ'), 4, "B3LYP QUADRUPOLE YZ")    #TEST
+
+# prefer array dipole/quadrupole over deprecated scalar variables in section above
+compare_values(ref_b3lyp_di_au, psi4.variable('B3LYP DIPOLE'), 4, "B3LYP DIPOLE")  #TEST
+compare_values(ref_b3lyp_quad_au, psi4.variable('B3LYP QUADRUPOLE'), 4, "B3LYP QUADRUPOLE")  #TEST

--- a/tests/scf-property/input.dat
+++ b/tests/scf-property/input.dat
@@ -3,9 +3,9 @@
 import warnings  #TEST
 import numpy as np  #TEST
 from psi4.driver import constants  #TEST
-ref_hf_di_au = np.array([[0.0, 0.0, 0.22531665104559076]])  #TEST
+ref_hf_di_au = np.array([0.0, 0.0, 0.22531665104559076])  #TEST
 ref_hf_quad_au = np.array([[-5.69804565317, 0.0, 0.0], [0.0, -4.53353128969, 0.0], [0.0, 0.0, -5.25978856037]])  #TEST
-ref_b3lyp_di_au = np.array([[0.0, 0.0, 0.252480541747]])  #TEST
+ref_b3lyp_di_au = np.array([0.0, 0.0, 0.252480541747])  #TEST
 ref_b3lyp_quad_au = np.array([[-5.66266837697, 0.0, 0.0], [0.0, -4.46523692003, 0.0], [0.0, 0.0, -5.22054902407]])  #TEST
 
 ref_hf_di_debye = ref_hf_di_au * constants.dipmom_au2debye  #TEST
@@ -48,9 +48,9 @@ compare_values(-38.91591819679808, psi4.variable("HF TOTAL ENERGY"), 6, "SCF ene
 
 with warnings.catch_warnings():  #TEST
     warnings.simplefilter("ignore")  #TEST
-    compare_values(ref_hf_di_debye[0][0], psi4.variable('SCF DIPOLE X'), 4, "SCF DIPOLE X")    #TEST
-    compare_values(ref_hf_di_debye[0][1], psi4.variable('SCF DIPOLE Y'), 4, "SCF DIPOLE Y")    #TEST
-    compare_values(ref_hf_di_debye[0][2], psi4.variable('SCF DIPOLE Z'), 4, "SCF DIPOLE Z")    #TEST
+    compare_values(ref_hf_di_debye[0], psi4.variable('SCF DIPOLE X'), 4, "SCF DIPOLE X")    #TEST
+    compare_values(ref_hf_di_debye[1], psi4.variable('SCF DIPOLE Y'), 4, "SCF DIPOLE Y")    #TEST
+    compare_values(ref_hf_di_debye[2], psi4.variable('SCF DIPOLE Z'), 4, "SCF DIPOLE Z")    #TEST
     compare_values(ref_hf_quad_debye[0][0], psi4.variable('SCF QUADRUPOLE XX'), 4, "SCF QUADRUPOLE XX")    #TEST
     compare_values(ref_hf_quad_debye[1][1], psi4.variable('SCF QUADRUPOLE YY'), 4, "SCF QUADRUPOLE YY")    #TEST
     compare_values(ref_hf_quad_debye[2][2], psi4.variable('SCF QUADRUPOLE ZZ'), 4, "SCF QUADRUPOLE ZZ")    #TEST
@@ -69,9 +69,9 @@ compare_values(-39.14134740550916, variable('CURRENT ENERGY'), 6, "B3LYP energy"
 
 with warnings.catch_warnings():  #TEST
     warnings.simplefilter("ignore")  #TEST
-    compare_values(ref_b3lyp_di_debye[0][0], psi4.variable('B3LYP DIPOLE X'), 4, "B3LYP DIPOLE X")    #TEST
-    compare_values(ref_b3lyp_di_debye[0][1], psi4.variable('B3LYP DIPOLE Y'), 4, "B3LYP DIPOLE Y")    #TEST
-    compare_values(ref_b3lyp_di_debye[0][2], psi4.variable('B3LYP DIPOLE Z'), 4, "B3LYP DIPOLE Z")    #TEST
+    compare_values(ref_b3lyp_di_debye[0], psi4.variable('B3LYP DIPOLE X'), 4, "B3LYP DIPOLE X")    #TEST
+    compare_values(ref_b3lyp_di_debye[1], psi4.variable('B3LYP DIPOLE Y'), 4, "B3LYP DIPOLE Y")    #TEST
+    compare_values(ref_b3lyp_di_debye[2], psi4.variable('B3LYP DIPOLE Z'), 4, "B3LYP DIPOLE Z")    #TEST
     compare_values(ref_b3lyp_quad_debye[0][0], psi4.variable('B3LYP QUADRUPOLE XX'), 4, "B3LYP QUADRUPOLE XX")    #TEST
     compare_values(ref_b3lyp_quad_debye[1][1], psi4.variable('B3LYP QUADRUPOLE YY'), 4, "B3LYP QUADRUPOLE YY")    #TEST
     compare_values(ref_b3lyp_quad_debye[2][2], psi4.variable('B3LYP QUADRUPOLE ZZ'), 4, "B3LYP QUADRUPOLE ZZ")    #TEST


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

## Todos
- [x] deprecate DIPOLE X and QUADRUPOLE XX qcvars that were anomolously in Debye-Ang units
- [x] add DIPOLE and QUADRUPOLE array qcvars in atomic units
- [x] edit all the tests so that they check both for the interim
- [x] the `P::e.globals` and `Wfn.variables_` maps work in `core.Matrix`. Want to keep this storage for continuity and the preservation of symmetry, but 2D is not what one expects for dipole or charges (much less what one expects for octupole). So selected properties vars are returned as ndarray from the `variable()` query fns. This means you can't assume the return is a Matrix.
- [x] schema handling addressed accordingly and tested for run_json and run_qcschema setups. Note that return units now au
- [x] handling >quadrupole

**EDIT** change of plans from first post. in order not to have to go from unique multipole elements (10 for octupole) to complete array (27) c-side and flat since P::e.globals restricted to Matrix, now only the compressed array is stored in globals/variables_ and that gets turned into (and back) the complete multidimensional ndarray when queried py-side. quadrupole has been turned back c-side to `(6)`, rather than `(3,3)` for consistency with the other poles.

## Checklist
- [x] Tests added for any new features 
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
