### PR TITLE
cast int to list for array variable

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -562,6 +562,8 @@ bool py_psi_set_local_option_int(std::string const& module, std::string const& k
         Process::environment.options.set_bool(module, nonconst_key, value ? true : false);
     } else if (data.type() == "string" || data.type() == "istring") {
         Process::environment.options.set_str(module, nonconst_key, std::to_string(value));
+    } else if (data.type() == "array") {
+        Process::environment.options.set_local_array_int(module, nonconst_key, value, nullptr);
     } else {
         Process::environment.options.set_int(module, nonconst_key, value);
     }
@@ -611,6 +613,8 @@ bool py_psi_set_global_option_int(std::string const& key, int value) {
         Process::environment.options.set_global_bool(nonconst_key, value ? true : false);
     } else if (data.type() == "string" || data.type() == "istring") {
         Process::environment.options.set_global_str(nonconst_key, std::to_string(value));
+    } else if (data.type() == "array") {
+        Process::environment.options.set_global_array_int(nonconst_key, value, nullptr);
     } else {
         Process::environment.options.set_global_int(nonconst_key, value);
     }

--- a/tests/fnocc4/input.dat
+++ b/tests/fnocc4/input.dat
@@ -18,6 +18,7 @@ set {
   occ_tolerance       1e-4
   scf_type cd
   cc_type cd
+  docc 5
 }
 energy('ccsd(t)')
 edfccsd  = variable("CCSD CORRELATION ENERGY")


### PR DESCRIPTION
## Description
Assigning an int to an array variable accepts it as a one-item array, rather than throwing a fit. @robertodr, this should work for https://github.com/psi4/psi4/pull/1814#issuecomment-642655962. Feel free to just incorporate these lines into your TDDFT PR.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
