### PR TITLE
Debug and Quarantine HF MO Hessian: OCC's Open-Heart Surgery V

### DIFF
--- a/psi4/src/psi4/libdpd/contract222.cc
+++ b/psi4/src/psi4/libdpd/contract222.cc
@@ -39,6 +39,23 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {
 
+/* dpd_contract222(): Contracts a pair of two-index quantities to
+** give a product two-index quantity.
+**
+** Arguments:
+**   dpdfile2 *X: A pointer to the leftmost dpd two-index
+**               buffer in the product.
+**   dpdfile2 *Y: A pointer to the rightmost dpd two-index
+**               buffer in the product.
+**   dpdfile2 *Z: A pointer to the dpd two-index target
+**   int target_X: Indicates which index (0 = bra, 1 =
+**                 ket) of X is the target index.
+**   int target_Y: Indicates which index (0 = bra, 1 =
+**                 ket) of Y is the target index.
+**   double alpha: A prefactor for the product alpha * X * Y.
+**   double beta: A prefactor for the target beta * Z.
+*/
+
 int DPD::contract222(dpdfile2 *X, dpdfile2 *Y, dpdfile2 *Z, int target_X, int target_Y, double alpha, double beta) {
     int h, nirreps, Xtrans, Ytrans, *numlinks;
     int GX, GY, GZ;

--- a/psi4/src/psi4/occ/README.txt
+++ b/psi4/src/psi4/occ/README.txt
@@ -1,0 +1,6 @@
+* There are currently three very similar families of dpdfiles that look like Fock matrices:
+  Fock <X|X> - An intermediate used during construction of the Fock matrix. Just the J/K part.
+  F <X|X>    - The Fock matrix without diagonal elements
+  FD <X|X>   - The Fock matrix
+* Ideally, those can be condensed. The F uses in the amplitude conditions will change to FD upon changing the conditions from = to += form
+  As for Fock uses, reconsider if that's the best way to construct the Fock matrix. If it is, then rename it.

--- a/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
@@ -64,10 +64,10 @@ void OCCWave::kappa_orb_resp_iter() {
         global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, qpsr, ID("[V,O]"), ID("[V,O]"), "MO Ints (VO|VO)");
         global_dpd_->buf4_close(&K);
 
-        // (ai|bj) -> (aj|bi)
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), 0,
-                               "MO Ints (VO|VO)");
-        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[V,O]"), ID("[V,O]"), "MO Ints (aj|bi)");
+        // <OO|VV> -> <OV|VO>
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+                               "MO Ints <OO|VV>");
+        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[O,V]"), ID("[V,O]"), "MO Ints <OV|VO>");
         global_dpd_->buf4_close(&K);
 
         // <OV|OV> -> <VO|VO>
@@ -201,16 +201,16 @@ void OCCWave::kappa_orb_resp_iter() {
         global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, qpsr, ID("[v,o]"), ID("[v,o]"), "MO Ints (vo|vo)");
         global_dpd_->buf4_close(&K);
 
-        // (AI|BJ) -> (AJ|BI)
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), 0,
-                               "MO Ints (VO|VO)");
-        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[V,O]"), ID("[V,O]"), "MO Ints (AJ|BI)");
+        // <OO|VV> -> <OV|VO>
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
+                               "MO Ints <OO|VV>");
+        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[O,V]"), ID("[V,O]"), "MO Ints <OV|VO>");
         global_dpd_->buf4_close(&K);
 
-        // (ai|bj) -> (aj|bi)
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[v,o]"), ID("[v,o]"), ID("[v,o]"), ID("[v,o]"), 0,
-                               "MO Ints (vo|vo)");
-        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[v,o]"), ID("[v,o]"), "MO Ints (aj|bi)");
+        // <oo|vv> -> <ov|vo>
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o,o]"), ID("[v,v]"), 0,
+                               "MO Ints <oo|vv>");
+        global_dpd_->buf4_sort(&K, PSIF_LIBTRANS_DPD, psrq, ID("[o,v]"), ID("[v,o]"), "MO Ints <ov|vo>");
         global_dpd_->buf4_close(&K);
 
         // <OV|OV> -> <VO|VO>
