### PR TITLE
DFGrad IV: Consolidate Metric Gradient

### DIFF
--- a/psi4/src/psi4/dfmp2/corr_grad.cc
+++ b/psi4/src/psi4/dfmp2/corr_grad.cc
@@ -594,7 +594,7 @@ void DFCorrGrad::build_AB_x_terms() {
     psio_->read_entry(unit_c_, "V", (char*)Kp[0], sizeof(double) * naux * naux);
 
     std::map<std::string, SharedMatrix> densities = {{"Coulomb", J}, {"Exchange", K}};
-    
+ 
     auto results = mints_->metric_grad(densities, "DF_BASIS_SCF");
 
     for (const auto& kv: results) {

--- a/psi4/src/psi4/dfmp2/corr_grad.h
+++ b/psi4/src/psi4/dfmp2/corr_grad.h
@@ -37,6 +37,7 @@ namespace psi {
 class ERISieve;
 class BasisSet;
 class PSIO;
+class MintsHelper;
 
 namespace dfmp2 {
 
@@ -56,6 +57,7 @@ class CorrGrad {
     double cutoff_;
 
     std::shared_ptr<BasisSet> primary_;
+    std::shared_ptr<MintsHelper> mints_;
 
     /**
      * Rules:
@@ -84,7 +86,7 @@ class CorrGrad {
     void common_init();
 
    public:
-    CorrGrad(std::shared_ptr<BasisSet> primary);
+    CorrGrad(std::shared_ptr<MintsHelper> mints);
     virtual ~CorrGrad();
 
     /**
@@ -93,8 +95,7 @@ class CorrGrad {
      * @param options Options reference, with preset parameters
      * @return abstract Corr object, tuned in with preset options
      */
-    static std::shared_ptr<CorrGrad> build_CorrGrad(std::shared_ptr<BasisSet> primary,
-                                                    std::shared_ptr<BasisSet> auxiliary);
+    static std::shared_ptr<CorrGrad> build_CorrGrad(std::shared_ptr<MintsHelper> mints);
 
     void set_Ca(SharedMatrix Ca) { Ca_ = Ca; }
     void set_Cb(SharedMatrix Cb) { Cb_ = Cb; }
@@ -181,7 +182,7 @@ class DFCorrGrad : public CorrGrad {
     size_t unit_c_;
 
    public:
-    DFCorrGrad(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
+    DFCorrGrad(std::shared_ptr<MintsHelper> mints);
     ~DFCorrGrad() override;
 
     void compute_gradient() override;

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2174,6 +2174,109 @@ SharedMatrix MintsHelper::core_hamiltonian_grad(SharedMatrix D) {
     return ret;
 }
 
+std::map<std::string, SharedMatrix> MintsHelper::metric_grad(std::map<std::string, SharedMatrix> D, std::string aux_name) {
+    // Construct integral factory.
+    auto auxiliary = basissets_[aux_name];
+    auto rifactory = std::make_shared<IntegralFactory>(auxiliary, BasisSet::zero_ao_basis_set(), auxiliary, BasisSet::zero_ao_basis_set());
+    std::vector<std::shared_ptr<TwoBodyAOInt> > Jint;
+    for (int t = 0; t < nthread_; t++) {
+        Jint.push_back(std::shared_ptr<TwoBodyAOInt>(rifactory->eri(1)));
+    }
+
+    // Construct temporary matrices for each thread
+    int natom = basisset_->molecule()->natom();
+    std::map<std::string, std::vector<SharedMatrix>> temps;
+    for (auto kv: D) {
+        temps[kv.first] = std::vector<SharedMatrix>();
+        auto& temp = temps[kv.first];
+        for (int j = 0; j < nthread_; j++) {
+            temp.push_back(std::make_shared<Matrix>("temp", natom, 3));
+        }
+    }
+
+    // Construct pairs of aux AOs
+    std::vector<std::pair<int, int>> PQ_pairs;
+    for (int P = 0; P < auxiliary->nshell(); P++) {
+        for (auto Q = 0; Q <= P; Q++) {
+            PQ_pairs.push_back(std::pair<int, int>(P, Q));
+        }
+    }
+
+   // Perform threading contraction of "densities" against metric derivative integrals.
+#pragma omp parallel for schedule(dynamic) num_threads(nthread_)
+    for (long int PQ = 0L; PQ < PQ_pairs.size(); PQ++) {
+        auto P = PQ_pairs[PQ].first;
+        auto Q = PQ_pairs[PQ].second;
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        Jint[thread]->compute_shell_deriv1(P, 0, Q, 0);
+        const auto buffer = Jint[thread]->buffer();
+
+        int nP = auxiliary->shell(P).nfunction();
+        int cP = auxiliary->shell(P).ncartesian();
+        int aP = auxiliary->shell(P).ncenter();
+        int oP = auxiliary->shell(P).function_index();
+
+        int nQ = auxiliary->shell(Q).nfunction();
+        int cQ = auxiliary->shell(Q).ncartesian();
+        int aQ = auxiliary->shell(Q).ncenter();
+        int oQ = auxiliary->shell(Q).function_index();
+
+        int ncart = cP * cQ;
+        const double *Px = buffer + 0*ncart;
+        const double *Py = buffer + 1*ncart;
+        const double *Pz = buffer + 2*ncart;
+        const double *Qx = buffer + 3*ncart;
+        const double *Qy = buffer + 4*ncart;
+        const double *Qz = buffer + 5*ncart;
+
+        double perm = (P == Q ? 1.0 : 2.0);
+
+        std::vector<std::pair<double**, double**>> read_write_pairs;
+        for (auto kv: D) {
+            double ** temp1 = D[kv.first]->pointer();
+            double ** temp2 = temps[kv.first][thread]->pointer();
+            std::pair<double**, double**> pair = std::make_pair(temp1, temp2);
+            read_write_pairs.push_back(pair); 
+        }
+
+        for (int p = 0; p < nP; p++) {
+            for (int q = 0; q < nQ; q++) {
+                for (auto pair : read_write_pairs) {
+                    double val = 0.5 * perm * pair.first[p+oP][q+oQ];
+                    auto grad_mat = pair.second;
+                    grad_mat[aP][0] -= val * (*Px);
+                    grad_mat[aP][1] -= val * (*Py);
+                    grad_mat[aP][2] -= val * (*Pz);
+                    grad_mat[aQ][0] -= val * (*Qx);
+                    grad_mat[aQ][1] -= val * (*Qy);
+                    grad_mat[aQ][2] -= val * (*Qz);
+                }
+
+                Px++;
+                Py++;
+                Pz++;
+                Qx++;
+                Qy++;
+                Qz++;
+            }
+        }
+    }
+
+    // Sum results across the various threads
+    std::map<std::string, SharedMatrix> gradient_contributions;
+    for (auto kv: temps) {
+        auto gradient_contribution = std::make_shared<Matrix>(kv.first + " Gradient", natom, 3);
+        for (auto thread_matrix: kv.second) {
+            gradient_contribution->add(thread_matrix);
+        }
+        gradient_contributions[kv.first] = gradient_contribution;
+    }
+    return gradient_contributions;
+}
+
 void MintsHelper::play() {}
 
 /* 1st and 2nd derivatives of OEI in AO basis  */

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2174,7 +2174,7 @@ SharedMatrix MintsHelper::core_hamiltonian_grad(SharedMatrix D) {
     return ret;
 }
 
-std::map<std::string, SharedMatrix> MintsHelper::metric_grad(std::map<std::string, SharedMatrix> D, std::string aux_name) {
+std::map<std::string, SharedMatrix> MintsHelper::metric_grad(std::map<std::string, SharedMatrix>& D, const std::string& aux_name) {
     // Construct integral factory.
     auto auxiliary = basissets_[aux_name];
     auto rifactory = std::make_shared<IntegralFactory>(auxiliary, BasisSet::zero_ao_basis_set(), auxiliary, BasisSet::zero_ao_basis_set());
@@ -2236,15 +2236,15 @@ std::map<std::string, SharedMatrix> MintsHelper::metric_grad(std::map<std::strin
 
         std::vector<std::pair<double**, double**>> read_write_pairs;
         for (auto kv: D) {
-            double ** temp1 = D[kv.first]->pointer();
-            double ** temp2 = temps[kv.first][thread]->pointer();
-            std::pair<double**, double**> pair = std::make_pair(temp1, temp2);
-            read_write_pairs.push_back(pair); 
+            auto temp1 = D[kv.first]->pointer();
+            auto temp2 = temps[kv.first][thread]->pointer();
+            auto pair = std::make_pair(temp1, temp2);
+            read_write_pairs.push_back(pair);
         }
 
         for (int p = 0; p < nP; p++) {
             for (int q = 0; q < nQ; q++) {
-                for (auto pair : read_write_pairs) {
+                for (auto& pair : read_write_pairs) {
                     double val = 0.5 * perm * pair.first[p+oP][q+oQ];
                     auto grad_mat = pair.second;
                     grad_mat[aP][0] -= val * (*Px);

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -332,6 +332,9 @@ class PSI_API MintsHelper {
 
     // Computes all "core" gradient terms T + V + perturb
     SharedMatrix core_hamiltonian_grad(SharedMatrix D);
+    // Computes the metric derivative gradient terms for DF methods
+    // Uses a vector of "densities" for methods that decompose the "densities"
+    std::map<std::string, SharedMatrix> metric_grad(std::map<std::string, SharedMatrix> D, std::string aux_name);
 
     SharedMatrix kinetic_grad(SharedMatrix D);
     SharedMatrix potential_grad(SharedMatrix D);

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -334,7 +334,7 @@ class PSI_API MintsHelper {
     SharedMatrix core_hamiltonian_grad(SharedMatrix D);
     // Computes the metric derivative gradient terms for DF methods
     // Uses a vector of "densities" for methods that decompose the "densities"
-    std::map<std::string, SharedMatrix> metric_grad(std::map<std::string, SharedMatrix> D, std::string aux_name);
+    std::map<std::string, SharedMatrix> metric_grad(std::map<std::string, SharedMatrix>& D, const std::string& aux_name);
 
     SharedMatrix kinetic_grad(SharedMatrix D);
     SharedMatrix potential_grad(SharedMatrix D);

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -937,51 +937,29 @@ void DFJKGrad::build_AB_x_terms()
 
         double perm = (P == Q ? 1.0 : 2.0);
 
-        double** grad_Jp;
-        double** grad_Kp;
-        double** grad_wKp;
+        std::vector<std::pair<double**, double**>> pairs = {};
 
         if (do_J_) {
-            grad_Jp = Jtemps[thread]->pointer();
+            pairs.push_back({Dp, Jtemps[thread]->pointer()});
         }
         if (do_K_) {
-            grad_Kp = Ktemps[thread]->pointer();
+            pairs.push_back({Vp, Ktemps[thread]->pointer()});
         }
         if (do_wK_) {
-            grad_wKp = wKtemps[thread]->pointer();
+            pairs.push_back({Wp, wKtemps[thread]->pointer()});
         }
 
         for (int p = 0; p < nP; p++) {
             for (int q = 0; q < nQ; q++) {
-
-                if (do_J_) {
-                    double Uval = 0.5 * perm * Dp[p + oP][q + oQ];
-                    grad_Jp[aP][0] -= Uval * (*Px);
-                    grad_Jp[aP][1] -= Uval * (*Py);
-                    grad_Jp[aP][2] -= Uval * (*Pz);
-                    grad_Jp[aQ][0] -= Uval * (*Qx);
-                    grad_Jp[aQ][1] -= Uval * (*Qy);
-                    grad_Jp[aQ][2] -= Uval * (*Qz);
-                }
-
-                if (do_K_) {
-                    double Vval = 0.5 * perm * Vp[p + oP][q + oQ];
-                    grad_Kp[aP][0] -= Vval * (*Px);
-                    grad_Kp[aP][1] -= Vval * (*Py);
-                    grad_Kp[aP][2] -= Vval * (*Pz);
-                    grad_Kp[aQ][0] -= Vval * (*Qx);
-                    grad_Kp[aQ][1] -= Vval * (*Qy);
-                    grad_Kp[aQ][2] -= Vval * (*Qz);
-                }
-
-                if (do_wK_) {
-                    double Wval = 0.5 * perm * Wp[p + oP][q + oQ];
-                    grad_wKp[aP][0] -= Wval * (*Px);
-                    grad_wKp[aP][1] -= Wval * (*Py);
-                    grad_wKp[aP][2] -= Wval * (*Pz);
-                    grad_wKp[aQ][0] -= Wval * (*Qx);
-                    grad_wKp[aQ][1] -= Wval * (*Qy);
-                    grad_wKp[aQ][2] -= Wval * (*Qz);
+                for (auto pair : pairs) {
+                    double val = 0.5 * perm * pair.first[p+oP][q+oQ];
+                    auto grad_mat = pair.second;
+                    grad_mat[aP][0] -= val * (*Px);
+                    grad_mat[aP][1] -= val * (*Px);
+                    grad_mat[aP][2] -= val * (*Px);
+                    grad_mat[aQ][0] -= val * (*Qx);
+                    grad_mat[aQ][1] -= val * (*Qx);
+                    grad_mat[aQ][2] -= val * (*Qx);
                 }
 
                 Px++;

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -840,7 +840,7 @@ void DFJKGrad::build_AB_x_terms()
     auto naux = auxiliary_->nbf();
 
     std::map<std::string, SharedMatrix> densities;
-    
+
     if (do_J_) {
         auto d = std::make_shared<Vector>("d", naux);
         auto dp = d->pointer();

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -843,18 +843,21 @@ void DFJKGrad::build_AB_x_terms()
     int naux = auxiliary_->nbf();
 
     // => Forcing Terms/Gradients <= //
+    SharedMatrix D;
     SharedMatrix V;
     SharedMatrix W;
-    SharedVector d;
 
+    double** Dp;
     double** Vp;
     double** Wp;
-    double*  dp;
 
     if (do_J_) {
-        d = std::make_shared<Vector>("d", naux);
-        dp = d->pointer();
+        auto d = std::make_shared<Vector>("d", naux);
+        auto dp = d->pointer();
         psio_->read_entry(unit_c_, "c", (char*) dp, sizeof(double) * naux);
+        D = std::make_shared<Matrix>("D", naux, naux);
+        Dp = D->pointer();
+        C_DGER(naux, naux, 1, dp, 1, dp, 1, Dp[0], naux);
     }
     if (do_K_) {
         V = std::make_shared<Matrix>("V", naux, naux);
@@ -952,7 +955,7 @@ void DFJKGrad::build_AB_x_terms()
             for (int q = 0; q < nQ; q++) {
 
                 if (do_J_) {
-                    double Uval = 0.5 * perm * dp[p + oP] * dp[q + oQ];
+                    double Uval = 0.5 * perm * Dp[p + oP][q + oQ];
                     grad_Jp[aP][0] -= Uval * (*Px);
                     grad_Jp[aP][1] -= Uval * (*Py);
                     grad_Jp[aP][2] -= Uval * (*Pz);

--- a/psi4/src/psi4/scfgrad/jk_grad.h
+++ b/psi4/src/psi4/scfgrad/jk_grad.h
@@ -39,6 +39,7 @@ class ERISieve;
 class BasisSet;
 class PSIO;
 class TwoBodyAOInt;
+class MintsHelper;
 
 namespace scfgrad {
 
@@ -93,8 +94,7 @@ public:
     * @param options Options reference, with preset parameters
     * @return abstract JK object, tuned in with preset options
     */
-    static std::shared_ptr<JKGrad> build_JKGrad(int deriv, std::shared_ptr<BasisSet> primary,
-                                                std::shared_ptr<BasisSet> auxiliary);
+    static std::shared_ptr<JKGrad> build_JKGrad(int deriv, std::shared_ptr<MintsHelper> mints);
 
     void set_Ca(SharedMatrix Ca) { Ca_ = Ca; }
     void set_Cb(SharedMatrix Cb) { Cb_ = Cb; }
@@ -169,6 +169,7 @@ class DFJKGrad : public JKGrad {
 
 protected:
     std::shared_ptr<BasisSet> auxiliary_;
+    std::shared_ptr<MintsHelper> mints_;
 
     std::shared_ptr<PSIO> psio_;
 
@@ -194,7 +195,7 @@ protected:
     size_t unit_c_;
 
 public:
-    DFJKGrad(int deriv, std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
+    DFJKGrad(int deriv, std::shared_ptr<MintsHelper> mints);
     ~DFJKGrad() override;
 
     void compute_gradient() override;

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -213,7 +213,7 @@ SharedMatrix SCFDeriv::compute_gradient()
     // => Two-Electron Gradient <= //
     timer_on("Grad: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(1, basisset_, get_basisset("DF_BASIS_SCF"));
+    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(1, mintshelper_);
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca_occ);
@@ -988,7 +988,7 @@ SharedMatrix SCFDeriv::compute_hessian()
 
     timer_on("Hess: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(2, basisset_, get_basisset("DF_BASIS_SCF"));
+    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(2, mintshelper_);
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca);

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -213,7 +213,7 @@ SharedMatrix SCFDeriv::compute_gradient()
     // => Two-Electron Gradient <= //
     timer_on("Grad: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(1, mintshelper_);
+    auto jk = JKGrad::build_JKGrad(1, mintshelper_);
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca_occ);
@@ -988,7 +988,7 @@ SharedMatrix SCFDeriv::compute_hessian()
 
     timer_on("Hess: JK");
 
-    std::shared_ptr<JKGrad> jk = JKGrad::build_JKGrad(2, mintshelper_);
+    auto jk = JKGrad::build_JKGrad(2, mintshelper_);
     jk->set_memory((size_t) (options_.get_double("SCF_MEM_SAFETY_FACTOR") * memory_ / 8L));
 
     jk->set_Ca(Ca);


### PR DESCRIPTION
## Description
Previously, the `dfocc`, `dfmp2` and `scfgrad` modules all had nearly identical code to compute the **metric term** of density fitted gradients, the contraction against the metric integral derivatives. `dfmp2` even did this _twice_ for a total of 4 times near identical logic appears. (It was 5 before #1953.) This PR consolidates those into a single `MintsHelper` method.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Various classes and functions now take in a `MintsHelper` rather than basis sets directly
- [x] Metric integral derivative contractions are consolidated into `MintsHelper`

## Checklist
- [x] Timing tests show that with these changes, there's a slowdown of <0.1s, and scaling is effectively constant compared to the scaling of the much more expensive SCF iterations and the `Amn_x` term. I can live with this.
- [x] Quick tests and gradient tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
