### PR TITLE
LCCD standard suite, misc.

### DIFF
--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${ENABLE_ambit})
         ExternalProject_Add(ambit_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/jturney/ambit/archive/v0.4.tar.gz
+            URL https://github.com/jturney/ambit/archive/v0.4.1.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz
+        URL https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/header.py
+++ b/psi4/header.py
@@ -59,19 +59,26 @@ def print_header():
                          Git: Rev {}
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
 
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
-    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -964,10 +964,10 @@ void export_mints(py::module& m) {
         // One-electron
         .def("ao_overlap", oneelectron(&MintsHelper::ao_overlap), "AO basis overlap integrals")
         .def("ao_overlap", oneelectron_mixed_basis(&MintsHelper::ao_overlap), "AO mixed basis overlap integrals")
-        .def("so_overlap", &MintsHelper::so_overlap, "SO basis overlap integrals")
+        .def("so_overlap", &MintsHelper::so_overlap, "SO basis overlap integrals", "include_perturbations"_a = true)
         .def("ao_kinetic", oneelectron(&MintsHelper::ao_kinetic), "AO basis kinetic integrals")
         .def("ao_kinetic", oneelectron_mixed_basis(&MintsHelper::ao_kinetic), "AO mixed basis kinetic integrals")
-        .def("so_kinetic", &MintsHelper::so_kinetic, "SO basis kinetic integrals")
+        .def("so_kinetic", &MintsHelper::so_kinetic, "SO basis kinetic integrals", "include_perturbations"_a = true)
         .def("ao_potential", oneelectron(&MintsHelper::ao_potential), "AO potential integrals")
         .def("ao_potential", oneelectron_mixed_basis(&MintsHelper::ao_potential), "AO mixed basis potential integrals")
         .def("so_potential", &MintsHelper::so_potential, "SO basis potential integrals",

--- a/psi4/src/psi4/fnocc/coupled_pair.cc
+++ b/psi4/src/psi4/fnocc/coupled_pair.cc
@@ -155,6 +155,8 @@ double CoupledPair::compute_energy() {
     tstop();
 
     // mp2 energy
+    set_scalar_variable("MP2 SINGLES ENERGY", 0.0);  // fnocc RHF only
+    set_scalar_variable("MP2 DOUBLES ENERGY", emp2_os + emp2_ss);
     set_scalar_variable("MP2 CORRELATION ENERGY", emp2);
     set_scalar_variable("MP2 OPPOSITE-SPIN CORRELATION ENERGY", emp2_os);
     set_scalar_variable("MP2 SAME-SPIN CORRELATION ENERGY", emp2_ss);
@@ -164,6 +166,8 @@ double CoupledPair::compute_energy() {
     char *cepatype = (char *)malloc(100 * sizeof(char));
     if (cepa_level == 0) {
         if (options_.get_bool("CEPA_NO_SINGLES")) {
+            set_scalar_variable("LCCD SINGLES ENERGY", 0.0);  // fnocc RHF only
+            set_scalar_variable("LCCD DOUBLES ENERGY", eccsd_os + eccsd_ss);
             set_scalar_variable("LCCD CORRELATION ENERGY", eccsd);
             set_scalar_variable("LCCD OPPOSITE-SPIN CORRELATION ENERGY", eccsd_os);
             set_scalar_variable("LCCD SAME-SPIN CORRELATION ENERGY", eccsd_ss);

--- a/psi4/src/psi4/fnocc/coupled_pair.cc
+++ b/psi4/src/psi4/fnocc/coupled_pair.cc
@@ -173,10 +173,14 @@ double CoupledPair::compute_energy() {
             set_scalar_variable("LCCD SAME-SPIN CORRELATION ENERGY", eccsd_ss);
             set_scalar_variable("LCCD TOTAL ENERGY", eccsd + escf);
         } else {
+            set_scalar_variable("LCCSD SINGLES ENERGY", 0.0);  // fnocc RHF only
+            set_scalar_variable("LCCSD DOUBLES ENERGY", eccsd_os + eccsd_ss);
             set_scalar_variable("LCCSD CORRELATION ENERGY", eccsd);
             set_scalar_variable("LCCSD OPPOSITE-SPIN CORRELATION ENERGY", eccsd_os);
             set_scalar_variable("LCCSD SAME-SPIN CORRELATION ENERGY", eccsd_ss);
             set_scalar_variable("LCCSD TOTAL ENERGY", eccsd + escf);
+            set_scalar_variable("CEPA(0) SINGLES ENERGY", 0.0);  // fnocc RHF only
+            set_scalar_variable("CEPA(0) DOUBLES ENERGY", eccsd_os + eccsd_ss);
             set_scalar_variable("CEPA(0) CORRELATION ENERGY", eccsd);
             set_scalar_variable("CEPA(0) OPPOSITE-SPIN CORRELATION ENERGY", eccsd_os);
             set_scalar_variable("CEPA(0) SAME-SPIN CORRELATION ENERGY", eccsd_ss);

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -615,6 +615,9 @@ void OCCWave::cepa_manager() {
     outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
     outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
     outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+    outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", EcepaAA);
+    outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", EcepaAB);
+    outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", EcepaBB);
     outfile->Printf("\tLCCD Correlation Energy (a.u.)     : %20.14f\n", Ecorr);
     outfile->Printf("\tLCCD Total Energy (a.u.)           : %20.14f\n", Ecepa);
     outfile->Printf("\t============================================================================== \n");
@@ -623,6 +626,11 @@ void OCCWave::cepa_manager() {
     // Set the global variables with the energies
     variables_["LCCD TOTAL ENERGY"] = Ecepa;
     variables_["LCCD CORRELATION ENERGY"] = Ecorr;
+    variables_["LCCD SAME-SPIN CORRELATION ENERGY"] = EcepaAA + EcepaBB;
+    variables_["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = EcepaAB;
+    variables_["LCCD SAME-SPIN CORRELATION ENERGY"] = EcepaAA + EcepaBB;
+    variables_["LCCD SINGLES ENERGY"] = 0.0;  // CEPA is RHF/UHF only
+    variables_["LCCD DOUBLES ENERGY"] = EcepaAB + EcepaAA + EcepaBB;
     variables_["CURRENT REFERENCE ENERGY"] = Eref;
     variables_["CUSTOM SCS-LCCD CORRELATION ENERGY"] = os_scale * EcepaAB + ss_scale * (EcepaAA + EcepaBB);
     variables_["CUSTOM SCS-LCCD TOTAL ENERGY"] = Escf + variables_["CUSTOM SCS-LCCD CORRELATION ENERGY"];
@@ -632,6 +640,7 @@ void OCCWave::cepa_manager() {
                                                          {"NONE", Ecepa}};
     variables_["CURRENT ENERGY"] = spin_scale_energies[spin_scale_type_];
     variables_["CURRENT CORRELATION ENERGY"] = variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
+    energy_ = variables_["CURRENT ENERGY"];
 
     // Compute Analytic Gradients
     if (dertype == "FIRST" || ekt_ip_ == "TRUE" || ekt_ea_ == "TRUE") {

--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -547,6 +547,9 @@ void OCCWave::ocepa_manager() {
         outfile->Printf("\tNuclear Repulsion Energy (a.u.)    : %20.14f\n", Enuc);
         outfile->Printf("\tSCF Energy (a.u.)                  : %20.14f\n", Escf);
         outfile->Printf("\tREF Energy (a.u.)                  : %20.14f\n", Eref);
+        outfile->Printf("\tAlpha-Alpha Contribution (a.u.)    : %20.14f\n", EcepaAA);
+        outfile->Printf("\tAlpha-Beta Contribution (a.u.)     : %20.14f\n", EcepaAB);
+        outfile->Printf("\tBeta-Beta Contribution (a.u.)      : %20.14f\n", EcepaBB);
         outfile->Printf("\tOLCCD Correlation Energy (a.u.)    : %20.14f\n", EcepaL - Escf);
         outfile->Printf("\tEolccd - Eref (a.u.)               : %20.14f\n", EcepaL - Eref);
         outfile->Printf("\tOLCCD Total Energy (a.u.)          : %20.14f\n", EcepaL);
@@ -557,7 +560,10 @@ void OCCWave::ocepa_manager() {
         variables_["OLCCD TOTAL ENERGY"] = EcepaL;
         variables_["CURRENT REFERENCE ENERGY"] = Escf;
 
+        variables_["OLCCD REFERENCE CORRECTION ENERGY"] = Eref - Escf;
         variables_["OLCCD CORRELATION ENERGY"] = EcepaL - Escf;
+        variables_["OLCCD SAME-SPIN CORRELATION ENERGY"] = EcepaAA + EcepaBB;
+        variables_["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = EcepaAB;
 
         variables_["CUSTOM SCS-OLCCD CORRELATION ENERGY"] = os_scale * EcepaAB + ss_scale * (EcepaAA + EcepaBB);
         variables_["CUSTOM SCS-OLCCD TOTAL ENERGY"] = Escf + variables_["CUSTOM SCS-OLCCD CORRELATION ENERGY"];
@@ -567,6 +573,14 @@ void OCCWave::ocepa_manager() {
         variables_["CURRENT ENERGY"] = spin_scale_energies[spin_scale_type_];
         variables_["CURRENT CORRELATION ENERGY"] =
             variables_["CURRENT ENERGY"] - variables_["CURRENT REFERENCE ENERGY"];
+        energy_ = variables_["CURRENT ENERGY"];
+
+        // ordinary ROHF-MP2 not available in course of ROHF-OLCCD
+        if (reference == "ROHF") {
+            del_scalar_variable("MP2 CORRELATION ENERGY");
+            del_scalar_variable("MP2 SINGLES ENERGY");
+            del_scalar_variable("MP2 TOTAL ENERGY");
+        }
 
         if (natorb == "TRUE") nbo();
         if (occ_orb_energy == "TRUE") semi_canonic();
@@ -628,7 +642,6 @@ void OCCWave::cepa_manager() {
     variables_["LCCD CORRELATION ENERGY"] = Ecorr;
     variables_["LCCD SAME-SPIN CORRELATION ENERGY"] = EcepaAA + EcepaBB;
     variables_["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = EcepaAB;
-    variables_["LCCD SAME-SPIN CORRELATION ENERGY"] = EcepaAA + EcepaBB;
     variables_["LCCD SINGLES ENERGY"] = 0.0;  // CEPA is RHF/UHF only
     variables_["LCCD DOUBLES ENERGY"] = EcepaAB + EcepaAA + EcepaBB;
     variables_["CURRENT REFERENCE ENERGY"] = Eref;

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -3,6 +3,7 @@ import pytest
 #    contractual_ccsd,
 #    contractual_ccsd_prt_pr,
 #    contractual_current,
+#    contractual_lccd,
 #    contractual_mp2,
 #    query_has_qcvar,
 #    query_qcvar,
@@ -26,7 +27,7 @@ def runner_asserter(inp, subject, method, basis, tnm):
     # ? precedence on next two
     mp2_type = inp.get("corl_type", inp["keywords"].get("mp2_type", "df"))  # hard-code of read_options.cc MP2_TYPE
     cc_type = inp.get("corl_type", inp["keywords"].get("cc_type", "conv"))  # hard-code of read_options.cc CC_TYPE
-    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type}
+    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type, "lccd": cc_type}
     corl_type = corl_natural_values[method]
 
     natural_ref = {"conv": "pk", "df": "df", "cd": "cd"}
@@ -53,14 +54,13 @@ def runner_asserter(inp, subject, method, basis, tnm):
     psi4.set_options(
         {
             # "guess": "sad",
-            # "e_convergence": 8,
-            # "d_convergence": 7,
-            # "r_convergence": 7,
-
             # "e_convergence": 10,
             # "d_convergence": 9,
             # "r_convergence": 9,
             # "pcg_convergence": 9,
+
+            # runtime conv crit, solely for occ/dfocc needs
+            "e_convergence": 7,
             "pcg_convergence": 7,
             "points": 5,
         }
@@ -104,6 +104,9 @@ def runner_asserter(inp, subject, method, basis, tnm):
         print("BLOCK", chash, contractual_args)
         if method == "mp2":
             _asserter(asserter_args, contractual_args, contractual_mp2)
+        elif method == "lccd":
+            _asserter(asserter_args, contractual_args, contractual_mp2)
+            _asserter(asserter_args, contractual_args, contractual_lccd)
         elif method == "ccsd":
             _asserter(asserter_args, contractual_args, contractual_mp2)
             _asserter(asserter_args, contractual_args, contractual_ccsd)
@@ -138,6 +141,12 @@ def runner_asserter(inp, subject, method, basis, tnm):
             ref_block[f"{method.upper()} TOTAL GRADIENT"], wfn.gradient().np, tnm + " grad wfn", atol=atol
         )
         assert compare_values(ref_block[f"{method.upper()} TOTAL GRADIENT"], ret.np, tnm + " grad return", atol=atol)
+
+    # generics
+    assert compare(ref_block["N BASIS FUNCTIONS"], wfn.nso(), tnm + " nbasis wfn"), f"nbasis {wfn.nso()} != {ref_block['N BASIS FUNCTIONS']}"
+    assert compare(ref_block["N MOLECULAR ORBITALS"], wfn.nmo(), tnm + " nmo wfn"), f"nmo {wfn.nmo()} != {ref_block['N MOLECULAR ORBITALS']}"
+    assert compare(ref_block["N ALPHA ELECTRONS"], wfn.nalpha(), tnm + " nalpha wfn"), f"nalpha {wfn.nalpha()} != {ref_block['N ALPHA ELECTRONS']}"
+    assert compare(ref_block["N BETA ELECTRONS"], wfn.nbeta(), tnm + " nbeta wfn"), f"nbeta {wfn.nbeta()} != {ref_block['N BETA ELECTRONS']}"
 
 
 def _asserter(asserter_args, contractual_args, contractual_fn):

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -4,6 +4,7 @@ import pytest
 #    contractual_ccsd_prt_pr,
 #    contractual_current,
 #    contractual_lccd,
+#    contractual_lccsd,
 #    contractual_mp2,
 #    query_has_qcvar,
 #    query_qcvar,
@@ -27,7 +28,7 @@ def runner_asserter(inp, subject, method, basis, tnm):
     # ? precedence on next two
     mp2_type = inp.get("corl_type", inp["keywords"].get("mp2_type", "df"))  # hard-code of read_options.cc MP2_TYPE
     cc_type = inp.get("corl_type", inp["keywords"].get("cc_type", "conv"))  # hard-code of read_options.cc CC_TYPE
-    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type, "lccd": cc_type}
+    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type, "lccd": cc_type, "lccsd": cc_type}
     corl_type = corl_natural_values[method]
 
     natural_ref = {"conv": "pk", "df": "df", "cd": "cd"}
@@ -107,6 +108,9 @@ def runner_asserter(inp, subject, method, basis, tnm):
         elif method == "lccd":
             _asserter(asserter_args, contractual_args, contractual_mp2)
             _asserter(asserter_args, contractual_args, contractual_lccd)
+        elif method == "lccsd":
+            _asserter(asserter_args, contractual_args, contractual_mp2)
+            _asserter(asserter_args, contractual_args, contractual_lccsd)
         elif method == "ccsd":
             _asserter(asserter_args, contractual_args, contractual_mp2)
             _asserter(asserter_args, contractual_args, contractual_ccsd)

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -6,6 +6,7 @@ import pytest
 #    contractual_lccd,
 #    contractual_lccsd,
 #    contractual_mp2,
+#    contractual_olccd,
 #    query_has_qcvar,
 #    query_qcvar,
 #)  # skip is temporary until references in place at qcng
@@ -28,7 +29,7 @@ def runner_asserter(inp, subject, method, basis, tnm):
     # ? precedence on next two
     mp2_type = inp.get("corl_type", inp["keywords"].get("mp2_type", "df"))  # hard-code of read_options.cc MP2_TYPE
     cc_type = inp.get("corl_type", inp["keywords"].get("cc_type", "conv"))  # hard-code of read_options.cc CC_TYPE
-    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type, "lccd": cc_type, "lccsd": cc_type}
+    corl_natural_values = {"mp2": mp2_type, "ccsd": cc_type, "ccsd(t)": cc_type, "lccd": cc_type, "lccsd": cc_type, "olccd": cc_type}
     corl_type = corl_natural_values[method]
 
     natural_ref = {"conv": "pk", "df": "df", "cd": "cd"}
@@ -118,6 +119,9 @@ def runner_asserter(inp, subject, method, basis, tnm):
             _asserter(asserter_args, contractual_args, contractual_mp2)
             _asserter(asserter_args, contractual_args, contractual_ccsd)
             _asserter(asserter_args, contractual_args, contractual_ccsd_prt_pr)
+        elif method == "olccd":
+            _asserter(asserter_args, contractual_args, contractual_mp2)
+            _asserter(asserter_args, contractual_args, contractual_olccd)
 
     if "wrong" in inp:
         errmsg, reason = inp["wrong"]
@@ -178,4 +182,4 @@ def _asserter(asserter_args, contractual_args, contractual_fn):
                 #   If a plain bool is compared in the assert, the printed message will show booleans and not numbers.
             else:
                 # verify and forgive known contract violations
-                assert compare(False, query_has_qcvar(obj, pv), label + " SKIP")
+                assert compare(False, query_has_qcvar(obj, pv), label + " SKIP"), f"{label} wrongly present"

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -49,6 +49,7 @@ _nyi4 = "spin components rhf mp2 energies NYI"
 _nyi5 = "df/cd open-shell ccsd energies NYI"
 _nyi6 = "rohf ccsd energies mp2 submethod NYI"
 _nyi7 = "rohf lccd energies NYI"
+_nyi8 = "rohf lccsd energies NYI"
 
 # http://patorjk.com/software/taag/#p=display&c=bash&f=Soft&t=MP3
 
@@ -649,6 +650,138 @@ def test_lccd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, requ
 )
 def test_lccd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
     method = "lccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    if inp.get("marks", False):
+        pytest.xfail(inp["marks"])
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+#
+#  ,--.    ,-----. ,-----. ,---.  ,------.      ,------.
+#  |  |   '  .--./'  .--./'   .-' |  .-.  \     |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
+#  |  |   |  |    |  |    `.  `-. |  |  \  :    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
+#  |  '--.'  '--'\'  '--'\.-'    ||  '--'  /    |  `---.|  ||  |\   --.|  |   ' '-' ' \   '
+#  `-----' `-----' `-----'`-----' `-------'     `------'`--''--' `----'`--'   .`-  /.-'  /
+#                                                                             `---' `---'
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are scf_types managed properly by proc.py? Generally skip corl_type=cd, so df & conv only.
+
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "pk",     },             }, id="lccsd  rhf   pk/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "direct", },             }, id="lccsd  rhf drct/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "df",     },             }, id="lccsd  rhf   df/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "mem_df", },             }, id="lccsd  rhf  mem/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "disk_df",},             }, id="lccsd  rhf disk/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "cd",     },             }, id="lccsd  rhf   cd/conv rr fnocc",),
+        # yapf: enable
+    ],
+)
+def test_lccsd_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccsd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects",
+    [
+        pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),
+        pytest.param("aug-cc-pvdz", ["h2o", "nh2", "nh2"], id="adz", marks=pytest.mark.long),
+        pytest.param("cfour-qz2p", ["h2o", "nh2", "nh2"], id="qz2p", marks=pytest.mark.long),
+    ],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are all possible ways of computing <method> working?
+
+        ###### fnocc
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "true",                   },}, id="lccsd  rhf    conv fc: * fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",                  },}, id="lccsd  rhf    conv ae: * fnocc",),
+        # yapf: enable
+    ],
+)
+def test_lccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccsd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
+
+        ###### default qc_module
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccsd  rhf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd  uhf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd rohf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccsd  rhf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd  uhf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd rohf    conv ae: dd     ",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd  rhf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd  uhf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd rohf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd  rhf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd  uhf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd rohf    df   ae: dd     ",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi4}, id="lccsd  rhf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccsd  uhf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccsd rohf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi4}, id="lccsd  rhf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccsd  uhf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccsd rohf    cd   ae: dd     ",),
+
+        ###### default qc_module, cc_type
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     },               }, id="lccsd  rhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd  uhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd rohf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    },               }, id="lccsd  rhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd  uhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd rohf         ae: dd     ",),
+        # yapf: enable
+    ],
+)
+def test_lccsd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccsd"
     tnm = request.node.name
     subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
 

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -48,6 +48,7 @@ _nyi3 = "cd mp2 gradients NYI"
 _nyi4 = "spin components rhf mp2 energies NYI"
 _nyi5 = "df/cd open-shell ccsd energies NYI"
 _nyi6 = "rohf ccsd energies mp2 submethod NYI"