@@ -632,10 +632,10 @@ void OCCWave::compute_sigma_vector() {
         global_dpd_->contract422(&K, &P, &S, 0, 0, 8.0, 1.0);
         global_dpd_->buf4_close(&K);
 
-        // sigma_ai -= 2 \sum_{bj} (aj|bi) P_bj
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), 0,
-                               "MO Ints (aj|bi)");
-        global_dpd_->contract422(&K, &P, &S, 0, 0, -2.0, 1.0);
+        // sigma_ai -= 2 \sum_{bj} <ia|bj> P_bj
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,V]"), ID("[V,O]"), ID("[O,V]"), ID("[V,O]"), 0,
+                               "MO Ints <OV|VO>");
+        global_dpd_->contract422(&K, &P, &S, 0, 1, -2.0, 1.0);
         global_dpd_->buf4_close(&K);
 
         // sigma_ai -= 2 \sum_{bj} <ai|bj> P_bj
@@ -687,10 +687,10 @@ void OCCWave::compute_sigma_vector() {
         global_dpd_->contract422(&K, &P, &S, 0, 0, 4.0, 1.0);
         global_dpd_->buf4_close(&K);
 
-        // sigma_AI -= 2 \sum_{BJ} (AJ|BI) P_BJ
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), ID("[V,O]"), 0,
-                               "MO Ints (AJ|BI)");
-        global_dpd_->contract422(&K, &P, &S, 0, 0, -2.0, 1.0);
+        // sigma_AI -= 2 \sum_{BJ} <IA|BJ> P_BJ
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,V]"), ID("[V,O]"), ID("[O,V]"), ID("[V,O]"), 0,
+                               "MO Ints <OV|VO>");
+        global_dpd_->contract422(&K, &P, &S, 0, 1, -2.0, 1.0);
         global_dpd_->buf4_close(&K);
 
         // sigma_AI -= 2 \sum_{BJ} <AI|BJ> P_BJ
@@ -745,10 +745,10 @@ void OCCWave::compute_sigma_vector() {
         global_dpd_->contract422(&K, &P, &S, 0, 0, 4.0, 1.0);
         global_dpd_->buf4_close(&K);
 
-        // sigma_ai -= 2 \sum_{bj} (aj|bi) P_bj
-        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[v,o]"), ID("[v,o]"), ID("[v,o]"), ID("[v,o]"), 0,
-                               "MO Ints (aj|bi)");
-        global_dpd_->contract422(&K, &P, &S, 0, 0, -2.0, 1.0);
+        // sigma_ai -= 2 \sum_{bj} <ia|bj> P_bj
+        global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[o,v]"), ID("[v,o]"), ID("[o,v]"), ID("[v,o]"), 0,
+                               "MO Ints <ov|vo>");
+        global_dpd_->contract422(&K, &P, &S, 0, 1, -2.0, 1.0);
         global_dpd_->buf4_close(&K);
 
         // sigma_ai -= 2 \sum_{bj} <ai|bj> P_bj

