### PR TITLE
CGRSolver Minor Commenting, Bug Fix

### DIFF
--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -91,7 +91,7 @@ std::shared_ptr<CGRSolver> CGRSolver::build_solver(Options& options, std::shared
     }
     if (options["SOLVER_PRECONDITION"].has_changed()) {
         if (options.get_str("SOLVER_PRECONDITION") == "SUBSPACE") {
-            outfile->Printf("  !!!Warning!!!\n")
+            outfile->Printf("  !!!Warning!!!\n");
             outfile->Printf("  The subspace preconditioner has been broken for some time and was removed in Psi4 1.4.\n");
             outfile->Printf("  Setting preconditioner to Jacobi instead.\n\n");
             solver->set_precondition("JACOBI");

--- a/psi4/src/psi4/libfock/solver.h
+++ b/psi4/src/psi4/libfock/solver.h
@@ -187,6 +187,8 @@ class USolver : public Solver {
 
 // => APPLIED CLASSES <= //
 
+// Conjugate gradients with a spin-restricted Hamiltonian.
+// Solves the equations Hx=b.
 class CGRSolver : public RSolver {
    protected:
     /// Force vectors
@@ -220,14 +222,16 @@ class CGRSolver : public RSolver {
     SharedMatrix A_;
     /// A subspace indices
     std::vector<std::vector<int> > A_inds_;
-    /// Shifts (to solve (A-mI)
+    /// Shifts [to solve (A-mI)]; Outer vector indexes irreps, inner indexes basis vectors of that irrep
     std::vector<std::vector<double> > shifts_;
     /// Number of guess vectors to use for subspace preconditioner
     int nguess_;
 
+    /// Initializes shifts_ to 0
     void setup();
     void guess();
     void residual();
+    /// Write (H_-shifts_)*x_ to Ap_
     void products_x();
     void products_p();
     void alpha();


### PR DESCRIPTION
## Description
Fixes #1918 by removing the subspace preconditioner, per @robertodr's recommendation.

This also adds some more comments to the code, crucially, the fact that this solves the problem `Hx=b` as opposed to `Hx+b=0`. Signs are important.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Disables the broken subspace preconditioner in the CGRSolver.

## Checklist
- [x] Tested that a helpful warning runs if the user specifies a subspace preconditioner for the CGRSolver.

## Status
- [x] Ready for review
- [x] Ready for merge
