### PR TITLE
Moves import of qcelemental in main Psi4 script to be later in the file.

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -36,7 +36,6 @@ import datetime
 import argparse
 from argparse import RawTextHelpFormatter
 from pathlib import Path
-import qcelemental as qcel
 
 # yapf: disable
 parser = argparse.ArgumentParser(description="Psi4: Open-Source Quantum Chemistry", formatter_class=RawTextHelpFormatter)
@@ -243,6 +242,7 @@ if args["scratch"] is not None:
 
 # If this is a json or qcschema call, compute and stop
 if args["qcschema"]:
+    import qcelemental as qcel
 
     # Handle the reading and deserialization manually
     filename = args["input"]


### PR DESCRIPTION
## Description
The main script (`run_psi4.py` in the source tree or `psi4` when installed) was importing qcelemental before it had a chance to modify the Python search path.  If you didn't already have a copy of qcelemental in your Python search path would cause an error. Encountered this on our cluster while trying to run the tests.

## Status
- [x] Ready for review
- [x] Ready for merge
