### PR TITLE
Psi3 doesn't mentioning in the build docs.

### DIFF
--- a/doc/sphinxman/source/build_obtaining.rst
+++ b/doc/sphinxman/source/build_obtaining.rst
@@ -295,32 +295,6 @@ Tarball from GitHub Repository
 
   Not applicable as source not under git control.
 
-
-.. _`faq:psi3sourceforge`:
-
-Psi3 from SourceForge
----------------------
-
-* **Get Initially**
-
-  A tarball of the most recent version of Psi3 (3.4.0 circa 2009) is
-  available from `SourceForge
-  <http://sourceforge.net/projects/psicode/files/psi/3.4.0/>`_
-
-* **Build**
-
-  Follow the ``INSTALL`` file that comes with the distribution. An old
-  computer is probably handy for generating a working executable.
-
-* **Get Updates**
-
-  Updates are not forthcoming.
-
-* **Contribute Back**
-
-  This code is not under any development.
-
-
 .. _`faq:githubworkflow`:
 
 What is the suggested GitHub workflow


### PR DESCRIPTION
## Description
Removes the obsolete mention of Psi3 in the build docs.

If someone wants psi3, they can find it by Google...

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
