### PR TITLE
accommodate mkl 2020.1 and cholesky-basis, take 5

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -7,6 +7,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
     CTEST_OUTPUT_ON_FAILURE: 1
+    MKL_CBWR: AUTO
   strategy:
     maxParallel: 8
     matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ option_with_print(ENABLE_OPENMP "Enables OpenMP parallelization" ON)
 option_with_print(ENABLE_AUTO_BLAS "Enables CMake to auto-detect BLAS" ON)
 option_with_print(ENABLE_AUTO_LAPACK "Enables CMake to auto-detect LAPACK" ON)
 option_with_print(ENABLE_PLUGIN_TESTING "Test the plugin templates build and run" OFF)
-option_with_print(ENABLE_CYTHONIZE "Compile each python file rather than plaintext" OFF)
+option_with_print(ENABLE_CYTHONIZE "Compile each python file rather than plaintext (requires cython) !experimental!" OFF)
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
                   "-xHost" "-march=native" "/arch:AVX2")
 option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF

--- a/tests/scf-cholesky-basis/input.dat
+++ b/tests/scf-cholesky-basis/input.dat
@@ -15,16 +15,16 @@ e_canonical   = -230.64152543331906
 # indices. Since there's no guarantee that the same functions get
 # picked every time, we need to allow for changes in the energy that
 # go to zero when the tolerance is tightened.
-# MKL 2020.1 seems to often pick different fns, so need to relax the tolerance from 1.e-8 to 2.e-8
+# MKL 2020.1 can use alternate code path, necessitating relaxing the tolerance from 1.e-8 to 2.e-8, incl. canonical
 
 tol_4 = 3
 tol_5 = 4
 tol_6 = 5
-tol_7 = 2.e-8
-tol_8 = 2.e-8
-tol_9 = 2.e-8
-tol_10 = 2.e-8
-tol_11 = 2.e-8
+tol_7 = 8
+tol_8 = 8
+tol_9 = 8
+tol_10 = 8
+tol_11 = 8
 tol_can = 8
 
 molecule {

--- a/tests/scf-cholesky-basis/input.dat
+++ b/tests/scf-cholesky-basis/input.dat
@@ -15,6 +15,7 @@ e_canonical   = -230.64152543331906
 # indices. Since there's no guarantee that the same functions get
 # picked every time, we need to allow for changes in the energy that
 # go to zero when the tolerance is tightened.
+# MKL 2020.1 seems to often pick different fns, so need to relax the tolerance from 1.e-8 to 2.e-8
 
 tol_4 = 3
 tol_5 = 4
@@ -22,8 +23,8 @@ tol_6 = 5
 tol_7 = 2.e-8
 tol_8 = 2.e-8
 tol_9 = 2.e-8
-tol_10 = 8
-tol_11 = 8
+tol_10 = 2.e-8
+tol_11 = 2.e-8
 tol_can = 8
 
 molecule {


### PR DESCRIPTION
## Description
MKL 2020.1 often selects a different basis fn set than 2019.4 or 2020.0, so answers often differ by 1.14e-8. This relaxes tolerance to 2.e-8. Alternative is to add `mkl!=2020.1` to `conda create` line, but this would be disruptive to conda packaging.

* **Note** A definitive test of above statement that returns to 1.e-8 but bans 2020.1 is running at https://dev.azure.com/psi4/psi4/_build/results?buildId=1969&view=logs&j=96451287-da82-57a8-2c11-8da7db9ab71a , but I'll get a head start and submit this PR.

## Status
- [x] Ready for review
- [x] Ready for merge