+_nyi7 = "rohf lccd energies NYI"
 
 # http://patorjk.com/software/taag/#p=display&c=bash&f=Soft&t=MP3
 
@@ -478,6 +479,190 @@ def test_mp2_gradient_default(inp, dertype, basis, subjects, clsd_open_pmols, re
 
 
 #
+#  ,--.    ,-----. ,-----.,------.      ,------.
+#  |  |   '  .--./'  .--./|  .-.  \     |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
+#  |  |   |  |    |  |    |  |  \  :    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
+#  |  '--.'  '--'\'  '--'\|  '--'  /    |  `---.|  ||  |\   --.|  |   ' '-' ' \   '
+#  `-----' `-----' `-----'`-------'     `------'`--''--' `----'`--'   .`-  /.-'  /
+#                                                                     `---' `---'
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are scf_types managed properly by proc.py? Generally skip corl_type=cd, so df & conv only.
+
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "pk",     },             }, id="lccd  rhf   pk/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "direct", },             }, id="lccd  rhf drct/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "df",     },             }, id="lccd  rhf   df/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "mem_df", }, "error": _p1}, id="lccd  rhf  mem/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "disk_df",},             }, id="lccd  rhf disk/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "cd",     },             }, id="lccd  rhf   cd/df   rr dfocc",),
+
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "pk",     },             }, id="lccd  rhf   pk/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "direct", },             }, id="lccd  rhf drct/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "df",     },             }, id="lccd  rhf   df/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "mem_df", },             }, id="lccd  rhf  mem/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "disk_df",},             }, id="lccd  rhf disk/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "cd",     },             }, id="lccd  rhf   cd/conv rr occ  ",),
+
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "pk",     },             }, id="lccd  rhf   pk/df   rr fnocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "direct", },             }, id="lccd  rhf drct/df   rr fnocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "df",     },             }, id="lccd  rhf   df/df   rr fnocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "mem_df", },             }, id="lccd  rhf  mem/df   rr fnocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "disk_df",},             }, id="lccd  rhf disk/df   rr fnocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "cd",     },             }, id="lccd  rhf   cd/df   rr fnocc",),
+
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "pk",     },             }, id="lccd  rhf   pk/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "direct", },             }, id="lccd  rhf drct/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "df",     },             }, id="lccd  rhf   df/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "mem_df", },             }, id="lccd  rhf  mem/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "disk_df",},             }, id="lccd  rhf disk/conv rr fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "cd",     },             }, id="lccd  rhf   cd/conv rr fnocc",),
+        # yapf: enable
+    ],
+)
+def test_lccd_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects",
+    [
+        pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),
+        pytest.param("aug-cc-pvdz", ["h2o", "nh2", "nh2"], id="adz", marks=pytest.mark.long),
+        pytest.param("cfour-qz2p", ["h2o", "nh2", "nh2"], id="qz2p", marks=pytest.mark.long),
+    ],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are all possible ways of computing <method> working?
+
+        ###### fnocc
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "true",                   },}, id="lccd  rhf    conv fc: * fnocc",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "fnocc", "freeze_core": "false",                  },}, id="lccd  rhf    conv ae: * fnocc",),
+
+        ###### occ/dfocc
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  rhf    conv fc:   occ  ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  uhf    conv fc: * occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  rhf    conv ae:   occ  ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  uhf    conv ae: * occ  ",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  rhf    df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  uhf    df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  rhf    df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  uhf    df   ae:   dfocc",),
+        ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="lccd  rhf pk/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="lccd  uhf pk/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="lccd  rhf pk/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="lccd  uhf pk/df   ae:   dfocc",),
+        ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "cd",  },}, id="lccd  rhf cd/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "cd",  },}, id="lccd  uhf cd/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "cd",  },}, id="lccd  rhf cd/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "cd",  },}, id="lccd  uhf cd/df   ae:   dfocc",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  rhf    cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",                     },}, id="lccd  uhf    cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  rhf    cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false",                    },}, id="lccd  uhf    cd   ae: * dfocc",),
+        ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="lccd  rhf pk/cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="lccd  uhf pk/cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="lccd  rhf pk/cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="lccd  uhf pk/cd   ae: * dfocc",),
+        # yapf: enable
+    ],
+)
+def test_lccd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
+
+        ###### default qc_module
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccd  rhf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccd  uhf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi7}, id="lccd rohf    conv fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccd  rhf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccd  uhf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi7}, id="lccd rohf    conv ae: dd     ",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd  rhf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd  uhf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd rohf    df   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd  rhf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd  uhf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd rohf    df   ae: dd     ",),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi4}, id="lccd  rhf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccd  uhf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccd rohf    cd   fc: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi4}, id="lccd  rhf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccd  uhf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccd rohf    cd   ae: dd     ",),
+
+        ###### default qc_module, cc_type
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     },               }, id="lccd  rhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     },               }, id="lccd  uhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }, "marks": _nyi7}, id="lccd rohf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    },               }, id="lccd  rhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    },               }, id="lccd  uhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi7}, id="lccd rohf         ae: dd     ",),
+        # yapf: enable
+    ],
+)
+def test_lccd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "lccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    if inp.get("marks", False):
+        pytest.xfail(inp["marks"])
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+#
 #   ,-----. ,-----. ,---.  ,------.      ,------.
 #  '  .--./'  .--./'   .-' |  .-.  \     |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
 #  |  |    |  |    `.  `-. |  |  \  :    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
