### PR TITLE
fix threading in sapt cphf

### DIFF
--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -65,7 +65,7 @@ SAPT::SAPT(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunc
 #endif
 
 #ifdef _OPENMP
-    omp_set_max_active_levels(0);
+    omp_set_nested(0);
 #endif
 
     initialize(MonomerA, MonomerB);


### PR DESCRIPTION
## Description
This partially reverts #1823 and reopens #1820. The attempt to update OpenMP syntax caused  outrageous CPHF iterations for sapt  with more than one thread and for >double-zeta basis sets.

```
    Iter     Energy [mEh]          dE [mEh]         Residual      Time [s]
       1 -1328115.94527411 1328115.945274106   82108.848515395             1
       2 -808873.32594920 -519242.619324907   43451.688666137             2
       3 -296640.46386268 -512232.862086516   32804.415609124             3
       4  333490.09801172 -630130.561874404   34046.370717066             4
       5 1671552.17203003 -1338062.074018315   56004.396085803             4
       6 13698345.73019254 -12026793.558162510  344787.457633287             5
       7 -3546455.02303636 17244800.753228907   93826.473521208             6
       8 -1533796.48314396 -2012658.539892400   57723.614037136             7
       9 -499317.88252071 -1034478.600623253   54202.304843513             8
      10  842882.68064645 -1342200.563167160   77577.115912486             9
      11 10985391.53586249 -10142508.855216034  438590.756423259            10
      12 -3227723.70021011 14213115.236072602  110579.601555807            11
      13 -1262295.14487745 -1965428.555332662   64414.226793794            11
      14 -344481.73535989 -917813.409517556   66358.190915373            12
      15 1270218.17221537 -1614699.907575266  113531.143520574            13
      16 -14683932.45018955 15954150.622404918  665246.510118182            14
      17 -2102251.26175256 -12581681.188436987   97682.706587764            15
      18 -774469.20123848 -1327782.060514077   71301.522796551            16
      19  434577.29351654 -1209046.494755025   91453.663971012            17
      20 6270242.49774886 -5835665.204232313  357174.337476779            17
      21 -3323605.23554375 9593847.733292609  150213.104016802            18
      22 -1263277.17636199 -2060328.059181767   73827.751134365            19
      23 -279192.63896875 -984084.537393233   67326.241707876            20
      24 1391940.63398407 -1671133.272952828  106325.475310588            21
      25 -20002406.89729887 21394347.531282943  835829.365499684            22
      26 -2062499.69457425 -17939907.202724621   87641.599632480            23
      27 -785909.82443207 -1276589.870142181   59961.822150188            23
      28  299446.28501843 -1085356.109450493   71518.295316707            24
      29 5556514.54958980 -5257068.264571375  271524.834839076            25
      30 -2756549.97425513 8313064.523844934  107249.208042271            26
      31 -986206.05685129 -1770343.917403843   59553.662164835            27
      32   65177.33906907 -1051383.395920360   65666.150927125            28
      33 1930580.66898109 -1865403.329912022  126327.702518117            29
      34 -104573420.61264811 106504001.281629220 4567783.332559221            30
      35 -2213182.03892370 -102360238.573724419   89221.078778708            30
      36 -776194.37625183 -1436987.662671869   60695.551405078            31
      37  418962.59791755 -1195156.974169378   77900.366130716            32
      38 9579470.53991217 -9160507.941994620  483148.344629913            33
      39 -2267065.96612157 11846536.506033733   97502.798240522            34
      40 -820532.88538969 -1446533.080731877   58868.116181267            35
      41  140323.71074950 -960856.596139194   66509.006349917            36
      42 4230732.46021989 -4090408.749470387  237095.836226854            36
      43 -2588451.61397282 6819184.074192710  108478.660443089            37
      44 -968588.15837896 -1619863.455593858   57129.491446952            38
      45   33735.11653143 -1002323.274910389   61028.696116012            39
      46 3064765.64310791 -3031030.526576484  171406.833176849            40
      47 -3498409.66987667 6563175.312984586  147573.502448223            41
      48 -955281.18964934 -2543128.480227337   59257.181369090            42
      49   74922.56535148 -1030203.755000821   60060.199220002            42
      50 2685742.99000289 -2610820.424651409  145310.606948504            43
    CHF Iterations did not converge
```

## Status
- [x] Ready for review
- [x] Ready for merge
