### PR TITLE
Overlap Half-derivative Integrals

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1055,32 +1055,37 @@ void export_mints(py::module& m) {
 
         // First and second derivatives of one and two electron integrals in AO and MO basis.
         .def("ao_oei_deriv1", &MintsHelper::ao_oei_deriv1,
-             "Gradient of AO basis OEI integrals: returns (3 * natoms) matrices")
+             "Gradient of AO basis OEI integrals: returns (3 * natoms) matrices", "oei_type"_a, "atom"_a)
         .def("ao_oei_deriv2", &MintsHelper::ao_oei_deriv2,
-             "Hessian  of AO basis OEI integrals: returns (3 * natoms)^2 matrices")
+             "Hessian  of AO basis OEI integrals: returns (3 * natoms)^2 matrices", "oei_type"_a, "atom1"_a, "atom2"_a)
         .def("ao_overlap_half_deriv1", &MintsHelper::ao_overlap_half_deriv1,
-             "Half-derivative of AO basis overlap integrals: returns (3 * natoms) matrices")
+             "Half-derivative of AO basis overlap integrals: returns (3 * natoms) matrices","side"_a, "atom"_a)
         .def("ao_tei_deriv1", &MintsHelper::ao_tei_deriv1,
-             "Gradient of AO basis TEI integrals: returns (3 * natoms) matrices", "atom"_a, "omega"_a = 0.0,
-             "factory"_a = nullptr)
+             "Gradient of AO basis TEI integrals: returns (3 * natoms) matrices",
+             "atom"_a, "omega"_a = 0.0, "factory"_a = nullptr)
         .def("ao_tei_deriv2", &MintsHelper::ao_tei_deriv2,
-             "Hessian  of AO basis TEI integrals: returns (3 * natoms)^2 matrices")
+             "Hessian  of AO basis TEI integrals: returns (3 * natoms)^2 matrices", "atom1"_a, "atom2"_a)
         .def("mo_oei_deriv1", &MintsHelper::mo_oei_deriv1,
-             "Gradient of MO basis OEI integrals: returns (3 * natoms) matrices")
+             "Gradient of MO basis OEI integrals: returns (3 * natoms) matrices",
+             "oei_type"_a, "atom"_a, "C1"_a, "C2"_a)
         .def("mo_oei_deriv2", &MintsHelper::mo_oei_deriv2,
-             "Hessian  of MO basis OEI integrals: returns (3 * natoms)^2 matrices")
+             "Hessian  of MO basis OEI integrals: returns (3 * natoms)^2 matrices",
+             "oei_type"_a, "atom1"_a, "atom2"_a, "C1"_a, "C2"_a)
         .def("mo_overlap_half_deriv1", &MintsHelper::mo_overlap_half_deriv1,
-             "Half-derivative of MO basis overlap integrals: returns (3 * natoms) matrices")
+             "Half-derivative of MO basis overlap integrals: returns (3 * natoms) matrices",
+             "side"_a, "atom"_a, "C1"_a, "C2"_a)
         .def("mo_tei_deriv1", &MintsHelper::mo_tei_deriv1,
-             "Gradient of MO basis TEI integrals: returns (3 * natoms) matrices")
+             "Gradient of MO basis TEI integrals: returns (3 * natoms) matrices",
+             "atom"_a, "C1"_a, "C2"_a, "C3"_a, "C4"_a)
         .def("mo_tei_deriv2", &MintsHelper::mo_tei_deriv2,
-             "Hessian  of MO basis TEI integrals: returns (3 * natoms)^2 matrices")
+             "Hessian  of MO basis TEI integrals: returns (3 * natoms)^2 matrices",
+             "atom1"_a, "atom2"_a, "C1"_a, "C2"_a, "C3"_a, "C4"_a)
         
         // First derivatives of electric dipole integrals in AO and MO basis.
         .def("ao_elec_dip_deriv1", &MintsHelper::ao_elec_dip_deriv1,
-             "Gradient of AO basis electric dipole integrals: returns (3 * natoms) matrices")
+             "Gradient of AO basis electric dipole integrals: returns (3 * natoms) matrices", "atom"_a)
         .def("mo_elec_dip_deriv1", &MintsHelper::mo_elec_dip_deriv1,
-             "Gradient of MO basis electric dipole integrals: returns (3 * natoms) matrices");
+             "Gradient of MO basis electric dipole integrals: returns (3 * natoms) matrices", "atom"_a, "C1"_a, "C2"_a);
 
     py::class_<Vector3>(m, "Vector3",
                         "Class for vectors of length three, often Cartesian coordinate vectors, "

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1058,6 +1058,8 @@ void export_mints(py::module& m) {
              "Gradient of AO basis OEI integrals: returns (3 * natoms) matrices")
         .def("ao_oei_deriv2", &MintsHelper::ao_oei_deriv2,
              "Hessian  of AO basis OEI integrals: returns (3 * natoms)^2 matrices")
+        .def("ao_overlap_half_deriv1", &MintsHelper::ao_overlap_half_deriv1,
+             "Half-derivative of AO basis overlap integrals: returns (3 * natoms) matrices")
         .def("ao_tei_deriv1", &MintsHelper::ao_tei_deriv1,
              "Gradient of AO basis TEI integrals: returns (3 * natoms) matrices", "atom"_a, "omega"_a = 0.0,
              "factory"_a = nullptr)
@@ -1067,6 +1069,8 @@ void export_mints(py::module& m) {
              "Gradient of MO basis OEI integrals: returns (3 * natoms) matrices")
         .def("mo_oei_deriv2", &MintsHelper::mo_oei_deriv2,
              "Hessian  of MO basis OEI integrals: returns (3 * natoms)^2 matrices")
+        .def("mo_overlap_half_deriv1", &MintsHelper::mo_overlap_half_deriv1,
+             "Half-derivative of MO basis overlap integrals: returns (3 * natoms) matrices")
         .def("mo_tei_deriv1", &MintsHelper::mo_tei_deriv1,
              "Gradient of MO basis TEI integrals: returns (3 * natoms) matrices")
         .def("mo_tei_deriv2", &MintsHelper::mo_tei_deriv2,

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -3275,7 +3275,7 @@ std::vector<SharedMatrix> MintsHelper::ao_oei_deriv1(const std::string &oei_type
 std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1(const std::string &half_der_side, int atom) {
     std::vector<SharedMatrix> ao_grad;
 
-    if (half_der_side == "LEFT" || half_der_side == "RIGHT") {
+    if (half_der_side == "LEFT" || half_der_side == "RIGHT")
         ao_grad = ao_overlap_half_deriv1_helper(half_der_side, atom);
     else
         throw PSIEXCEPTION("Not a valid choice of half derivative side: must be LEFT or RIGHT");

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -3390,7 +3390,7 @@ std::vector<SharedMatrix> MintsHelper::mo_overlap_half_deriv1(int atom, SharedMa
     cartcomp.push_back("Z");
 
     std::vector<SharedMatrix> ao_grad;
-    ao_grad = ao_overlap_half_deriv1(oei_type, atom);
+    ao_grad = ao_overlap_half_deriv1(atom);
 
     // Assuming C1 symmetry
     int nbf1 = ao_grad[0]->rowdim();

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2429,7 +2429,8 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1_helper(const std::
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_potential_deriv2_helper(int atom1, int atom2) {
-    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
+    /* NOTE: the x, y, and z in this vector must remain lowercase for this function */
+    std::array<std::string, 3> cartcomp{ {"x", "y", "z"} };
 
     std::shared_ptr<OneBodyAOInt> Vint(integral_->ao_potential(2));
 
@@ -2972,7 +2973,8 @@ std::vector<SharedMatrix> MintsHelper::ao_tei_deriv1(int atom, double omega,
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_tei_deriv2(int atom1, int atom2) {
-    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
+    /* NOTE: the x, y, and z in this vector must remain lowercase for this function */
+    std::array<std::string, 3> cartcomp{ {"x", "y", "z"} };
 
     int nthreads = 1;
 #ifdef _OPENMP

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2179,10 +2179,7 @@ void MintsHelper::play() {}
 /* 1st and 2nd derivatives of OEI in AO basis  */
 
 std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv1_helper(const std::string &type, int atom) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> GInt;
 
@@ -2204,7 +2201,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv1_helper(const st
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "ao_" << type << "_deriv1_" << atom << cartcomp[p];
-        grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+        grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
     }
 
     const double *buffer = GInt->buffer();
@@ -2287,10 +2284,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv1_helper(const st
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_potential_deriv1_helper(int atom) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> Vint(integral_->ao_potential(1));
 
@@ -2306,7 +2300,7 @@ std::vector<SharedMatrix> MintsHelper::ao_potential_deriv1_helper(int atom) {
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "ao_potential_deriv1_" << atom << cartcomp[p];
-        grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+        grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
     }
 
     const double *buffer = Vint->buffer();
@@ -2338,10 +2332,7 @@ std::vector<SharedMatrix> MintsHelper::ao_potential_deriv1_helper(int atom) {
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1_helper(const std::string &half_der_side, int atom) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> GInt(integral_->ao_overlap(1));
 
@@ -2355,7 +2346,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1_helper(const std::
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "ao_overlap_half_deriv1_" << atom << cartcomp[p];
-        grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+        grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
     }
 
     const double *buffer = GInt->buffer();
@@ -2438,10 +2429,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1_helper(const std::
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_potential_deriv2_helper(int atom1, int atom2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("x");
-    cartcomp.push_back("y");
-    cartcomp.push_back("z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> Vint(integral_->ao_potential(2));
 
@@ -2457,7 +2445,7 @@ std::vector<SharedMatrix> MintsHelper::ao_potential_deriv2_helper(int atom1, int
         for (int b = 0; b < 3; b++, ab++) {
             std::stringstream sstream;
             sstream << "ao_potential_deriv2_" << atom1 << atom2 << cartcomp[a] << cartcomp[b];
-            grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+            grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
             grad[ab]->zero();
         }
 
@@ -2672,10 +2660,7 @@ std::vector<SharedMatrix> MintsHelper::ao_potential_deriv2_helper(int atom1, int
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv2_helper(const std::string &type, int atom1, int atom2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> GInt;
 
@@ -2698,7 +2683,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv2_helper(const st
         for (int q = 0; q < 3; q++) {
             std::stringstream sstream;
             sstream << "ao_" << type << "_deriv2_" << atom1 << atom2 << cartcomp[p] << cartcomp[q];
-            grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+            grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
         }
 
     const double *buffer = GInt->buffer();
@@ -2784,7 +2769,7 @@ std::vector<SharedMatrix> MintsHelper::ao_overlap_kinetic_deriv2_helper(const st
 
 /* 1st derivatives of electric dipole integrals in the AO basis */
 std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1_helper(int atom) {
-    std::vector<std::string> cartcomp{ "X", "Y", "Z" };
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<OneBodyAOInt> Dint(integral_->ao_dipole(1));
 
@@ -2800,7 +2785,7 @@ std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1_helper(int atom) {
         sstream << "ao_mu" << cartcomp[p] << "_deriv1_";
         for (int q = 0; q < 3; q++) {
             sstream << atom << cartcomp[q];
-            grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1, nbf2)));
+            grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
         }
     }
 
@@ -2841,10 +2826,7 @@ std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1_helper(int atom) {
 
 std::vector<SharedMatrix> MintsHelper::ao_tei_deriv1(int atom, double omega,
                                                      std::shared_ptr<IntegralFactory> input_factory) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::shared_ptr<IntegralFactory> factory;
     if (input_factory) {
@@ -2876,7 +2858,7 @@ std::vector<SharedMatrix> MintsHelper::ao_tei_deriv1(int atom, double omega,
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "ao_tei_deriv1_" << atom << cartcomp[p];
-        grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1 * nbf2, nbf3 * nbf4)));
+        grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1 * nbf2, nbf3 * nbf4));
     }
 
     const double *buffer = ints->buffer();
@@ -2990,10 +2972,7 @@ std::vector<SharedMatrix> MintsHelper::ao_tei_deriv1(int atom, double omega,
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_tei_deriv2(int atom1, int atom2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("x");
-    cartcomp.push_back("y");
-    cartcomp.push_back("z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     int nthreads = 1;
 #ifdef _OPENMP
@@ -3018,7 +2997,7 @@ std::vector<SharedMatrix> MintsHelper::ao_tei_deriv2(int atom1, int atom2) {
         for (int q = 0; q < 3; q++) {
             std::stringstream sstream;
             sstream << "ao_tei_deriv2_" << atom1 << atom2 << cartcomp[p] << cartcomp[q];
-            grad.push_back(SharedMatrix(new Matrix(sstream.str(), nbf1 * nbf2, nbf3 * nbf4)));
+            grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1 * nbf2, nbf3 * nbf4));
         }
 
     std::vector<std::vector<int>> shell_quartets;
@@ -3296,10 +3275,8 @@ std::vector<SharedMatrix> MintsHelper::ao_oei_deriv1(const std::string &oei_type
 std::vector<SharedMatrix> MintsHelper::ao_overlap_half_deriv1(const std::string &half_der_side, int atom) {
     std::vector<SharedMatrix> ao_grad;
 
-    if (half_der_side == "LEFT")
-        ao_grad = ao_overlap_half_deriv1_helper("LEFT", atom);
-    else if (half_der_side == "RIGHT")
-        ao_grad = ao_overlap_half_deriv1_helper("RIGHT", atom);
+    if (half_der_side == "LEFT" || half_der_side == "RIGHT") {
+        ao_grad = ao_overlap_half_deriv1_helper(half_der_side, atom);
     else
         throw PSIEXCEPTION("Not a valid choice of half derivative side: must be LEFT or RIGHT");
 
@@ -3341,10 +3318,7 @@ std::vector<SharedMatrix> MintsHelper::ao_oei_deriv2(const std::string &oei_type
 
 std::vector<SharedMatrix> MintsHelper::mo_oei_deriv1(const std::string &oei_type, int atom, SharedMatrix C1,
                                                      SharedMatrix C2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad;
     ao_grad = ao_oei_deriv1(oei_type, atom);
@@ -3357,7 +3331,7 @@ std::vector<SharedMatrix> MintsHelper::mo_oei_deriv1(const std::string &oei_type
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "mo_" << oei_type << "_deriv1_" << atom << cartcomp[p];
-        SharedMatrix temp(new Matrix(sstream.str(), nbf1, nbf2));
+        auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
         temp->transform(C1, ao_grad[p], C2);
         mo_grad.push_back(temp);
     }
@@ -3366,10 +3340,7 @@ std::vector<SharedMatrix> MintsHelper::mo_oei_deriv1(const std::string &oei_type
 
 std::vector<SharedMatrix> MintsHelper::mo_oei_deriv2(const std::string &oei_type, int atom1, int atom2, SharedMatrix C1,
                                                      SharedMatrix C2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad;
     ao_grad = ao_oei_deriv2(oei_type, atom1, atom2);
@@ -3383,7 +3354,7 @@ std::vector<SharedMatrix> MintsHelper::mo_oei_deriv2(const std::string &oei_type
         for (int q = 0; q < 3; q++, pq++) {
             std::stringstream sstream;
             sstream << "mo_" << oei_type << "_deriv2_" << atom1 << atom2 << cartcomp[p] << cartcomp[q];
-            SharedMatrix temp(new Matrix(sstream.str(), nbf1, nbf2));
+            auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
             temp->transform(C1, ao_grad[pq], C2);
             mo_grad.push_back(temp);
         }
@@ -3391,10 +3362,7 @@ std::vector<SharedMatrix> MintsHelper::mo_oei_deriv2(const std::string &oei_type
 }
 
 std::vector<SharedMatrix> MintsHelper::mo_overlap_half_deriv1(const std::string &half_der_side, int atom, SharedMatrix C1, SharedMatrix C2) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad;
     ao_grad = ao_overlap_half_deriv1(half_der_side, atom);
@@ -3407,7 +3375,7 @@ std::vector<SharedMatrix> MintsHelper::mo_overlap_half_deriv1(const std::string 
     for (int p = 0; p < 3; p++) {
         std::stringstream sstream;
         sstream << "mo_overlap_half_deriv1_" << atom << cartcomp[p];
-        SharedMatrix temp(new Matrix(sstream.str(), nbf1, nbf2));
+        auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
         temp->transform(C1, ao_grad[p], C2);
         mo_grad.push_back(temp);
     }
@@ -3423,7 +3391,7 @@ std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1(int atom) {
 }
 
 std::vector<SharedMatrix> MintsHelper::mo_elec_dip_deriv1(int atom, SharedMatrix C1, SharedMatrix C2) {
-    std::vector<std::string> cartcomp{ "X", "Y", "Z" };
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad = ao_elec_dip_deriv1(atom);
 
@@ -3435,7 +3403,7 @@ std::vector<SharedMatrix> MintsHelper::mo_elec_dip_deriv1(int atom, SharedMatrix
     for (int p = 0; p < 9; p++) {
         std::stringstream sstream;
         sstream << "mo_elec_dip_deriv1_" << atom << cartcomp[p];
-        SharedMatrix temp(new Matrix(sstream.str(), nbf1, nbf2));
+        auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
         temp->transform(C1, ao_grad[p], C2);
         mo_grad.push_back(temp);
     }
@@ -3447,10 +3415,7 @@ std::vector<SharedMatrix> MintsHelper::mo_elec_dip_deriv1(int atom, SharedMatrix
 
 std::vector<SharedMatrix> MintsHelper::mo_tei_deriv1(int atom, SharedMatrix C1, SharedMatrix C2, SharedMatrix C3,
                                                      SharedMatrix C4) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad = ao_tei_deriv1(atom);
 
@@ -3467,10 +3432,7 @@ std::vector<SharedMatrix> MintsHelper::mo_tei_deriv1(int atom, SharedMatrix C1, 
 
 std::vector<SharedMatrix> MintsHelper::mo_tei_deriv2(int atom1, int atom2, SharedMatrix C1, SharedMatrix C2,
                                                      SharedMatrix C3, SharedMatrix C4) {
-    std::vector<std::string> cartcomp;
-    cartcomp.push_back("X");
-    cartcomp.push_back("Y");
-    cartcomp.push_back("Z");
+    std::array<std::string, 3> cartcomp{ {"X", "Y", "Z"} };
 
     std::vector<SharedMatrix> ao_grad = ao_tei_deriv2(atom1, atom2);
     std::vector<SharedMatrix> mo_grad;

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -176,12 +176,15 @@ class PSI_API MintsHelper {
 
     // Derivatives of OEI in AO and MO basis
     std::vector<SharedMatrix> ao_oei_deriv1(const std::string& oei_type, int atom);
+    std::vector<SharedMatrix> ao_overlap_half_deriv1(int atom);
     std::vector<SharedMatrix> ao_oei_deriv2(const std::string& oei_type, int atom1, int atom2);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv1_helper(const std::string& type, int atom);
+    std::vector<SharedMatrix> ao_overlap_half_deriv1_helper(int atom);
     std::vector<SharedMatrix> ao_potential_deriv1_helper(int atom);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv2_helper(const std::string& type, int atom1, int atom2);
     std::vector<SharedMatrix> ao_potential_deriv2_helper(int atom1, int atom2);
     std::vector<SharedMatrix> mo_oei_deriv1(const std::string& oei_type, int atom, SharedMatrix C1, SharedMatrix C2);
+    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
     std::vector<SharedMatrix> mo_oei_deriv2(const std::string& oei_type, int atom1, int atom2, SharedMatrix C1,
                                             SharedMatrix C2);
     // Derivatives of electric dipole moment integrals in AO and MO basis

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -177,16 +177,17 @@ class PSI_API MintsHelper {
     // Derivatives of OEI in AO and MO basis
     std::vector<SharedMatrix> ao_oei_deriv1(const std::string& oei_type, int atom);
     std::vector<SharedMatrix> ao_oei_deriv2(const std::string& oei_type, int atom1, int atom2);
-    std::vector<SharedMatrix> ao_overlap_half_deriv1(int atom);
+    std::vector<SharedMatrix> ao_overlap_half_deriv1(const std::string& half_der_side, int atom);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv1_helper(const std::string& type, int atom);
-    std::vector<SharedMatrix> ao_overlap_half_deriv1_helper(int atom);
+    std::vector<SharedMatrix> ao_overlap_half_deriv1_helper(const std::string& half_der_side, int atom);
     std::vector<SharedMatrix> ao_potential_deriv1_helper(int atom);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv2_helper(const std::string& type, int atom1, int atom2);
     std::vector<SharedMatrix> ao_potential_deriv2_helper(int atom1, int atom2);
     std::vector<SharedMatrix> mo_oei_deriv1(const std::string& oei_type, int atom, SharedMatrix C1, SharedMatrix C2);
     std::vector<SharedMatrix> mo_oei_deriv2(const std::string& oei_type, int atom1, int atom2, SharedMatrix C1,
                                             SharedMatrix C2);
-    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
+    std::vector<SharedMatrix> mo_overlap_half_deriv1(const std::string& half_der_side, int atom, SharedMatrix C1, 
+                                                     SharedMatrix C2);
 
     // Derivatives of electric dipole moment integrals in AO and MO basis
     std::vector<SharedMatrix> ao_elec_dip_deriv1(int atom);

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -185,8 +185,9 @@ class PSI_API MintsHelper {
     std::vector<SharedMatrix> ao_potential_deriv2_helper(int atom1, int atom2);
     std::vector<SharedMatrix> mo_oei_deriv1(const std::string& oei_type, int atom, SharedMatrix C1, SharedMatrix C2);
     std::vector<SharedMatrix> mo_oei_deriv2(const std::string& oei_type, int atom1, int atom2, SharedMatrix C1,
-    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
                                             SharedMatrix C2);
+    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
+
     // Derivatives of electric dipole moment integrals in AO and MO basis
     std::vector<SharedMatrix> ao_elec_dip_deriv1(int atom);
     std::vector<SharedMatrix> ao_elec_dip_deriv1_helper(int atom);

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -176,16 +176,16 @@ class PSI_API MintsHelper {
 
     // Derivatives of OEI in AO and MO basis
     std::vector<SharedMatrix> ao_oei_deriv1(const std::string& oei_type, int atom);
-    std::vector<SharedMatrix> ao_overlap_half_deriv1(int atom);
     std::vector<SharedMatrix> ao_oei_deriv2(const std::string& oei_type, int atom1, int atom2);
+    std::vector<SharedMatrix> ao_overlap_half_deriv1(int atom);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv1_helper(const std::string& type, int atom);
     std::vector<SharedMatrix> ao_overlap_half_deriv1_helper(int atom);
     std::vector<SharedMatrix> ao_potential_deriv1_helper(int atom);
     std::vector<SharedMatrix> ao_overlap_kinetic_deriv2_helper(const std::string& type, int atom1, int atom2);
     std::vector<SharedMatrix> ao_potential_deriv2_helper(int atom1, int atom2);
     std::vector<SharedMatrix> mo_oei_deriv1(const std::string& oei_type, int atom, SharedMatrix C1, SharedMatrix C2);
-    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
     std::vector<SharedMatrix> mo_oei_deriv2(const std::string& oei_type, int atom1, int atom2, SharedMatrix C1,
+    std::vector<SharedMatrix> mo_overlap_half_deriv1(int atom, SharedMatrix C1, SharedMatrix C2);
                                             SharedMatrix C2);
     // Derivatives of electric dipole moment integrals in AO and MO basis
     std::vector<SharedMatrix> ao_elec_dip_deriv1(int atom);

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -43,3 +43,38 @@ def test_export_ao_elec_dip_deriv():
     PSI4_MU_Grad = mints.dipole_grad(D)
     G_python_MU_mat = psi4.core.Matrix.from_array(MU_Gradient)
     assert psi4.compare_matrices(PSI4_MU_Grad, G_python_MU_mat, 10, "DIPOLE_GRADIENT_TEST")  # TEST
+
+def test_export_ao_overlap_half_deriv():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+
+    psi4.core.set_active_molecule(h2o)
+    psi4.set_options({'basis': 'STO-3G'})
+
+    rhf_e, wfn = psi4.energy('SCF', return_wfn=True)
+    C = wfn.Ca_subset("AO", "ALL")
+
+    mints = psi4.core.MintsHelper(wfn.basisset())
+
+    natoms = h2o.natom()
+    cart = ['_X', '_Y', '_Z']
+
+    deriv1_mat = {}
+    deriv1_np = {}
+
+    # Get overlap derivative and half-derivative integrals
+    for atom in range(natoms):
+        deriv1_mat["S_HALF_" + str(atom)] = mints.mo_overlap_half_deriv1(atom, C, C)
+        deriv1_mat["S_" + str(atom)] = mints.mo_oei_deriv1("OVERLAP", atom, C, C)
+        for atom_cart in range(3):
+            map_key1 = "S_HALF_" + str(atom) + cart[atom_cart]
+            map_key2 = "S_" + str(atom) + cart[atom_cart]
+            deriv1_np[map_key1] = np.asarray(deriv1_mat["S_HALF_" + str(atom)][atom_cart])
+            deriv1_np[map_key2] = np.asarray(deriv1_mat["S_" + str(atom)][atom_cart])
+
+            # Test the half-derivative integrals to make sure that (S_ii)^x = 2 * < i^x | i >
+            assert np.allclose(deriv1_np[map_key1].diagonal(), (deriv1_np[map_key2].diagonal())/2)

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -4,6 +4,7 @@ import numpy as np
 import psi4
 
 from .utils import compare_values
+from .utils import compare_arrays
 
 def test_export_ao_elec_dip_deriv():
     h2o = psi4.geometry("""
@@ -77,19 +78,13 @@ def test_export_ao_overlap_half_deriv():
             deriv1_np[map_key3] = np.asarray(deriv1_mat["S_" + str(atom)][atom_cart])
 
             # Test (S_ii)^x = 2 * < i^x | i >
-            assert np.allclose(deriv1_np[map_key1].diagonal(), (deriv1_np[map_key3].diagonal())/2)
+            assert compare_arrays(deriv1_np[map_key1].diagonal(), deriv1_np[map_key3].diagonal()/2)
 
             # Test (S_ii)^x = 2 * < i | i^x >
-            assert np.allclose(deriv1_np[map_key2].diagonal(), (deriv1_np[map_key3].diagonal())/2)
+            assert compare_arrays(deriv1_np[map_key2].diagonal(), deriv1_np[map_key3].diagonal()/2)
 
             # Test (S_ij)^x = < i^x | j > + < j^x | i >
-            r, c = deriv1_np[map_key1].shape
-            for i in range(r):
-                for j in range(c):
-                    assert np.allclose(deriv1_np[map_key1][i][j] + deriv1_np[map_key1][j][i], deriv1_np[map_key3][i][j])
+            assert compare_arrays(deriv1_np[map_key1] + deriv1_np[map_key1].transpose(), deriv1_np[map_key3])
 
             # Test (S_ij)^x = < i^x | j > + < i | j^x >
-            r, c = deriv1_np[map_key1].shape
-            for i in range(r):
-                for j in range(c):
-                    assert np.allclose(deriv1_np[map_key1][i][j] + deriv1_np[map_key2][i][j], deriv1_np[map_key3][i][j])
+            assert compare_arrays(deriv1_np[map_key1] + deriv1_np[map_key2], deriv1_np[map_key3])

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -13,10 +13,7 @@ def test_export_ao_elec_dip_deriv():
         symmetry c1
     """)
 
-    psi4.core.set_active_molecule(h2o)
-    psi4.set_options({'basis': 'cc-pVDZ'})
-
-    rhf_e, wfn = psi4.energy('SCF', return_wfn=True)
+    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
 
     mints = psi4.core.MintsHelper(wfn.basisset())
 
@@ -52,7 +49,7 @@ def test_export_ao_overlap_half_deriv():
         symmetry c1
     """)
 
-    rhf_e, wfn = psi4.energy('SCF/STO-3G', molecule=h2o, return_wfn=True)
+    rhf_e, wfn = psi4.energy('SCF/cc-PVDZ', molecule=h2o, return_wfn=True)
     C = wfn.Ca_subset("AO", "ALL")
 
     mints = psi4.core.MintsHelper(wfn.basisset())

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -52,10 +52,7 @@ def test_export_ao_overlap_half_deriv():
         symmetry c1
     """)
 
-    psi4.core.set_active_molecule(h2o)
-    psi4.set_options({'basis': 'STO-3G'})
-
-    rhf_e, wfn = psi4.energy('SCF', return_wfn=True)
+    rhf_e, wfn = psi4.energy('SCF/STO-3G', molecule=h2o, return_wfn=True)
     C = wfn.Ca_subset("AO", "ALL")
 
     mints = psi4.core.MintsHelper(wfn.basisset())

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -3,7 +3,6 @@ import pytest
 import numpy as np
 import psi4
 
-from .utils import compare_values
 from .utils import compare_arrays
 
 def test_export_ao_elec_dip_deriv():


### PR DESCRIPTION
## Description
Adds capabilities for overlap half-derivative integrals and exports them to Python side for use in calculating VCD

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Adds `.def("ao_overlap_half_deriv1")` and `.def("mo_overlap_half_deriv1")` binding to `psi4/src/export_mints.cc`
- [x] Adds `ao_overlap_half_deriv1()` and `mo_overlap_half_deriv1()` definition/declaration to `psi4/src/psi4/libmints/mintshelper.cc(h)`
- [x] Adds `ao_overlap_half_deriv1_helper()` helper function to `psi4/src/psi4/libmints/mintshelper.cc(h)`

## Questions
- None

## Checklist
- [x] Add test in `/tests/pytests/test_mints.py`
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