@@ -738,11 +923,11 @@ def test_ccsd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
 #                                      `-'          `-'                                    `---' `---'
 
 
-#@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
-#@pytest.mark.parametrize(
+# @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+# @pytest.mark.parametrize(
 #    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
-#)
-#@pytest.mark.parametrize(
+# )
+# @pytest.mark.parametrize(
 #    "inp",
 #    [
 #        # yapf: disable
@@ -779,8 +964,8 @@ def test_ccsd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
 #        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd_t_  rhf   cd/df   rr occ     ",),
 #        # yapf: enable
 #    ],
-#)
-#def test_ccsd_prt_pr_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, request):
+# )
+# def test_ccsd_prt_pr_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, request):
 #    method = "ccsd(t)"
 #    tnm = request.node.name
 #    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
@@ -866,11 +1051,11 @@ def test_ccsd_prt_pr_energy_module(inp, dertype, basis, subjects, clsd_open_pmol
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-#@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
-#@pytest.mark.parametrize(
+# @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+# @pytest.mark.parametrize(
 #    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
-#)
-#@pytest.mark.parametrize(
+# )
+# @pytest.mark.parametrize(
 #    "inp",
 #    [
 #        # yapf: disable
@@ -907,8 +1092,8 @@ def test_ccsd_prt_pr_energy_module(inp, dertype, basis, subjects, clsd_open_pmol
 #        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi6,}, id="ccsd_t_ rohf         ae: dd     ",),
 #        # yapf: enable
 #    ],
-#)
-#def test_ccsd_prt_pr_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
+# )
+# def test_ccsd_prt_pr_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
 #    method = "ccsd(t)"
 #    tnm = request.node.name
 #    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -40,16 +40,19 @@ _p13 = (psi4.ManagedMethodError, "not directable to QC_MODULE 'FNOCC'")
 _p14 = (psi4.ManagedMethodError, "not directable to QC_MODULE 'OCC'")
 _p15 = (psi4.ValidationError, "Invalid scf_type for DFCC.")
 _p16 = (psi4.ValidationError, "Frozen core is not available for the CC gradients.")
+_p17 = (RuntimeError, "Frozen core/virtual not implemented in Orbital-optimized methods")
 # yapf: enable
 
-_nyi1 = "fc conv mp2 gradients NYI"
-_nyi2 = "rohf mp2 gradients NYI"
-_nyi3 = "cd mp2 gradients NYI"
-_nyi4 = "spin components rhf mp2 energies NYI"
-_nyi5 = "df/cd open-shell ccsd energies NYI"
-_nyi6 = "rohf ccsd energies mp2 submethod NYI"
-_nyi7 = "rohf lccd energies NYI"
-_nyi8 = "rohf lccsd energies NYI"
+_nyi1 = pytest.mark.xfail(reason="fc conv mp2 gradients NYI", raises=psi4.ManagedMethodError, strict=True)
+_nyi2 = pytest.mark.xfail(reason="rohf mp2 gradients NYI", raises=psi4.ManagedMethodError, strict=True)
+_nyi3 = pytest.mark.xfail(reason="cd mp2 gradients NYI", raises=psi4.ManagedMethodError, strict=True)
+_nyi4 = pytest.mark.xfail(reason="spin components rhf mp2 energies NYI", raises=KeyError, strict=True)
+_nyi5 = pytest.mark.xfail(reason="df/cd open-shell ccsd energies NYI", raises=psi4.ManagedMethodError, strict=True)
+_nyi6 = pytest.mark.xfail(reason="rohf ccsd energies mp2 submethod NYI", raises=KeyError, strict=True)
+_nyi7 = pytest.mark.xfail(reason="rohf lccd energies NYI", raises=psi4.ManagedMethodError, strict=True)
+_nyi8 = pytest.mark.xfail(reason="rohf lccsd energies NYI", raises=psi4.ValidationError, strict=True)
+_nyi9 = pytest.mark.xfail(reason="fc conv orbital-optimized energies NYI", raises=RuntimeError, strict=True)
+_nyi10 = pytest.mark.xfail(reason="rohf olccd energies mp2 submethod NYI", raises=KeyError, strict=True)
 
 # http://patorjk.com/software/taag/#p=display&c=bash&f=Soft&t=MP3
 
@@ -241,34 +244,34 @@ def test_mp2_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
         ######## Does the simple interface (default qc_module, scf_type, mp2_type) work?
 
         ###### default qc_module
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv",                     "freeze_core": "true",                     },               }, id="mp2  rhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "conv",                     "freeze_core": "true",                     },               }, id="mp2  uhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv",                     "freeze_core": "true",                     },               }, id="mp2 rohf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv",                     "freeze_core": "false",                    },               }, id="mp2  rhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "conv",                     "freeze_core": "false",                    },               }, id="mp2  uhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv",                     "freeze_core": "false",                    },               }, id="mp2 rohf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv",                     "freeze_core": "true",                     }}, id="mp2  rhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "conv",                     "freeze_core": "true",                     }}, id="mp2  uhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv",                     "freeze_core": "true",                     }}, id="mp2 rohf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv",                     "freeze_core": "false",                    }}, id="mp2  rhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "conv",                     "freeze_core": "false",                    }}, id="mp2  uhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv",                     "freeze_core": "false",                    }}, id="mp2 rohf    conv ae: dd     ",            ),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "df",                       "freeze_core": "true",                     },               }, id="mp2  rhf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "df",                       "freeze_core": "true",                     },               }, id="mp2  uhf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "df",                       "freeze_core": "true",                     },               }, id="mp2 rohf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "df",                       "freeze_core": "false",                    },               }, id="mp2  rhf    df   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "df",                       "freeze_core": "false",                    },               }, id="mp2  uhf    df   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "df",                       "freeze_core": "false",                    },               }, id="mp2 rohf    df   ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "df",                       "freeze_core": "true",                     }}, id="mp2  rhf    df   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "df",                       "freeze_core": "true",                     }}, id="mp2  uhf    df   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "df",                       "freeze_core": "true",                     }}, id="mp2 rohf    df   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "df",                       "freeze_core": "false",                    }}, id="mp2  rhf    df   ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "df",                       "freeze_core": "false",                    }}, id="mp2  uhf    df   ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "df",                       "freeze_core": "false",                    }}, id="mp2 rohf    df   ae: dd     ",            ),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi4}, id="mp2  rhf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "cd",                       "freeze_core": "true",                     },               }, id="mp2  uhf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "cd",                       "freeze_core": "true",                     },               }, id="mp2 rohf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi4}, id="mp2  rhf    cd   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "cd",                       "freeze_core": "false",                    },               }, id="mp2  uhf    cd   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "cd",                       "freeze_core": "false",                    },               }, id="mp2 rohf    cd   ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "cd",                       "freeze_core": "true",                     }}, id="mp2  rhf    cd   fc: dd     ", marks=_nyi4),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "cd",                       "freeze_core": "true",                     }}, id="mp2  uhf    cd   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "cd",                       "freeze_core": "true",                     }}, id="mp2 rohf    cd   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "cd",                       "freeze_core": "false",                    }}, id="mp2  rhf    cd   ae: dd     ", marks=_nyi4),
+        pytest.param({"keywords": {"reference": "uhf",  "mp2_type": "cd",                       "freeze_core": "false",                    }}, id="mp2  uhf    cd   ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "cd",                       "freeze_core": "false",                    }}, id="mp2 rohf    cd   ae: dd     ",            ),
 
         ###### default qc_module, mp2_type
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                     },               }, id="mp2  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                     },               }, id="mp2  uhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "true",                     },               }, id="mp2 rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                    },               }, id="mp2  rhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "false",                    },               }, id="mp2  uhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "false",                    },               }, id="mp2 rohf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                     }}, id="mp2  rhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                     }}, id="mp2  uhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "true",                     }}, id="mp2 rohf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                    }}, id="mp2  rhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "false",                    }}, id="mp2  uhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "false",                    }}, id="mp2 rohf         ae: dd     ",            ),
         # yapf: enable
     ],
 )
