### PR TITLE
1851 for `detci`

### DIFF
--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -41,6 +41,7 @@
 #include "psi4/detci/slaterd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsio/psio.hpp"
 
 #include "psi4/pragma.h"
 PRAGMA_WARNING_PUSH
@@ -65,6 +66,8 @@ CIWavefunction::~CIWavefunction() {
 }
 
 void CIWavefunction::common_init() {
+    psio_ = _default_psio_lib_; // We can't assume the incoming ref_wfn had its own psio
+
     title((options_.get_str("WFN") == "CASSCF") || (options_.get_str("WFN") == "RASSCF"));
 
     // Build and set structs


### PR DESCRIPTION
## Description
A recent forum request needed to use serialized wavefunctions with `detci`. That's a very easy one, and one I can easily see myself needing as I start getting into some FCI benchmarking, so might as well fix it now.

I decided to use `_default_psio_lib_` rather than making a new PSIO object because `_default_psio_lib_` is used elsewhere in `detci`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] `detci` has now escaped #1851

## Checklist
- [x] All `ci` ctests pass

## Status
- [x] Ready for review
- [x] Ready for merge
