### PR TITLE
More TDMs from DETCI

### DIFF
--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -476,12 +476,31 @@ std::vector<std::vector<SharedMatrix> > CIWavefunction::opdm(SharedCIVector Ivec
             offset += CalcInfo_->ci_orbs[h];
         }
 
-        std::vector<SharedMatrix> opdm_root_vec;
-        opdm_root_vec.push_back(new_OPDM_a);
-        opdm_root_vec.push_back(new_OPDM_b);
-        opdm_root_vec.push_back(new_OPDM);
+        std::vector<SharedMatrix> opdm_root_vec = {new_OPDM_a, new_OPDM_b, new_OPDM};
 
         opdm_list.push_back(opdm_root_vec);
+
+        // Now for the other order.
+        if (Iroot != Jroot) {
+            auto alpha_transpose = new_OPDM_a->transpose();
+            opdm_name.str(std::string());
+            opdm_name << "MO-basis Alpha OPDM <" << Jroot << "| Etu |" << Iroot << ">";
+            alpha_transpose->set_name(opdm_name.str());
+
+            auto beta_transpose = new_OPDM_b->transpose();
+            opdm_name.str(std::string());
+            opdm_name << "MO-basis Beta OPDM <" << Jroot << "| Etu |" << Iroot << ">";
+            beta_transpose->set_name(opdm_name.str());
+
+            auto sum_transpose = new_OPDM->transpose();
+            opdm_name.str(std::string());
+            opdm_name << "MO-basis OPDM <" << Jroot << "| Etu |" << Iroot << ">";
+            sum_transpose->set_name(opdm_name.str());
+
+            opdm_root_vec = {alpha_transpose, beta_transpose, sum_transpose};
+            opdm_list.push_back(opdm_root_vec);
+        }
+
 
     } /* end loop over states_vec */
 

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -112,14 +112,16 @@ void CIWavefunction::form_opdm() {
     // Transition-OPDM's
     if (Parameters_->transdens) {
         states_vec.clear();
-        for (int i = 0; i < Parameters_->num_roots - 1; ++i) {
-            states_vec.push_back(std::make_tuple(0, i + 1));
+        for (int i = 0; i < Parameters_->num_roots; ++i) {
+            for (int j = i + 1; j < Parameters_->num_roots; ++j) {
+                states_vec.push_back(std::make_tuple(i, j));
+            }
         }
         opdm_list = opdm(Ivec, Jvec, states_vec);
-        for (int i = 0; i < Parameters_->num_roots - 1; i++) {
-            opdm_map_[opdm_list[i][0]->name()] = opdm_list[i][0];
-            opdm_map_[opdm_list[i][1]->name()] = opdm_list[i][1];
-            opdm_map_[opdm_list[i][2]->name()] = opdm_list[i][2];
+        for (const auto& tdm : opdm_list) {
+            opdm_map_[tdm[0]->name()] = tdm[0];
+            opdm_map_[tdm[1]->name()] = tdm[1];
+            opdm_map_[tdm[2]->name()] = tdm[2];
         }
     }
 

--- a/tests/pytests/test_detci_opdm.py
+++ b/tests/pytests/test_detci_opdm.py
@@ -1,0 +1,50 @@
+import pytest
+import psi4
+import numpy as np
+
+def test_pdms():
+    h2o = psi4.geometry("""
+        H
+        H 1 0.7
+    """)
+
+    psi4.set_options({"opdm": True, "num_roots": 3})
+    wfn = psi4.energy("fci/cc-pvdz", return_wfn=True)[1]
+    # Okay, I need three matrix comparisons...
+
+    ref_opdm = psi4.core.Matrix.from_array([np.array([[ 9.84317436e-01,  4.69564137e-03,  3.68310242e-03],
+        [ 4.69564137e-03,  2.71595295e-03, -8.89586171e-04],
+        [ 3.68310242e-03, -8.89586171e-04,  4.24202798e-04]]),
+        np.zeros((0,0)),
+        np.array([[7.6893825e-05]]),
+        np.array([[7.6893825e-05]]),
+        np.zeros((0,0)),
+        np.array([[0.00416892, 0.00440128, 0.00073837],
+        [0.00440128, 0.00473526, 0.00083457],
+        [0.00073837, 0.00083457, 0.00017527]]),
+        np.array([[0.00165458]]),
+        np.array([[0.00165458]])
+        ])
+
+    # Test OPDM
+    assert psi4.compare_matrices(ref_opdm, wfn.get_opdm(-1, -1, "A", True), 6, "OPDM")
+
+    ref_tdm = psi4.core.Matrix.from_array([np.array([[ 1.11543287e-02,  6.66837005e-02, -9.01185592e-03],
+        [-3.95119873e-02,  2.57584925e-02,  4.69185262e-02],
+        [-1.44471817e-03,  7.47375607e-05,  4.47155049e-04]]),
+        np.zeros((0,0)),
+        np.array([[-1.17823927e-05]]),
+        np.array([[-1.17823927e-05]]),
+        np.zeros((0,0)),
+        np.array([[-0.0436292 , -0.01418167, -0.00124078],
+        [ 0.04298612,  0.00671799,  0.00043999],
+        [ 0.01168194,  0.0019797 ,  0.0001121 ]]),
+        np.array([[-0.00026865]]),
+        np.array([[-0.00026865]])
+        ])
+
+    # Test transition matrix
+    assert psi4.compare_matrices(ref_tdm, wfn.get_opdm(1, 2, "A", True), 6, "TDM")
+    # Test the swapping the bra and the key produces the transpose matrix.
+    assert psi4.compare_matrices(wfn.get_opdm(2, 1, "A", True), wfn.get_opdm(1, 2, "A", True).transpose(), 6, "TDM")
+


### PR DESCRIPTION
## Description
Closes #1890

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] When DETCI computes TDMs, it does so for all excitations to higher roots, not just excitations from the ground state.
- [x] Added OPDM and TPDM tests.

## Questions
- [x] ~~Is it worth adding the i > j case, or is it i < j the standard convention for multistate problems? If so, rather than have these be explicitly constructed, it's probably best to just take the adjoint of the i < j case.~~ Added.
- [x] ~~We currently have zero test coverage of OPDMs from `detci`. We could check that Matrices are equal for a same-state OPDM and a TDM. This is a bit larger than usual for a Matrix comparison, but I think it'll be fine with H2/cc-pVDZ. I assume this would go in pytests?~~ Added.

## Status
- [x] Ready for review
- [x] Ready for merge
