### PR TITLE
Fix BCC if there are frozen virtual orbitals

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/rotate.cc
+++ b/psi4/src/psi4/cc/ccenergy/rotate.cc
@@ -231,8 +231,11 @@ int CCEnergyWavefunction::rotate() {
         Fvv = (double ***)malloc(nirreps * sizeof(double **));
         X = block_matrix(nmo, nmo);
         for (int h = 0; h < nirreps; h++) {
-            /* leave the frozen core orbitals alone */
+            /* leave the frozen orbitals alone */
             for (int i = offset[h]; i < offset[h] + moinfo_.frdocc[h]; i++) X[i][i] = 1.0;
+            for (int end = offset[h] + moinfo_.orbspi[h], start = end - moinfo_.fruocc[h],
+                 i = start; i < end; i++)
+                X[i][i] = 1.0;
 
             Foo[h] = block_matrix(moinfo_.occpi[h], moinfo_.occpi[h]);
             Fvv[h] = block_matrix(moinfo_.virtpi[h], moinfo_.virtpi[h]);
@@ -243,10 +246,9 @@ int CCEnergyWavefunction::rotate() {
                      j++, J++)
                     Foo[h][I][J] = fock[i][j];
 
-            for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h], A = 0; a < offset[h] + moinfo_.orbspi[h];
-                 a++, A++)
-                for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h], B = 0; b < offset[h] + moinfo_.orbspi[h];
-                     b++, B++)
+            for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h],
+                 end = start + moinfo_.virtpi[h], a = start, A = 0; a < end; a++, A++)
+                for (int b = start, B = 0; b < end; b++, B++)
                     Fvv[h][A][B] = fock[a][b];
 
             /*
@@ -296,10 +298,10 @@ int CCEnergyWavefunction::rotate() {
     mat_print(Fvv[h], moinfo.virtpi[h], moinfo.virtpi[h], outfile);
     */
 
-                for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h], A = 0; a < offset[h] + moinfo_.orbspi[h];
-                     a++, A++)
-                    for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h], B = 0;
-                         b < offset[h] + moinfo_.orbspi[h]; b++, B++)
+                for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.occpi[h],
+                     end = start + moinfo_.virtpi[h],
+                     a = start, A = 0; a < end; a++, A++)
+                    for (int b = start, B = 0; b < end; b++, B++)
                         X[a][b] = Fvv[h][B][A];
             }
 
@@ -541,6 +543,9 @@ int CCEnergyWavefunction::rotate() {
         for (int h = 0; h < nirreps; h++) {
             /* leave the frozen core orbitals alone */
             for (int i = offset[h]; i < offset[h] + moinfo_.frdocc[h]; i++) X[i][i] = 1.0;
+            for (int end = offset[h] + moinfo_.orbspi[h], start = end - moinfo_.fruocc[h],
+                 i = start; i < end; i++)
+                X[i][i] = 1.0;
 
             Foo[h] = block_matrix(moinfo_.aoccpi[h], moinfo_.aoccpi[h]);
             Fvv[h] = block_matrix(moinfo_.avirtpi[h], moinfo_.avirtpi[h]);
@@ -551,10 +556,9 @@ int CCEnergyWavefunction::rotate() {
                      j < offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h]; j++, J++)
                     Foo[h][I][J] = fock_a[i][j];
 
-            for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h], A = 0; a < offset[h] + moinfo_.orbspi[h];
-                 a++, A++)
-                for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h], B = 0;
-                     b < offset[h] + moinfo_.orbspi[h]; b++, B++)
+            for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h],
+                 end = start + moinfo_.avirtpi[h], a = start, A = 0; a < end; a++, A++)
+                for (int b = start, B = 0; b < end; b++, B++)
                     Fvv[h][A][B] = fock_a[a][b];
 
             if (moinfo_.aoccpi[h]) {
@@ -586,10 +590,10 @@ int CCEnergyWavefunction::rotate() {
                 free(evals);
                 free(work);
 
-                for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h], A = 0;
-                     a < offset[h] + moinfo_.orbspi[h]; a++, A++)
-                    for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h], B = 0;
-                         b < offset[h] + moinfo_.orbspi[h]; b++, B++)
+                for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.aoccpi[h],
+                     end = start + moinfo_.avirtpi[h],
+                     a = start, A = 0; a < end; a++, A++)
+                    for (int b = start, B = 0; b < end; b++, B++)
                         X[a][b] = Fvv[h][B][A];
             }
 