@@ -278,8 +281,6 @@ def test_mp2_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, requ
     subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
 
     inpcopy = {k: v for k, v in inp.items()}
-    if inp.get("marks", False):
-        pytest.xfail(inp["marks"])
     inpcopy["driver"] = "energy"
     inpcopy["call"] = method
     inpcopy["keywords"]["basis"] = basis
@@ -341,7 +342,7 @@ def test_mp2_gradient_scftype(inp, dertype, basis, subjects, clsd_open_pmols, re
     if inp.get("error", False) and inp["error"].get(dertype, False):
         inpcopy["error"] = inp["error"][dertype]
     if inp.get("marks", False) and inp["marks"].get(dertype, False):
-        pytest.xfail(inp["marks"][dertype])
+        request.node.add_marker(inp["marks"][dertype])
 
     inpcopy["driver"] = "gradient"
     inpcopy["call"] = method
@@ -408,7 +409,7 @@ def test_mp2_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, req
     if inp.get("error", False) and inp["error"].get(dertype, False):
         inpcopy["error"] = inp["error"][dertype]
     if inp.get("marks", False) and inp["marks"].get(dertype, False):
-        pytest.xfail(inp["marks"][dertype])
+        request.node.add_marker(inp["marks"][dertype])
 
     inpcopy["driver"] = "gradient"
     inpcopy["call"] = method
@@ -469,7 +470,7 @@ def test_mp2_gradient_default(inp, dertype, basis, subjects, clsd_open_pmols, re
     if inp.get("error", False) and inp["error"].get(dertype, False):
         inpcopy["error"] = inp["error"][dertype]
     if inp.get("marks", False) and inp["marks"].get(dertype, False):
-        pytest.xfail(inp["marks"][dertype])
+        request.node.add_marker(inp["marks"][dertype])
 
     inpcopy["driver"] = "gradient"
     inpcopy["call"] = method
@@ -617,34 +618,34 @@ def test_lccd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, requ
         ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
 
         ###### default qc_module
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccd  rhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccd  uhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi7}, id="lccd rohf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccd  rhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccd  uhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi7}, id="lccd rohf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccd  rhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccd  uhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccd rohf    conv fc: dd     ", marks=_nyi7),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccd  rhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccd  uhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccd rohf    conv ae: dd     ", marks=_nyi7),
         ####
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd  rhf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd  uhf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccd rohf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd  rhf    df   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd  uhf    df   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccd rohf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccd  rhf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccd  uhf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccd rohf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccd  rhf    df   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccd  uhf    df   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccd rohf    df   ae: dd     ",            ),
         ####
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi4}, id="lccd  rhf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccd  uhf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccd rohf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi4}, id="lccd  rhf    cd   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccd  uhf    cd   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccd rohf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccd  rhf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccd  uhf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccd rohf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccd  rhf    cd   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccd  uhf    cd   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccd rohf    cd   ae: dd     ",            ),
 
         ###### default qc_module, cc_type
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     },               }, id="lccd  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     },               }, id="lccd  uhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }, "marks": _nyi7}, id="lccd rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    },               }, id="lccd  rhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    },               }, id="lccd  uhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi7}, id="lccd rohf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="lccd  rhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }}, id="lccd  uhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }}, id="lccd rohf         fc: dd     ", marks=_nyi7),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="lccd  rhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }}, id="lccd  uhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }}, id="lccd rohf         ae: dd     ", marks=_nyi7),
         # yapf: enable
     ],
 )
