### PR TITLE
Fix warnings

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1253,7 +1253,7 @@ def scf_helper(name, post_scf=True, **kwargs):
     # Grab a few kwargs
     use_c1 = kwargs.get('use_c1', False)
     scf_molecule = kwargs.get('molecule', core.get_active_molecule())
-    read_orbitals = core.get_option('SCF', 'GUESS') == "READ"
+    read_orbitals = core.get_option('SCF', 'GUESS') is "READ"
     do_timer = kwargs.pop("do_timer", True)
     ref_wfn = kwargs.pop('ref_wfn', None)
     if ref_wfn is not None:

--- a/psi4/driver/qcdb/modelchems.py
+++ b/psi4/driver/qcdb/modelchems.py
@@ -145,7 +145,7 @@ class BasisSet(QCEssential):
         text += """  DOI:                  %s\n""" % (self.doi)
         text += """  Literature citations:\n"""
         for rol, cit in self.citations.items():
-            text += """    %17s: %s\n""" (rol, cit.doi)
+            text += """    %17s: %s\n""" % (rol, cit.doi)
         text += """  Comment:              %s\n""" % (self.comment)
         text += """\n"""
         return text
@@ -167,7 +167,7 @@ class Method(QCEssential):
         text += """  DOI:                  %s\n""" % (self.doi)
         text += """  Literature citations:\n"""
         for rol, cit in self.citations.items():
-            text += """    %17s: %s\n""" (rol, cit.doi)
+            text += """    %17s: %s\n""" % (rol, cit.doi)
         text += """  Comment:              %s\n""" % (self.comment)
         text += """\n"""
         return text
@@ -189,7 +189,7 @@ class Error(QCEssential):
         text += """  DOI:                  %s\n""" % (self.doi)
         text += """  Literature citations:\n"""
         for rol, cit in self.citations.items():
-            text += """    %17s: %s\n""" (rol, cit.doi)
+            text += """    %17s: %s\n""" % (rol, cit.doi)
         text += """  Comment:              %s\n""" % (self.comment)
         text += """\n"""
         return text

--- a/psi4/driver/qcdb/modelchems.py
+++ b/psi4/driver/qcdb/modelchems.py
@@ -92,7 +92,7 @@ class QCEssential(object):
         text += """  DOI:                  %s\n""" % (self.doi)
         text += """  Literature citations:\n"""
         for rol, cit in self.citations.items():
-            text += """    %17s: %s\n""" (rol, cit.doi)
+            text += """    %17s: %s\n""" % (rol, cit.doi)
         text += """  Comment:              %s\n""" % (self.comment)
         text += """\n"""
         return text


### PR DESCRIPTION
## Description
On Python 3.8.2, I was getting the following warnings
```
/usr/lib/psi4/driver/qcdb/modelchems.py:95: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  text += """    %17s: %s\n""" (rol, cit.doi)
/usr/lib/psi4/driver/qcdb/modelchems.py:148: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  text += """    %17s: %s\n""" (rol, cit.doi)
/usr/lib/psi4/driver/qcdb/modelchems.py:170: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  text += """    %17s: %s\n""" (rol, cit.doi)
/usr/lib/psi4/driver/qcdb/modelchems.py:192: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  text += """    %17s: %s\n""" (rol, cit.doi)
/usr/lib/psi4/driver/procrouting/proc.py:1249: SyntaxWarning: "is" with a literal. Did you mean "=="?
  read_orbitals = core.get_option('SCF', 'GUESS') is "READ"
```
after running something like 
```
#! Sample HF/cc-pVDZ H2O Computation
import psi4
psi4.set_memory('500 MB')

h2o = psi4.geometry("""
O
H 1 0.96
H 1 0.96 2 104.5
""")

psi4.energy('scf/cc-pvdz')
```

It looked like two simple fixes. The string formatting was missing a `%` and the comparison could be replaced by `==`.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Fewer warnings.

## Questions
- [ ] Does this need a test?

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
