### PR TITLE
close detci files so independent psiapi calcs possible

### DIFF
--- a/psi4/driver/psifiles.py
+++ b/psi4/driver/psifiles.py
@@ -214,6 +214,10 @@ PSIF_DFOCC_ABIC             =  280  # DFOCC <AB|IC>
 PSIF_DFOCC_MIABC            =  281  # DFOCC M_iabc
 PSIF_DFOCC_TEMP             =  282  # DFOCC temporary storage
 PSIF_SAD                    =  300  # A SAD file (File for SAD related quantities
+PSIF_CI_HD_FILE             =  350  # DETCI H diagonal
+PSIF_CI_C_FILE              =  351  # DETCI CI coeffs
+PSIF_CI_S_FILE              =  352  # DETCI sigma coeffs
+PSIF_CI_D_FILE              =  353  # DETCI D correction vectors
 PSIF_DCT_DPD                =  400  # DCT DPD handle
 PSIF_DCT_DENSITY            =  401  # DCT density
 

--- a/psi4/include/psi4/psifiles.h
+++ b/psi4/include/psi4/psifiles.h
@@ -294,6 +294,12 @@
 
 #define PSIF_SAD                 300  /*- A SAD file (File for SAD related quantities -*/
 
+// following four are not completely managed by PSIO and starting number resettable through CI_FILE_START option
+#define PSIF_CI_HD_FILE          350  /*- DETCI H diagonal -*/
+#define PSIF_CI_C_FILE           351  /*- DETCI CI coeffs -*/
+#define PSIF_CI_S_FILE           352  /*- DETCI sigma coeffs -*/
+#define PSIF_CI_D_FILE           353  /*- DETCI D correction vectors -*/
+
 #define PSIF_DCT_DPD             400 /*- DCT DPD handle -*/
 #define PSIF_DCT_DENSITY         401 /*- DCT density -*/
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -573,7 +573,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- What file do we start at for hd/c/s/d CIvects? Should be 50 for normal
         CI calculations and 54 if we are going to do a second monomer. !expert -*/
-        options.add_int("CI_FILE_START", 50);
+        options.add_int("CI_FILE_START", 350);
 
         /*- Guess vector type.  Accepted values are ``UNIT`` for a unit vector
         guess (|detci__num_roots| and |detci__num_init_vecs| must both be 1); ``H0_BLOCK`` to use

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -571,8 +571,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- SUBSECTION Guess Vectors -*/
 
-        /*- What file do we start at for hd/c/s/d CIvects? Should be 50 for normal
-        CI calculations and 54 if we are going to do a second monomer. !expert -*/
+        /*- What file do we start at for hd/c/s/d CIvects? Should be 350 for normal
+        CI calculations and 354 if we are going to do a second monomer. !expert -*/
         options.add_int("CI_FILE_START", 350);
 
         /*- Guess vector type.  Accepted values are ``UNIT`` for a unit vector

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -24,6 +24,9 @@ def runner_asserter(inp, subject, method, basis, tnm):
     reference = inp["keywords"]["reference"]
     fcae = {"true": "fc", "false": "ae"}[inp["keywords"]["freeze_core"]]
 
+    if qc_module == "psi4-detci" and basis != "cc-pvdz":
+        pytest.skip(f"basis {basis} too big for {qc_module}")
+
     # <<<  Reference Values  >>>
 
     # ? precedence on next two

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -103,13 +103,13 @@ _nyi10 = pytest.mark.xfail(reason="rohf olccd energies mp2 submethod NYI", raise
         pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "mem_df", },             }, id="mp2  rhf  mem/conv rr fnocc",),
         pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "disk_df",},             }, id="mp2  rhf disk/conv rr fnocc",),
         pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "fnocc", "freeze_core": "false",  "scf_type": "cd",     },             }, id="mp2  rhf   cd/conv rr fnocc",),
-        # below work fine but have to be careful b/c detci can't do fc, then ae w/o psio error, interfere w/detci lines below
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "pk",     },}, id="mp2  rhf   pk/conv rr detci",),
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "direct", },}, id="mp2  rhf drct/conv rr detci",),
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "df",     },}, id="mp2  rhf   df/conv rr detci",),
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "mem_df", },}, id="mp2  rhf  mem/conv rr detci",),
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "disk_df",},}, id="mp2  rhf disk/conv rr detci",),
-        # pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",  "scf_type": "cd",     },}, id="mp2  rhf   cd/conv rr detci",),
+
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "pk",     },             }, id="mp2  rhf   pk/conv rr detci",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "direct", },             }, id="mp2  rhf drct/conv rr detci",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "df",     },             }, id="mp2  rhf   df/conv rr detci",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "mem_df", },             }, id="mp2  rhf  mem/conv rr detci",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "disk_df",},             }, id="mp2  rhf disk/conv rr detci",),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",   "scf_type": "cd",     },             }, id="mp2  rhf   cd/conv rr detci",),
         # yapf: enable
     ],
 )
@@ -168,12 +168,11 @@ def test_mp2_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, requ
         pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "fnocc", "freeze_core": "false",                  },}, id="mp2  rhf    conv ae:   fnocc",),
 
         ###### detci
-        # * detci must have ae before fc to avoid psio error. cleaning doesn't help
         # * detci rohf mp2 does not match other programs in the stored reference
-        #pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "false",                  },}, id="mp2  rhf    conv ae:   detci"),
-        #pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",                   },}, id="mp2  rhf    conv fc:   detci",),
-        #pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",                   },}, id="mp2 rohf    conv fc:   detci", marks=pytest.mark.xfail(reason="detci rohf mp2 diff ans", raises=AssertionError)),
-        #pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv", "qc_module": "detci", "freeze_core": "false",                  },}, id="mp2 rohf    conv ae:   detci", marks=pytest.mark.xfail(reason="detci rohf mp2 diff ans", raises=AssertionError)),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "false",                  },}, id="mp2  rhf    conv ae:   detci"),
+        pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",                   },}, id="mp2  rhf    conv fc:   detci",),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv", "qc_module": "detci", "freeze_core": "true",                   },}, id="mp2 rohf    conv fc:   detci", marks=pytest.mark.xfail(reason="detci rohf mp2 diff ans", raises=AssertionError)),
+        pytest.param({"keywords": {"reference": "rohf", "mp2_type": "conv", "qc_module": "detci", "freeze_core": "false",                  },}, id="mp2 rohf    conv ae:   detci", marks=pytest.mark.xfail(reason="detci rohf mp2 diff ans", raises=AssertionError)),
 
         ###### occ/dfocc
         pytest.param({"keywords": {"reference": "rhf",  "mp2_type": "conv", "qc_module": "occ", "freeze_core": "true",                     },}, id="mp2  rhf    conv fc: * occ  ",),


### PR DESCRIPTION
## Description
now we can have >1 detci test in the whole pytest suite

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] cepa directed to fnocc was running conv when user requested (unavailable) df. now stops. thanks, @JonathonMisiewicz 
- [x] close detci files so independent psiapi calcs possible

## Questions
- [x] @CDSherrill should `CI_FILE_START` be shifted so others aren't confused by seeming overlap with https://github.com/psi4/psi4/blob/master/psi4/include/psi4/psifiles.h#L77-L81 ? maybe 350

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
