### PR TITLE
DFGrad II: Comment and Correct `dfmp2`

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -266,6 +266,8 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_mints.py
               ../tests/pytests/test_standard_suite.py
               ../tests/pytests/standard_suite_runner.py
+              ../tests/pytests/test_detci_opdm.py
+              ../tests/pytests/test_gradients.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 
     # <<<  install psi4 share/ & include/  >>>

--- a/psi4/src/psi4/dfmp2/README.txt
+++ b/psi4/src/psi4/dfmp2/README.txt
@@ -1,0 +1,43 @@
+General Notes About the Code
+
+1. There are several references to previous gradient papers in the comments.
+  DiStasio : DOI 10.1002/jcc; J. Comput. Chem. 28, 839–856, (2007)
+    "An Improved Algorithm for Analytical Gradient
+    Evaluation in Resolution-of-the-Identity Second-Order
+    Møller-Plesset Perturbation Theory: Application to
+    Alanine Tetrapeptide Conformational Analysis"
+      Most of our equations come from here.
+  Wang : DOI 10.1063/1.5100175; J. Chem. Phys. 151, 044118 (2019)
+    "Analytic gradients for the single-reference
+    driven similarity renormalization group
+    second-order perturbation theory"
+      This theory gives gradients for a family of methods that add
+      another parameter to MP2, so these formulas apply to MP2 as well.
+      Table II of this paper will be crucial in explaining a trick that
+      does not appear in DiStasio. (See Sec. 3 here.)
+  Aikens : DOI 10.1007/s00214-003-0453-3; Theor. Chem. Acc. 110, 233-253 (2003)
+    "A derivation of the frozen-orbital unrestricted open-shell
+    and restricted closed-shell second-order perturbation theory
+    analytic gradient expressions"
+      This is the conventional-integral paper that DiStasio worked from to
+      get their DF gradients. This sometimes clarifies obscure points in
+      DiStasio, but they are not clear about one crucial point:
+      If one block of a quantity is not given, but its adjoint is, is the first
+      block zero, or the adjoint of the first block?
+2. Conventions
+    OPDM = One-particle density matrix
+    EWDM = Energy-weighted density matrix
+    All intermediates used in other functions are defined by comments starting DEFINITION.
+    When a previous intermediate is updated, it is defined by comments starting UPDATE.
+3. The Trick
+    The RHF gradient code does NOT use the formulas of the DiStasio or Aikens papers.
+    I can't find where the formulas come from, but they're very close to the DiStasio and
+    Aikens formulas, but there are consistent deviations from the formulas that are
+    accounted for by the addition of a "magic" term later on. In the comments, I refer to
+    this as the "subtle trick." Grep for that if you want to see where it appears.
+4. Cholesky Decomposition
+    Several times, the code needs to contract a two-index MO quantity by the four-index electron
+    repulsion integrals and end with a two-index AO quantity. If the two-index quantity were
+    separable, this would be a perfect opportunity to use our efficient libfock/jk.cc technology.
+    This two-index quantity is the one-particle density matrix, which is NOT separable.
+    To remedy this, we Cholesky decompose the OPDM, which gets it in the desired form.

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -2955,7 +2955,7 @@ void UDFMP2::form_Aia() {
 
         // Stripe (A|ia) out to disk
         timer_on("DFMP2 Aia Write");
-        psio_->write(PSIF_DFMP2_AIA, "(A|ia)", (char*)Aiap[0], sizeof(double) * nrows * naocc_a * navir_a, next_AIA,
+        psio_->write(PSIF_DFMP2_AIA, "A(Q|ia)", (char*)Aiap[0], sizeof(double) * nrows * naocc_a * navir_a, next_AIA,
                      &next_AIA);
         timer_off("DFMP2 Aia Write");
 
@@ -3188,7 +3188,7 @@ void UDFMP2::form_energy() {
             next_BIA = psio_get_address(PSIO_ZERO, sizeof(double) * (istart * navir * naux));
             psio_->read(PSIF_DFMP2_QIA, "B(ia|Q)", (char*)Biap[0], sizeof(double) * (ni * navir * naux), next_BIA,
                         &next_BIA);
-            timer_off("DFMP2 Qia Read");
+            timer_off("DFMP2 Bia Read");
 
             for (int block_j = 0; block_j <= block_i; block_j++) {
                 // Sizing
@@ -3334,11 +3334,11 @@ void UDFMP2::form_energy() {
                 size_t nj = jstop - jstart;
 
                 // Read iaQ chunk
-                timer_on("DFMP2 Qia Read");
+                timer_on("DFMP2 Bia Read");
                 next_BIAb = psio_get_address(PSIO_ZERO, sizeof(double) * (jstart * navir_b * naux));
                 psio_->read(PSIF_DFMP2_QIA, "B(ia|Q)", (char*)Bjbp[0], sizeof(double) * (nj * navir_b * naux), next_BIAb,
                             &next_BIAb);
-                timer_off("DFMP2 Qia Read");
+                timer_off("DFMP2 Bia Read");
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread) reduction(+ : e_os)
                 for (long int ij = 0L; ij < ni * nj; ij++) {

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -2095,11 +2095,11 @@ void RDFMP2::form_P() {
         C_DGEMM('T', 'N', nfvir, navir, nso, 1.0, Cfvirp[0], nfvir, Lmap[0], navir, 0.0, PAbp[0], navir);
         for (int b = 0; b < navir; b++) {
             for (int A = 0; A < nfvir; A++) {
-                PAbp[A][b] /= -(eps_avirp[b] - eps_fvirp[A]);
+                PAbp[A][b] /= (eps_avirp[b] - eps_fvirp[A]);
             }
         }
 
-        for (int B = 0; B < nfocc; B++) {
+        for (int B = 0; B < nfvir; B++) {
             C_DCOPY(navir, PAbp[B], 1, &Ppqp[nfocc + naocc + navir + B][nfocc + naocc], 1);
             C_DCOPY(navir, PAbp[B], 1, &Ppqp[nfocc + naocc][nfocc + naocc + navir + B], nmo);
         }

--- a/psi4/src/psi4/dfmp2/mp2.h
+++ b/psi4/src/psi4/dfmp2/mp2.h
@@ -85,14 +85,14 @@ class DFMP2 : public Wavefunction {
     virtual void form_L() = 0;
     // Form the unrelaxed correlation OPDM; Compute DiStasio 6 and 9; Assemble DiStasio 6-9 into one matrix
     virtual void form_P() = 0;
-    // Form the unrelaxed correlation energy-weighted OPDM; DiStasio 11-17
+    // Form part of the unrelaxed correlation EWDM; DiStasio 11-13... plus fudge factors
     virtual void form_W() = 0;
     // Form the full Lagrangian, solve the Z-vector equations, and apply final corrections to W and P (DiStasio 10, 16, 17)
     virtual void form_Z() = 0;
     // Manage the formation of W and P contributions to the gradient
     virtual void form_gradient() = 0;
 
-    // Compute singles correction [for ROHF-MBPT(2) or dual-basis]
+    // Compute singles correction [nonzero for ROHF-MBPT(2) or dual-basis]
     virtual void form_singles();
     // Apply the fitting and transposition to a given disk entry Aia tensor
     virtual void apply_fitting(SharedMatrix Jm12, size_t file, size_t naux, size_t nia);
@@ -137,7 +137,7 @@ class RDFMP2 : public DFMP2 {
 
     // Print additional header
     void print_header() override;
-    // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
+    // Form the (A|ia) = (A|mn) C_mi C_ma tensor(s)
     void form_Aia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
     void form_Bia() override;

--- a/psi4/src/psi4/dfmp2/mp2.h
+++ b/psi4/src/psi4/dfmp2/mp2.h
@@ -81,7 +81,7 @@ class DFMP2 : public Wavefunction {
     virtual void form_AB_x_terms() = 0;
     // Form the (A|mn)^x contribution to the gradient; Term 1 of DiStasio 1
     virtual void form_Amn_x_terms() = 0;
-    // Form the Lma and Lmi matrices; DiStasio 19 and 20
+    // Form the L_μa and L_μi matrices; DiStasio 19 and 20
     virtual void form_L() = 0;
     // Form the unrelaxed correlation OPDM; Compute DiStasio 6 and 9; Assemble DiStasio 6-9 into one matrix
     virtual void form_P() = 0;

--- a/psi4/src/psi4/dfmp2/mp2.h
+++ b/psi4/src/psi4/dfmp2/mp2.h
@@ -38,6 +38,8 @@ class PSIO;
 
 namespace dfmp2 {
 
+// References to DiStasio are to J Comput Chem 28: 839–856, 2007; DOI: 10.1002/jcc.20604
+
 class DFMP2 : public Wavefunction {
    protected:
     // Auxiliary basis
@@ -60,32 +62,32 @@ class DFMP2 : public Wavefunction {
     // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
     virtual void form_Aia() = 0;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
-    virtual void form_Qia() = 0;
+    virtual void form_Bia() = 0;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia) and J_QA^-1 (A|ia)
-    virtual void form_Qia_gradient() = 0;
-    // Transpose the integrals to (ai|Q)
-    virtual void form_Qia_transpose() = 0;
+    virtual void form_Bia_Cia() = 0;
+    // Transpose the B integrals to (ai|Q)
+    virtual void form_Bia_transpose() = 0;
     // Form the energy contributions
     virtual void form_energy() = 0;
-    // Form the energy contributions and gradients
+    // Form the VV block of the correlation OPDM (DiStasio 8) and Gamma_ia^Q (DiStasio 2)
     virtual void form_Pab() = 0;
-    // Form the energy contributions and gradients
+    // Form the OO block of the correlation OPDM (DiStasio 7)
     virtual void form_Pij() = 0;
-    // Form the small gamma
+    // Form the small gamma; Eq. 3 of DiStasio
     virtual void form_gamma() = 0;
     // Transpose the G
     virtual void form_G_transpose() = 0;
-    // Form the (A|B)^x contribution to the gradient
+    // Form the (A|B)^x contribution to the gradient; Term 2 of DiStasio 1
     virtual void form_AB_x_terms() = 0;
-    // Form the (A|mn)^x contribution to the gradient
+    // Form the (A|mn)^x contribution to the gradient; Term 1 of DiStasio 1
     virtual void form_Amn_x_terms() = 0;
-    // Form the Lma and Lmi matrices
+    // Form the Lma and Lmi matrices; DiStasio 19 and 20
     virtual void form_L() = 0;
-    // Form the unrelaxed OPDM
+    // Form the unrelaxed correlation OPDM; Compute DiStasio 6 and 9; Assemble DiStasio 6-9 into one matrix
     virtual void form_P() = 0;
-    // Form the unrelaxed energy-weighted OPDM
+    // Form the unrelaxed correlation energy-weighted OPDM; DiStasio 11-17
     virtual void form_W() = 0;
-    // Form the full Lagrangian, solve the Z-vector equations, and apply final corrections to W and P
+    // Form the full Lagrangian, solve the Z-vector equations, and apply final corrections to W and P (DiStasio 10, 16, 17)
     virtual void form_Z() = 0;
     // Manage the formation of W and P contributions to the gradient
     virtual void form_gradient() = 0;
@@ -138,11 +140,11 @@ class RDFMP2 : public DFMP2 {
     // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
     void form_Aia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
-    void form_Qia() override;
+    void form_Bia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia) and J_QA^-1 (A|ia)
-    void form_Qia_gradient() override;
+    void form_Bia_Cia() override;
     // Transpose the integrals to (ai|Q)
-    void form_Qia_transpose() override;
+    void form_Bia_transpose() override;
     // Form the energy contributions
     void form_energy() override;
     // Form the energy contributions and gradients
@@ -192,11 +194,11 @@ class UDFMP2 : public DFMP2 {
     // Form the (A|ia) = (A|mn) C_mi C_na tensor(s)
     void form_Aia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia)
-    void form_Qia() override;
+    void form_Bia() override;
     // Apply the fitting (Q|ia) = J_QA^-1/2 (A|ia) and J_QA^-1 (A|ia)
-    void form_Qia_gradient() override;
+    void form_Bia_Cia() override;
     // Transpose the integrals to (ai|Q)
-    void form_Qia_transpose() override;
+    void form_Bia_transpose() override;
     // Form the energy contributions
     void form_energy() override;
     // Form the energy contributions and gradients

--- a/tests/pytests/test_gradients.py
+++ b/tests/pytests/test_gradients.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+import psi4
+
+from .utils import compare_values
+
+# Reference data generated from Psi's dfmp2 module
+data = {
+    "df-mp2 ae": np.array([[ 0, 0,  9.62190509e-03],
+         [0,  5.49835030e-03, -4.81095255e-03],
+         [0, -5.49835030e-03, -4.81095255e-03]]),
+    "df-mp2 fc": np.array([[ 0, 0,  1.02432654e-02],
+         [0,  5.88581965e-03, -5.12163268e-03],
+         [0, -5.88581965e-03, -5.12163268e-03]]),
+    "df-mp2 fv": np.array([[ 0, 0,  1.22918833e-02],
+         [0,  5.52107556e-03, -6.14594166e-03],
+         [0, -5.52107556e-03, -6.14594166e-03]]),
+    "df-mp2 fc/fv": np.array([[ 0, 0,  1.25984187e-02],
+         [0,  5.71563223e-03, -6.29920936e-03],
+         [0, -5.71563223e-03, -6.29920936e-03]])
+    }
+
+@pytest.mark.slow
+# TODO: That "true" needs to be a string is silly. Convert it to a boolean when you can do that without incurring a NaN energy.
+@pytest.mark.parametrize("inp", [
+    pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df'}, 'ref': data["df-mp2 ae"]}, id='df-mp2 ae'),
+    pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df', 'freeze_core': 'true'}, 'ref': data["df-mp2 fc"]}, id='df-mp2 fc'),
+    pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df', 'num_frozen_uocc': 4}, 'ref': data["df-mp2 fv"]}, id='df-mp2 fv'),
+    pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df', 'freeze_core': 'true', 'num_frozen_uocc': 4}, 'ref': data["df-mp2 fc/fv"]}, id='df-omp2 fc/fv')
+    ]
+)
+def test_gradient(inp):
+    h2o = psi4.geometry("""
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+    """)
+
+    psi4.set_options({'basis': 'aug-cc-pvdz', 'points': 5})
+    psi4.set_options(inp['options'])
+    
+    analytic_gradient = psi4.gradient(inp['name'], dertype=1)
+    print(analytic_gradient)
+    findif_gradient = psi4.gradient(inp['name'], dertype=0)
+    reference_gradient = inp["ref"]
+
+    assert compare_values(findif_gradient, analytic_gradient, 5, "analytic vs. findif gradient")
+    assert compare_values(reference_gradient, analytic_gradient.np, 5, "analytic vs. reference gradient")
+


### PR DESCRIPTION
## Description
This PR closes #1916 and corrects a bug causing third-decimal errors in gradients computed by `dfmp2` with the frozen virtual approximation. See the commit marked "Bugfix!" to see exactly what the issue was. There was a sign error, and Rob was looping over frozen core orbitals when he meant to loop over frozen virtual orbitals.

More importantly for me, this code inserts many, many comments into Rob's code, so I know what I'm doing when I modify it throughout the rest of this PR series. This includes uncovering a very devious computational trick, that as far as I know is unpublished, and also some errors in the original papers. Many thanks to Francesco and Shuhe for the DSRG-PT2 paper, which formed part of the Rosetta Stone for figuring out how this code works.

Several explicit types are now `auto`. Reviewers, double-check that I didn't accidentally remove a pass-by-reference or `const` declaration when doing so.

Lastly, `test_gradients.py` has been added to pytests to confirm the accuracy of `dfmp2` gradients. This PR series will culminate with the addition of DF-ODC-12 to `test_gradients.py`. Currently, DF-ODC-12 would fail due to #1579.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Corrects a critical bug causing errors in frozen virtual gradients computed with the `dfmp2` module
- [x] Adds many comments to `dfmp2`
- [x] Replaces a lot of explicit type with `auto`

## Checklist
- [x] Tests added for newly working features
- [x] `dfmp2` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
