### PR TITLE
try fixing Azure Clang OpenMP

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -32,8 +32,9 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
-        APT_INSTALL: 'gfortran clang libomp-dev'
+        #APT_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
+        #APT_INSTALL: 'gfortran clang libomp-dev'
+        APT_INSTALL: 'gfortran clang-6.0'
 
   steps:
   - bash: |

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -32,7 +32,8 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran clang'
+        API_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
+        APT_INSTALL: 'gfortran clang libomp-dev'
 
   steps:
   - bash: |

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -32,7 +32,7 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        API_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
+        APT_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
         APT_INSTALL: 'gfortran clang libomp-dev'
 
   steps:

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -2,9 +2,9 @@ jobs:
 
   # Configure, build, install, and test job
   - job: 'windows_build'
-    displayName: 'Windows VS2015'
+    displayName: 'Windows VS2017'
     pool:
-      vmImage: 'vs2015-win2012r2'
+      vmImage: 'vs2017-win2016'
     timeoutInMinutes: 360
     variables:
       llvm.version: '7.0.1' # Note: LLVM 8.0.0 fails to build the optimized libint

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -50,9 +50,6 @@ if not os.path.isdir(data_dir):
     raise KeyError("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable"
                     "      Current value of PSIDATADIR is %s" % data_dir)
 
-if "KMP_AFFINITY" not in os.environ:
-    os.environ["KMP_AFFINITY"] = "compact"
-
 # Init core
 try:
     from . import core

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -50,6 +50,9 @@ if not os.path.isdir(data_dir):
     raise KeyError("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable"
                     "      Current value of PSIDATADIR is %s" % data_dir)
 
+if "KMP_AFFINITY" not in os.environ:
+    os.environ["KMP_AFFINITY"] = "compact"
+
 # Init core
 try:
     from . import core

--- a/tests/mints9/input.dat
+++ b/tests/mints9/input.dat
@@ -199,7 +199,7 @@ except qcdb.BasisSetNotFound:
 compare_integers(1, error_tripped, 'squashed 4z aux for 5z orb')  #TEST
 
 df_basis_scf uggh {
-    assign he DEF2-UNIVERSAL-JKFIT
+    assign he DEF2-QZVPP-JKFIT
 }
 
 print('[15]   <<<  forced JK for cc-pV5Z on HeNe  >>>')
@@ -207,7 +207,7 @@ wert = psi4.core.BasisSet.build(hene, 'DF_BASIS_SCF', '', 'JKFIT', get_global_op
 compare_integers(169, wert.nbf(), 'nbf()')  #TEST
 compare_integers(241, wert.nao(), 'nao()')  #TEST
 compare_strings('UGGH', wert.name(), 'callby')  #TEST
-compare_strings('CC-PV5Z-JKFIT + DEF2-UNIVERSAL-JKFIT', wert.blend(), 'blend')  #TEST
+compare_strings('CC-PV5Z-JKFIT + DEF2-QZVPP-JKFIT', wert.blend(), 'blend')  #TEST
 hene.print_out()
 
 


### PR DESCRIPTION
## Description
misc.

## Todos
- [x] adds a specific def2-qzvpp back so we can check aliases are working
- [ ] ~supply `KMP_AFFINITY` if not set by user. untested~
- [x] fix the `omp.h` not found that's breaking all the Azure Clang builds.
- [x] update the Windows image since Azure is canceling VS2015 next month - https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
