### PR TITLE
add cct3 plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ option(ENABLE_PCMSolver "Enables PCMSolver library (requires Fortran)" OFF)
 option(ENABLE_snsmp2 "Enables SNSMP2 plugin (can also be added at runtime)" OFF)
 option(ENABLE_v2rdm_casscf "Enables V2RDM_CASSCF plugin (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_psi4fockci "Enables Psi4FockCI plugin (can also be added at runtime)" OFF)
+option(ENABLE_cct3 "Enables psi4_cct3 plugin (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_gpu_dfcc "Enables GPU_DFCC plugin for gpu-accelerated df-cc (requires CUDA; can also be added at runtime)" OFF)
 option(ENABLE_mdi "Enables MolSSI driver interface" OFF)
 # These options are relevant to pasture, expert only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ option(ENABLE_PCMSolver "Enables PCMSolver library (requires Fortran)" OFF)
 option(ENABLE_snsmp2 "Enables SNSMP2 plugin (can also be added at runtime)" OFF)
 option(ENABLE_v2rdm_casscf "Enables V2RDM_CASSCF plugin (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_psi4fockci "Enables Psi4FockCI plugin (can also be added at runtime)" OFF)
-option(ENABLE_cct3 "Enables psi4_cct3 plugin (requires Fortran; can also be added at runtime)" OFF)
+option(ENABLE_cct3 "Enables cct3 plugin (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_gpu_dfcc "Enables GPU_DFCC plugin for gpu-accelerated df-cc (requires CUDA; can also be added at runtime)" OFF)
 option(ENABLE_mdi "Enables MolSSI driver interface" OFF)
 # These options are relevant to pasture, expert only

--- a/external/downstream/CMakeLists.txt
+++ b/external/downstream/CMakeLists.txt
@@ -1,9 +1,10 @@
 foreach(dir pasture
+            adcc
+            cct3
+            psi4fockci
             gpu_dfcc
             snsmp2
             v2rdm_casscf
-            adcc
-            psi4fockci
 )
 
    add_subdirectory(${dir})

--- a/external/downstream/cct3/CMakeLists.txt
+++ b/external/downstream/cct3/CMakeLists.txt
@@ -1,0 +1,44 @@
+if(${ENABLE_cct3})
+    find_package(cct3 0.8 CONFIG QUIET)
+
+    if(${cct3_FOUND})
+        get_property(_loc TARGET cct3::cct3 PROPERTY LOCATION)
+        message(STATUS "${Cyan}Found cct3${ColourReset}: ${_loc} (found version ${cct3_VERSION})")
+        add_library(cct3_external INTERFACE)  # dummy
+
+    else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_cct3})
+            message(FATAL_ERROR "Suitable cct3 could not be externally located as user insists")
+        endif()
+
+        include(ExternalProject)
+        message(STATUS "Suitable cct3 could not be located, ${Magenta}Building cct3${ColourReset} instead.")
+
+        ExternalProject_Add(cct3_external
+            DEPENDS psi4-core
+            URL https://github.com/loriab/psi4_cct3/archive/cmake.tar.gz
+            UPDATE_COMMAND ""
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                       -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+                       -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+                       -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
+                       -DENABLE_XHOST=${ENABLE_XHOST}
+                       -DENABLE_GENERIC=${ENABLE_GENERIC}
+                       -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
+                       -Dpsi4_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/psi4
+                       -Dpybind11_DIR=${pybind11_DIR}
+                       -DTargetLAPACK_DIR=${TargetLAPACK_DIR}
+            CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                             -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+                             -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
+                             -DCMAKE_PREFIX_PATH:PATH=${STAGED_INSTALL_PREFIX})
+
+        set(cct3_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/cct3 CACHE PATH "path to internally built cct3Config.cmake" FORCE)
+    endif()
+else()
+    add_library(cct3_external INTERFACE)  # dummy
+endif()
+

--- a/external/downstream/cct3/CMakeLists.txt
+++ b/external/downstream/cct3/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_cct3})
-    find_package(cct3 0.8 CONFIG QUIET)
+    find_package(cct3 0.1 CONFIG QUIET)
 
     if(${cct3_FOUND})
         get_property(_loc TARGET cct3::cct3 PROPERTY LOCATION)
