### PR TITLE
WIP: Repulsive potentials with Psi4

### DIFF
--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -117,10 +117,10 @@ def molecule_from_arrays(cls,
                          provenance=None,
                          connectivity=None,
                          missing_enabled_return='error',
-                         tooclose=0.1,
+                         tooclose=1e-6,
                          zero_ghost_fragments=False,
                          nonphysical=False,
-                         mtol=1.e-3,
+                         mtol=1.e-8,
                          verbose=1,
                          return_dict=False):
     """Construct Molecule from unvalidated arrays and variables.

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1474,7 +1474,7 @@ class Molecule(LibmintsMolecule):
             )
             molrec['fragment_charges'] = [None] * len(fragments)
             molrec['fragment_multiplicities'] = [None] * len(fragments)
-            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=0, domain='qm', **molrec)
+            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=0, domain='qm', tooclose=1e-6, **molrec)
             forgive.append('fragment_charges')
             forgive.append('fragment_multiplicities')
         compare_molrecs(validated_molrec, molrec, 'to_dict', atol=1.e-6, forgive=forgive, verbose=0)

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -80,10 +80,10 @@ class Molecule(LibmintsMolecule):
                  missing_enabled_return_qm='none',
                  missing_enabled_return_efp='none',
                  missing_enabled_return='error',
-                 tooclose=0.1,
+                 tooclose=1e-6,
                  zero_ghost_fragments=False,
                  nonphysical=False,
-                 mtol=1.e-3,
+                 mtol=1.e-8,
                  verbose=1):
         """Initialize Molecule object from LibmintsMolecule"""
         super(Molecule, self).__init__()
@@ -1465,7 +1465,7 @@ class Molecule(LibmintsMolecule):
         #   to_dict, but is included as a check. in practice, only fills in mass
         #   numbers and heals user chgmult.
         try:
-            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=0, domain='qm', **molrec)
+            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=0, domain='qm', tooclose=1e-6, **molrec)
         except qcel.ValidationError as err:
             # * this can legitimately happen if total chg or mult has been set
             #   independently b/c fragment chg/mult not reset. so try again.

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -505,7 +505,7 @@ class PSI_API Molecule {
      * Force the molecule to have the symmetry specified in pg_.
      * This is to handle noise coming in from optking.
      */
-    void symmetrize(double tol = 0.05, bool suppress_mol_print_in_exc = false);
+    void symmetrize(double tol = 5e-7, bool suppress_mol_print_in_exc = false);
     /// @}
 
     /**
@@ -668,7 +668,7 @@ class PSI_API Molecule {
     /// Returns the Schoenflies symbol
     std::string schoenflies_symbol() const;
     /// Check if current geometry fits current point group
-    bool valid_atom_map(double tol = 0.05) const;
+    bool valid_atom_map(double tol = 1e-6) const;
     /// Return point group name such as C3v or S8.
     std::string full_point_group() const;
     /// Return point group name such as Cnv or Sn.

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -317,9 +317,9 @@ class PSI_API Molecule {
 
     /// @{
     /// Tests to see of an atom is at the passed position with a given tolerance
-    int atom_at_position1(double*, double tol = 0.05) const;
-    int atom_at_position2(Vector3&, double tol = 0.05) const;
-    int atom_at_position3(const std::array<double, 3>&, const double tol = 0.05) const;
+    int atom_at_position1(double*, double tol = 1e-6) const;
+    int atom_at_position2(Vector3&, double tol = 1e-6) const;
+    int atom_at_position3(const std::array<double, 3>&, const double tol = 1e-6) const;
     /// @}
 
     /// Do we reinterpret coordentries during a call to update_geometry?


### PR DESCRIPTION
## Description
The idea is to try to extend Psi4 to the calculation of repulsive potentials. Unfortunately, some of Psi4's machinery is preventing such calculations to be run due to chemists' short-sightedness ;)

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Change cutoffs so that close-lying atoms are accepted by the program (the cutoffs / disabling them should be an input parameter)
- [ ] Fix problem with the code putting atoms on top of each other

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
