### PR TITLE
Fix performance issue in DF SCF Hessians

### DIFF
--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -1529,22 +1529,21 @@ void DFJKGrad::compute_hessian()
                 for (int p = oP; p < oP+nP; p++) {
                     for (int m = oM; m < oM+nM; m++) {
                         for (int n = oN; n < oN+nN; n++) {
-                            Amnp[p][m*nso+n] += (*buffer++);
+                            Amnp[p][m*nso+n] = (*buffer++);
                         }
                     }
                 }
-                // c[A] = (A|mn) D[m][n]
-                C_DGEMV('N', np, nso*(size_t)nso, 1.0, Amnp[0], nso*(size_t)nso, Dtp[0], 1, 0.0, cp, 1);
-                // (A|mj) = (A|mn) C[n][j]
-                C_DGEMM('N','N',np*(size_t)nso,na,nso,1.0,Amnp[0],nso,Cap[0],na,0.0,Amip[0],na);
-                // (A|ij) = (A|mj) C[m][i]
-                #pragma omp parallel for
-                for (int p = 0; p < np; p++) {
-                    C_DGEMM('T','N',na,na,nso,1.0,Amip[p],na,Cap[0],na,0.0,&Aijp[0][p * (size_t) na * na],na);
-                }
-
             }
         }
+    }
+    // c[A] = (A|mn) D[m][n]
+    C_DGEMV('N', np, nso*(size_t)nso, 1.0, Amnp[0], nso*(size_t)nso, Dtp[0], 1, 0.0, cp, 1);
+    // (A|mj) = (A|mn) C[n][j]
+    C_DGEMM('N','N',np*(size_t)nso,na,nso,1.0,Amnp[0],nso,Cap[0],na,0.0,Amip[0],na);
+    // (A|ij) = (A|mj) C[m][i]
+    #pragma omp parallel for
+    for (int p = 0; p < np; p++) {
+        C_DGEMM('T','N',na,na,nso,1.0,Amip[p],na,Cap[0],na,0.0,&Aijp[0][p * (size_t) na * na],na);
     }
 
     // d[A] = Minv[A][B] c[B]


### PR DESCRIPTION
## Description
Some MO transformations were being performed many times instead of just once in the DF SCF analytic Hessians, as a result of some closed braces being in the wrong place.  The results were correct before but the code was *very* slow.  Sorry for the mistake - my bad.  Fixes #1145

## Status
- [x] Ready for review
- [x] Ready for merge