@@ -654,8 +655,6 @@ def test_lccd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, req
     subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
 
     inpcopy = {k: v for k, v in inp.items()}
-    if inp.get("marks", False):
-        pytest.xfail(inp["marks"])
     inpcopy["driver"] = "energy"
     inpcopy["call"] = method
     inpcopy["keywords"]["basis"] = basis
@@ -749,34 +748,34 @@ def test_lccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, req
         ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
 
         ###### default qc_module
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     },               }, id="lccsd  rhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd  uhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd rohf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    },               }, id="lccsd  rhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd  uhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd rohf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccsd  rhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccsd  uhf    conv fc: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }}, id="lccsd rohf    conv fc: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccsd  rhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccsd  uhf    conv ae: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }}, id="lccsd rohf    conv ae: dd     ", marks=_nyi8),
         ####
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd  rhf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd  uhf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     },               }, id="lccsd rohf    df   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd  rhf    df   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd  uhf    df   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    },               }, id="lccsd rohf    df   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccsd  rhf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccsd  uhf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     }}, id="lccsd rohf    df   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccsd  rhf    df   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccsd  uhf    df   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    }}, id="lccsd rohf    df   ae: dd     ",            ),
         ####
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi4}, id="lccsd  rhf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccsd  uhf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     },               }, id="lccsd rohf    cd   fc: dd     ",),
-        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi4}, id="lccsd  rhf    cd   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccsd  uhf    cd   ae: dd     ",),
-        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    },               }, id="lccsd rohf    cd   ae: dd     ",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccsd  rhf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccsd  uhf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     }}, id="lccsd rohf    cd   fc: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccsd  rhf    cd   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccsd  uhf    cd   ae: dd     ",            ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    }}, id="lccsd rohf    cd   ae: dd     ",            ),
 
         ###### default qc_module, cc_type
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     },               }, id="lccsd  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd  uhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }, "marks": _nyi8}, id="lccsd rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    },               }, id="lccsd  rhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd  uhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi8}, id="lccsd rohf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="lccsd  rhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }}, id="lccsd  uhf         fc: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }}, id="lccsd rohf         fc: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="lccsd  rhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }}, id="lccsd  uhf         ae: dd     ", marks=_nyi8),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }}, id="lccsd rohf         ae: dd     ", marks=_nyi8),
         # yapf: enable
     ],
 )
