### PR TITLE
Resolve compiler warning

### DIFF
--- a/psi4/src/psi4/libsapt_solver/amplitudes.cc
+++ b/psi4/src/psi4/libsapt_solver/amplitudes.cc
@@ -1132,7 +1132,7 @@ void SAPT2p3::ind30_amps(int AAfile, const char *ARlabel, int BBfile, const char
 
     free(X);
 
-    if (strcmp(amplabel, "Ind30 uAR Amplitudes")) {
+    if (amplabel == std::string("Ind30 uAR Amplitudes")) {
         e_ind30_vsasb_term_ = 2.0 * C_DDOT(noccA * nvirA, uAR[0], 1, sAR[0], 1);
     }
 

--- a/psi4/src/psi4/libsapt_solver/amplitudes.cc
+++ b/psi4/src/psi4/libsapt_solver/amplitudes.cc
@@ -1132,7 +1132,7 @@ void SAPT2p3::ind30_amps(int AAfile, const char *ARlabel, int BBfile, const char
 
     free(X);
 
-    if (amplabel == "Ind30 uAR Amplitudes") {
+    if (strcmp(amplabel, "Ind30 uAR Amplitudes")) {
         e_ind30_vsasb_term_ = 2.0 * C_DDOT(noccA * nvirA, uAR[0], 1, sAR[0], 1);
     }
 


### PR DESCRIPTION
## Description
While building Psi, my compiler complained:
```
/Users/jonathonmisiewicz/psi4/psi4/src/psi4/libsapt_solver/amplitudes.cc:1135:18: warning: result of comparison against a string literal is unspecified (use strncmp instead) [-Wstring-compare]
    if (amplabel == "Ind30 uAR Amplitudes") {
                 ^  ~~~~~~~~~~~~~~~~~~~~~~
```
Might as well fix it _before_ it causes some hard-to-debug problem.

## Status
- [x] Ready for review
- [x] Ready for merge
