### PR TITLE
switch out omp call

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -32,8 +32,6 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        #APT_REPOSITORY: 'http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages'
-        #APT_INSTALL: 'gfortran clang libomp-dev'
         APT_INSTALL: 'gfortran clang-6.0'
 
   steps:

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -50,9 +50,6 @@ if not os.path.isdir(data_dir):
     raise KeyError("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable"
                     "      Current value of PSIDATADIR is %s" % data_dir)
 
-if "KMP_AFFINITY" not in os.environ:
-    os.environ["KMP_AFFINITY"] = "compact"
-
 # Init core
 try:
     from . import core

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -50,6 +50,9 @@ if not os.path.isdir(data_dir):
     raise KeyError("Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable"
                     "      Current value of PSIDATADIR is %s" % data_dir)
 
+if "KMP_AFFINITY" not in os.environ:
+    os.environ["KMP_AFFINITY"] = "compact"
+
 # Init core
 try:
     from . import core

--- a/psi4/share/psi4/basis/NOTES
+++ b/psi4/share/psi4/basis/NOTES
@@ -1,7 +1,7 @@
 *******************************************************************************
 *******************************************************************************
 
-Friday, January 7, 2020 -- LAB
+Friday, February 7, 2020 -- LAB
 
 [48] Realizing that the diff_gbs.py script is great for detecting format
 errors preventing the parser from forming an atomic basis, I ran the

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -222,7 +222,7 @@ void VBase::build_collocation_cache(size_t memory) {
     }
 
     // Figure out stride as closest whole number to amount we need
-    size_t stride = (size_t)(1.0 / ((double)memory / collocation_size));
+    size_t stride = (size_t)(std::ceil(collocation_size / (double)memory));
 
     // More memory than needed
     if (stride == 0) {
@@ -281,10 +281,10 @@ void VBase::build_collocation_cache(size_t memory) {
     size_t saved_size = std::accumulate(saved_size_rank.begin(), saved_size_rank.end(), 0.0);
     size_t ncomputed = std::accumulate(ncomputed_rank.begin(), ncomputed_rank.end(), 0.0);
 
-    double mib_saved = 8.0 * (double)saved_size / 1024.0 / 1024.0 / 1024.0;
+    double gib_saved = 8.0 * (double)saved_size / 1024.0 / 1024.0 / 1024.0;
     double fraction = (double)ncomputed / grid_->blocks().size() * 100;
     if (print_) {
-        outfile->Printf("  Cached %.1lf%% of DFT collocation blocks in %.3lf [GiB].\n\n", fraction, mib_saved);
+        outfile->Printf("  Cached %.1lf%% of DFT collocation blocks in %.3lf [GiB].\n\n", fraction, gib_saved);
     }
 }
 void VBase::prepare_vv10_cache(DFTGrid& nlgrid, SharedMatrix D,

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -65,7 +65,7 @@ SAPT::SAPT(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunc
 #endif
 
 #ifdef _OPENMP
-    omp_set_nested(0);
+    omp_set_max_active_levels(0);
 #endif
 
     initialize(MonomerA, MonomerB);


### PR DESCRIPTION
## Description
- [x] Addresses #1820 with new syntax. Let's see if Windows and Mac setups can cope.
- [x] Addresses #1819 with explicit rounding direction.

before (stride, memory, collocation_size) `MEM 1       954741720.0000 1678037264`
```
(dev10) psilocaluser@bash:psinet:/home/psilocaluser/gits/hrw-release/objdir: (safeforqcel2018) grep iB dftmem.out 
    Memory:     500.0 MiB
  Memory set to  14.901 GiB by Python driver.
                        1 Threads,  15258 MiB Core
  DFHelper Memory: AOs need 3.981 GiB; user supplied 3.981 GiB. Using in-core AOs.
    Memory [MiB]:              4076
  Cached 100.0% of DFT collocation blocks in 12.502 [GiB].
```
after `MEM 2       954741720.0000 1678037264`
```
(dev10) psilocaluser@bash:psinet:/home/psilocaluser/gits/hrw-release/objdir: (safeforqcel2018) grep iB dftmem2.out 
    Memory:     500.0 MiB
  Memory set to  14.901 GiB by Python driver.
                        6 Threads,  15258 MiB Core
  DFHelper Memory: AOs need 4.062 GiB; user supplied 4.062 GiB. Using in-core AOs.
    Memory [MiB]:              4159
  Cached 50.0% of DFT collocation blocks in 6.277 [GiB].

```

## Status
- [x] Ready for review
- [x] Ready for merge