@@ -646,6 +650,9 @@ int CCEnergyWavefunction::rotate() {
         for (int h = 0; h < nirreps; h++) {
             /* leave the frozen core orbitals alone */
             for (int i = offset[h]; i < offset[h] + moinfo_.frdocc[h]; i++) X[i][i] = 1.0;
+            for (int end = offset[h] + moinfo_.orbspi[h], start = end - moinfo_.fruocc[h],
+                 i = start; i < end; i++)
+                X[i][i] = 1.0;
 
             Foo[h] = block_matrix(moinfo_.boccpi[h], moinfo_.boccpi[h]);
             Fvv[h] = block_matrix(moinfo_.bvirtpi[h], moinfo_.bvirtpi[h]);
@@ -656,10 +663,10 @@ int CCEnergyWavefunction::rotate() {
                      j < offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h]; j++, J++)
                     Foo[h][I][J] = fock_b[i][j];
 
-            for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h], A = 0; a < offset[h] + moinfo_.orbspi[h];
-                 a++, A++)
-                for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h], B = 0;
-                     b < offset[h] + moinfo_.orbspi[h]; b++, B++)
+            for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h],
+                 end = start + moinfo_.bvirtpi[h],
+                 a = start, A = 0; a < end; a++, A++)
+                for (int b = start, B = 0; b < end; b++, B++)
                     Fvv[h][A][B] = fock_b[a][b];
 
             if (moinfo_.boccpi[h]) {
@@ -691,10 +698,10 @@ int CCEnergyWavefunction::rotate() {
                 free(evals);
                 free(work);
 
-                for (int a = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h], A = 0;
-                     a < offset[h] + moinfo_.orbspi[h]; a++, A++)
-                    for (int b = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h], B = 0;
-                         b < offset[h] + moinfo_.orbspi[h]; b++, B++)
+                for (int start = offset[h] + moinfo_.frdocc[h] + moinfo_.boccpi[h],
+                     end = start + moinfo_.bvirtpi[h],
+                     a = start, A = 0; a < end; a++, A++)
+                    for (int b = start, B = 0; b < end; b++, B++)
                         X[a][b] = Fvv[h][B][A];
             }
 

--- a/psi4/src/psi4/cc/ccenergy/rotate.cc
+++ b/psi4/src/psi4/cc/ccenergy/rotate.cc
@@ -541,7 +541,7 @@ int CCEnergyWavefunction::rotate() {
         Fvv = (double ***)malloc(nirreps * sizeof(double **));
         X = block_matrix(nmo, nmo);
         for (int h = 0; h < nirreps; h++) {
-            /* leave the frozen core orbitals alone */
+            /* leave the frozen orbitals alone */
             for (int i = offset[h]; i < offset[h] + moinfo_.frdocc[h]; i++) X[i][i] = 1.0;
             for (int end = offset[h] + moinfo_.orbspi[h], start = end - moinfo_.fruocc[h],
                  i = start; i < end; i++)
@@ -648,7 +648,7 @@ int CCEnergyWavefunction::rotate() {
         Fvv = (double ***)malloc(nirreps * sizeof(double **));
         X = block_matrix(nmo, nmo);
         for (int h = 0; h < nirreps; h++) {
-            /* leave the frozen core orbitals alone */
+            /* leave the frozen orbitals alone */
             for (int i = offset[h]; i < offset[h] + moinfo_.frdocc[h]; i++) X[i][i] = 1.0;
             for (int end = offset[h] + moinfo_.orbspi[h], start = end - moinfo_.fruocc[h],
                  i = start; i < end; i++)


### PR DESCRIPTION
## Description
This PR fixes the segmentation fault of `CCEnergyWavefunction::rotation()` when there are frozen virtual orbitals.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
