### PR TITLE
Fix issue in options class

### DIFF
--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -600,13 +600,16 @@ void Options::set_str(const std::string& module, const std::string& key, std::st
     locals_[module][key] = new StringDataType(s);
     locals_[module][key].changed();
 
-    auto gl = get_global(key);
-    to_upper(s);
-    if (gl.choices().size() > 0) {
-        bool wrong_input = true;
-        for (size_t i = 0; i < gl.choices().size(); ++i)
-            if (s == gl.choices()[i]) wrong_input = false;
-        if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+    // check if this option is defined in global. If yes, check choices
+    if (exists_in_global(key)) {
+        auto gl = get_global(key);
+        to_upper(s);
+        if (gl.choices().size() > 0) {
+            bool wrong_input = true;
+            for (size_t i = 0; i < gl.choices().size(); ++i)
+                if (s == gl.choices()[i]) wrong_input = false;
+            if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+        }
     }
 }
 
@@ -614,13 +617,16 @@ void Options::set_str_i(const std::string& module, const std::string& key, std::
     locals_[module][key] = new IStringDataType(s);
     locals_[module][key].changed();
 
-    auto gl = get_global(key);
-    to_upper(s);
-    if (gl.choices().size() > 0) {
-        bool wrong_input = true;
-        for (size_t i = 0; i < gl.choices().size(); ++i)
-            if (s == gl.choices()[i]) wrong_input = false;
-        if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+    // check if this option is defined in global. If yes, check choices
+    if (exists_in_global(key)) {
+        auto gl = get_global(key);
+        to_upper(s);
+        if (gl.choices().size() > 0) {
+            bool wrong_input = true;
+            for (size_t i = 0; i < gl.choices().size(); ++i)
+                if (s == gl.choices()[i]) wrong_input = false;
+            if (wrong_input) throw DataTypeException(s + " is not a valid choice");
+        }
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixed a problem that prevents setting string options for modules when these are not defined to be global.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] When calling `Options::set_str` we now check if the option `key` exists in global. If yes, check if it matches any of the choices.

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
