### PR TITLE
Keep _default_psio_manager_ alive for Process::Environment

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -955,10 +955,6 @@ bool psi4_python_module_initialize() {
         return true;
     }
 
-    // Setup the environment
-    Process::environment.initialize();  // Defaults to obtaining the environment from the global environ variable
-    Process::environment.set_memory(524288000);
-
     // There should only be one of these in Psi4
     Wavefunction::initialize_singletons();
 
@@ -971,7 +967,13 @@ bool psi4_python_module_initialize() {
     timer_init();
 
     // Initialize the I/O library
+    // Must be done before initializing Process::environment as that needs
+    // to access some globals from psio
     psio_init();
+
+    // Setup the environment
+    Process::environment.initialize();  // Defaults to obtaining the environment from the global environ variable
+    Process::environment.set_memory(524288000);
 
     // Setup globals options
     Process::environment.options.set_read_globals(true);

--- a/psi4/src/psi4/libpsi4util/process.cc
+++ b/psi4/src/psi4/libpsi4util/process.cc
@@ -56,6 +56,9 @@ void Process::Environment::initialize() {
 #ifdef _OPENMP
     nthread_ = Process::environment.get_n_threads();
 #endif
+
+    /* See notes in process.h */
+    _psio_manager_keepalive = PSIOManager::shared_object();
 }
 
 void Process::Environment::set_n_threads(int nthread) {

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -37,6 +37,7 @@ PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
 PRAGMA_WARNING_POP
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
@@ -52,6 +53,21 @@ class PSI_API Process {
         size_t memory_;
         int nthread_;
         std::string datadir_;
+
+        /* Keep a shared_ptr to the default psio_manager
+         *
+         * If not, some destructors (like for Wavefunction) will call for the
+         * default _psio_manager. However, the default psio manager is also global.
+         * Destruction order is not specified for global variables, and therefore
+         * the default psio manager can be destructed BEFORE destructors from within
+         * wavefunction are called. By keeping a copy of the shared pointer here,
+         * we can keep it alive as long as we need.
+         *
+         * HOWEVER, pay attention to the order. Order of destruction is reverse
+         * of declaration within a class (guaranteed). So we put it early in the
+         * class definition
+         */
+        std::shared_ptr<PSIOManager> _psio_manager_keepalive;
 
         std::shared_ptr<Molecule> molecule_;
         SharedMatrix gradient_;


### PR DESCRIPTION
The global `_default_psio_manager_` shared_ptr can destruct
before Process::Environment. However, some destructors called
from Process::Environment may require it. So have Process::Environment
keep a copy of the shared_ptr

## Description
Some tasks being run by QCArchive/QCEngine would hang indefinitely, even though the calculation finished. GDB showed memory corruption when destructing the Process::Environment.

The cause was related to the destructor for DIISManager calling PSIO::close

https://github.com/psi4/psi4/blob/8d1a8787504a481f61956fb22b282b6f30005ebc/psi4/src/psi4/libpsio/close.cc#L82 

`PSIOManager::shared_object()` returns a copy of the global shared_ptr `_default_psio_manager_`. The main issue is that `_default_psio_manager_` can be destructed before Process::Environment, as order of destruction is not well-defined for globals.

The easiest solution is for Process::Environment to hold a copy of the shared_ptr for the global psio manager, even if it is not used. This prevents premature destruction.

How this issue caused indefinite hanging/locking isn't very clear, but crazy stuff can happen with memory corruptions.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [X] Fix crashing/hanging in certain instances due to using already destructed global objects

## Checklist
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
