### PR TITLE
Simplify partial Cholesky with Gershgorin theorem

### DIFF
--- a/psi4/src/psi4/libmints/orthog.h
+++ b/psi4/src/psi4/libmints/orthog.h
@@ -56,8 +56,6 @@ class PSI_API BasisSetOrthogonalization {
     SharedMatrix eigvec_;
     /// and eigenvalues
     SharedVector eigval_;
-    /// Basis function <r^2> values
-    SharedVector rsq_;
 
     /** The tolerance for linearly independent basis functions.
      * The interpretation depends on the orthogonalization
@@ -106,8 +104,8 @@ class PSI_API BasisSetOrthogonalization {
     std::vector<std::vector<int>> sort_indices() const;
 
    public:
-    BasisSetOrthogonalization(OrthogonalizationMethod method, SharedMatrix overlap, SharedVector rsq,
-                              double lindep_tolerance, double cholesky_tolerance, int print = 0);
+    BasisSetOrthogonalization(OrthogonalizationMethod method, SharedMatrix overlap, double lindep_tolerance,
+                              double cholesky_tolerance, int print = 0);
 
     OrthogonalizationMethod orthog_method() const { return orthog_method_; }
 

--- a/psi4/src/psi4/libmints/quadrupole.cc
+++ b/psi4/src/psi4/libmints/quadrupole.cc
@@ -190,37 +190,3 @@ void QuadrupoleInt::compute_pair(const GaussianShell &s1, const GaussianShell &s
         }
     }
 }
-
-std::vector<double> QuadrupoleInt::compute_R_squared() {
-    if (bs1_ != bs2_) throw PSIEXCEPTION("QuadrupoleInt::compute_R_squared needs bs1_ == bs2_.");
-
-    std::vector<double> rsq(bs1_->nbf());
-    int ns1 = bs1_->nshell();
-    int offset = 0;
-    for (int is = 0; is < ns1; ++is) {
-        // Get shell
-        const auto &shell = bs1_->shell(is);
-        // Set origin to nucleus
-        set_origin(shell.center());
-        // Compute the integrals
-        compute_shell(is, is);
-
-        // Number of functions on shell
-        int ni = force_cartesian_ ? bs1_->shell(is).ncartesian() : bs1_->shell(is).nfunction();
-        // Lenght of one shell
-        size_t length = std::pow((size_t)ni, 2);
-        for (int i = 0; i < ni; i++) {
-            int ioff = i * ni + i;
-            double xx = buffer_[ioff];
-            double yy = buffer_[ioff + 3 * length];
-            double zz = buffer_[ioff + 5 * length];
-
-            // Looks like the quadrupoles are computed with a minus sign
-            rsq[offset + i] = -(xx + yy + zz);
-        }
-
-        offset += ni;
-    }
-
-    return rsq;
-}

--- a/psi4/src/psi4/libmints/quadrupole.h
+++ b/psi4/src/psi4/libmints/quadrupole.h
@@ -55,9 +55,6 @@ class QuadrupoleInt : public OneBodyAOInt {
     ~QuadrupoleInt() override;
 
     static SharedVector nuclear_contribution(std::shared_ptr<Molecule> mol, const Vector3 &origin);
-
-    /// Compute <r^2> for all basis functions
-    std::vector<double> compute_R_squared();
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -710,35 +710,7 @@ void HF::form_Shalf() {
     double lindep_tolerance = options_.get_double("S_TOLERANCE");
     double cholesky_tolerance = options_.get_double("S_CHOLESKY_TOLERANCE");
 
-    // Compute <r^2> for Cholesky (may be also triggered by auto mode)
-    SharedVector rsq;
-    if (method == BasisSetOrthogonalization::Automatic || method == BasisSetOrthogonalization::PartialCholesky) {
-        // Integral factory
-        IntegralFactory integral(basisset_, basisset_, basisset_, basisset_);
-        auto quad = (QuadrupoleInt*)integral.ao_quadrupole();
-        // Basis funtion r^2 values
-        std::vector<double> bf_rsq = quad->compute_R_squared();
-
-        const Dimension& nao = AO2SO_->rowspi();
-        const Dimension& nso = AO2SO_->colspi();
-
-        // AO2SO has the info we need for the translation
-        rsq = std::make_shared<Vector>(nso);
-        for (int h = 0; h < nirrep_; h++) {
-            for (int so = 0; so < nso[h]; so++) {
-                // Find an AO that contributes to the SO
-                int ao;
-                for (ao = 0; ao < nao[h]; ao++)
-                    if (AO2SO_->get(h, ao, so) != 0.0) {
-                        rsq->set(h, so, bf_rsq[ao]);
-                        break;
-                    }
-                if (ao == nao[h]) throw PSIEXCEPTION("Did not find atomic orbital!");
-            }
-        }
-    }
-
-    BasisSetOrthogonalization orthog(method, S_, rsq, lindep_tolerance, cholesky_tolerance, print_);
+    BasisSetOrthogonalization orthog(method, S_, lindep_tolerance, cholesky_tolerance, print_);
 
     // Transform
     X_ = orthog.basis_to_orthog_basis();


### PR DESCRIPTION
## Description
This PR modifies the partial Cholesky approach by determining the initial pivot by an approach motivated by the Gershgorin circle theorem. By ordering the basis functions in terms of increasing values of  `\sum_j |S_{ij}|`, the Cholesky procedure is initialized with functions that are as close as possible to eigenfunctions of S. Although the original scheme works well, this one is conceptually more attractive as it needs no external input. Moreover, this one should be more generally applicable, e.g. in the case of computing strongly repulsive potentials where some tight functions might have large overlap.

The two approaches appear to reproduce similar results, so the change should not break anything.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Switch to using Gershgorin theorem in partial Cholesky code.
- [x] Remove hacks that were needed for the old implementation.

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
