### PR TITLE
improvements to the FCHK writer

### DIFF
--- a/doc/sphinxman/source/fchk.rst
+++ b/doc/sphinxman/source/fchk.rst
@@ -52,8 +52,8 @@ calculation, and hand it to the fchk driver function::
     energy, wfn = energy('scf', return_wfn=True)
     fchk(wfn,'output.fchk')
 
-The file will be written to the name passed to the FCHK writer's *write()*
-method.  Note that for MP2 and CCSD methods, the energy can be computed without
+The file will be written to the name passed to the fchk function.
+Note that for MP2 and CCSD methods, the energy can be computed without
 the expensive steps required to compute the density, so energy calls for these
 methods will return a wavefunction that has the Hartree--Fock density.  If a
 density is required for these methods, the user should instead request a

--- a/doc/sphinxman/source/fchk.rst
+++ b/doc/sphinxman/source/fchk.rst
@@ -47,11 +47,10 @@ generate FCHK files.  Wavefunction information, such as orbitals, densities,
 orbital energies and basis set information is currently supported, but geometry
 optimization and vibrational frequency information are not supported at this
 time.  To generate a FCHK file, simply store the wavefunction from the energy
-calculation, and use it to create an FCHK writer::
+calculation, and hand it to the fchk driver function::
 
     energy, wfn = energy('scf', return_wfn=True)
-    fchk_writer = psi4.core.FCHKWriter(wfn)
-    fchk_writer.write('output.fchk')
+    fchk(wfn,'output.fchk')
 
 The file will be written to the name passed to the FCHK writer's *write()*
 method.  Note that for MP2 and CCSD methods, the energy can be computed without
@@ -61,8 +60,8 @@ density is required for these methods, the user should instead request a
 gradient computation, to ensure that the density is updated appropriately::
 
     grad, wfn = gradient('mp2', return_wfn=True)
-    fchk_writer = psi4.core.FCHKWriter(wfn)
-    fchk_writer.write('output.fchk')
+    fchk(wfn,'output.fchk')
+
 
 .. autofunction:: psi4.fchk(wfn, filename)
 

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -290,6 +290,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_mdi.py
               ../tests/pytests/test_weird_basis.py
               ../tests/pytests/test_ccresponse.py
+              ../tests/pytests/test_fchk_writer.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 
     # <<<  install psi4 share/ & include/  >>>

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -39,6 +39,7 @@ from psi4.driver.inputparser import process_input
 from psi4.driver.p4util.util import *
 from psi4.driver.p4util.testing import *
 from psi4.driver.p4util.fcidump import *
+from psi4.driver.p4util.fchk import *
 from psi4.driver.p4util.text import *
 from psi4.driver.qmmm import QMMM
 from psi4.driver.pluginutil import *

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1931,7 +1931,7 @@ def gdma(wfn, datafile=""):
     if not datafile:
         os.remove(commands)
 
-def fchk(wfn, filename, debug=False, strict_label=True):
+def fchk(wfn, filename, *, debug=False, strict_label=True):
     """Function to write wavefunction information in *wfn* to *filename* in
     Gaussian FCHK format.
 
@@ -1949,7 +1949,8 @@ def fchk(wfn, filename, debug=False, strict_label=True):
     :param debug: returns a dictionary to aid with debugging
 
     :type strict_label: boolean
-    :param strict_label: Set a standard label if possible. A warning will be printed if this is not possible.
+    :param strict_label: If true set a density label compliant with what Gaussian would write. A warning will be printed if this is not possible.
+                         Otherwise set the density label according to the method name.
 
     Notes
     -----
@@ -1977,7 +1978,7 @@ def fchk(wfn, filename, debug=False, strict_label=True):
     """
     # * Known limitations and notes *
     #
-    # OCC: (occ theory module only, not dfocc) is turned off as densities are not correctly set. 
+    # OCC: (occ theory module only, not dfocc) is turned off as densities are not correctly set.
     # DFMP2: Contains natural orbitals in wfn.C() and wfn.epsilon() data. This is fixed to contain respective HF data.
 
     allowed = ['DFMP2', 'SCF', 'CCENERGY', 'DCT', 'DFOCC']
