### PR TITLE
Expose flexible cube generation to Python

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -255,6 +255,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_tdscf_excitations.py
               ../tests/pytests/test_misc.py
               ../tests/pytests/test_multipole_potential.py
+              ../tests/pytests/test_pyside_cubegen.py
               ../tests/pytests/test_dipoles.py
               ../tests/pytests/test_dertype.py
               ../tests/pytests/test_mp2.py

--- a/psi4/src/export_cubeprop.cc
+++ b/psi4/src/export_cubeprop.cc
@@ -31,6 +31,7 @@
 #include "psi4/libcubeprop/cubeprop.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libmints/wavefunction.h"
+#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/basisset.h"
 
 using namespace psi;
@@ -39,6 +40,8 @@ namespace py = pybind11;
 void export_cubeprop(py::module& m) {
     py::class_<CubeProperties, std::shared_ptr<CubeProperties>>(m, "CubeProperties", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
+        .def("compute_density", &CubeProperties::compute_density)
+        .def("compute_orbitals", &CubeProperties::compute_orbitals)
         .def("basisset", &CubeProperties::basisset, "Returns orbital/primary basis set associated with cubeprop.")
         .def("raw_compute_properties", &CubeProperties::raw_compute_properties,
              "Compute all relevant properties from options object specifications");

--- a/psi4/src/export_cubeprop.cc
+++ b/psi4/src/export_cubeprop.cc
@@ -36,12 +36,15 @@
 
 using namespace psi;
 namespace py = pybind11;
+using namespace pybind11::literals;
 
 void export_cubeprop(py::module& m) {
     py::class_<CubeProperties, std::shared_ptr<CubeProperties>>(m, "CubeProperties", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
-        .def("compute_density", &CubeProperties::compute_density)
-        .def("compute_orbitals", &CubeProperties::compute_orbitals)
+        .def("compute_density", &CubeProperties::compute_density, "Compute and dump a cube file for a density matrix",
+             "D"_a, "key"_a)
+        .def("compute_orbitals", &CubeProperties::compute_orbitals,
+             "Compute and dump a cube file for a set of orbitals", "C"_a, "indices"_a, "labels"_a, "key"_a)
         .def("basisset", &CubeProperties::basisset, "Returns orbital/primary basis set associated with cubeprop.")
         .def("raw_compute_properties", &CubeProperties::raw_compute_properties,
              "Compute all relevant properties from options object specifications");

--- a/tests/pytests/test_pyside_cubegen.py
+++ b/tests/pytests/test_pyside_cubegen.py
@@ -1,0 +1,37 @@
+"""
+Test Python-side generation of cube files
+"""
+import psi4
+from .utils import compare_cubes
+
+
+def test_pyside_cubegen():
+    mol = psi4.geometry("""
+        O 0 0 0
+        H 0 0 1.795239827225189
+        H 1.693194615993441 0 -0.599043184453037
+        symmetry c1
+        units au
+        """)
+
+    psi4.core.be_quiet()
+    psi4.set_options({'basis': "sto-3g",
+                      'scf_type': 'pk',
+                      'cubeprop_tasks': ['density', 'orbitals']})
+    scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
+    psi4.cubeprop(wfn)
+
+    cubegen = psi4.core.CubeProperties(wfn)
+    Dtot = wfn.Da()
+    Dtot.add(wfn.Db())
+    cubegen.compute_density(Dtot, "Dtot")
+
+    alpha_orbitals = wfn.Ca_subset("AO", "OCC").np
+    # select the three highest occupied orbitals
+    occs = alpha_orbitals[:, -3:]
+    occs_pm = psi4.core.Matrix.from_array(occs)
+    cubegen.compute_orbitals(occs_pm, [0, 2], ["1", "3"], "orbital")
+
+    compare_cubes("Dt.cube", "Dtot.cube")
+    compare_cubes("Psi_a_5_5-A.cube", "orbital_3_3.cube")
+    compare_cubes("Psi_a_4_4-A.cube", "orbital_1_1.cube")

--- a/tests/pytests/test_pyside_cubegen.py
+++ b/tests/pytests/test_pyside_cubegen.py
@@ -32,6 +32,6 @@ def test_pyside_cubegen():
     occs_pm = psi4.core.Matrix.from_array(occs)
     cubegen.compute_orbitals(occs_pm, [0, 2], ["1", "3"], "orbital")
 
-    compare_cubes("Dt.cube", "Dtot.cube")
-    compare_cubes("Psi_a_5_5-A.cube", "orbital_3_3.cube")
-    compare_cubes("Psi_a_4_4-A.cube", "orbital_1_1.cube")
+    assert compare_cubes("Dt.cube", "Dtot.cube")
+    assert compare_cubes("Psi_a_5_5-A.cube", "orbital_3_3.cube")
+    assert compare_cubes("Psi_a_3_3-A.cube", "orbital_1_1.cube")


### PR DESCRIPTION
## Description
This PR exposes the two functions `compute_orbitals` and `compute_density` from `CubeProperties` to the Python layer. This allows for more flexible dumping of cube files.

Example Code:
```Python
import psi4
import numpy as np


def test_cube_files(expected, computed):
    expected = np.genfromtxt(expected, skip_header=9, skip_footer=1)
    computed = np.genfromtxt(computed, skip_header=9, skip_footer=1)
    np.testing.assert_allclose(expected, computed, atol=1e-14)


mol = psi4.geometry("""
    O 0 0 0
    H 0 0 1.795239827225189
    H 1.693194615993441 0 -0.599043184453037
    symmetry c1
    units au
    """)

psi4.core.be_quiet()
psi4.set_options({'basis': "sto-3g",
                  'scf_type': 'pk',
                  'cubeprop_tasks': ['density', 'orbitals']})
scf_e, wfn = psi4.energy('SCF', return_wfn=True)
psi4.cubeprop(wfn)

cubegen = psi4.core.CubeProperties(wfn)

dt = wfn.Da()
dt.add(wfn.Db())
cubegen.compute_density(dt, "hf_density")

# obtain alpha coefficients
orbs = wfn.Ca_subset("AO", "OCC").np
# select the two highest occupied orbitals
occs = orbs[:, -2:]
occs_pm = psi4.core.Matrix.from_array(occs)
cubegen.compute_orbitals(occs_pm, [0, 1], ["homo-1", "homo"], "orbital")


test_cube_files("Dt.cube", "hf_density.cube")
test_cube_files("Psi_a_5_5-A.cube", "orbital_2_homo.cube")
test_cube_files("Psi_a_4_4-A.cube", "orbital_1_homo-1.cube")
```

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] export functions 

## Questions
- [x] ~~Should some tests be added for this? Like in the example code above to be 100% safe?~~ I added a simple test like in the example script to be safe.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
