### PR TITLE
Delegate `basissets_` Management to `wavefunction.mintshelper()`

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -189,9 +189,6 @@ def scf_initialize(self):
     # Initilize all integratals and perform the first guess
     if self.attempt_number_ == 1:
         mints = core.MintsHelper(self.basisset())
-        if core.get_global_option('RELATIVISTIC') in ['X2C', 'DKH']:
-            mintshelper = self.mintshelper()
-            mintshelper.set_basisset('BASIS_RELATIVISTIC',self.get_basisset('BASIS_RELATIVISTIC'))
 
         self.initialize_jk(self.memory_jk_, jk=jk)
         if self.V_potential():
@@ -513,8 +510,6 @@ def scf_finalize_energy(self):
             core.print_out("    SO Integrals not on disk. Computing...")
             mints = core.MintsHelper(self.basisset())
             #next 2 lines fix a bug that prohibits relativistic stability analysis
-            if core.get_global_option('RELATIVISTIC') in ['X2C', 'DKH']:
-                mints.set_basisset('BASIS_RELATIVISTIC',self.get_basisset('BASIS_RELATIVISTIC'))
 
             mints.integrals()
             core.print_out("done.\n")

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -2699,7 +2699,7 @@ void RDFMP2::form_gradient() {
 
     timer_on("Grad: JK");
 
-    auto jk = CorrGrad::build_CorrGrad(basisset_, basissets_["DF_BASIS_SCF"]);
+    auto jk = CorrGrad::build_CorrGrad(basisset_, get_basisset("DF_BASIS_SCF"));
     jk->set_memory((size_t)(options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Cocc);

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1098,9 +1098,9 @@ class PSI_API MemDFJK : public JK {
     */
     void print_header() const override;
 
-    void set_omega_alpha(double alpha);
-    void set_omega_beta(double beta);
-    void set_wcombine(bool wcombine);
+    void set_omega_alpha(double alpha) override;
+    void set_omega_beta(double beta) override;
+    void set_wcombine(bool wcombine) override;
 
     /**
      * Returns the DFHelper object

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -151,6 +151,7 @@ class PSI_API MintsHelper {
     std::shared_ptr<IntegralFactory> integral() const;
 
     /// Getters and setters for other basis sets
+    std::map<std::string, std::shared_ptr<BasisSet>> basissets() const {return basissets_; };
     std::shared_ptr<BasisSet> get_basisset(std::string label);
     void set_basisset(std::string label, std::shared_ptr<BasisSet> basis);
     bool basisset_exists(std::string label);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -91,9 +91,6 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Module name for CURRENT ENERGY
     std::string module_;
 
-    /// DF/RI/F12/etc basis sets
-    std::map<std::string, std::shared_ptr<BasisSet>> basissets_;
-
     /// The ORBITAL basis
     std::shared_ptr<BasisSet> basisset_;
 

--- a/psi4/src/psi4/liboptions/liboptions.h
+++ b/psi4/src/psi4/liboptions/liboptions.h
@@ -215,7 +215,7 @@ class StringDataType : public DataType {
     void assign(double d) override;
     void assign(std::string s) override;
 
-    std::vector<std::string> choices() { return choices_; }
+    std::vector<std::string> choices() override { return choices_; }
 };
 
 #ifdef __INTEL_COMPILER
@@ -244,7 +244,7 @@ class IStringDataType : public DataType {
     void assign(double d) override;
     void assign(std::string s) override;
 
-    std::vector<std::string> choices() { return choices_; }
+    std::vector<std::string> choices() override { return choices_; }
 };
 
 class PSI_API Data {

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -213,7 +213,7 @@ SharedMatrix SCFDeriv::compute_gradient()
     // => Two-Electron Gradient <= //
     timer_on("Grad: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(1, basisset_, basissets_["DF_BASIS_SCF"]);
+    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(1, basisset_, get_basisset("DF_BASIS_SCF"));
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca_occ);
@@ -988,7 +988,7 @@ SharedMatrix SCFDeriv::compute_hessian()
 
     timer_on("Hess: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(2, basisset_, basissets_["DF_BASIS_SCF"]);
+    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(2, basisset_, get_basisset("DF_BASIS_SCF"));
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca);


### PR DESCRIPTION
## Description
In master Psi, both the `Wavefunction` class and the `MintsHelper` class have their own copy of `basissets_`, a map from basis name to the actual `BasisSet`. There are `get_basisset`, `set_basisset`, and `basisset_exists` methods to manipulate `basissets_`, which are identical between the two classes. So `basissets_` and associated methods are functionally identical on the two classes.

The problem is that every `Wavefunction` object is already guaranteed to have a `MintsHelper` object, there is no reason for the `Wavefunction` object to ever have a different `basissets_` from its `MintsHelper` (because `Wavefunction`’s only use for `basissets_` is aforementioned methods), but there is no mechanism to synchronize the `basissets_` variables of a `Wavefunction` and its `MintsHelper`. So we can have two sources disagreeing about the same information.

This PR solves the problem by moving the responsibility for managing `basissets_` onto `MintsHelper`. The `Wavefunction` methods now just call the relevant `MintsHelper` methods. ~~I’m in favor of deprecating the offending `Wavefunction` methods, but I’ll open this to core developer discussion before adding that to the PR because I expect changing `Wavefunction` API will be controversial.~~

I’ve also marked some functions as override to silence annoying compiler warnings.

Obligatory Pings: @jturney for `libmints` changes, @loriab for API changes.


## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Silences compiler warnings
- [x] Eliminates `wavefunction.basissets_` so that `wavefunction.mintshelper().basissets_` is the source of truth

## Questions
~~Do we want to deprecate `wavefunction.basissets()`, `wavefunction.get_basisset()`, `wavefunction.set_basisset()`, and `wavefunction.basisset_exists()` in favor of `wavefunction.mintshelper().method_name_here()`?~~

## Checklist
- [x] Quick tests, dkh tests, and x2c tests all pass

## Status
- [x] Ready for review
- [x] Ready for merge