@@ -2013,10 +2014,8 @@ def fchk(wfn, filename, debug=False, strict_label=True):
     current = varlist['CURRENT ENERGY']
 
     # delete problematic entries
-    delete_list = ['CURRENT ENERGY', 'CURRENT REFERENCE ENERGY']
-    for key in delete_list:
-        if key in varlist:
-            del varlist[key]
+    for key in ['CURRENT ENERGY', 'CURRENT REFERENCE ENERGY']:
+        varlist.pop(key, None)
 
     # find closest matching energy
     for (key, val) in varlist.items():

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1982,7 +1982,7 @@ def fchk(wfn, filename, debug=False, strict_label=True):
 
     allowed = ['DFMP2', 'SCF', 'CCENERGY', 'DCT', 'DFOCC']
     module_ = wfn.module().upper()
-    if (module_ not in allowed):
+    if module_ not in allowed:
         core.print_out(f"FCHKWriter: Theory module {module_} is currently not supported by the FCHK writer.")
         return None
 
@@ -1990,7 +1990,7 @@ def fchk(wfn, filename, debug=False, strict_label=True):
         core.print_out(f"FCHKWriter: Limited ECP support! No ECP data will be written to the FCHK file.")
 
     # fix orbital coefficients and energies for DFMP2
-    if (module_ in ['DFMP2']):
+    if module_ in ['DFMP2']:
         wfn_ = core.Wavefunction.build(wfn.molecule(), core.get_global_option('BASIS'))
         wfn_.deep_copy(wfn)
         refwfn = wfn.reference_wavefunction()
@@ -2003,7 +2003,7 @@ def fchk(wfn, filename, debug=False, strict_label=True):
     else:
         fw = core.FCHKWriter(wfn)
 
-    if (module_ in ['DCT', 'DFOCC']):
+    if module_ in ['DCT', 'DFOCC']:
         core.print_out("""FCHKWriter: Caution! For orbital-optimized correlated methods
             the 'Orbital Energy' field contains ambiguous data. \n""")
 
@@ -2020,9 +2020,9 @@ def fchk(wfn, filename, debug=False, strict_label=True):
 
     # find closest matching energy
     for (key, val) in varlist.items():
-        print(key,val)
         if (np.isclose(val, current, 1e-12)):
             method = key.split()[0]
+            break
 
     # The 'official' list of labels for compatibility.
     # OMP2,MP2.5,OCCD, etc get reduced to MP2,CC.
@@ -2042,6 +2042,8 @@ def fchk(wfn, filename, debug=False, strict_label=True):
         in_list = False
         for key in allowed_labels:
             if key in method:
+                if key is not method:
+                    core.print_out(f"FCHKWriter: !WARNING! method '{method}'' renamed to label '{key}'.\n")
                 fchk_label = allowed_labels[key]
                 in_list = True
         if not in_list:
@@ -2051,7 +2053,7 @@ def fchk(wfn, filename, debug=False, strict_label=True):
 
     fw.write(filename)
     # needed for the pytest. The SCF density below follows PSI4 ordering not FCHK ordering.
