### PR TITLE
removed omp_set_nested() which is deprecated in OMP 5.0 

### DIFF
--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -65,7 +65,7 @@ SAPT::SAPT(SharedWavefunction Dimer, SharedWavefunction MonomerA, SharedWavefunc
 #endif
 
 #ifdef _OPENMP
-    omp_set_nested(0);
+    omp_set_max_active_levels(1);
 #endif
 
     initialize(MonomerA, MonomerB);


### PR DESCRIPTION
## Description
fixes #1820 (another try)
The docs (https://www.openmp.org/spec-html/5.0/openmpse57.html) say that setting `OMP_NESTED=FALSE` means `max-active-levels-var=1`. The function switched from bool argument for `omp_set_nested()` to integer for `omp_set_max_active_levels`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] replaces `omp_set_nested(0)` with `omp_set_max_active_levels(1)`. Both mean to say 'no nested OMP'.

## Checklist
- [x] tu-sapt5 /w junQZ basis passes. This originally caused problems with the old fix, see issue. Also test_threading.py and system 20 of S66 with sapt0/QZ (5min run time) are OK. All three give comparable results and timings as current conda psi4 devel (`Psi4 1.4a2.dev523`)
- [x] visually threading looks OK, using `top` (whatever that is worth)

## Status
- [x] Ready for review
- [x] Ready for merge