@@ -786,8 +785,6 @@ def test_lccsd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, re
     subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
 
     inpcopy = {k: v for k, v in inp.items()}
-    if inp.get("marks", False):
-        pytest.xfail(inp["marks"])
     inpcopy["driver"] = "energy"
     inpcopy["call"] = method
     inpcopy["keywords"]["basis"] = basis
@@ -943,34 +940,34 @@ def test_ccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, requ
         ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
 
         ###### default qc_module
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     },                }, id="ccsd  rhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     },                }, id="ccsd  uhf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }, "marks": _nyi6,}, id="ccsd rohf    conv fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    },                }, id="ccsd  rhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    },                }, id="ccsd  uhf    conv ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }, "marks": _nyi6,}, id="ccsd rohf    conv ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="ccsd  rhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="ccsd  uhf    conv fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }}, id="ccsd rohf    conv fc: dd     ", marks=_nyi6),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="ccsd  rhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="ccsd  uhf    conv ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }}, id="ccsd rohf    conv ae: dd     ", marks=_nyi6),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     },                }, id="ccsd  rhf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     }, "marks": _nyi5,}, id="ccsd  uhf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     }, "marks": _nyi5,}, id="ccsd rohf    df   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    },                }, id="ccsd  rhf    df   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    }, "marks": _nyi5,}, id="ccsd  uhf    df   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    }, "marks": _nyi5,}, id="ccsd rohf    df   ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="ccsd  rhf    df   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="ccsd  uhf    df   fc: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     }}, id="ccsd rohf    df   fc: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="ccsd  rhf    df   ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="ccsd  uhf    df   ae: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    }}, id="ccsd rohf    df   ae: dd     ", marks=_nyi5),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     },                }, id="ccsd  rhf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi5,}, id="ccsd  uhf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     }, "marks": _nyi5,}, id="ccsd rohf    cd   fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    },                }, id="ccsd  rhf    cd   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi5,}, id="ccsd  uhf    cd   ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    }, "marks": _nyi5,}, id="ccsd rohf    cd   ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="ccsd  rhf    cd   fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="ccsd  uhf    cd   fc: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     }}, id="ccsd rohf    cd   fc: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="ccsd  rhf    cd   ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="ccsd  uhf    cd   ae: dd     ", marks=_nyi5),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    }}, id="ccsd rohf    cd   ae: dd     ", marks=_nyi5),
 
         ###### default qc_module, cc_type
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     },                }, id="ccsd  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     },                }, id="ccsd  uhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }, "marks": _nyi6,}, id="ccsd rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    },                }, id="ccsd  rhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    },                }, id="ccsd  uhf         ae: dd     ",),
-        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }, "marks": _nyi6,}, id="ccsd rohf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="ccsd  rhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }}, id="ccsd  uhf         fc: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }}, id="ccsd rohf         fc: dd     ", marks=_nyi6),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="ccsd  rhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }}, id="ccsd  uhf         ae: dd     ",            ),
+        pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }}, id="ccsd rohf         ae: dd     ", marks=_nyi6),
         # yapf: enable
     ],
 )
