### PR TITLE
Fixed ECP and f-electron combinations.

### DIFF
--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -250,6 +250,10 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
                 if (largest_shell < current_shell) {
                     largest_shell = current_shell;
                 }
+                // If center is a post-lanthanide in > 6th period, freeze its f electrons too
+                if (current_shell > 5) {
+                    if ((Z + ECP - delta) >= 18 ) delta += 14;
+                }
                 // If this center has an ECP, some electrons are already frozen
                 if (ECP > 0) delta -= ECP;
                 // Keep track of current valence electrons

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -250,7 +250,8 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
                 if (largest_shell < current_shell) {
                     largest_shell = current_shell;
                 }
-                // If center is a post-lanthanide in > 6th period, freeze its f electrons too
+                // If center is a post-lanthanide or a post-actinide in Nth period,
+                // freeze all 14 of its (N-2)f electrons too
                 if (current_shell > 5) {
                     if ((Z + ECP - delta) >= 18 ) delta += 14;
                 }

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -63,3 +63,23 @@ set guess sad
 Eghne = energy('mp2', molecule=ghne)
 Eghxe = energy('mp2', molecule=ghxe)
 compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy frozen [He] and [Kr] by hand")  #TEST
+
+molecule bih3 {
+0 1
+   BI         0.00000000      0.76521375      0.00000000
+   H          1.43645600     -0.25507125      0.00000000
+   H         -0.71822800     -0.25507125      1.24400700
+   H         -0.71822800     -0.25507125     -1.24400700
+}
+
+set freeze_core 0
+E, wfn = energy("mp2/def2-svp", return_wfn=True)
+
+compare_values(wfn.nfrzc(), 0, 1, "Number of frozen e- with freeze_core = 0")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 0")
+
+set freeze_core 1
+E, wfn = energy("mp2/def2-svp", return_wfn=True)
+compare_values(wfn.nfrzc(), 4, 1, "Number of frozen orbitals with freeze_core = 1")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 1")
+


### PR DESCRIPTION
## Description
In some basis sets that contain ECPs, the "valence" f-shell is included in the effective core. This seems true for all post-lanthanide/actinide atoms. 

In current master, those 60 ECP electrons are always frozen, but in a non-ECP basis with frozen core we'd freeze only 54 of those. The simple solution is to always freeze the 4f electrons (for 6th period) if the shell is full.



## Checklist
- [x] Tests added for any new features
- [x] `ctest -L ecp` passes.

## Status
- [x] Ready for review
- [x] Ready for merge
