### PR TITLE
CC Density != SCF Density

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -365,6 +365,7 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
         }
 
         /* Transform Da/b to so basis and set in wfn */
+        // If this becomes a wavefunction subclass someday, just redefine the densities directly.
         if (ref_wfn->same_a_b_dens()) {
             Pa->scale(0.5);
             auto Pa_so = linalg::triplet(ref_wfn->Ca(), Pa, ref_wfn->Ca(), false, false, true);

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -42,6 +42,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
+#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
@@ -76,6 +77,11 @@ CCEnergyWavefunction::~CCEnergyWavefunction() {}
 void CCEnergyWavefunction::init() {
     shallow_copy(reference_wavefunction_);
     module_ = "ccenergy";
+    // shallow_copy leaves this wfn's Density as the same object as the ref's.
+    // Because ccdensity/ccdensity.cc needs to modify the object at that memory
+    // location, make this object's densities point to a different memory locationn
+    Da_ = reference_wavefunction_->Da()->clone();
+    Db_ = reference_wavefunction_->same_a_b_dens() ? Da_ : reference_wavefunction_->Db()->clone();
 }
 
 double CCEnergyWavefunction::compute_energy() {


### PR DESCRIPTION
## Description
When computing a gradient through the `cc` mega-module, the reference wavefunction's density would be overwritten with the correlated wavefunction's density. This was because the CCEnergyWavefunction's `Da_` and `Db_` were exactly the same objects as the reference wavefunction's. Of course changing the object associated with one variable name would change the object associated with the other variable name. They're the same object.

This PR makes them different objects, to stop this aberrant behavior.

Obligatory @lothian ping to confirm this shouldn't create other problems in the `cc` mega-module.
Obligatory @hokru ping because this should allow eliminating `recompute_scf_density` from #1884. Fixing up the DCT density is next.

Developers, please tag as bugfix and 1.4.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Fixed a bug where the `cc` mega-module would set the reference wavefunction's density

## Checklist
- [x] `ctest -L ^cc -j4` and `ctest -L quick -j4` pass on my Mac

## Status
- [x] Ready for review
- [x] Ready for merge
