### PR TITLE
DCT Density to Wavefunction

### DIFF
--- a/psi4/src/psi4/dct/dct.h
+++ b/psi4/src/psi4/dct/dct.h
@@ -255,10 +255,12 @@ class DCTSolver : public Wavefunction {
     void compute_R_AA_and_BB();
     void presort_mo_tpdm_AB();
     void presort_mo_tpdm_AA();
+    void construct_oo_density_RHF();
 
     // UHF-reference DCT
     void compute_gradient_UHF();
     double compute_energy_UHF();
+    void construct_oo_density_UHF();
 
     bool augment_b(double *vec, double tol);
     /// Controls convergence of the orbital updates

--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -128,6 +128,8 @@ double DCTSolver::compute_energy_RHF() {
 
     print_opdm_RHF();
 
+    if (orbital_optimized_) { construct_oo_density_RHF(); }
+
     return new_total_energy_;
 }
 

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -154,9 +154,8 @@ double DCTSolver::compute_energy_UHF() {
     print_opdm();
 
     if (orbital_optimized_) {
-        // Compute one-electron properties
+        construct_oo_density_UHF();
         compute_oe_properties();
-        // Write to MOLDEN file if requested
         if (options_.get_bool("MOLDEN_WRITE")) write_molden_file();
     }
 

--- a/psi4/src/psi4/dct/dct_density_RHF.cc
+++ b/psi4/src/psi4/dct/dct_density_RHF.cc
@@ -351,5 +351,32 @@ void DCTSolver::compute_unrelaxed_density_VVVV_RHF() {
     psio_->close(PSIF_DCT_DENSITY, 1);
 }
 
+void DCTSolver::construct_oo_density_RHF() {
+    // Form one-particle density matrix
+    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
+
+    // Alpha spin
+    for (int h = 0; h < nirrep_; ++h) {
+        // O-O
+        for (int i = 0; i < naoccpi_[h]; ++i) {
+            for (int j = 0; j <= i; ++j) {
+                a_opdm->set(h, i, j, (aocc_tau_->get(h, i, j) + kappa_mo_a_->get(h, i, j)));
+                if (i != j) a_opdm->set(h, j, i, (aocc_tau_->get(h, i, j) + kappa_mo_a_->get(h, i, j)));
+            }
+        }
+        // V-V
+        for (int a = 0; a < navirpi_[h]; ++a) {
+            for (int b = 0; b <= a; ++b) {
+                a_opdm->set(h, a + naoccpi_[h], b + naoccpi_[h], avir_tau_->get(h, a, b));
+                if (a != b) a_opdm->set(h, b + naoccpi_[h], a + naoccpi_[h], avir_tau_->get(h, a, b));
+            }
+        }
+    }
+
+    // With the OPDMs constructed, let's set them on the wavefunction.
+    Da_ = linalg::triplet(Ca_, a_opdm, Ca_, false, false, true);
+    Db_ = Da_->clone();
+}
+
 }  // namespace dct
 }  // namespace psi

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -3832,6 +3832,10 @@ void DCTSolver::compute_ewdm_dc() {
     a_opdm->add(a_zia);
     b_opdm->add(b_zia);
 
+    // With the OPDMs constructed, let's set them on the wavefunction.
+    Da_ = linalg::triplet(Ca_, a_opdm, Ca_, false, false, true);
+    Db_ = linalg::triplet(Cb_, b_opdm, Cb_, false, false, true);
+
     // Scale the energy-weighted density matrix by -2.0 to make it the same form as in the coupled-cluster code
     aW.scale(-2.0);
     bW.scale(-2.0);


### PR DESCRIPTION
## Description
The DCT density, when available, is now on the wavefunction.

If you are an orbital optimized method, the density matrices can be computed without solving response equations. This is done in the new `construct_density_oo_UHF` method and its RHF sibling. This allowed me to migrate some code out of `compute_oe_properties`, which was only ever implemented for UHF.
If you are not an orbital optimized method, the density matrices must be computed after solving response equations (if implemented in Psi). This is done in the `compute_ewdm_dc` method, which was already responsible for assembling the OPDM in this case.

Obligatory @hokru ping, as this should clean up #1884.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] DCT densities (when available) are now on the wavefunction

## Checklist
- [x] `ctest -L dct -j4` and `ctest -L quick -j4` pass on my Mac

## Status
- [x] Ready for review
- [x] Ready for merge
