### PR TITLE
Fix zero damping in to_print

### DIFF
--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1238,7 +1238,7 @@ class Molecule(LibmintsMolecule):
         molrec = self.to_dict(np_out=True)
 
         # flip zeros
-        molrec['geom'][np.abs(molrec['geom']) < 5**(-(ZERO))] = 0
+        molrec['geom'][np.abs(molrec['geom']) < 5**(-(prec))] = 0
 
         smol = qcel.molparse.to_string(
             molrec,


### PR DESCRIPTION
## Description
Currently `mol.to_string` cuts off coordinate values `< 5**(-(ZERO))` which is actually `0.9999999999999839`. Switching `ZERO` to `prec` (with default value `12`) correctly dampens for printing, without collapsing all atoms within 1 unit of the center.

## Todos
- [x] `ZERO` to `prec`

## Status
- [x] Ready for review
- [x] Ready for merge
