### PR TITLE
Fixed the error in E(30)ind (1677)

### DIFF
--- a/psi4/src/psi4/libsapt_solver/amplitudes.cc
+++ b/psi4/src/psi4/libsapt_solver/amplitudes.cc
@@ -1122,19 +1122,23 @@ void SAPT2p3::ind30_amps(int AAfile, const char *ARlabel, int BBfile, const char
 
     double **uAR = block_matrix(noccA, nvirA);
 
-    C_DGEMM('N', 'T', noccA, nvirA, nvirA, 1.0, sAR[0], nvirA, wBRR[0], nvirA, 0.0, uAR[0], nvirA);
-
-    C_DGEMM('N', 'N', noccA, nvirA, noccA, -1.0, wBAA[0], noccA, sAR[0], nvirA, 1.0, uAR[0], nvirA);
-
     double **B_p_AR = get_DF_ints(AAfile, ARlabel, 0, noccA, 0, nvirA);
     double **B_p_BS = get_DF_ints(BBfile, BSlabel, 0, noccB, 0, nvirB);
 
     double *X = init_array(ndf_ + 3);
 
     C_DGEMV('t', noccB * nvirB, ndf_ + 3, 1.0, B_p_BS[0], ndf_ + 3, sBS[0], 1, 0.0, X, 1);
-    C_DGEMV('n', noccA * nvirA, ndf_ + 3, 2.0, B_p_AR[0], ndf_ + 3, X, 1, 1.0, uAR[0], 1);
+    C_DGEMV('n', noccA * nvirA, ndf_ + 3, 2.0, B_p_AR[0], ndf_ + 3, X, 1, 0.0, uAR[0], 1);
 
     free(X);
+
+    if (amplabel == "Ind30 uAR Amplitudes") {
+        e_ind30_vsasb_term_ = 2.0 * C_DDOT(noccA * nvirA, uAR[0], 1, sAR[0], 1);
+    }
+
+    C_DGEMM('N', 'T', noccA, nvirA, nvirA, 1.0, sAR[0], nvirA, wBRR[0], nvirA, 1.0, uAR[0], nvirA);
+
+    C_DGEMM('N', 'N', noccA, nvirA, noccA, -1.0, wBAA[0], noccA, sAR[0], nvirA, 1.0, uAR[0], nvirA);
 
     double **tARBS = block_matrix(noccA * nvirA, noccB * nvirB);
 

--- a/psi4/src/psi4/libsapt_solver/ind30.cc
+++ b/psi4/src/psi4/libsapt_solver/ind30.cc
@@ -53,11 +53,12 @@ void SAPT2p3::ind30() {
 
     free_block(tBS);
 
-    e_ind30_ = indA_B + indB_A;
+    e_ind30_ = indA_B + indB_A + e_ind30_vsasb_term_;
 
     if (debug_) {
         outfile->Printf("\n    Ind30_1             = %18.12lf [Eh]\n", indA_B);
         outfile->Printf("    Ind30_2             = %18.12lf [Eh]\n", indB_A);
+        outfile->Printf("    Ind30_3             = %18.12lf [Eh]\n", e_ind30_vsasb_term_);
     }
     if (print_) {
         outfile->Printf("    Ind30               = %18.12lf [Eh]\n", e_ind30_);

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.h
@@ -55,6 +55,7 @@ class SAPT2p3 : public SAPT2p {
     double e_sapt2p3_;
     double e_sapt2pp3_ccd_;
     double e_sapt2p3_ccd_;
+    double e_ind30_vsasb_term_;
 
     void Y3(int, const char *, const char *, const char *, int, const char *, const char *, const char *, const char *,
             const char *, const char *, size_t, size_t, size_t, double *, size_t, const char *);


### PR DESCRIPTION
## Description
Includes the small missing term in SAPT E(30)ind (issue #1677) with one extra DDOT of size o*v. The additional term is passed around using the variable `e_ind30_vsasb_term_` defined in `sapt2p3.h`  - please change if that's not the preferred way. The results on the A24 database agree with the Psi4NumPy code of Jonathan Waldrop.

## Status
- [x] Ready for review
- [ ] Ready for merge
