### PR TITLE
fix UHF after RHF CCSD gradient crash

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -414,6 +414,8 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
         // Process::environment.globals["CC ROOT n QUADRUPOLE ZZ"]
 
         free_block(moinfo.opdm);
+        free_block(moinfo.opdm_a);
+        free_block(moinfo.opdm_b);
 
         psio_close(PSIF_CC_TMP, 0);
         psio_open(PSIF_CC_TMP, PSIO_OPEN_NEW);

--- a/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
@@ -169,6 +169,8 @@ void sortone_RHF(const struct RHO_Params& rho_params) {
     }
 
     moinfo.opdm = O;
+    moinfo.opdm_a = nullptr;
+    moinfo.opdm_b = nullptr;
 }
 }
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
@@ -250,6 +250,7 @@ void sortone_UHF(const struct RHO_Params& rho_params) {
 
     moinfo.opdm_a = O_a;
     moinfo.opdm_b = O_b;
+    moinfo.opdm = nullptr;
 }
 }
 }  // namespace psi


### PR DESCRIPTION
## Description
UHF CCSD gradients were crashing but only in subsequent jobs like the below. Culprit was freeing the opdm https://github.com/psi4/psi4/blob/master/psi4/src/psi4/cc/ccdensity/ccdensity.cc#L416. opdm wasn't getting set for UHF, but it wasn't null either for `free_block` to pass by. Is this a sensible solution?

```
molecule hf {
                H
                F 1 0.917
}

set reference rhf
gradient("ccsd/cc-pvdz", molecule=hf)

clean()

set reference uhf
gradient("ccsd/cc-pvdz", molecule=hf)
```

snapshot of what was getting set for the various references:
```
>>> grep O ccdensity/sortone* | grep -v OEI | grep O | grep opdm
ccdensity/sortone_RHF.cc:** matrix, O (moinfo.opdm), which we also symmetrize by computing Opq
ccdensity/sortone_RHF.cc:    moinfo.opdm = O;
ccdensity/sortone_ROHF.cc:** matrix, O (moinfo.opdm), which we also symmetrize by computing Opq
ccdensity/sortone_ROHF.cc:    moinfo.opdm_a = O_a;
ccdensity/sortone_ROHF.cc:    moinfo.opdm_b = O_b;
ccdensity/sortone_ROHF.cc:    moinfo.opdm = O;
ccdensity/sortone_UHF.cc:** spin-factored matrices, O_a (moinfo.opdm_a) and O_b
ccdensity/sortone_UHF.cc:** (moinfo.opdm_b), which we also symmetrize by computing Opq = 1/2
ccdensity/sortone_UHF.cc:    moinfo.opdm_a = O_a;
ccdensity/sortone_UHF.cc:    moinfo.opdm_b = O_b;
```

## Checklist
- [ ] ~Tests added for any new features~
- [x] all CC tests run

## Status
- [x] Ready for review
- [x] Ready for merge

closes #1652 