### PR TITLE
Bandaid over 1851... Segfault to error message.

### DIFF
--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -69,6 +69,9 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
 
     nopen_ = 0;
     for (int h = 0; h < nirrep_; h++) nopen_ += soccpi_[h];
+    if (!psio_) {
+        throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing ADC. See GitHub issue #1851.");
+    }
     if (nopen_) throw PSIEXCEPTION("Openshell calculation has not been implemented yet!");
 
     aoccount = 0, boccount = 0, avircount = 0, bvircount = 0;

--- a/psi4/src/psi4/dct/dct.cc
+++ b/psi4/src/psi4/dct/dct.cc
@@ -51,6 +51,10 @@ DCTSolver::DCTSolver(SharedWavefunction ref_wfn, Options &options) : Wavefunctio
     Fa_ = ref_wfn->Fa()->clone();
     Fb_ = ref_wfn->Fb()->clone();
 
+    if (!psio_) {
+        throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing DCT. See GitHub issue #1851.");
+    }
+
     maxiter_ = options.get_int("MAXITER");
     print_ = options.get_int("PRINT");
     maxdiis_ = options.get_int("DIIS_MAX_VECS");
@@ -115,10 +119,10 @@ void DCTSolver::dpd_buf4_add(dpdbuf4 *A, dpdbuf4 *B, double alpha) {
 }
 
 DCTSolver::~DCTSolver() {
-    delete []aocc_off_;
-    delete []avir_off_;
-    delete []bocc_off_;
-    delete []bvir_off_;
+    delete[] aocc_off_;
+    delete[] avir_off_;
+    delete[] bocc_off_;
+    delete[] bvir_off_;
 }
 
 }  // namespace dct

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -106,6 +106,10 @@ void DFOCC::common_init() {
     triples_iabc_type_ = options_.get_str("TRIPLES_IABC_TYPE");
     do_cd = options_.get_str("CHOLESKY");
 
+    if (!psio_) {
+        throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing DFOCC. See GitHub issue #1851.");
+    }
+
     // title
     title();
 

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -173,6 +173,9 @@ void OCCWave::common_init() {
     else if (reference == "UHF" || reference == "UKS" || reference == "ROHF")
         reference_ = "UNRESTRICTED";
 
+    if (!psio_) {
+        throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing OCC. See GitHub issue #1851.");
+    }
     // Only UHF is allowed for the standard methods, except for MP2
     if (reference == "ROHF" && orb_opt_ == "FALSE" && wfn_type_ != "OMP2") {
         throw PSIEXCEPTION("The ROHF reference is not available for the standard methods (except for MP2)!");


### PR DESCRIPTION
## Description
Per discussion on the conference call, this PR gives some error messages for cases where using a serialized wavefunction would give a segfault. 1851 is still an issue, but one that shouldn't hold up 1.4 or eat my time to straighten out `dfocc`. I'm modernizing enough modules in Psi as it is...

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Replace some segfaults from #1851 with actual error messages

## Checklist
- [x] Tested that all four error modules used to segfault and now give an error message

## Status
- [x] Ready for review
- [x] Ready for merge