@@ -16,6 +16,7 @@ if(${ENABLE_cct3})
 
         ExternalProject_Add(cct3_external
             DEPENDS psi4-core
+            #URL https://github.com/piecuch-group/cct3/archive/master.tar.gz
             URL https://github.com/loriab/psi4_cct3/archive/cmake.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -67,3 +67,8 @@ try:
 except ImportError:
     pass
 
+try:
+    import psi4_cct3
+except ImportError:
+    pass
+

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -68,7 +68,7 @@ except ImportError:
     pass
 
 try:
-    import psi4_cct3
+    import cct3
 except ImportError:
     pass
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -807,8 +807,8 @@ def select_ccsd(name, **kwargs):
             if module == 'FNOCC':
                 func = run_fnocc
             elif module == 'CCT3' and extras.addons("cct3"):
-                import psi4_cct3
-                func = psi4_cct3.run_cct3
+                import cct3
+                func = cct3.run_cct3
             elif module in ['', 'CCENERGY']:
                 func = run_ccenergy
         elif mtd_type == 'DF':
@@ -828,8 +828,8 @@ def select_ccsd(name, **kwargs):
     elif reference == 'ROHF':
         if mtd_type == 'CONV':
             if module == 'CCT3' and extras.addons("cct3"):
-                import psi4_cct3
-                func = psi4_cct3.run_cct3
+                import cct3
+                func = cct3.run_cct3
             elif module in ['', 'CCENERGY']:
                 func = run_ccenergy
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -806,6 +806,9 @@ def select_ccsd(name, **kwargs):
         if mtd_type == 'CONV':
             if module == 'FNOCC':
                 func = run_fnocc
+            elif module == 'CCT3' and extras.addons("cct3"):
+                import psi4_cct3
+                func = psi4_cct3.run_cct3
             elif module in ['', 'CCENERGY']:
                 func = run_ccenergy
         elif mtd_type == 'DF':
@@ -824,7 +827,10 @@ def select_ccsd(name, **kwargs):
                 func = run_ccenergy
     elif reference == 'ROHF':
         if mtd_type == 'CONV':
-            if module in ['', 'CCENERGY']:
+            if module == 'CCT3' and extras.addons("cct3"):
+                import psi4_cct3
+                func = psi4_cct3.run_cct3
+            elif module in ['', 'CCENERGY']:
                 func = run_ccenergy
 
     if func is None:

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -150,6 +150,7 @@ _addons_ = {
     "psi4fockci": which_import("psi4fockci", return_bool=True),
     "adcc": which_import("adcc", return_bool=True),
     "mdi": which_import("mdi", return_bool=True),
+    "cct3": which_import("psi4_cct3", return_bool=True),
 }
 
 

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -150,7 +150,7 @@ _addons_ = {
     "psi4fockci": which_import("psi4fockci", return_bool=True),
     "adcc": which_import("adcc", return_bool=True),
     "mdi": which_import("mdi", return_bool=True),
-    "cct3": which_import("psi4_cct3", return_bool=True),
+    "cct3": which_import("cct3", return_bool=True),
 }
 
 

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -103,6 +103,8 @@ void DataType::assign(double) { throw DataTypeException("assign(double) failure"
 
 void DataType::assign(std::string) { throw DataTypeException("assign(std:string) failure"); }
 
+std::vector<std::string> DataType::choices() { throw DataTypeException("choices() failure"); }
+
 void DataType::reset() { throw DataTypeException("reset() failure"); }
 
 Data& DataType::operator[](std::string) { throw NOT_IMPLEMENTED_EXCEPTION(); }
@@ -382,6 +384,8 @@ void Data::assign(double d) { ptr_->assign(d); }
 
 void Data::assign(std::string s) { ptr_->assign(s); }
 
+std::vector<std::string> Data::choices() { return ptr_->choices(); }
+
 void Data::reset() { ptr_->reset(); }
 
 DataType* Data::get() const { return ptr_.get(); }
@@ -595,11 +599,29 @@ void Options::set_double(const std::string& module, const std::string& key, doub
 void Options::set_str(const std::string& module, const std::string& key, std::string s) {
     locals_[module][key] = new StringDataType(s);
     locals_[module][key].changed();
+
+    auto gl = get_global(key);
+    to_upper(s);
+    if (gl.choices().size() > 0) {
+        bool wrong_input = true;
+        for (size_t i = 0; i < gl.choices().size(); ++i)
+            if (s == gl.choices()[i]) wrong_input = false;
+        if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+    }
 }
 
 void Options::set_str_i(const std::string& module, const std::string& key, std::string s) {
     locals_[module][key] = new IStringDataType(s);
     locals_[module][key].changed();
+
+    auto gl = get_global(key);
+    to_upper(s);
+    if (gl.choices().size() > 0) {
+        bool wrong_input = true;
+        for (size_t i = 0; i < gl.choices().size(); ++i)
+            if (s == gl.choices()[i]) wrong_input = false;
+        if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+    }
 }
 
 void Options::set_array(const std::string& module, const std::string& key) {

--- a/psi4/src/psi4/liboptions/liboptions.h
+++ b/psi4/src/psi4/liboptions/liboptions.h
@@ -111,6 +111,8 @@ class DataType {
     virtual void assign(double);
     virtual void assign(std::string);
 
+    virtual std::vector<std::string> choices();
+
     virtual void reset();
 
     virtual Data& operator[](std::string);
@@ -212,6 +214,8 @@ class StringDataType : public DataType {
     void assign(int i) override;
     void assign(double d) override;
     void assign(std::string s) override;
+
+    std::vector<std::string> choices() { return choices_; }
 };
 
 #ifdef __INTEL_COMPILER
@@ -239,6 +243,8 @@ class IStringDataType : public DataType {
     void assign(int i) override;
     void assign(double d) override;
     void assign(std::string s) override;
+
+    std::vector<std::string> choices() { return choices_; }
 };
 
 class PSI_API Data {
@@ -282,6 +288,8 @@ class PSI_API Data {
     void assign(int i);
     void assign(double d);
     void assign(std::string s);
+
+    std::vector<std::string> choices();
 
     void reset();
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -170,7 +170,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     /*- When several modules can compute the same methods and the default
     routing is not suitable, this targets a module. ``CCENERGY`` covers
     CCHBAR, etc. ``OCC`` covers OCC and DFOCC. -*/
-    options.add_str("QC_MODULE", "", "CCENERGY DETCI DFMP2 FNOCC OCC ADCC");
+    options.add_str("QC_MODULE", "", "CCENERGY DETCI DFMP2 FNOCC OCC ADCC CCT3");
     /*- What algorithm to use for the SCF computation. See Table :ref:`SCF
     Convergence & Algorithm <table:conv_scf>` for default algorithm for
     different calculation types. -*/

--- a/tests/pytests/test_addons.py
+++ b/tests/pytests/test_addons.py
@@ -1238,7 +1238,7 @@ EXCLISTS
 @pytest.mark.smoke
 @using_cct3
 def test_cct3():
-    import psi4_cct3
+    import cct3
 
     psi4.geometry("""
         units bohr
@@ -1270,14 +1270,14 @@ def test_cct3():
     psi4.driver.qcdb.libmintsbasisset.basishorde["ANONYMOUS1234"] = basisspec_psi4_yo__anonymous1234
 
     psi4.set_options({
-        "psi4_cct3__froz": 0,
-        "psi4_cct3__act_occ": 1,
-        "psi4_cct3__act_unocc": 1,
-        "psi4_cct3__etol": 16,
-        "psi4_cct3__calc_type": "cct3",
+        "cct3__froz": 0,
+        "cct3__act_occ": 1,
+        "cct3__act_unocc": 1,
+        "cct3__etol": 16,
+        "cct3__calc_type": "cct3",
         "basis": "anonymous1234",
     })
 
-    ene = psi4.energy("psi4_cct3")
+    ene = psi4.energy("cct3")
     assert psi4.compare_values(-4.220587742726, ene, 10, "cc(t;3) energy")
 

--- a/tests/pytests/test_addons.py
+++ b/tests/pytests/test_addons.py
@@ -40,7 +40,11 @@ using_snsmp2 = pytest.mark.skipif(psi4.addons("snsmp2") is False,
                                 reason="Psi4 not detecting plugin snsmp2. Build plugin if necessary and add to envvar PYTHONPATH (or rebuild Psi with -DENABLE_snsmp2)")
 using_resp = pytest.mark.skipif(psi4.addons("resp") is False,
                                 reason="Psi4 not detecting plugin resp. Build plugin if necessary and add to envvar PYTHONPATH (or rebuild Psi with -DENABLE_resp)")
-using_psi4fockci = pytest.mark.skipif(psi4.addons("psi4fockci") is False, reason="Psi4 not detecting plugin psi4fockci. Build plugin if necessary and add to envvar PYTHONPATH")
+using_psi4fockci = pytest.mark.skipif(psi4.addons("psi4fockci") is False,
+                                reason="Psi4 not detecting plugin psi4fockci. Build plugin if necessary and add to envvar PYTHONPATH")
+using_cct3 = pytest.mark.skipif(psi4.addons("cct3") is False,
+                                reason="Psi4 not detecting plugin cct3. Build plugin if necessary and add to envvar PYTHONPATH")
+
 
 @pytest.mark.smoke
 @using_gdma
@@ -1229,3 +1233,51 @@ EXCLISTS
     assert psi4.compare_values(ref_pe_energy, wfn.get_variable("PE ENERGY"), 6, "PE Energy contribution")
     assert psi4.compare_values(ref_scf_energy, scf_energy, 6, "Total PE-SCF Energy")
     psi4.core.print_variables()
+
+
+@pytest.mark.smoke
+@using_cct3
+def test_cct3():
+    import psi4_cct3
+
+    psi4.geometry("""
+        units bohr
+        h -2.514213562373  -1.000000000000   0.000000000000
+        h -2.514213562373   1.000000000000   0.000000000000
+        h  2.514213562373  -1.000000000000   0.000000000000
+        h  2.514213562373   1.000000000000   0.000000000000
+        h -1.000000000000  -2.414213562373   0.000000000000
+        h -1.000000000000   2.414213562373   0.000000000000
+        h  1.000000000000  -2.414213562373   0.000000000000
+        h  1.000000000000   2.414213562373   0.000000000000
+        symmetry d2h
+    """)
+
+    def basisspec_psi4_yo__anonymous1234(mol, role):
+        bas = """
+            cartesian
+            ****
+            H   0
+            S   3  1.0000
+                  4.50038     0.0704800
+                  0.681277    0.407890
+                  0.151374    0.647670
+            ****
+        """
+        mol.set_basis_all_atoms("mbs_my", role=role)
+        return {"mbs_my": bas}
+
+    psi4.driver.qcdb.libmintsbasisset.basishorde["ANONYMOUS1234"] = basisspec_psi4_yo__anonymous1234
+
+    psi4.set_options({
+        "psi4_cct3__froz": 0,
+        "psi4_cct3__act_occ": 1,
+        "psi4_cct3__act_unocc": 1,
+        "psi4_cct3__etol": 16,
+        "psi4_cct3__calc_type": "cct3",
+        "basis": "anonymous1234",
+    })
+
+    ene = psi4.energy("psi4_cct3")
+    assert psi4.compare_values(-4.220587742726, ene, 10, "cc(t;3) energy")
+


### PR DESCRIPTION
## Description
Add cct3 plugin. Patch liboptions.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] add build connection, proc.py connection, and token smoke test
- [x] fix embarrassing bug where enum-like string options weren't validating when set in local scope. that is, `set guess nonsense` would protest, but `set scf guess nonsense` would pass. this isn't perfect as validation occurs against a union of allowed values among different local scopes, but it's an improving patch.
- [x] @edeustua is going to rename the repo to plain `cct3`, so this'll need a name adjustment pass.
- this is connected with https://github.com/piecuch-group/psi4_cct3/pull/2
- note that cct3 builds slowly as it has some hefty fortran files

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