@@ -980,8 +977,6 @@ def test_ccsd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, req
     subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
 
     inpcopy = {k: v for k, v in inp.items()}
-    if inp.get("marks", False):
-        pytest.xfail(inp["marks"])
     inpcopy["driver"] = "energy"
     inpcopy["call"] = method
     inpcopy["keywords"]["basis"] = basis
@@ -1037,7 +1032,7 @@ def test_ccsd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
     if inp.get("error", False) and inp["error"].get(dertype, False):
         inpcopy["error"] = inp["error"][dertype]
     if inp.get("marks", False) and inp["marks"].get(dertype, False):
-        pytest.xfail(inp["marks"][dertype])
+        request.node.add_marker(inp["marks"][dertype])
 
     inpcopy["driver"] = "gradient"
     inpcopy["call"] = method
@@ -1233,9 +1228,185 @@ def test_ccsd_prt_pr_energy_module(inp, dertype, basis, subjects, clsd_open_pmol
 #
 #    inpcopy = {k: v for k, v in inp.items()}
 #    if inp.get("marks", False):
-#        pytest.xfail(inp["marks"])
+#        request.node.add_marker(inp["marks"][dertype])
 #    inpcopy["driver"] = "energy"
 #    inpcopy["call"] = method
 #    inpcopy["keywords"]["basis"] = basis
 #
 #    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+#
+#   ,-----. ,--.    ,-----. ,-----.,------.      ,------.
+#  '  .-.  '|  |   '  .--./'  .--./|  .-.  \     |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
+#  |  | |  ||  |   |  |    |  |    |  |  \  :    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
+#  '  '-'  '|  '--.'  '--'\'  '--'\|  '--'  /    |  `---.|  ||  |\   --.|  |   ' '-' ' \   '
+#   `-----' `-----' `-----' `-----'`-------'     `------'`--''--' `----'`--'   .`-  /.-'  /
+#                                                                              `---' `---'
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are scf_types managed properly by proc.py? Generally skip corl_type=cd, so df & conv only.
+
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "pk",     },             }, id="olccd  rhf   pk/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "direct", },             }, id="olccd  rhf drct/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "df",     },             }, id="olccd  rhf   df/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "mem_df", }, "error": _p1}, id="olccd  rhf  mem/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "disk_df",},             }, id="olccd  rhf disk/df   rr dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",   "freeze_core": "false",  "scf_type": "cd",     },             }, id="olccd  rhf   cd/df   rr dfocc",),
+
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "pk",     },             }, id="olccd  rhf   pk/conv rr occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "direct", },             }, id="olccd  rhf drct/conv rr occ  ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "df",     },             }, id="olccd  rhf   df/conv rr occ  ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "mem_df", },             }, id="olccd  rhf  mem/conv rr occ  ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "disk_df",},             }, id="olccd  rhf disk/conv rr occ  ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ",   "freeze_core": "false",  "scf_type": "cd",     },             }, id="olccd  rhf   cd/conv rr occ  ",),
+        # yapf: enable
+    ],
+)
+def test_olccd_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "olccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects",
+    [
+        pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),
+        pytest.param("aug-cc-pvdz", ["h2o", "nh2", "nh2"], id="adz", marks=pytest.mark.long),
+        pytest.param("cfour-qz2p", ["h2o", "nh2", "nh2"], id="qz2p", marks=pytest.mark.long),
+    ],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Are all possible ways of computing <method> working?
+
+        ###### occ/dfocc
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "true",                     }, "error": _p17}, id="olccd  rhf    conv fc: * occ  ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "true",                     }, "error": _p17}, id="olccd  uhf    conv fc: * occ  ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv", "qc_module": "occ", "freeze_core": "true",                     }, "error": _p17}, id="olccd rohf    conv fc: * occ  ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd  rhf    conv ae: * occ  ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd  uhf    conv ae: * occ  ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd rohf    conv ae: * occ  ",),
+        # ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  rhf    df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  uhf    df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd rohf    df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd  rhf    df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd  uhf    df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd rohf    df   ae:   dfocc",),
+        # ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd  rhf pk/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd  uhf pk/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd rohf pk/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd  rhf pk/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd  uhf pk/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd rohf pk/df   ae:   dfocc",),
+        # ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "cd",  },}, id="olccd  rhf cd/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "cd",  },}, id="olccd  uhf cd/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "cd",  },}, id="olccd rohf cd/df   fc:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "cd",  },}, id="olccd  rhf cd/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "cd",  },}, id="olccd  uhf cd/df   ae:   dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",   "qc_module": "occ", "freeze_core": "false", "scf_type": "cd",  },}, id="olccd rohf cd/df   ae:   dfocc",),
+        # ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  rhf    cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  uhf    cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd rohf    cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd  rhf    cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd  uhf    cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false",                    },}, id="olccd rohf    cd   ae: * dfocc",),
+        # ##
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd  rhf pk/cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd  uhf pk/cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",   "qc_module": "occ", "freeze_core": "true",  "scf_type": "pk",  },}, id="olccd rohf pk/cd   fc: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd  rhf pk/cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd  uhf pk/cd   ae: * dfocc",),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",   "qc_module": "occ", "freeze_core": "false", "scf_type": "pk",  },}, id="olccd rohf pk/cd   ae: * dfocc",),
+        # yapf: enable
+    ],
+)
+def test_olccd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "olccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+@pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
+@pytest.mark.parametrize(
+    "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
+)
+@pytest.mark.parametrize(
+    "inp",
+    [
+        # yapf: disable
+        ######## Does the simple interface (default qc_module, scf_type, cc_type) work?
+
+        ###### default qc_module
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="olccd  rhf    conv fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "true",                     }}, id="olccd  uhf    conv fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "true",                     }}, id="olccd rohf    conv fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="olccd  rhf    conv ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv",                     "freeze_core": "false",                    }}, id="olccd  uhf    conv ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv",                     "freeze_core": "false",                    }}, id="olccd rohf    conv ae: dd     ", marks=_nyi10),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="olccd  rhf    df   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "true",                     }}, id="olccd  uhf    df   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "true",                     }}, id="olccd rohf    df   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="olccd  rhf    df   ae: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",                       "freeze_core": "false",                    }}, id="olccd  uhf    df   ae: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "df",                       "freeze_core": "false",                    }}, id="olccd rohf    df   ae: dd     ",             ),
+        ####
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="olccd  rhf    cd   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "true",                     }}, id="olccd  uhf    cd   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "true",                     }}, id="olccd rohf    cd   fc: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="olccd  rhf    cd   ae: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "cd",                       "freeze_core": "false",                    }}, id="olccd  uhf    cd   ae: dd     ",             ),
+        # pytest.param({"keywords": {"reference": "rohf", "cc_type": "cd",                       "freeze_core": "false",                    }}, id="olccd rohf    cd   ae: dd     ",             ),
+
+        ###### default qc_module, cc_type
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                     }}, id="olccd  rhf         fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                     }}, id="olccd  uhf         fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "true",                     }}, id="olccd rohf         fc: dd     ", marks=_nyi9 ),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                    }}, id="olccd  rhf         ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "false",                    }}, id="olccd  uhf         ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "false",                    }}, id="olccd rohf         ae: dd     ", marks=_nyi10),
+        # yapf: enable
+    ],
+)
+def test_olccd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, request):
+    method = "olccd"
+    tnm = request.node.name
+    subject = clsd_open_pmols[subjects[std_refs.index(inp["keywords"]["reference"])]]
+
+    inpcopy = {k: v for k, v in inp.items()}
+    inpcopy["driver"] = "energy"
+    inpcopy["call"] = method
+    inpcopy["keywords"]["basis"] = basis
+
+    runner_asserter(inpcopy, subject, method, basis, tnm)


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

## Todos
- [x] bump pb11 internal build to v2.5.0
- [x] bump ambit internal build to v0.4.1
- [x] update paper and acknowledge more folks in header
- [x] add extra arg to bindings of so_overlap/kinetic so p4n ref impl can run as-is
- [x] fix missing qcvars, wfn settings in fnocc and occ for conventional LCCD
- [x] add conventional LCCD tests to standard_suite courtesy of @JonathonMisiewicz reference implementation over at p4n, https://github.com/psi4/psi4numpy/tree/master/Coupled-Electron-Pair-Approximation
- [x] depends on https://github.com/MolSSI/QCEngine/pull/244 for data. Furthermore all standard_suite tests are presently suppressed until qcng v0.15 minted

## Status
- [x] Ready for review
- [x] Ready for merge