-    if (debug):
+    if debug:
         ret = {
             "filename": filename,
             "detected energy": method,

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1980,6 +1980,9 @@ def fchk(wfn, filename, debug=False):
         core.print_out(f"FCHKWriter: Theory module {module_} is currently not supported by the FCHK writer.")
         return None
 
+    if (wfn.basisset().has_ECP()):
+        core.print_out(f"FCHKWriter: Limited ECP support! No ECP data will be written to the FCHK file.")
+
     # fix orbital coefficients and energies for DFMP2
     if (module_ in ['DFMP2']):
         wfn_ = core.Wavefunction.build(wfn.molecule(), core.get_global_option('BASIS'))

--- a/psi4/driver/p4util/CMakeLists.txt
+++ b/psi4/driver/p4util/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(APPEND sources
   exceptions
   fcidump
+  fchk
   inpsight
   numpy_helper
   optproc

--- a/psi4/driver/p4util/fchk.py
+++ b/psi4/driver/p4util/fchk.py
@@ -32,6 +32,7 @@ from psi4.driver.p4util.testing import compare_strings, compare_arrays, compare_
 from psi4 import core
 from .exceptions import ValidationError
 
+__all__ = ['fchkfile_to_string','compare_fchkfiles']
 
 def _consume_fchk_section(input_list, index):
     """compare a float or integer matrix section"""

--- a/psi4/driver/p4util/fchk.py
+++ b/psi4/driver/p4util/fchk.py
@@ -1,0 +1,121 @@
+#
+# @BEGIN LICENSE
+#
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2019 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
+#
+# This file is part of Psi4.
+#
+# Psi4 is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# Psi4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Psi4; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# @END LICENSE
+#
+"""Module with utility functions for FCHK files."""
+
+import numpy as np
+from psi4.driver.p4util.testing import compare_strings, compare_arrays, compare_values, compare_integers
+from psi4 import core
+from .exceptions import ValidationError
+
+
+def consume_fchk_section(input_list, index):
+    """compare a float matrix section"""
+
+    n = int(input_list[index].split()[-1])
+    kind = input_list[index].split()[-3]
+
+    if " R " in kind:
+        dtype = np.float64
+        format_counter = 5
+    elif " I " in kind:
+        dtype = np.float64
+        format_counter = 6
+    else:
+        raise ValidationError('Unknow field type in FCHK reader\n')
+
+    extra = 0 if n <= format_counter else n % format_counter
+    lines = 1 if n <= format_counter else int(n / format_counter)
+    offset = lines + 1 if extra > 0 else lines
+    string = ''
+    for j in range(lines):
+        string += "".join(str(x) for x in input_list[index + 1 + j])
+    if extra > 0:
+        string += "".join(str(x) for x in input_list[index + 1 + lines])
+    field = np.fromiter(string.split(), dtype=dtype)
+    return offset + 1, field
+
+
+def fchkfile_to_string(fname):
+    """ Load FCHK file into a string"""
+    with open(fname, 'r') as handle:
+        fchk_string = handle.read()
+    return fchk_string
+
+
+def compare_fchkfiles(expected, computed, label):
+    # """Function to compare two FCHK files.
+
+    # :param expected: reference FCHK file name
+    # :param computed: computed FCHK file name
+    # :param label: string labelling the test
+    # """
+
+    high_accuracy = 9
+    low_accuracy = 3
+
+    # those need super high scf convergence (d_conv 1e-12). Unsure how it is
+    # on different machines. Thus they get low_accuracy.
+    # Rest seems okay with d_conv 1e-10.
+    sensitive = ['Current cartesian coordinates', 'MO coefficients']
+
+    fchk_ref = fchkfile_to_string('dct.ref').splitlines()
+    fchk_calc = fchkfile_to_string('dct.fchk').splitlines()
+
+    if len(fchk_ref) != len(fchk_calc):
+        raise ValidationError('The two FCHK files to compare have a different file length! \n')
+
+    i = 0
+    max_length = len(fchk_calc)
+    tests = []
+    for start in range(max_length):
+        if i >= max_length:
+            break
+        if "N=" in fchk_calc[i]:
+            offset, calc = consume_fchk_section(fchk_calc, i)
+            _, ref = consume_fchk_section(fchk_ref, i)
+            if any(x in fchk_calc[i] for x in sensitive):
+                test = compare_arrays(ref, calc, low_accuracy, f" matrix section: {fchk_calc[i]}")
+            else:
+                test = compare_arrays(ref, calc, high_accuracy, f" matrix section: {fchk_calc[i]}")
+            i += offset
+        elif " R " in fchk_calc[i] and not "N=" in fchk_calc[i]:
+            calc = fchk_calc[i].split()[-1]
+            ref = fchk_ref[i].split()[-1]
+            test = compare_values(ref, calc, high_accuracy, f" float value: {fchk_calc[i]}")
+            i += 1
+        elif " I " in fchk_calc[i] and not "N=" in fchk_calc[i]:
+            calc = fchk_calc[i].split()[-1]
+            ref = fchk_ref[i].split()[-1]
+            test = compare_integers(ref, calc, f" int value: {fchk_calc[i]}")
+            i += 1
+        else:
+            test = compare_strings(fchk_calc[i], fchk_ref[i], f"FCK text line {i+1}.")
+            i += 1
+        tests.append(test)
+
+    return compare_integers(True, all(tests), label)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1548,7 +1548,7 @@ void export_mints(py::module& m) {
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("write", &FCHKWriter::write, "Write wavefunction information to file", "filename"_a)
         .def("SCF_Dtot",&FCHKWriter::SCF_Dtot,py::return_value_policy::reference_internal)
-        .def("set_postscf_density_label", &FCHKWriter::set_pHF_density_label, "Set base label for post-SCF density, e.g. ' CC Density'.", "label"_a);
+        .def("set_postscf_density_label", &FCHKWriter::set_postscf_density_label, "Set base label for post-SCF density, e.g. ' CC Density'.", "label"_a);
 
     py::class_<MoldenWriter, std::shared_ptr<MoldenWriter>>(m, "MoldenWriter",
                                                             "Writes wavefunction information in molden format")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -320,6 +320,7 @@ void export_mints(py::module& m) {
     typedef void (Vector::*vector_setitem_2)(int, int, double);
     typedef double (Vector::*vector_getitem_1)(int) const;
     typedef double (Vector::*vector_getitem_2)(int, int) const;
+    typedef void (Vector::*vector_one)(const Vector &other);
 
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
         .def(py::init<int>())
@@ -365,6 +366,7 @@ void export_mints(py::module& m) {
         .def("set", vector_setitem_1(&Vector::set), "Sets a single element value located at m", "m"_a, "val"_a)
         .def("set", vector_setitem_2(&Vector::set), "Sets a single element value located at m in irrep h", "h"_a, "m"_a,
              "val"_a)
+        .def("copy", vector_one(&Vector::copy), "Returns a copy of the matrix")
         .def("print_out", &Vector::print_out, "Prints the vector to the output file")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", "sc"_a)
         .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h", "h"_a = 0)
@@ -1544,7 +1546,9 @@ void export_mints(py::module& m) {
                                                         "Extracts information from a wavefunction object, \
                                                                           and writes it to an FCHK file")
         .def(py::init<std::shared_ptr<Wavefunction>>())
-        .def("write", &FCHKWriter::write, "Write wavefunction information to file", "filename"_a);
+        .def("write", &FCHKWriter::write, "Write wavefunction information to file", "filename"_a)
+        .def("SCF_Dtot",&FCHKWriter::SCF_Dtot,py::return_value_policy::reference_internal)
+        .def("set_postscf_density_label", &FCHKWriter::set_pHF_density_label, "Set base label for post-SCF density, e.g. ' CC Density'.", "label"_a);
 
     py::class_<MoldenWriter, std::shared_ptr<MoldenWriter>>(m, "MoldenWriter",
                                                             "Writes wavefunction information in molden format")

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -134,7 +134,7 @@ void DFOCC::get_moinfo() {
         }
 
         // Read orbital coefficients from reference_wavefunction
-        Ca_ = SharedMatrix(reference_wavefunction_->Ca());
+        Ca_ = reference_wavefunction_->Ca()->clone();
         CmoA = SharedTensor2d(new Tensor2d("Alpha MO Coefficients", nso_, nmo_));
         CmoA->set(Ca_);
         if (orb_opt_ == "TRUE" || qchf_ == "TRUE") {
@@ -317,12 +317,12 @@ void DFOCC::get_moinfo() {
         }
 
         // Read orbital coefficients from reference_wavefunction
-        Ca_ = SharedMatrix(reference_wavefunction_->Ca());
+        Ca_ = reference_wavefunction_->Ca()->clone();
         CmoA = SharedTensor2d(new Tensor2d("Alpha MO Coefficients", nso_, nmo_));
         CmoA->set(Ca_);
         if (print_ > 2) CmoA->print();
 
-        Cb_ = SharedMatrix(reference_wavefunction_->Cb());
+        Cb_ = reference_wavefunction_->Cb()->clone();
         CmoB = SharedTensor2d(new Tensor2d("Beta MO Coefficients", nso_, nmo_));
         CmoB->set(Cb_);
         if (orb_opt_ == "TRUE" || qchf_ == "TRUE") {

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -312,7 +312,7 @@ void FCHKWriter::write_matrix(const char *label, const std::vector<int> &mat) {
     if (count % 6) fprintf(chk_, "\n");
 }
 
-void FCHKWriter::set_pHF_density_label(const std::string &label) {
+void FCHKWriter::set_postscf_density_label(const std::string &label) {
     postscf_density_label_ = ("Total" + label);
     spin_postscf_density_label_ = ("Spin" + label);
 }

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -382,14 +382,11 @@ void FCHKWriter::write(const std::string &filename) {
     std::vector<double> atomic_weights;
     double to_bohr = mol->units() == Molecule::Angstrom ? 1.0 / pc_bohr2angstroms : 1.0;
     for (int atom = 0; atom < natoms; ++atom) {
-        double Z = mol->Z(atom);
-        auto intZ = static_cast<int>(Z);
-        double mass = an2masses[intZ];
-        auto intmass = static_cast<int>(mass);
-        atomic_weights.push_back(mass);
-        int_atomic_weights.push_back(intmass);
-        nuc_charges.push_back(Z);
-        atomic_numbers.push_back(intZ);
+        int intZ = static_cast<int>(mol->Z(atom));
+        atomic_weights.push_back(mol->mass(atom));
+        int_atomic_weights.push_back(mol->mass_number(atom));
+        nuc_charges.push_back(mol->Z(atom));
+        atomic_numbers.push_back(intZ > 0 ? mol->true_atomic_number(atom) : intZ); // care about ECP & ghosts!
         const Vector3 &xyz = mol->xyz(atom);
         coords.push_back(xyz[0]);
         coords.push_back(xyz[1]);

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -66,7 +66,7 @@ class PSI_API FCHKWriter {
     SharedMatrix Cb_ao;
     FCHKWriter(std::shared_ptr<Wavefunction> wavefunction);
     void write(const std::string &filename);
-    void set_pHF_density_label(const std::string &label);
+    void set_postscf_density_label(const std::string &label);
     const SharedMatrix SCF_Dtot() const { return Dtot_ao; }
 };
 

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -57,10 +57,17 @@ class PSI_API FCHKWriter {
     void write_matrix(const char *label, const SharedMatrix &mat);
     void write_matrix(const char *label, const std::vector<double> &mat);
     void write_matrix(const char *label, const std::vector<int> &mat);
+    std::string postscf_density_label_;
+    std::string spin_postscf_density_label_;
 
    public:
+    SharedMatrix Dtot_ao;
+    SharedMatrix Ca_ao;
+    SharedMatrix Cb_ao;
     FCHKWriter(std::shared_ptr<Wavefunction> wavefunction);
     void write(const std::string &filename);
+    void set_pHF_density_label(const std::string &label);
+    const SharedMatrix SCF_Dtot() const { return Dtot_ao; }
 };
 
 class PSI_API MoldenWriter {

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -22,7 +22,7 @@ def tear_down():
                 'pytest_output.dat',
                 'pytest_output.*grad',
                 '*pcmsolver.inp', 'PEDRA.OUT*', 'timer.dat',
-                'FCIDUMP_SCF', 'FCIDUMP_MP2']
+                'FCIDUMP_SCF', 'FCIDUMP_MP2','*.fchk']
     pytest_scratches = []
     for pat in patterns:
         pytest_scratches.extend(glob.glob(pat))

--- a/tests/pytests/test_fchk_writer.py
+++ b/tests/pytests/test_fchk_writer.py
@@ -1,0 +1,72 @@
+import pytest
+import psi4
+import numpy as np
+import re
+from ast import literal_eval
+
+# checks for
+# - correct HF density
+# - principal execution 
+
+def calcD(wfn):
+  Ca_occ=wfn.Ca_subset("AO","OCC").np
+  Cb_occ=wfn.Cb_subset("AO","OCC").np
+  Da=np.dot(Ca_occ,Ca_occ.T)
+  Db=np.dot(Cb_occ,Cb_occ.T)
+  return Da+Db
+
+@pytest.mark.parametrize('inp2', [
+    pytest.param({'name': 'hf', 'options': {'scf_type': 'df'} }, id='df-uhf'),
+    pytest.param({'name': 'pbe', 'options': {'scf_type': 'df'} }, id='df-uhf-dft'), 
+    pytest.param({'name': 'mp2', 'options': {'scf_type': 'df','qc_module': 'occ'} }, id='df-uhf-mp2'),
+    pytest.param({'name': 'ccsd', 'options': {'scf_type': 'pk','cc_type':'conv'} }, id='conv-uhf-ccsd') 
+    ])
+def test_uhf_fchk(inp2):
+  """  FCHK UHF """
+  mol = psi4.geometry("""
+  0 3
+  O 0.0 0.0 0.0
+  O 0.0 0.0 1.1
+  """)
+  psi4.set_options({
+  "BASIS": "pcseg-0",
+  'reference':'uhf',
+  'd_convergence': 1e-10,
+  })
+  psi4.set_options(inp2['options'])
+  e, wfn = psi4.gradient(inp2['name'], return_wfn=True,molecule=mol)
+  ret = psi4.driver.fchk(wfn, f"uhf-{inp2['name']}.fchk", debug=True)
+  psi4.compare_arrays(ret["Total SCF Density"],calcD(wfn),9)
+
+
+@pytest.mark.parametrize('inp', [
+    pytest.param({'name': 'hf', 'options': {'scf_type': 'df'} }, id='df-rhf)'),
+    pytest.param({'name': 'pbe', 'options': {'scf_type': 'df'} }, id='df-rhf-dft)'),
+    pytest.param({'name': 'mp2', 'options': {'scf_type': 'df','mp2_type':'df'} }, id='df-rhf-mp2'),
+    pytest.param({'name': 'omp2', 'options': {'scf_type': 'df','mp2_type':'df'} }, id='df-rhf-omp2'),
+    pytest.param({'name': 'cc2', 'options': {'scf_type': 'pk','cc_type':'conv'}}, id='conv-rhf-cc2'),
+    pytest.param({'name': 'ccsd', 'options': {'scf_type': 'pk','cc_type':'conv'}}, id='conv-rhf-ccsd'),
+    pytest.param({'name': 'dct', 'options': {'scf_type': 'pk','dct_type':'conv'}}, id='conv-rhf-dct'),
+    pytest.param({'name': 'mp2', 'options': {'scf_type': 'pk','mp2_type':'conv','qc_module':'occ'}}, marks=pytest.mark.xfail(reason="OCC not allowed in FCHK"), id='conv-rhf-mp2(occ)'),
+    ])
+def test_rhf_fchk(inp):
+  """  FCHK RHF """
+  mol = psi4.geometry("""
+  0 1
+  O
+  H 1 1.0
+  H 1 1.0 2 104.5
+  # symmetry c1
+  """)
+  psi4.set_options({
+  "BASIS": "pcseg-0",
+  })
+  psi4.set_options(inp['options'])
+  e, wfn = psi4.gradient(inp['name'], return_wfn=True, molecule=mol)
+  ret = psi4.driver.fchk(wfn, f"rhf-{inp['name']}.fchk", debug=True)
+  if inp['name'] in ['mp2','dct','omp2']: 
+      refwfn = wfn.reference_wavefunction()
+      expected = calcD(refwfn)
+  else:
+      expected = calcD(wfn)
+  psi4.compare_arrays(ret["Total SCF Density"],expected,9)

--- a/tests/pytests/test_fchk_writer.py
+++ b/tests/pytests/test_fchk_writer.py
@@ -3,17 +3,37 @@ import psi4
 import numpy as np
 import re
 from ast import literal_eval
+import os
+from distutils import dir_util
 
 # checks for
 # - correct HF density
 # - principal execution 
+# - comparison against reference file
+
+@pytest.fixture
+def datadir(tmpdir, request):
+    """
+    from: https://stackoverflow.com/a/29631801
+    Fixture responsible for searching a folder with the same name of test
+    module and, if available, moving all contents to a temporary directory so
+    tests can use them freely.
+    """
+    filename = request.module.__file__
+    test_dir, _ = os.path.splitext(filename)
+
+    if os.path.isdir(test_dir):
+        dir_util.copy_tree(test_dir, str(tmpdir))
+
+    return tmpdir
+
 
 def calcD(wfn):
-  Ca_occ=wfn.Ca_subset("AO","OCC").np
-  Cb_occ=wfn.Cb_subset("AO","OCC").np
-  Da=np.dot(Ca_occ,Ca_occ.T)
-  Db=np.dot(Cb_occ,Cb_occ.T)
-  return Da+Db
+    Ca_occ = wfn.Ca_subset("AO", "OCC").np
+    Cb_occ = wfn.Cb_subset("AO", "OCC").np
+    Da = np.dot(Ca_occ, Ca_occ.T)
+    Db = np.dot(Cb_occ, Cb_occ.T)
+    return Da + Db
 
 @pytest.mark.parametrize('inp2', [
     pytest.param({'name': 'hf', 'options': {'scf_type': 'df'} }, id='df-uhf'),
@@ -21,23 +41,25 @@ def calcD(wfn):
     pytest.param({'name': 'mp2', 'options': {'scf_type': 'df','qc_module': 'occ'} }, id='df-uhf-mp2'),
     pytest.param({'name': 'ccsd', 'options': {'scf_type': 'pk','cc_type':'conv'} }, id='conv-uhf-ccsd') 
     ])
-def test_uhf_fchk(inp2):
-  """  FCHK UHF """
-  mol = psi4.geometry("""
+def test_uhf_fchk(inp2, datadir):
+    """  FCHK UHF """
+    mol = psi4.geometry("""
   0 3
   O 0.0 0.0 0.0
   O 0.0 0.0 1.1
   """)
-  psi4.set_options({
-  "BASIS": "pcseg-0",
-  'reference':'uhf',
-  'd_convergence': 1e-10,
-  })
-  psi4.set_options(inp2['options'])
-  e, wfn = psi4.gradient(inp2['name'], return_wfn=True,molecule=mol)
-  ret = psi4.driver.fchk(wfn, f"uhf-{inp2['name']}.fchk", debug=True)
-  psi4.compare_arrays(ret["Total SCF Density"],calcD(wfn),9, "FCHK UHF Density")
-
+    psi4.set_options({
+        "BASIS": "pcseg-0",
+        'reference': 'uhf',
+        'd_convergence': 1e-12,
+    })
+    FCHK_file = f"uhf-{inp2['name']}.fchk"
+    reference_file = datadir.join(f"uhf-{inp2['name']}.ref")
+    psi4.set_options(inp2['options'])
+    e, wfn = psi4.gradient(inp2['name'], return_wfn=True, molecule=mol)
+    ret = psi4.driver.fchk(wfn, FCHK_file, debug=True)
+    assert psi4.compare_arrays(ret["Total SCF Density"], calcD(wfn), 9, "FCHK UHF Density")
+    assert psi4.compare_fchkfiles(reference_file, FCHK_file, f" File comparison: {FCHK_file}")
 
 @pytest.mark.parametrize('inp', [
     pytest.param({'name': 'hf', 'options': {'scf_type': 'df'} }, id='df-rhf)'),
@@ -49,24 +71,29 @@ def test_uhf_fchk(inp2):
     pytest.param({'name': 'dct', 'options': {'scf_type': 'pk','dct_type':'conv'}}, id='conv-rhf-dct'),
     pytest.param({'name': 'mp2', 'options': {'scf_type': 'pk','mp2_type':'conv','qc_module':'occ'}}, marks=pytest.mark.xfail(reason="OCC not allowed in FCHK"), id='conv-rhf-mp2(occ)'),
     ])
-def test_rhf_fchk(inp):
-  """  FCHK RHF """
-  mol = psi4.geometry("""
+def test_rhf_fchk(inp, datadir):
+    """  FCHK RHF """
+    mol = psi4.geometry("""
   0 1
   O
   H 1 1.0
   H 1 1.0 2 104.5
   # symmetry c1
   """)
-  psi4.set_options({
-  "BASIS": "pcseg-0",
-  })
-  psi4.set_options(inp['options'])
-  e, wfn = psi4.gradient(inp['name'], return_wfn=True, molecule=mol)
-  ret = psi4.driver.fchk(wfn, f"rhf-{inp['name']}.fchk", debug=True)
-  if inp['name'] in ['mp2','dct','omp2']: 
-      refwfn = wfn.reference_wavefunction()
-      expected = calcD(refwfn)
-  else:
-      expected = calcD(wfn)
-  psi4.compare_arrays(ret["Total SCF Density"],expected,9, "FCHK RHF Density")
+    psi4.set_options({
+        "BASIS": "pcseg-0",
+        'd_convergence': 1e-12,
+    })
+    FCHK_file = f"rhf-{inp['name']}.fchk"
+    reference_file = datadir.join(f"rhf-{inp['name']}.ref")
+    psi4.set_options(inp['options'])
+    e, wfn = psi4.gradient(inp['name'], return_wfn=True, molecule=mol)
+    ret = psi4.driver.fchk(wfn, FCHK_file, debug=True)
+    if inp['name'] in ['mp2', 'dct', 'omp2']:
+        refwfn = wfn.reference_wavefunction()
+        expected = calcD(refwfn)
+    else:
+        expected = calcD(wfn)
+    assert psi4.compare_arrays(ret["Total SCF Density"], expected, 9, "FCHK RHF Density")
+    assert psi4.compare_fchkfiles(reference_file, FCHK_file, f" File comparison: {FCHK_file}")
+

--- a/tests/pytests/test_fchk_writer.py
+++ b/tests/pytests/test_fchk_writer.py
@@ -36,7 +36,7 @@ def test_uhf_fchk(inp2):
   psi4.set_options(inp2['options'])
   e, wfn = psi4.gradient(inp2['name'], return_wfn=True,molecule=mol)
   ret = psi4.driver.fchk(wfn, f"uhf-{inp2['name']}.fchk", debug=True)
-  psi4.compare_arrays(ret["Total SCF Density"],calcD(wfn),9)
+  psi4.compare_arrays(ret["Total SCF Density"],calcD(wfn),9, "FCHK UHF Density")
 
 
 @pytest.mark.parametrize('inp', [
@@ -69,4 +69,4 @@ def test_rhf_fchk(inp):
       expected = calcD(refwfn)
   else:
       expected = calcD(wfn)
-  psi4.compare_arrays(ret["Total SCF Density"],expected,9)
+  psi4.compare_arrays(ret["Total SCF Density"],expected,9, "FCHK RHF Density")

--- a/tests/pytests/utils.py
+++ b/tests/pytests/utils.py
@@ -25,6 +25,7 @@ __all__ = [
     'compare_matrices',
     'compare_wavefunctions',
     'compare_fcidumps',
+    'compare_fchkfiles',
     'run_psi4_cli',
     'tnm',
 ]
@@ -64,7 +65,7 @@ compare_vectors = true_false_decorator(psi4.compare_vectors)
 compare_matrices = true_false_decorator(psi4.compare_matrices)
 compare_fcidumps = true_false_decorator(psi4.compare_fcidumps)
 compare_wavefunctions = true_false_decorator(psi4.compare_wavefunctions)
-
+compare_fchkfiles = true_false_decorator(psi4.compare_fchkfiles)
 
 def tnm():
     """Returns the name of the calling function, usually name of test case."""


### PR DESCRIPTION
## Description
Tries to set the correct density label and solves some bugs with writing the incorrect densities.

Relates issue: #1272 

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] deducts density label (`|SCF|MP2|CC|CI|DCT`) for the FCHK file from the method.
- [x] allows PSI4 method names as density label with option `strict_label=False`
- [x] related issue [1886](https://github.com/psi4/psi4/issues/1886) is handled within the FCHK driver.
- [x] new pytests for FCHK files that check if the correct SCF density and SCF orbital coefficients is set.
- [x] No densities available from `occ` gradients. FCHK driver exists with a warning.
- [x] DCT, DFOCC densities available
- [x] exposes `Vector.copy()` to python
- [x] better ECP support. Fixes #2021.
- [x] adds a 'compare_fchkfiles` function.

## Checklist
- [x] docs changed to reflect that the high-level `fchk()` should be called (instead of `FCHKWriter()` directly)
- [x] new test passes
- [x] manual inspect of various fchk files using this (ugly) script: https://gist.github.com/hokru/f1b00a87665ac345415b4ad3e0006f1d

## Status
- [x] Ready for review
- [x] Ready for merge
