### PR TITLE
module provenance of Wavefunction

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -288,6 +288,7 @@ def _core_wavefunction_to_file(wfn, filename=None):
         },
         'string': {
             'name': wfn.name(),
+            'module': wfn.module(),
             'basisname': wfn.basisset().name()
         },
         'boolean': {

--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -136,6 +136,7 @@ def _mergedapis_compare_wavefunctions(expected, computed, *args, **kwargs):
     compare(expected.nmo(), computed.nmo(), 'compare nmo', **kwargscopy)
     compare(expected.nso(), computed.nso(), 'compare nso', **kwargscopy)
     compare(expected.name(), computed.name(), 'compare name', **kwargscopy)
+    compare(expected.module(), computed.module(), 'compare module', **kwargscopy)
     compare_values(expected.energy(), computed.energy(), 'compare energy', atol=atol, **kwargscopy)
     compare_values(expected.efzc(), computed.efzc(), 'compare frozen core energy', atol=atol, **kwargscopy)
     compare_values(expected.get_dipole_field_strength()[0],

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -47,7 +47,7 @@ def mcscf_solver(ref_wfn):
     # Build CIWavefunction
     core.prepare_options_for_module("DETCI")
     ciwfn = core.CIWavefunction(ref_wfn)
-    ciwfn.set_module("mcscf")
+    ciwfn.set_module("detci")
 
     # Hush a lot of CI output
     ciwfn.set_print(0)

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -47,6 +47,7 @@ def mcscf_solver(ref_wfn):
     # Build CIWavefunction
     core.prepare_options_for_module("DETCI")
     ciwfn = core.CIWavefunction(ref_wfn)
+    ciwfn.set_module("mcscf")
 
     # Hush a lot of CI output
     ciwfn.set_print(0)

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3309,7 +3309,7 @@ def run_adcc(name, **kwargs):
 
 
     if core.get_option('ADC', 'REFERENCE') not in ["RHF", "UHF"]:
-        raise ValidationError('ADCC requires reference RHF or UHF')
+        raise ValidationError('adcc requires reference RHF or UHF')
 
     # Bypass the scf call if a reference wavefunction is given
     ref_wfn = kwargs.pop('ref_wfn', None)
@@ -3410,7 +3410,7 @@ def run_adcc(name, **kwargs):
     try:
         state = adcrunner[name](ref_wfn, **kwargs, output=CoreStream())
     except InvalidReference as ex:
-        raise ValidationError("Cannot run ADCC because the passed reference wavefunction is "
+        raise ValidationError("Cannot run adcc because the passed reference wavefunction is "
                               "not supported in adcc. Check Psi4 SCF parameters. adcc reports: "
                               "{}".format(str(ex)))
     core.print_out("\n")

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3309,7 +3309,7 @@ def run_adcc(name, **kwargs):
 
 
     if core.get_option('ADC', 'REFERENCE') not in ["RHF", "UHF"]:
-        raise ValidationError('ADC requires reference RHF or UHF')
+        raise ValidationError('ADCC requires reference RHF or UHF')
 
     # Bypass the scf call if a reference wavefunction is given
     ref_wfn = kwargs.pop('ref_wfn', None)
@@ -3410,7 +3410,7 @@ def run_adcc(name, **kwargs):
     try:
         state = adcrunner[name](ref_wfn, **kwargs, output=CoreStream())
     except InvalidReference as ex:
-        raise ValidationError("Cannot run ADC because the passed reference wavefunction is "
+        raise ValidationError("Cannot run ADCC because the passed reference wavefunction is "
                               "not supported in adcc. Check Psi4 SCF parameters. adcc reports: "
                               "{}".format(str(ex)))
     core.print_out("\n")
@@ -3426,6 +3426,7 @@ def run_adcc(name, **kwargs):
     adc_wfn.shallow_copy(ref_wfn)
     adc_wfn.set_reference_wavefunction(ref_wfn)
     adc_wfn.set_name(name)
+    adc_wfn.set_module("adcc")
 
     # MP(3) energy for CVS-ADC(3) calculations is still a missing feature in adcc
     # ... we store this variant here to be able to fall back to MP(2) energies.

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1253,7 +1253,7 @@ def scf_helper(name, post_scf=True, **kwargs):
     # Grab a few kwargs
     use_c1 = kwargs.get('use_c1', False)
     scf_molecule = kwargs.get('molecule', core.get_active_molecule())
-    read_orbitals = core.get_option('SCF', 'GUESS') is "READ"
+    read_orbitals = core.get_option('SCF', 'GUESS') == "READ"
     do_timer = kwargs.pop("do_timer", True)
     ref_wfn = kwargs.pop('ref_wfn', None)
     if ref_wfn is not None:
@@ -4098,6 +4098,7 @@ def run_sapt(name, **kwargs):
     p4util.banner(name.upper())
     core.print_out('\n')
     e_sapt = core.sapt(dimer_wfn, monomerA_wfn, monomerB_wfn)
+    dimer_wfn.set_module("sapt")
 
     from psi4.driver.qcdb.psivardefs import sapt_psivars
     p4util.expand_psivars(sapt_psivars())
@@ -4246,6 +4247,7 @@ def run_sapt_ct(name, **kwargs):
     core.IO.change_file_namespace(psif.PSIF_SAPT_MONOMERB, 'monomerB', 'dimer')
     e_sapt = core.sapt(dimer_wfn, monomerA_wfn, monomerB_wfn)
     CTd = core.variable('SAPT CT ENERGY')
+    dimer_wfn.set_module("sapt")
 
     core.print_out('\n')
     p4util.banner('Monomer Basis SAPT')

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -183,6 +183,10 @@ void export_wavefunction(py::module& m) {
         .def("set_name", &Wavefunction::set_name, "Sets the level of theory this wavefunction corresponds to.")
         .def("name", &Wavefunction::name, py::return_value_policy::copy,
              "The level of theory this wavefunction corresponds to.")
+        .def("set_module", &Wavefunction::set_module, "module"_a,
+             "Sets name of the last/highest level of theory module (internal or external) touching the wavefunction.")
+        .def("module", &Wavefunction::module, py::return_value_policy::copy,
+             "Name of the last/highest level of theory module (internal or external) touching the wavefunction.")
         .def("alpha_orbital_space", &Wavefunction::alpha_orbital_space, "docstring")
         .def("beta_orbital_space", &Wavefunction::beta_orbital_space, "docstring")
         .def("molecule", &Wavefunction::molecule, "Returns the Wavefunction's molecule.")

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -42,6 +42,7 @@ namespace adc {
 ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(options) {
     shallow_copy(ref_wfn);
     reference_wavefunction_ = ref_wfn;
+    module_ = "adc";
 
     std::vector<std::string> irreps_ = molecule_->irrep_labels();
     aoccpi_ = new int[nirrep_];

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -73,7 +73,10 @@ CCEnergyWavefunction::CCEnergyWavefunction(std::shared_ptr<Wavefunction> referen
 
 CCEnergyWavefunction::~CCEnergyWavefunction() {}
 
-void CCEnergyWavefunction::init() { shallow_copy(reference_wavefunction_); }
+void CCEnergyWavefunction::init() {
+    shallow_copy(reference_wavefunction_);
+    module_ = "ccenergy";
+}
 
 double CCEnergyWavefunction::compute_energy() {
     int done = 0;

--- a/psi4/src/psi4/dct/dct.cc
+++ b/psi4/src/psi4/dct/dct.cc
@@ -91,6 +91,7 @@ DCTSolver::DCTSolver(SharedWavefunction ref_wfn, Options &options) : Wavefunctio
         same_a_b_orbs_ = false;
         name_ = "U" + options.get_str("DCT_FUNCTIONAL");
     }
+    module_ = "dct";
 
     // Sets up the memory, and orbital info
     init();

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -124,6 +124,7 @@ void CIWavefunction::common_init() {
     if (Parameters_->bendazzoli) form_ov();
 
     name_ = "CIWavefunction";
+    module_ = "detci";
 
     // Init H0 block
     H0block_init(CIblks_->vectlen);

--- a/psi4/src/psi4/dfep2/dfep2.cc
+++ b/psi4/src/psi4/dfep2/dfep2.cc
@@ -63,6 +63,8 @@ DFEP2Wavefunction::DFEP2Wavefunction(std::shared_ptr<Wavefunction> ref_wfn)
     outfile->Printf("                            by Daniel G. A. Smith\n");
     outfile->Printf("         ---------------------------------------------------------\n\n");
 
+    module_ = "dfep2";
+
     conv_thresh_ = options_.get_double("EP2_CONVERGENCE");
     max_iter_ = options_.get_int("EP2_MAXITER");
     debug_ = options_.get_int("DEBUG");

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -173,6 +173,7 @@ void DFMP2::common_init() {
 
     // copy(reference_wavefunction_);
     name_ = "DF-MP2";
+    module_ = "dfmp2";
 
     variables_["MP2 SINGLES ENERGY"] = 0.0;
     variables_["MP2 DOUBLES ENERGY"] = 0.0;

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -51,6 +51,8 @@ void DFOCC::common_init() {
     print_ = options_.get_int("PRINT");
     if (print_ > 0) options_.print();
 
+    module_ = "dfocc";
+
     cc_maxiter = options_.get_int("CC_MAXITER");
     mo_maxiter = options_.get_int("MO_MAXITER");
     num_vecs = options_.get_int("MO_DIIS_NUM_VECS");

--- a/psi4/src/psi4/dmrg/dmrgscf.cc
+++ b/psi4/src/psi4/dmrg/dmrgscf.cc
@@ -917,6 +917,7 @@ SharedWavefunction dmrg(SharedWavefunction wfn, Options& options)
     wfn->set_energy(Energy);
     wfn->set_scalar_variable("CURRENT ENERGY", Energy);
     wfn->set_scalar_variable("DMRG-SCF TOTAL ENERGY", Energy);
+    wfn->set_module("chemps2");
 
     if ((( dmrg_molden ) || (( dmrg_caspt2 ) && ( PSEUDOCANONICAL ))) && ( nIterations > 0 )){
 
@@ -1112,6 +1113,7 @@ SharedWavefunction dmrg(SharedWavefunction wfn, Options& options)
        wfn->set_energy(Energy + E_CASPT2);
        wfn->set_scalar_variable("CURRENT ENERGY", Energy + E_CASPT2);
        wfn->set_scalar_variable("DMRG-CASPT2 TOTAL ENERGY", Energy + E_CASPT2);
+       wfn->set_module("chemps2");
 
     }
 

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -66,6 +66,8 @@ FISAPT::FISAPT(SharedWavefunction scf, Options& options) : options_(options), re
 FISAPT::~FISAPT() {}
 
 void FISAPT::common_init() {
+    reference_->set_module("fisapt");
+
     primary_ = reference_->basisset();
     doubles_ = Process::environment.get_memory() / sizeof(double) * options_.get_double("FISAPT_MEM_SAFETY_FACTOR");
 

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -81,6 +81,8 @@ CoupledCluster::~CoupledCluster() {}
   * initialize.  set variables and options_.
   */
 void CoupledCluster::common_init() {
+    module_ = "fnocc";
+
     mp2_only = options_.get_bool("RUN_MP2");
     mp4_only = options_.get_bool("RUN_MP4");
     mp3_only = options_.get_bool("RUN_MP3");

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -67,6 +67,8 @@ FrozenNO::FrozenNO(SharedWavefunction wfn, Options& options) : Wavefunction(opti
 FrozenNO::~FrozenNO() {}
 
 void FrozenNO::common_init() {
+    module_ = "fnocc";
+
     nso = nmo = ndocc = nvirt = nfzc = nfzv = 0;
     for (int h = 0; h < nirrep_; h++) {
         nfzc += frzcpi_[h];

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -152,6 +152,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
 
     // set strings
     name_ = strings["name"];
+    module_ = strings["module"];
 
     // set booleans
     PCM_enabled_ = booleans["PCM_enabled"];
@@ -176,6 +177,7 @@ void Wavefunction::shallow_copy(SharedWavefunction other) { shallow_copy(other.g
 
 void Wavefunction::shallow_copy(const Wavefunction *other) {
     name_ = other->name_;
+    module_ = other->module_;
     basisset_ = other->basisset_;
     basissets_ = other->basissets_;
     sobasisset_ = other->sobasisset_;
@@ -255,6 +257,7 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     /// From typical constructor
     /// Some member data is not clone-able so we will copy
     name_ = other->name_;
+    module_ = other->module_;
     molecule_ = std::make_shared<Molecule>(other->molecule_->clone());
     basisset_ = other->basisset_;
     basissets_ = other->basissets_;  // Still cannot copy basissets
@@ -344,6 +347,7 @@ std::shared_ptr<Wavefunction> Wavefunction::c1_deep_copy(std::shared_ptr<BasisSe
     /// From typical constructor
     /// Some member data is not clone-able so we will copy
     wfn->name_ = name_;
+    wfn->module_ = module_;
     wfn->integral_ = std::make_shared<IntegralFactory>(wfn->basisset_, wfn->basisset_, wfn->basisset_, wfn->basisset_);
     wfn->mintshelper_ = std::make_shared<MintsHelper>(wfn->basisset_, wfn->options_);
     wfn->sobasisset_ = std::make_shared<SOBasisSet>(wfn->basisset_, wfn->integral_);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -88,6 +88,9 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Name of the wavefunction
     std::string name_;
 
+    /// Module name for CURRENT ENERGY
+    std::string module_;
+
     /// DF/RI/F12/etc basis sets
     std::map<std::string, std::shared_ptr<BasisSet>> basissets_;
 
@@ -639,6 +642,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
 
     /// Returns the wavefunction name
     const std::string& name() const { return name_; }
+
+    /// Set the module name (e.g. "OCC", "CCENERGY", "CCT3")
+    void set_module(const std::string& module) { module_ = module; }
+
+    /// Returns the module name
+    const std::string& module() const { return module_; }
 
     // Set the print flag level
     void set_print(size_t print) { print_ = print; }

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -104,6 +104,8 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
     vAAB_ = nullptr;
     vBAB_ = nullptr;
 
+    module_ = "sapt";
+
     // We inherit from the dimer basis
     ribasis_ = get_basisset("DF_BASIS_SAPT");
     elstbasis_ = get_basisset("DF_BASIS_ELST");

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -104,8 +104,6 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
     vAAB_ = nullptr;
     vBAB_ = nullptr;
 
-    module_ = "sapt";
-
     // We inherit from the dimer basis
     ribasis_ = get_basisset("DF_BASIS_SAPT");
     elstbasis_ = get_basisset("DF_BASIS_ELST");

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -93,6 +93,7 @@ void HF::common_init() {
     attempt_number_ = 1;
     reset_occ_ = false;
     sad_ = false;
+    module_ = "scf";
 
     // This quantity is needed fairly soon
     nirrep_ = factory_->nirrep();

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -57,6 +57,8 @@ void OCCWave::common_init() {
     // print title and options
     print_ = options_.get_int("PRINT");
     if (print_ > 0) options_.print();
+
+    module_ = "occ";
     wfn_type_ = options_.get_str("WFN_TYPE");
     orb_opt_ = options_.get_str("ORB_OPT");
     title();

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -79,7 +79,7 @@ SCFDeriv::~SCFDeriv()
 void SCFDeriv::common_init()
 {
 
-
+    module_ = "scf";
     print_ = options_.get_int("PRINT");
     debug_ = options_.get_int("DEBUG");
 }


### PR DESCRIPTION
## Description
Some info about module-level provenance of a Wfn would be handy.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] add `Wavefunction.module_` member data and export
- [x] add setting to most modules (not psimrcc or fockci)
- [x] incorporate into stdsuite testing

## Questions
- [x] @dgasmith I've given mcscf its own name. prefer "detci"?
- [x] @maxscheurer I edited a couple error messages to ADCC from ADC. ok?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
