### PR TITLE
Enables LibXC density screening

### DIFF
--- a/doc/sphinxman/source/dft.rst
+++ b/doc/sphinxman/source/dft.rst
@@ -574,6 +574,12 @@ and the basis cutoffs, but it is likely that significant speed gains may be
 realized by relaxing the basis cutoff tolerance, with negligible decrease in
 accuracy.
 
+Small density values can introduce numerical instabilities with some functionals that
+can result in trailing SCF convergence issues or even numerical failures (NaNs).
+If the default settings of the LibXC library are insufficient, a custom value can be 
+request by setting |scf__dft_density_tolerance|. For notorious cases a value of 1E-10
+is sensible.
+
 An example of a fully specified grid is as follows::
 
     molecule {
@@ -584,12 +590,13 @@ An example of a fully specified grid is as follows::
     set {
     basis cc-pvdz
     scf_type df
-    dft_spherical_points 590     # Often needed
-    dft_radial_points 99         # Often needed
-    dft_radial_scheme treutler   # Rarely needed
-    dft_nuclear_scheme treutler  # Rarely needed
-    dft_basis_tolerance 1.0E-11  # Can speed things up, but benchmark the error
-    dft_pruning_scheme robust    # generally safe and will speed things up
+    dft_spherical_points 590      # Often needed
+    dft_radial_points 99          # Often needed
+    dft_radial_scheme treutler    # Rarely needed
+    dft_nuclear_scheme treutler   # Rarely needed
+    dft_density_tolerance 1.0E-10 # Rarely needed
+    dft_basis_tolerance 1.0E-11   # Can speed things up, but benchmark the error
+    dft_pruning_scheme robust     # Generally safe and will speed things up
     }
 
     energy('b3lyp')

--- a/psi4/driver/procrouting/dft/superfunctionals.py
+++ b/psi4/driver/procrouting/dft/superfunctionals.py
@@ -77,6 +77,11 @@ def build_superfunctional(name, restricted, npoints=None, deriv=1):
     # Lock and unlock the functional
     sup[0].set_lock(False)
 
+    # set LibXC density screening
+    dens_tol = core.get_option("SCF", "DFT_DENSITY_TOLERANCE")
+    if (dens_tol > 0.0):
+        sup[0].set_density_tolerance(dens_tol)
+
     # Set options
     if core.has_option_changed("SCF", "DFT_OMEGA") and sup[0].is_x_lrc():
         omega = core.get_option("SCF", "DFT_OMEGA")

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -83,6 +83,7 @@ void export_functional(py::module &m) {
         .def("grac_shift", &SuperFunctional::grac_shift, "Shift of the bulk potenital.")
         .def("grac_alpha", &SuperFunctional::grac_alpha, "GRAC Alpha.")
         .def("grac_beta", &SuperFunctional::grac_beta, "GRAC Beta.")
+        .def("density_tolerance", &SuperFunctional::density_tolerance, "Density threshold for LibXC.")
         .def("is_gga", &SuperFunctional::is_gga, "Is this a GGA?")
         .def("is_meta", &SuperFunctional::is_meta, "Is this a MGGA?")
         .def("is_x_lrc", &SuperFunctional::is_x_lrc, "Contains range-seperated exchange?")
@@ -111,6 +112,9 @@ void export_functional(py::module &m) {
         .def("set_grac_shift", &SuperFunctional::set_grac_shift, "Sets the GRAC bulk shift value.")
         .def("set_grac_alpha", &SuperFunctional::set_grac_alpha, "Sets the GRAC alpha parameter.")
         .def("set_grac_beta", &SuperFunctional::set_grac_beta, "Sets the GRAC beta parameter.")
+        .def("set_density_tolerance", &SuperFunctional::set_density_tolerance, "Sets the density threshold for LibXC.")
+        .def("copy_density_tolerance", &SuperFunctional::copy_density_tolerance, "Copy the density threshold variable to the SuperFunctional layer.")
+        .def("print_density_threshold", &SuperFunctional::py_print_density_threshold, "Queries the LibXCFunctionals for their density threshold values")
         .def("needs_xc", &SuperFunctional::needs_xc, "Does this functional need XC quantities.")
         .def("needs_vv10", &SuperFunctional::needs_vv10, "Does this functional need VV10 dispersion.")
         .def("needs_grac", &SuperFunctional::needs_grac, "Does this functional need GRAC.")
@@ -127,6 +131,7 @@ void export_functional(py::module &m) {
         .def("omega", &Functional::omega, "docstring")
         .def("lsda_cutoff", &Functional::lsda_cutoff, "docstring")
         .def("meta_cutoff", &Functional::meta_cutoff, "docstring")
+        .def("density_cutoff", &Functional::density_cutoff, "docstring")
         .def("is_gga", &Functional::is_gga, "docstring")
         .def("is_meta", &Functional::is_meta, "docstring")
         .def("is_lrc", &Functional::is_lrc, "docstring")
@@ -139,6 +144,7 @@ void export_functional(py::module &m) {
         .def("set_omega", &Functional::set_omega, "docstring")
         .def("set_lsda_cutoff", &Functional::set_lsda_cutoff, "docstring")
         .def("set_meta_cutoff", &Functional::set_meta_cutoff, "docstring")
+        .def("set_density_cutoff", &Functional::set_density_cutoff, "docstring")
         .def("set_parameter", &Functional::set_parameter, "docstring")
         .def("print_out", &Functional::py_print, "docstring")
         .def("print_detail", &Functional::py_print_detail, "docstring");
@@ -148,6 +154,8 @@ void export_functional(py::module &m) {
         .def("get_mix_data", &LibXCFunctional::get_mix_data, "docstring")
         .def("set_tweak", &LibXCFunctional::set_tweak, "docstring")
         .def("set_omega", &LibXCFunctional::set_omega, "docstring")
+        .def("set_density_cutoff", &LibXCFunctional::set_density_cutoff, "docstring")
+        .def("density_cutoff", &LibXCFunctional::density_cutoff, "docstring")
         .def("query_libxc", &LibXCFunctional::query_libxc, "query libxc regarding functional parameters.");
 
     py::class_<VBase, std::shared_ptr<VBase>>(m, "VBase", "docstring")

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -113,7 +113,6 @@ void export_functional(py::module &m) {
         .def("set_grac_alpha", &SuperFunctional::set_grac_alpha, "Sets the GRAC alpha parameter.")
         .def("set_grac_beta", &SuperFunctional::set_grac_beta, "Sets the GRAC beta parameter.")
         .def("set_density_tolerance", &SuperFunctional::set_density_tolerance, "Sets the density threshold for LibXC.")
-        .def("copy_density_tolerance", &SuperFunctional::copy_density_tolerance, "Copy the density threshold variable to the SuperFunctional layer.")
         .def("print_density_threshold", &SuperFunctional::py_print_density_threshold, "Queries the LibXCFunctionals for their density threshold values")
         .def("needs_xc", &SuperFunctional::needs_xc, "Does this functional need XC quantities.")
         .def("needs_vv10", &SuperFunctional::needs_vv10, "Does this functional need VV10 dispersion.")

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -161,6 +161,7 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
 
     // Set any other parameters
     user_omega_ = false;
+    density_cutoff_ = -1.0;
     exc_ = xc_functional_->info->flags & XC_FLAGS_HAVE_EXC;
     vxc_ = xc_functional_->info->flags & XC_FLAGS_HAVE_VXC;
     fxc_ = xc_functional_->info->flags & XC_FLAGS_HAVE_FXC;
@@ -194,11 +195,21 @@ std::shared_ptr<Functional> LibXCFunctional::build_worker() {
     func->set_meta(meta_);
     func->set_lsda_cutoff(lsda_cutoff_);
     func->set_meta_cutoff(meta_cutoff_);
+    func->set_density_cutoff(density_cutoff_);
     func->exc_ = exc_;
     func->vxc_ = vxc_;
     func->fxc_ = fxc_;
 
     return static_cast<std::shared_ptr<Functional>>(func);
+}
+void LibXCFunctional::set_density_cutoff(double cut) {
+    density_cutoff_ = cut;
+    if (density_cutoff_ > 0){
+        xc_func_set_dens_threshold(xc_functional_.get(),cut);
+    }
+}
+double LibXCFunctional::query_density_cutoff() {
+    return xc_functional_->dens_threshold ;
 }
 void LibXCFunctional::set_omega(double omega) {
     omega_ = omega;

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -62,6 +62,8 @@ class LibXCFunctional : public Functional {
     bool needs_vv10_;
     double vv10_b_;
     double vv10_c_;
+    // LibXC density setting
+    double density_cutoff_;
 
     // User defined tweakers
     std::vector<double> user_tweakers_;
@@ -77,12 +79,14 @@ class LibXCFunctional : public Functional {
     std::shared_ptr<Functional> build_worker() override;
 
     // Setters and getters
+    void set_density_cutoff(double cut) override;
     void set_omega(double omega);
     void set_tweak(std::vector<double> values);
     std::vector<std::tuple<std::string, int, double>> get_mix_data();
 
     // Make queries to libxc
     std::map<std::string, double> query_libxc(const std::string& functional);
+    double query_density_cutoff() override;
 
     // Only used to pass information up the chain
     double global_exchange() { return global_exch_; }
@@ -90,6 +94,7 @@ class LibXCFunctional : public Functional {
     double needs_vv10() { return needs_vv10_; }
     double vv10_b() { return vv10_b_; }
     double vv10_c() { return vv10_c_; }
+    double density_cutoff() { return density_cutoff_; }
 };
 }
 

--- a/psi4/src/psi4/libfunctional/functional.cc
+++ b/psi4/src/psi4/libfunctional/functional.cc
@@ -47,6 +47,7 @@ void Functional::common_init() {
 
     lsda_cutoff_ = 1.0E-20;
     meta_cutoff_ = 1.0E-20;
+    density_cutoff_ = -1.0;
 }
 void Functional::set_parameter(const std::string& key, double val) {
     throw PSIEXCEPTION("Functional: pseudo-abstract class.");
@@ -82,4 +83,6 @@ void Functional::compute_functional(const std::map<std::string, SharedVector>& i
                                     const std::map<std::string, SharedVector>& out, int npoints, int deriv) {
     throw PSIEXCEPTION("Functional: pseudo-abstract class.");
 }
+double Functional::query_density_cutoff(){throw PSIEXCEPTION("Functional: pseudo-abstract class.");}
+void Functional::set_density_cutoff(double cut){throw PSIEXCEPTION("Functional: pseudo-abstract class.");}
 }

--- a/psi4/src/psi4/libfunctional/functional.h
+++ b/psi4/src/psi4/libfunctional/functional.h
@@ -78,6 +78,8 @@ class Functional {
     double lsda_cutoff_;
     // Tau-based cutoff
     double meta_cutoff_;
+    // LibXC Densty-based cutoff
+    double density_cutoff_;
 
     // Initialize null functional
     void common_init();
@@ -113,12 +115,13 @@ class Functional {
         omega_ = omega;
         lrc_ = (omega_ != 0.0);
     }
-    void set_name(const std::string& name) { name_ = name; }
-    void set_description(const std::string& description) { description_ = description; }
-    void set_citation(const std::string& citation) { citation_ = citation; }
+    void set_name(const std::string &name) { name_ = name; }
+    void set_description(const std::string &description) { description_ = description; }
+    void set_citation(const std::string &citation) { citation_ = citation; }
 
     void set_lsda_cutoff(double cut) { lsda_cutoff_ = cut; }
     void set_meta_cutoff(double cut) { meta_cutoff_ = cut; }
+    virtual void set_density_cutoff(double cut);
 
     // => Accessors <= //
 
@@ -136,6 +139,8 @@ class Functional {
 
     double lsda_cutoff() const { return lsda_cutoff_; }
     double meta_cutoff() const { return meta_cutoff_; }
+    double density_cutoff() const { return density_cutoff_; }
+    virtual double query_density_cutoff();
 
     // => Utility <= //
     virtual void print(std::string out_fname = "outfile", int print = 1) const;

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -384,37 +384,20 @@ void SuperFunctional::add_c_functional(std::shared_ptr<Functional> fun) {
     can_edit();
     c_functionals_.push_back(fun);
 }
-void SuperFunctional::copy_density_tolerance(double cut) {
-    can_edit();
-    density_tolerance_ = cut;
-}
 void SuperFunctional::set_density_tolerance(double cut) {
-    // modify both LibXCFunctional and Functional
     density_tolerance_ = cut;
-    if (libxc_xc_func_) {
-        for (int Q = 0; Q < c_functionals_.size(); Q++) {
-            c_functionals_[Q]->set_density_cutoff(density_tolerance_);
-        }
-    } else {
         for (int Q = 0; Q < c_functionals_.size(); Q++) {
             c_functionals_[Q]->set_density_cutoff(density_tolerance_);
         };
         for (int Q = 0; Q < x_functionals_.size(); Q++) {
             x_functionals_[Q]->set_density_cutoff(density_tolerance_);
         };
-    };
 }
 void SuperFunctional::print_density_threshold(std::string out, int level) const {
     if (level < 1) return;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
     printer->Printf("   => LibXC Density Thresholds  <==\n\n");
     double val = 0.0;
-    if (libxc_xc_func_) {
-        for (int Q = 0; Q < c_functionals_.size(); Q++) {
-            val = c_functionals_[Q]->query_density_cutoff();
-            printer->Printf("    %s:  %6.2E \n", c_functionals_[Q]->name().c_str(), val);
-        }
-    } else {
         for (int Q = 0; Q < c_functionals_.size(); Q++) {
             val = c_functionals_[Q]->query_density_cutoff();
             printer->Printf("    %s:  %6.2E \n", c_functionals_[Q]->name().c_str(), val);
@@ -423,7 +406,6 @@ void SuperFunctional::print_density_threshold(std::string out, int level) const 
             val = x_functionals_[Q]->query_density_cutoff();
             printer->Printf("    %s:  %6.2E \n", x_functionals_[Q]->name().c_str(), val);
         };
-    };
     printer->Printf("\n");
 }
 std::shared_ptr<Functional> SuperFunctional::c_functional(const std::string& name) {

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -192,7 +192,6 @@ class SuperFunctional {
     void set_grac_alpha(double grac_alpha);
     void set_grac_beta(double grac_beta);
     void set_density_tolerance(double cut);
-    void copy_density_tolerance(double cut);
     void print_density_threshold(std::string out_fname = "outfile", int print = 1) const;
     void py_print_density_threshold() const { print_density_threshold("outfile", 1); }
     // => Accessors <= //

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -102,6 +102,9 @@ class SuperFunctional {
     std::map<std::string, SharedVector> ac_values_;
     std::map<std::string, SharedVector> vv_values_;
 
+    // => Other LibXC settings
+    double density_tolerance_;
+
     // Set up a null Superfunctional
     void common_init();
 
@@ -188,7 +191,10 @@ class SuperFunctional {
     void set_grac_shift(double grac_shift);
     void set_grac_alpha(double grac_alpha);
     void set_grac_beta(double grac_beta);
-
+    void set_density_tolerance(double cut);
+    void copy_density_tolerance(double cut);
+    void print_density_threshold(std::string out_fname = "outfile", int print = 1) const;
+    void py_print_density_threshold() const { print_density_threshold("outfile", 1); }
     // => Accessors <= //
 
     std::string name() const { return name_; }
@@ -211,6 +217,7 @@ class SuperFunctional {
     double grac_shift() const { return grac_shift_; }
     double grac_alpha() const { return grac_alpha_; }
     double grac_beta() const { return grac_beta_; }
+    double density_tolerance() const { return density_tolerance_; }
 
     bool needs_xc() const { return ((c_functionals_.size() + x_functionals_.size()) > 0); }
     bool needs_vv10() const { return needs_vv10_; };

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1536,6 +1536,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("DFT_BASIS_TOLERANCE", 1.0E-12);
         /*- grid weight cutoff. Disable with -1.0. !expert -*/
         options.add_double("DFT_WEIGHTS_TOLERANCE", 1.0E-15);
+        /*- density cutoff for LibXC. A negative value turns the feature off and LibXC defaults are used. !expert -*/
+        options.add_double("DFT_DENSITY_TOLERANCE", -1.0);
         /*- The DFT grid specification, such as SG1.!expert -*/
         options.add_str("DFT_GRID_NAME", "", "SG0 SG1");
         /*- Select approach for pruning. Options ``ROBUST`` and ``TREUTLER`` prune based on regions (proximity to nucleus) while

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10
-                  dft1-alt dft2 dft3 dft-omega docs-bases docs-dft extern1 extern2
+                  dft1-alt dft2 dft3 dft-omega dft-dens-cut docs-bases docs-dft extern1 extern2
                   fsapt1 fsapt2 fsapt-terms fsapt-allterms fsapt-ext isapt1 isapt2
                   fci-dipole fci-h2o fci-h2o-2 fci-h2o-fzcv fci-tdm fci-tdm-2
                   fci-coverage

--- a/tests/dft-dens-cut/CMakeLists.txt
+++ b/tests/dft-dens-cut/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dft-dens-cut "psi;quicktests;dft;scf;cart")

--- a/tests/dft-dens-cut/input.dat
+++ b/tests/dft-dens-cut/input.dat
@@ -1,0 +1,129 @@
+# LibXC density screening test. Tests empty, C-only, X-only and XC superfunctionals.
+# 'super_mix' showcases how to use different screening values for X and C parts.
+# SCF will fail or crash (nans) without screening!
+
+molecule h2o {
+0 2
+H
+}
+
+set {
+print 1
+basis sto-3g
+dft_spherical_points 302
+dft_radial_points 50
+dft_pruning_scheme treutler
+reference uks
+}
+
+cut_val = 1e-10
+set DFT_DENSITY_TOLERANCE $cut_val
+
+
+# build the various functionals.
+def super(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   Empty SuperFunctional\n')
+    return sup
+
+
+def super_c(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   C-only SuperFunctional\n')
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    return sup
+
+
+def super_x(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   X-only SuperFunctional\n')
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    return sup
+
+
+def super_xc(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   XC SuperFunctional\n')
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    return sup
+
+
+# LibXCFunctional PsiAPI test. Custom thresholds.
+def super_mix(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   XC SuperFunctional\n')
+    Cfun = core.LibXCFunctional('XC_MGGA_C_TPSS', restricted)
+    Cfun.set_density_cutoff(1e-9)
+    Xfun = core.LibXCFunctional('XC_MGGA_X_TPSS', restricted)
+    Xfun2 = core.LibXCFunctional('XC_LDA_X', restricted)
+    Xfun.set_density_cutoff(1e-8)
+    sup.add_c_functional(Cfun)
+    sup.add_x_functional(Xfun)
+    sup.add_x_functional(Xfun2)
+    return sup
+
+
+ref_vals = { #TEST
+    'WB97X-V':-0.4650551043168708, #TEST
+    'EMPTY': -0.0794260295393005, #TEST
+    'Conly': -0.0794260295393005, #TEST
+    'Xonly': -0.4667410699056061, #TEST
+    'XC': -0.8540561102719116, #TEST
+    'MIX': -0.7988413011640255, #TEST
+    'CUT_C': 1.0E-9.as_integer_ratio(), #TEST
+    'CUT_X': 1.0E-8.as_integer_ratio(), #TEST
+} #TEST
+
+
+# libxc-defined functional
+func_call, wfn1 = energy('WB97X-V',return_wfn=True)
+func = wfn1.V_potential().functional()
+cut = func.density_tolerance()
+compare_values(ref_vals["WB97X-V"], func_call, 6, "is_libxc SuperFunctional")  #TEST
+compare_integers(cut_val.as_integer_ratio(), cut.as_integer_ratio(), "is_libxc density_tolernace")
+
+# empty functional (=HF)
+func_call = energy('SCF', dft_functional=super)
+compare_values(ref_vals["EMPTY"], func_call, 6, "Empty SuperFunctional")  #TEST
+
+# C-only functional and smo
+func_call, wfn = energy('SCF', dft_functional=super_c, return_wfn=True)
+compare_values(ref_vals["Conly"], func_call, 6, "C-only SuperFunctional")  #TEST
+
+# test the PsiAPI
+func = wfn.V_potential().functional()
+func.print_density_threshold()
+density_cutoff = func.c_functionals()[0].density_cutoff()
+compare_values(cut_val.as_integer_ratio(), density_cutoff.as_integer_ratio(),
+               "LibXCFunctional density_cutoff")  #TEST
+density_tolerance = func.density_tolerance()
+compare_integers(cut_val.as_integer_ratio(), density_tolerance.as_integer_ratio(),
+               "SuperFunctional density_tolerance")  #TEST
+
+# X-only
+func_call = energy('SCF', dft_functional=super_x)
+compare_values(ref_vals["Xonly"], func_call, 6, "X-only SuperFunctional")  #TEST
+
+# XC (normal case)
+func_call = energy('SCF', dft_functional=super_xc)
+compare_values(ref_vals["XC"], func_call, 6, "normal XC SuperFunctional")  #TEST
+
+# turn off default screening for next test to allow custom values
+set DFT_DENSITY_TOLERANCE -1.0
+
+# custom XC with different sceening values for X and C
+func_call, wfn_mix = energy('SCF', dft_functional=super_mix,return_wfn=True)
+compare_values(ref_vals["MIX"], func_call, 6, "individual screening")  #TEST
+func = wfn_mix.V_potential().functional()
+cut_c = func.c_functionals()[0].density_cutoff()
+cut_x = func.x_functionals()[0].density_cutoff()
+compare_integers(ref_vals["CUT_C"],cut_c.as_integer_ratio(),"screening value C")  #TEST
+compare_integers(ref_vals["CUT_X"],cut_x.as_integer_ratio(),"screening value X")  #TEST

--- a/tests/dft-dens-cut/input.dat
+++ b/tests/dft-dens-cut/input.dat
@@ -88,13 +88,13 @@ func_call, wfn1 = energy('WB97X-V',return_wfn=True)
 func = wfn1.V_potential().functional()
 cut = func.density_tolerance()
 compare_values(ref_vals["WB97X-V"], func_call, 6, "is_libxc SuperFunctional")  #TEST
-compare_integers(cut_val.as_integer_ratio(), cut.as_integer_ratio(), "is_libxc density_tolernace")
+compare_integers(cut_val.as_integer_ratio(), cut.as_integer_ratio(), "is_libxc density_tolerance")
 
 # empty functional (=HF)
 func_call = energy('SCF', dft_functional=super)
 compare_values(ref_vals["EMPTY"], func_call, 6, "Empty SuperFunctional")  #TEST
 
-# C-only functional and smo
+# C-only functional
 func_call, wfn = energy('SCF', dft_functional=super_c, return_wfn=True)
 compare_values(ref_vals["Conly"], func_call, 6, "C-only SuperFunctional")  #TEST
 

--- a/tests/dft-dens-cut/output.ref
+++ b/tests/dft-dens-cut/output.ref
@@ -1,0 +1,1663 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4a2.dev514 
+
+                         Git: Rev {rho_cutoff} 479097d dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
+    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 15 April 2020 11:27AM
+
+    Process ID: 47675
+    Host:       hokru.local
+    PSIDATADIR: /Users/kruse/qc/psi4.bin/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+# LibXC density screening test. Tests empty, C-only, X-only and XC superfunctionals.
+# 'super_mix' showcases how to use different screening values for X and C parts.
+# SCF will fail or crash (nans) without screening!
+
+molecule h2o {
+0 2
+H
+}
+
+set {
+print 1
+basis sto-3g
+dft_spherical_points 302
+dft_radial_points 50
+dft_pruning_scheme treutler
+reference uks
+}
+
+cut_val = 1e-10
+set DFT_DENSITY_TOLERANCE $cut_val
+
+
+# build the various functionals.
+def super(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   Empty SuperFunctional\n')
+    return sup
+
+
+def super_c(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   C-only SuperFunctional\n')
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    return sup
+
+
+def super_x(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   X-only SuperFunctional\n')
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    return sup
+
+
+def super_xc(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   XC SuperFunctional\n')
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    sup.add_x_functional(core.LibXCFunctional('XC_MGGA_X_TPSS', restricted))
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    sup.add_c_functional(core.LibXCFunctional('XC_MGGA_C_TPSS', restricted))
+    return sup
+
+
+# LibXCFunctional PsiAPI test. Custom thresholds.
+def super_mix(name, npoints, deriv, restricted):
+    sup = core.SuperFunctional.blank()
+    sup.set_name('test')
+    sup.set_description('   XC SuperFunctional\n')
+    Cfun = core.LibXCFunctional('XC_MGGA_C_TPSS', restricted)
+    Cfun.set_density_cutoff(1e-9)
+    Xfun = core.LibXCFunctional('XC_MGGA_X_TPSS', restricted)
+    Xfun2 = core.LibXCFunctional('XC_LDA_X', restricted)
+    Xfun.set_density_cutoff(1e-8)
+    sup.add_c_functional(Cfun)
+    sup.add_x_functional(Xfun)
+    sup.add_x_functional(Xfun2)
+    return sup
+
+
+ref_vals = { #TEST
+    'WB97X-V':-0.4650551043168708, #TEST
+    'EMPTY': -0.0794260295393005, #TEST
+    'Conly': -0.0794260295393005, #TEST
+    'Xonly': -0.4667410699056061, #TEST
+    'XC': -0.8540561102719116, #TEST
+    'MIX': -0.7988413011640255, #TEST
+    'CUT_C': 1.0E-9.as_integer_ratio(), #TEST
+    'CUT_X': 1.0E-8.as_integer_ratio(), #TEST
+} #TEST
+
+
+# libxc-defined functional
+func_call, wfn1 = energy('WB97X-V',return_wfn=True)
+func = wfn1.V_potential().functional()
+cut = func.density_tolerance()
+print(cut)
+compare_values(ref_vals["WB97X-V"], func_call, 6, "is_libxc SuperFunctional")  #TEST
+compare_integers(cut_val.as_integer_ratio(), cut.as_integer_ratio()," is_libxc density_tolernace")
+
+# empty functional (=HF)
+func_call = energy('SCF', dft_functional=super)
+compare_values(ref_vals["EMPTY"], func_call, 6, "Empty SuperFunctional")  #TEST
+
+# C-only functional and smo
+func_call, wfn = energy('SCF', dft_functional=super_c, return_wfn=True)
+compare_values(ref_vals["Conly"], func_call, 6, "C-only SuperFunctional")  #TEST
+
+# test the PsiAPI
+func = wfn.V_potential().functional()
+func.print_density_threshold()
+density_cutoff = func.c_functionals()[0].density_cutoff()
+compare_values(cut_val.as_integer_ratio(), density_cutoff.as_integer_ratio(),
+               "LibXCFunctional density_cutoff")  #TEST
+density_tolerance = func.density_tolerance()
+compare_integers(cut_val.as_integer_ratio(), density_tolerance.as_integer_ratio(),
+               "SuperFunctional density_tolerance")  #TEST
+
+# X-only
+func_call = energy('SCF', dft_functional=super_x)
+compare_values(ref_vals["Xonly"], func_call, 6, "X-only SuperFunctional")  #TEST
+
+# XC (normal case)
+func_call = energy('SCF', dft_functional=super_xc)
+compare_values(ref_vals["XC"], func_call, 6, "normal XC SuperFunctional")  #TEST
+
+# turn off default screening for next test to allow custom values
+set DFT_DENSITY_TOLERANCE -1.0
+
+# custom XC with different sceening values for X and C
+func_call, wfn_mix = energy('SCF', dft_functional=super_mix,return_wfn=True)
+compare_values(ref_vals["MIX"], func_call, 6, "individual screening")  #TEST
+func = wfn_mix.V_potential().functional()
+cut_c = func.c_functionals()[0].density_cutoff()
+cut_x = func.x_functionals()[0].density_cutoff()
+compare_integers(ref_vals["CUT_C"],cut_c.as_integer_ratio(),"screening value C")  #TEST
+compare_integers(ref_vals["CUT_X"],cut_x.as_integer_ratio(),"screening value X")  #TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:34 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+  ==> DFT Potential <==
+
+   => Composite Functional: WB97X-V <= 
+
+    wB97X-V Hyb-GGA Exchange-Correlation Functional
+
+    N. Mardirossian and M. Head-Gordon, Phys. Chem. Chem. Phys. 16, 9904 (2014)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange-Correlation Functionals <=
+
+    1.0000   wB97X-V range-separated functional
+
+   => Exact (HF) Exchange <=
+
+    0.8330            HF,LR [omega = 0.3000]
+    0.1670               HF 
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X_V:  1.00E-10 
+
+   => VV10 Non-Local Parameters <=
+
+    VV10 B              =     6.0000E+00
+    VV10 C              =     1.0000E-02
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =       TREUTLER
+    Pruning Type           =         REGION
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             50
+    Spherical Points       =            302
+    Total Points           =           8416
+    Total Blocks           =             98
+    Max Points             =            256
+    Max Functions          =              1
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                  Yes
+    Omega:                3.000E-01
+    OpenMP threads:               1
+    Memory [MiB]:               374
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Cached 100.0% of DFT collocation blocks in 0.000 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.46505510431687   -4.65055e-01   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.46505510431687    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.352842  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.670955  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.46505510431687
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.1953223815292989
+    DFT Exchange-Correlation Energy =      -0.1984017296398981
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0046060933510037
+    Total Energy =                         -0.4650551043168708
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:34 2020
+Module time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+    is_libxc SuperFunctional..........................................PASSED
+     is_libxc density_tolernace.......................................PASSED
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:34 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                    No
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.07942602953930   -7.94260e-02   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.07942602953930    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag     0.307730  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.307730  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.07942602953930
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.3871558200179748
+    Total Energy =                         -0.0794260295393006
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:34 2020
+Module time:
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.49 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+    Empty SuperFunctional.............................................PASSED
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:34 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+  ==> DFT Potential <==
+
+   => Composite Functional: test <= 
+
+   C-only SuperFunctional
+
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => LibXC Density Thresholds  <==
+
+    XC_MGGA_C_TPSS:  1.00E-10 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =       TREUTLER
+    Pruning Type           =         REGION
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             50
+    Spherical Points       =            302
+    Total Points           =           8416
+    Total Blocks           =             98
+    Max Points             =            256
+    Max Functions          =              1
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                    No
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               374
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Cached 100.0% of DFT collocation blocks in 0.001 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.07942602953930   -7.94260e-02   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.07942602953930    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag     0.307730  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.320385  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.07942602953930
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.3871558200179748
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                         -0.0794260295393005
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:34 2020
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+    C-only SuperFunctional............................................PASSED
+   => LibXC Density Thresholds  <==
+
+    XC_MGGA_C_TPSS:  1.00E-10 
+
+    LibXCFunctional density_cutoff....................................PASSED
+    SuperFunctional density_tolerance.................................PASSED
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:34 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+  ==> DFT Potential <==
+
+   => Composite Functional: test <= 
+
+   X-only SuperFunctional
+
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+
+   => LibXC Density Thresholds  <==
+
+    XC_MGGA_X_TPSS:  1.00E-10 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =       TREUTLER
+    Pruning Type           =         REGION
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             50
+    Spherical Points       =            302
+    Total Points           =           8416
+    Total Blocks           =             98
+    Max Points             =            256
+    Max Functions          =              1
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                    No
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               374
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Cached 100.0% of DFT collocation blocks in 0.001 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.46674106990561   -4.66741e-01   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.46674106990561    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.199493  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.307730  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.46674106990561
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.3871558200179748
+    DFT Exchange-Correlation Energy =      -0.3873150403663055
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                         -0.4667410699056061
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:35 2020
+Module time:
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.84 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    X-only SuperFunctional............................................PASSED
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:35 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+  ==> DFT Potential <==
+
+   => Composite Functional: test <= 
+
+   XC SuperFunctional
+
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+    1.0000   XC_MGGA_X_TPSS
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+    1.0000   XC_MGGA_C_TPSS
+
+   => LibXC Density Thresholds  <==
+
+    XC_MGGA_C_TPSS:  1.00E-10 
+    XC_MGGA_C_TPSS:  1.00E-10 
+    XC_MGGA_X_TPSS:  1.00E-10 
+    XC_MGGA_X_TPSS:  1.00E-10 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =       TREUTLER
+    Pruning Type           =         REGION
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             50
+    Spherical Points       =            302
+    Total Points           =           8416
+    Total Blocks           =             98
+    Max Points             =            256
+    Max Functions          =              1
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                    No
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               374
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Cached 100.0% of DFT collocation blocks in 0.001 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.85405611027191   -8.54056e-01   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.85405611027191    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.706716  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.333041  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.85405611027191
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.3871558200179748
+    DFT Exchange-Correlation Energy =      -0.7746300807326111
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                         -0.8540561102719116
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:35 2020
+Module time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    normal XC SuperFunctional.........................................PASSED
+
+Scratch directory: /Users/kruse/scratch/PSI4/H_atom/dft-dens-cut/
+
+*** tstart() called on hokru.local
+*** at Wed Apr 15 11:27:35 2020
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    19 file /Users/kruse/qc/psi4.bin/share/psi4/basis/sto-3g.gbs 
+
+SCF: DFT_DENSITY_TOLERANCE is turned off! Using LibXC defaults.
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UKS Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 1
+    Number of basis function: 1
+    Number of Cartesian functions: 1
+    Spherical Harmonics?: true
+    Max angular momentum: 0
+
+  ==> DFT Potential <==
+
+   => Composite Functional: test <= 
+
+   XC SuperFunctional
+
+
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =           TRUE
+
+    Exchange Hybrid     =          FALSE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    1.0000   XC_MGGA_X_TPSS
+    1.0000         XC_LDA_X
+
+   => Correlation Functionals <=
+
+    1.0000   XC_MGGA_C_TPSS
+
+   => LibXC Density Thresholds  <==
+
+    XC_MGGA_C_TPSS:  1.00E-09 
+    XC_MGGA_X_TPSS:  1.00E-08 
+    XC_LDA_X:  1.00E-24 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =       TREUTLER
+    Pruning Type           =         REGION
+    Nuclear Scheme         =       TREUTLER
+
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             50
+    Spherical Points       =            302
+    Total Points           =           8416
+    Total Blocks           =             98
+    Max Points             =            256
+    Max Functions          =              1
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /Users/kruse/qc/psi4.bin/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                    No
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               374
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis function: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Cached 100.0% of DFT collocation blocks in 0.001 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0000000000E+00.
+  Reciprocal condition number of the overlap matrix is 1.0000000000E+00.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         1       1       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        0       0       0       0       0       0
+     B2u        0       0       0       0       0       0
+     B3u        0       0       0       0       0       0
+   -------------------------------------------------------
+    Total       1       1       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UKS iter   1:    -0.79884130116403   -7.98841e-01   0.00000e+00 DIIS
+   @DF-UKS iter   2:    -0.79884130116403    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.642293  
+
+    Alpha Virtual:                                                        
+
+    
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.320385  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UKS Final Energy:    -0.79884130116403
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4665818495572753
+    Two-Electron Energy =                   0.3871558200179748
+    DFT Exchange-Correlation Energy =      -0.7194152716247250
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                         -0.7988413011640255
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on hokru.local at Wed Apr 15 11:27:35 2020
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    individual screening..............................................PASSED
+    screening value C.................................................PASSED
+    screening value X.................................................PASSED
+
+    Psi4 stopped on: Wednesday, 15 April 2020 11:27AM
+    Psi4 wall time for execution: 0:00:01.31
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Enables screening of small densities using LibXC's built-in functionality. Enables user to set custom values. 
This fixes, e.g., issues with calculating the H-atom with many functionals.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] introduces `xc_func_set_dens_threshold`
- [x] `DFT_DENSITY_TOLERANCE` as a (expert) user option
- [x] related PsiAPI options for Functional/LibXCFunctional/Superfunctional

## Questions
- [ ] `lsda/meta_cutoff` routines seem unused. Remove?
- [x] default is **off** 

## Checklist
- [x] Tests added for any new features
- [x] documentation added
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge

----

Python API notes (as one would use in `superfunctionals.py`)
It is recommend to set the threshold via the SuperFunctional class
e.g. `sup[0].set_density_tolerance(1e-10) `


Alternatively one can set the threshold also via the LibXCFunctional class, and potentially
set individual thresholds for the components. Below sets the same threshold for all XC kernels.
```
    dens_cut=core.get_option("SCF","DFT_DENSITY_TOLERANCE")
    if sup[0].is_libxc_func():
        sup[0].c_functionals()[0].set_density_cutoff(dens_cut)
        # print("screening python:",sup[0].c_functionals()[0].density_tolerance())
    else:
        for x_func in sup[0].x_functionals():
            x_func.set_density_cutoff(dens_cut)
        for c_func in sup[0].c_functionals():
            c_func.set_density_cutoff(dens_cut)
```
---

Tests concerning the threshold:
`1e-12` passes all tests without issues
`1e-10` fails only at `pcmsolver-dft` else everything passes


Testing meta-GGA TPSS/aug-pcseg-1 on the A24 benchmark set /w ghost-atoms (simple organic molecules):
[cut10_tpss.apc1.out.txt](https://github.com/psi4/psi4/files/4475320/cut10_tpss.apc1.out.txt)
[cut12_tpss.apc1.out.txt](https://github.com/psi4/psi4/files/4475322/cut12_tpss.apc1.out.txt)
[master_tpss.apc1.out.txt](https://github.com/psi4/psi4/files/4475323/master_tpss.apc1.out.txt)

Looking at the files with vimdiff even `1e-10` shows no practical differences, but offers a better stability (see test cases).  Dipole moments unchanged within accuracy of printout. It is maybe the best choice, but I cannot do exhaustive testing.
`1e-12` is the conservative choice to keep closest to current master.

**Why stay with LibXC defaults:**
However, LibXC defaults (see https://gist.github.com/hokru/546307545c7bf0d96de5cf867e036cae) are sometimes crude out of necessity (< 1e-10) and any custom value will be set recursively for all components.
This can lead to confusion especially if it is a functional definition provided by LibXC itself.
For example for CAM-B3LYP a LibXC query will report a default of `1e-32`, which is misleading because `XC_GGA_X_ITYH` has a default of only `1e-8`. As discussed in https://gitlab.com/libxc/libxc/-/issues/99#note_324078822 this can cause numerical instabilities for density thresholds lower than `1e-10`.
(affects  CAM-B3LYP in `dft-grad-lr2`)
Thus I suggest we stay with LibXC defaults and only in the (hopefully rare) cases a user is facing numerical issues the use of `set dft_density_tolerance 1e-10` is recommended.