--- a/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
@@ -407,18 +407,18 @@ void OCCWave::orb_resp_pcg_rhf() {
         compute_sigma_vector();
         
         // Build line search parameter alpha
-        double alpha_A = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
+        double alpha = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
 
         // Build kappa-new
         kappa_newA->zero();
         kappa_newA->copy(p_pcgA);
-        kappa_newA->scale(alpha_A);
+        kappa_newA->scale(alpha);
         kappa_newA->add(kappaA);
 
         // Build r-new
         r_pcg_newA->zero();
         r_pcg_newA->copy(sigma_pcgA);
-        r_pcg_newA->scale(-alpha_A);
+        r_pcg_newA->scale(-alpha);
         r_pcg_newA->add(r_pcgA);
         rms_r_pcgA = r_pcg_newA->rms();
 
@@ -517,28 +517,27 @@ void OCCWave::orb_resp_pcg_uhf() {
         compute_sigma_vector();
 
         // Build line search parameter alpha
-        double alpha_A = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
-        double alpha_B = r_pcgB->dot(z_pcgB) / p_pcgB->dot(sigma_pcgB);
+        double alpha = (r_pcgA->dot(z_pcgA) + r_pcgB->dot(z_pcgB)) / (p_pcgA->dot(sigma_pcgA) + p_pcgB->dot(sigma_pcgB));
 
         // Build kappa-new
         kappa_newA->zero();
         kappa_newA->copy(p_pcgA);
-        kappa_newA->scale(alpha_A);
+        kappa_newA->scale(alpha);
         kappa_newA->add(kappaA);
         kappa_newB->zero();
         kappa_newB->copy(p_pcgB);
-        kappa_newB->scale(alpha_B);
+        kappa_newB->scale(alpha);
         kappa_newB->add(kappaB);
 
         // Build r-new
         r_pcg_newA->zero();
         r_pcg_newA->copy(sigma_pcgA);
-        r_pcg_newA->scale(-alpha_A);
+        r_pcg_newA->scale(-alpha);
         r_pcg_newA->add(r_pcgA);
         rms_r_pcgA = r_pcg_newA->rms();
         r_pcg_newB->zero();
         r_pcg_newB->copy(sigma_pcgB);
-        r_pcg_newB->scale(-alpha_B);
+        r_pcg_newB->scale(-alpha);
         r_pcg_newB->add(r_pcgB);
         rms_r_pcgB = r_pcg_newB->rms();
         rms_r_pcg = MAX0(rms_r_pcgA, rms_r_pcgB);

--- a/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
@@ -614,9 +614,8 @@ void OCCWave::compute_sigma_vector() {
         // sigma_AI = 2 \sum_{B} F_AB P_BJ
         global_dpd_->file2_init(&S, PSIF_OCC_DPD, 0, ID('V'), ID('O'), "Sigma <V|O>");
         global_dpd_->file2_init(&P, PSIF_OCC_DPD, 0, ID('V'), ID('O'), "P <V|O>");
-        // CAUTION! "Fock" libdpd entries are the Fock elements, as you expect, defined in
-        // fock_[alpha/beta]a. "F" is defined in trans_ints_[r/u]hf and is off-diagonal Fock elements.
-        // We need all Fock elements, so we use "Fock", not "F".
+        // CAUTION! "FD" libdpd entries are the Fock elements. "F" is off-diagonal only.
+        // We need all Fock elements, so use "FD", and not "F".
         global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "FD <V|V>");
         global_dpd_->contract222(&F, &P, &S, 0, 1, 2.0, 0.0);
         global_dpd_->file2_close(&F);
@@ -669,9 +668,8 @@ void OCCWave::compute_sigma_vector() {
         // sigma_AI = 2 \sum_{B} F_AB P_BI
         global_dpd_->file2_init(&S, PSIF_OCC_DPD, 0, ID('V'), ID('O'), "Sigma <V|O>");
         global_dpd_->file2_init(&P, PSIF_OCC_DPD, 0, ID('V'), ID('O'), "P <V|O>");
-        // CAUTION! "Fock" libdpd entries are the Fock elements, as you expect, defined in
-        // fock_[alpha/beta]a. "F" is defined in trans_ints_[r/u]hf and is off-diagonal Fock elements.
-        // We need all Fock elements, so we use "Fock", not "F".
+        // CAUTION! "FD" libdpd entries are the Fock elements. "F" is off-diagonal only.
+        // We need all Fock elements, so use "FD", and not "F".
         global_dpd_->file2_init(&F, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "FD <V|V>");
         global_dpd_->contract222(&F, &P, &S, 0, 1, 2.0, 0.0);
         global_dpd_->file2_close(&F);

--- a/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
@@ -383,6 +383,7 @@ void OCCWave::orb_resp_pcg_rhf() {
     itr_pcg = 0;
     idp_idx = 0;
     double rms_r_pcgA = 0.0;
+    double beta;
     pcg_conver = 1;  // assuming pcg will converge
 
     // Head of the loop
@@ -427,19 +428,19 @@ void OCCWave::orb_resp_pcg_rhf() {
 
         // Build line search parameter beta
         if (pcg_beta_type_ == "FLETCHER_REEVES") {
-            b_pcgA = r_pcg_newA->dot(z_pcg_newA) / r_pcgA->dot(z_pcgA);
+            beta = r_pcg_newA->dot(z_pcg_newA) / r_pcgA->dot(z_pcgA);
         }
 
         else if (pcg_beta_type_ == "POLAK_RIBIERE") {
             dr_pcgA->copy(r_pcg_newA);
             dr_pcgA->subtract(r_pcgA);
-            b_pcgA = z_pcg_newA->dot(dr_pcgA) / z_pcgA->dot(r_pcgA);
+            beta = z_pcg_newA->dot(dr_pcgA) / z_pcgA->dot(r_pcgA);
         }
 
         // Build p-new
         p_pcg_newA->zero();
         p_pcg_newA->copy(p_pcgA);
-        p_pcg_newA->scale(b_pcgA);
+        p_pcg_newA->scale(beta);
         p_pcg_newA->add(z_pcg_newA);
 
         // Reset
@@ -478,6 +479,7 @@ void OCCWave::orb_resp_pcg_uhf() {
     double rms_r_pcgA = 0.0;
     double rms_r_pcgB = 0.0;
     double rms_r_pcg = 0.0;
+    double beta;
     pcg_conver = 1;  // assuming pcg will converge
 
     // Head of the loop
@@ -548,8 +550,7 @@ void OCCWave::orb_resp_pcg_uhf() {
 
         // Build line search parameter beta
         if (pcg_beta_type_ == "FLETCHER_REEVES") {
-            b_pcgA = r_pcg_newA->dot(z_pcg_newA) / r_pcgA->dot(z_pcgA);
-            b_pcgB = r_pcg_newB->dot(z_pcg_newB) / r_pcgB->dot(z_pcgB);
+            beta = (r_pcg_newA->dot(z_pcg_newA) + r_pcg_newB->dot(z_pcg_newB)) / (r_pcgA->dot(z_pcgA) + r_pcgB->dot(z_pcgB));
         }
 
         else if (pcg_beta_type_ == "POLAK_RIBIERE") {
@@ -557,18 +558,17 @@ void OCCWave::orb_resp_pcg_uhf() {
             dr_pcgA->subtract(r_pcgA);
             dr_pcgB->copy(r_pcg_newB);
             dr_pcgB->subtract(r_pcgB);
-            b_pcgA = z_pcg_newA->dot(dr_pcgA) / z_pcgA->dot(r_pcgA);
-            b_pcgB = z_pcg_newB->dot(dr_pcgB) / z_pcgB->dot(r_pcgB);
+            beta = (z_pcg_newA->dot(dr_pcgA) + z_pcg_newB->dot(dr_pcgB)) / (z_pcgA->dot(r_pcgA) + z_pcgB->dot(r_pcgB));
         }
 
         // Build p-new
         p_pcg_newA->zero();
         p_pcg_newA->copy(p_pcgA);
-        p_pcg_newA->scale(b_pcgA);
+        p_pcg_newA->scale(beta);
         p_pcg_newA->add(z_pcg_newA);
         p_pcg_newB->zero();
         p_pcg_newB->copy(p_pcgB);
-        p_pcg_newB->scale(b_pcgB);
+        p_pcg_newB->scale(beta);
         p_pcg_newB->add(z_pcg_newB);
 
         // Reset

--- a/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp_iter.cc
@@ -407,18 +407,18 @@ void OCCWave::orb_resp_pcg_rhf() {
         compute_sigma_vector();
         
         // Build line search parameter alpha
-        a_pcgA = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
+        double alpha_A = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
 
         // Build kappa-new
         kappa_newA->zero();
         kappa_newA->copy(p_pcgA);
-        kappa_newA->scale(a_pcgA);
+        kappa_newA->scale(alpha_A);
         kappa_newA->add(kappaA);
 
         // Build r-new
         r_pcg_newA->zero();
         r_pcg_newA->copy(sigma_pcgA);
-        r_pcg_newA->scale(-a_pcgA);
+        r_pcg_newA->scale(-alpha_A);
         r_pcg_newA->add(r_pcgA);
         rms_r_pcgA = r_pcg_newA->rms();
 
@@ -517,28 +517,28 @@ void OCCWave::orb_resp_pcg_uhf() {
         compute_sigma_vector();
 
         // Build line search parameter alpha
-        a_pcgA = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
-        a_pcgB = r_pcgB->dot(z_pcgB) / p_pcgB->dot(sigma_pcgB);
+        double alpha_A = r_pcgA->dot(z_pcgA) / p_pcgA->dot(sigma_pcgA);
+        double alpha_B = r_pcgB->dot(z_pcgB) / p_pcgB->dot(sigma_pcgB);
 
         // Build kappa-new
         kappa_newA->zero();
         kappa_newA->copy(p_pcgA);
-        kappa_newA->scale(a_pcgA);
+        kappa_newA->scale(alpha_A);
         kappa_newA->add(kappaA);
         kappa_newB->zero();
         kappa_newB->copy(p_pcgB);
-        kappa_newB->scale(a_pcgB);
+        kappa_newB->scale(alpha_B);
         kappa_newB->add(kappaB);
 
         // Build r-new
         r_pcg_newA->zero();
         r_pcg_newA->copy(sigma_pcgA);
-        r_pcg_newA->scale(-a_pcgA);
+        r_pcg_newA->scale(-alpha_A);
         r_pcg_newA->add(r_pcgA);
         rms_r_pcgA = r_pcg_newA->rms();
         r_pcg_newB->zero();
         r_pcg_newB->copy(sigma_pcgB);
-        r_pcg_newB->scale(-a_pcgB);
+        r_pcg_newB->scale(-alpha_B);
         r_pcg_newB->add(r_pcgB);
         rms_r_pcgB = r_pcg_newB->rms();
         rms_r_pcg = MAX0(rms_r_pcgA, rms_r_pcgB);

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -100,15 +100,14 @@ void OCCWave::occ_iterations() {
         // PCG
         else if (orb_resp_solver_ == "PCG") {
             r_pcgA = new Array1d("Alpha PCG r vector", nidpA);
-            z_pcgA = new Array1d("Alpha PCG z vector", nidpA);
+            S_pcgA = new Array1d("Alpha PCG search direction vector", nidpA);
             p_pcgA = new Array1d("Alpha PCG p vector", nidpA);
             r_pcg_newA = new Array1d("Alpha New PCG r vector", nidpA);
-            z_pcg_newA = new Array1d("Alpha New PCG z vector", nidpA);
             p_pcg_newA = new Array1d("Alpha New PCG p vector", nidpA);
             sigma_pcgA = new Array1d("Alpha PCG sigma vector", nidpA);
             Minv_pcgA = new Array1d("Alpha PCG inverse of M matrix", nidpA);
             r_pcgA->zero();
-            z_pcgA->zero();
+            S_pcgA->zero();
             sigma_pcgA->zero();
             p_pcgA->zero();
             Minv_pcgA->zero();
@@ -120,15 +119,14 @@ void OCCWave::occ_iterations() {
 
             if (reference_ == "UNRESTRICTED") {
                 r_pcgB = new Array1d("Beta PCG r vector", nidpB);
-                z_pcgB = new Array1d("Beta PCG z vector", nidpB);
+                S_pcgB = new Array1d("Beta PCG search direction vector", nidpB);
                 p_pcgB = new Array1d("Beta PCG p vector", nidpB);
                 r_pcg_newB = new Array1d("Beta New PCG r vector", nidpB);
-                z_pcg_newB = new Array1d("Beta New PCG z vector", nidpB);
                 p_pcg_newB = new Array1d("Beta New PCG p vector", nidpB);
                 sigma_pcgB = new Array1d("Beta PCG sigma vector", nidpB);
                 Minv_pcgB = new Array1d("Beta PCG inverse of M matrix", nidpB);
                 r_pcgB->zero();
-                z_pcgB->zero();
+                S_pcgB->zero();
                 sigma_pcgB->zero();
                 p_pcgB->zero();
                 Minv_pcgB->zero();
@@ -396,22 +394,20 @@ void OCCWave::occ_iterations() {
         // PCG
         else if (orb_resp_solver_ == "PCG") {
             delete r_pcgA;
-            delete z_pcgA;
+            delete S_pcgA;
             delete p_pcgA;
             delete sigma_pcgA;
             delete Minv_pcgA;
             delete r_pcg_newA;
-            delete z_pcg_newA;
             delete p_pcg_newA;
             if (pcg_beta_type_ == "POLAK_RIBIERE") delete dr_pcgA;
             if (reference_ == "UNRESTRICTED") {
                 delete r_pcgB;
-                delete z_pcgB;
+                delete S_pcgB;
                 delete p_pcgB;
                 delete sigma_pcgB;
                 delete Minv_pcgB;
                 delete r_pcg_newB;
-                delete z_pcg_newB;
                 delete p_pcg_newB;
                 if (pcg_beta_type_ == "POLAK_RIBIERE") delete dr_pcgB;
             }

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -101,15 +101,14 @@ void OCCWave::occ_iterations() {
         else if (orb_resp_solver_ == "PCG") {
             r_pcgA = new Array1d("Alpha PCG r vector", nidpA);
             S_pcgA = new Array1d("Alpha PCG search direction vector", nidpA);
-            p_pcgA = new Array1d("Alpha PCG p vector", nidpA);
+            D_pcgA = new Array1d("Alpha PCG conjugate direction vector", nidpA);
             r_pcg_newA = new Array1d("Alpha New PCG r vector", nidpA);
-            p_pcg_newA = new Array1d("Alpha New PCG p vector", nidpA);
             sigma_pcgA = new Array1d("Alpha PCG sigma vector", nidpA);
             Minv_pcgA = new Array1d("Alpha PCG inverse of M matrix", nidpA);
             r_pcgA->zero();
             S_pcgA->zero();
             sigma_pcgA->zero();
-            p_pcgA->zero();
+            D_pcgA->zero();
             Minv_pcgA->zero();
 
             if (pcg_beta_type_ == "POLAK_RIBIERE") {
@@ -120,15 +119,14 @@ void OCCWave::occ_iterations() {
             if (reference_ == "UNRESTRICTED") {
                 r_pcgB = new Array1d("Beta PCG r vector", nidpB);
                 S_pcgB = new Array1d("Beta PCG search direction vector", nidpB);
-                p_pcgB = new Array1d("Beta PCG p vector", nidpB);
+                D_pcgB = new Array1d("Beta PCG conjugate direction vector", nidpB);
                 r_pcg_newB = new Array1d("Beta New PCG r vector", nidpB);
-                p_pcg_newB = new Array1d("Beta New PCG p vector", nidpB);
                 sigma_pcgB = new Array1d("Beta PCG sigma vector", nidpB);
                 Minv_pcgB = new Array1d("Beta PCG inverse of M matrix", nidpB);
                 r_pcgB->zero();
                 S_pcgB->zero();
                 sigma_pcgB->zero();
-                p_pcgB->zero();
+                D_pcgB->zero();
                 Minv_pcgB->zero();
                 if (pcg_beta_type_ == "POLAK_RIBIERE") {
                     dr_pcgB = new Array1d("Alpha PCG dr vector", nidpB);
@@ -395,20 +393,18 @@ void OCCWave::occ_iterations() {
         else if (orb_resp_solver_ == "PCG") {
             delete r_pcgA;
             delete S_pcgA;
-            delete p_pcgA;
+            delete D_pcgA;
             delete sigma_pcgA;
             delete Minv_pcgA;
             delete r_pcg_newA;
-            delete p_pcg_newA;
             if (pcg_beta_type_ == "POLAK_RIBIERE") delete dr_pcgA;
             if (reference_ == "UNRESTRICTED") {
                 delete r_pcgB;
                 delete S_pcgB;
-                delete p_pcgB;
+                delete D_pcgB;
                 delete sigma_pcgB;
                 delete Minv_pcgB;
                 delete r_pcg_newB;
-                delete p_pcg_newB;
                 if (pcg_beta_type_ == "POLAK_RIBIERE") delete dr_pcgB;
             }
         }

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -299,8 +299,6 @@ class OCCWave : public Wavefunction {
     double cutoff;
     double os_scale;
     double ss_scale;
-    double b_pcgA;
-    double b_pcgB;
     double rms_pcgA;
     double rms_pcgB;
     double rms_pcg;

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -73,6 +73,7 @@ class OCCWave : public Wavefunction {
     void kappa_msd();
     void kappa_orb_resp();
     void kappa_orb_resp_iter();
+    void compute_sigma_vector();
     void orb_resp_pcg_rhf();
     void orb_resp_pcg_uhf();
     void dump_ints();

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -299,8 +299,6 @@ class OCCWave : public Wavefunction {
     double cutoff;
     double os_scale;
     double ss_scale;
-    double a_pcgA;
-    double a_pcgB;
     double b_pcgA;
     double b_pcgB;
     double rms_pcgA;

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -441,8 +441,8 @@ class OCCWave : public Wavefunction {
     Array1d *kappa_newB;
     Array1d *r_pcgA;
     Array1d *r_pcgB;
-    Array1d *z_pcgA;
-    Array1d *z_pcgB;
+    Array1d *S_pcgA;
+    Array1d *S_pcgB;
     Array1d *p_pcgA;
     Array1d *p_pcgB;
     Array1d *sigma_pcgA;
@@ -451,8 +451,6 @@ class OCCWave : public Wavefunction {
     Array1d *Minv_pcgB;
     Array1d *r_pcg_newA;
     Array1d *r_pcg_newB;
-    Array1d *z_pcg_newA;
-    Array1d *z_pcg_newB;
     Array1d *p_pcg_newA;
     Array1d *p_pcg_newB;
     Array1d *dr_pcgA;

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -443,16 +443,14 @@ class OCCWave : public Wavefunction {
     Array1d *r_pcgB;
     Array1d *S_pcgA;
     Array1d *S_pcgB;
-    Array1d *p_pcgA;
-    Array1d *p_pcgB;
+    Array1d *D_pcgA;
+    Array1d *D_pcgB;
     Array1d *sigma_pcgA;
     Array1d *sigma_pcgB;
     Array1d *Minv_pcgA;
     Array1d *Minv_pcgB;
     Array1d *r_pcg_newA;
     Array1d *r_pcg_newB;
-    Array1d *p_pcg_newA;
-    Array1d *p_pcg_newB;
     Array1d *dr_pcgA;
     Array1d *dr_pcgB;
     Array1d *zvectorA;

--- a/psi4/src/psi4/occ/trans_ints_rhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_rhf.cc
@@ -194,7 +194,7 @@ void OCCWave::trans_ints_rhf() {
 void OCCWave::denominators_rhf() {
     // outfile->Printf("\n denominators is starting... \n");
     dpdbuf4 D;
-    dpdfile2 Fo, Fv;
+    dpdfile2 Fo, Fv, Fd;
 
     auto *aOccEvals = new double[nacooA];
     auto *aVirEvals = new double[nacvoA];
@@ -294,6 +294,16 @@ void OCCWave::denominators_rhf() {
         global_dpd_->file2_mat_print(&Fv, "outfile");
         global_dpd_->file2_close(&Fv);
     }
+
+    auto zero = Dimension(nirrep_);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "FD <O|O>");
+    FockA->get_block({zero, nalphapi_}, {zero, nalphapi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "FD <V|V>");
+    FockA->get_block({nalphapi_, nmopi_}, {nalphapi_, nmopi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
 
     // outfile->Printf("\n denominators done. \n");
 }  // end denominators

--- a/psi4/src/psi4/occ/trans_ints_uhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_uhf.cc
@@ -769,7 +769,7 @@ void OCCWave::trans_ints_uhf() {
 void OCCWave::denominators_uhf() {
     // outfile->Printf("\n denominators is starting... \n");
     dpdbuf4 D;
-    dpdfile2 Fo, Fv;
+    dpdfile2 Fo, Fv, Fd;
 
     auto *aOccEvals = new double[nacooA];
     auto *bOccEvals = new double[nacooB];
@@ -972,6 +972,24 @@ void OCCWave::denominators_uhf() {
         global_dpd_->file2_mat_print(&Fv, "outfile");
         global_dpd_->file2_close(&Fv);
     }
+
+    auto zero = Dimension(nirrep_);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "FD <O|O>");
+    FockA->get_block({zero, nalphapi_}, {zero, nalphapi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "FD <o|o>");
+    FockB->get_block({zero, nbetapi_}, {zero, nbetapi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "FD <V|V>");
+    FockA->get_block({nalphapi_, nmopi_}, {nalphapi_, nmopi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
+
+    global_dpd_->file2_init(&Fd, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "FD <v|v>");
+    FockB->get_block({nbetapi_, nmopi_}, {nbetapi_, nmopi_})->write_to_dpdfile2(&Fd);
+    global_dpd_->file2_close(&Fd);
 
     // outfile->Printf("\n denominators done. \n");
 }  // end denominators

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2690,9 +2690,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("ORTH_TYPE", "MGS", "GS MGS");
         /*- The optimization algorithm. Modified Steepest-Descent (MSD) takes a Newton-Raphson (NR) step
          with a crude approximation to diagonal elements of the MO Hessian. The ORB_RESP option obtains the orbital
-         rotation parameters by solving the orbital-reponse (coupled-perturbed CC) equations. Additionally, for both
+         rotation parameters with a crude approximation to all elements of the MO Hessian. Additionally, for both
          methods a DIIS extrapolation will be performed with the DO_DIIS = TRUE option. -*/
-        options.add_str("OPT_METHOD", "ORB_RESP", "MSD ORB_RESP");
+        options.add_str("OPT_METHOD", "MSD", "MSD ORB_RESP");
         /*- The algorithm will be used for solving the orbital-response equations. The LINEQ option create the MO
           Hessian and solve the simultaneous linear equations with method choosen by the LINEQ_SOLVER option. The PCG
           option does not create the MO Hessian explicitly, instead it solves the simultaneous equations iteratively


### PR DESCRIPTION
## Description
Think of the default orbital optimization algorithm in OCC with the following pseudocode:
```
orbital_gradient = compute_orbital_gradient()
try:
    orbital_step = compute_NR_step_via_PCG_with_HF_MO_hessian(orbital_gradient)
except ConvergenceError:
    orbital_step = compute_step_with_crude_diagonal_MO_hessian(orbital_gradient)
diis_step()
```

I traced a test failure in an upcoming PR (ocepa-grad2) to a failure in the approximate NR step. Five failures, in fact.
1. The HF MO Hessian couples alpha and beta IDPs. You need a single alpha, not a different alpha for each spin.
2. For the same reason, you need a single beta.
3. The Fock term assumed semicanonical orbitals. OCC does not use semicanonical orbitals.
4. The Fock matrix was acting on the wrong vector.
5. One of the tensor contractions involving TEI was incorrect.

After fixing those five bugs, I observed three things:
1. After accounting for whether you index by (v,o) or (o, v), the matrix-vector products of the new occ implementation match those of the SOUHF P4N tutorials,
2. The X (kappa) converged to does satisfy Ax=b
3. The orbital equations refuse to converge

My conclusion is that the implementation of the algorithm is now correct, but it's not a good way to generate orbital steps. The off-diagonal terms can end up being significant for the open-shell systems that would lead you to use an orbital-optimized method. This didn't cause obvious problems before because the previous errors rendered the PCG procedure non-convergent, so you would always fall back to the crude diagonal step _unless_ your orbital gradient was so low that you didn't need to iterate at all. So what we expect to see from this bug is difficulties converging occ tightly, which has been my experience.

To remedy the situation, the default orbital step is now the crude semicanonical step.

The next PR should be the final one in the series. I'll just need to rebase it onto this one, repair the two tests I mentioned on broken tests, and confirm the test suite is clean.

Pinging the usual suspects: @loriab, especially @dgasmith for PCG, and @jturney. I think Jet is sick today, so a different third reviewer would be welcome.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Debugged HF MO hessian based orbital step
- [x] Made HF MO hessian based orbital step opt-in rather than default; Not recommended

## Checklist
Can't run tests if the tests were already broken!
- [x] Confirmed b-Ax approximately zero for the first step of the `ocepa-grad2` test case
- [x] Confirmed Ax reproduces the Psi4Numpy reference SOUHF Ax by acting on a test alpha orbital and a test beta orbital

## Status
- [x] Ready for review
- [x] Ready for merge
