### PR TITLE
shift mp2.5 and mp3 default from conv to df

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -90,16 +90,17 @@ jobs:
         fockci \
         mp2d \
         pytest-xdist \
+        pybind11-headers \
         -c psi4/label/dev
       conda install \
         blas=*=mkl \
         mkl-include \
         qcelemental \
         qcengine \
-        pybind11 \
         pymdi \
+        adcc \
+        -c adcc \
         -c conda-forge
-      #conda install adcc -c adcc -c conda-forge
       pip install git+https://github.com/i-pi/i-pi.git@master-py3
       conda list
     displayName: 'Build Environment'
@@ -122,7 +123,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCMAKE_PREFIX_PATH=${CONDA}/envs/p4env \
         -DPYTHON_EXECUTABLE="${CONDA}/envs/p4env/bin/python" \
-        -DENABLE_adcc=OFF \
+        -DENABLE_adcc=ON \
         -DENABLE_CheMPS2=OFF \
         -DENABLE_dkh=ON \
         -DENABLE_libefp=ON \

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -77,30 +77,38 @@ jobs:
     displayName: "Add Conda to PATH"
 
   - bash: |
-      conda create -q -n p4env python=$PYTHON_VER psi4 gau2grid=2 --only-deps -c psi4/label/dev
-      source activate p4env
-      which python
-      conda install \
-        dftd3 \
-        gcp \
-        resp \
-        pycppe \
-        pylibefp \
-        snsmp2 \
-        fockci \
-        mp2d \
-        pytest-xdist \
-        pybind11-headers \
-        -c psi4/label/dev
-      conda install \
+      conda create -q \
+        -n p4env \
+        python=$PYTHON_VER \
+        psi4/label/dev::gau2grid=2 \
+        psi4/label/dev::libint \
+        psi4/label/dev::libxc \
+        psi4/label/dev::ambit \
+        psi4/label/dev::chemps2 \
+        psi4/label/dev::dkh \
+        psi4/label/dev::gdma \
+        psi4/label/dev::pcmsolver \
+        psi4/label/dev::simint \
+        psi4/label/dev::dftd3 \
+        psi4/label/dev::gcp \
+        psi4/label/dev::resp \
+        psi4/label/dev::pycppe \
+        psi4/label/dev::pylibefp \
+        psi4/label/dev::snsmp2 \
+        psi4/label/dev::fockci \
+        psi4/label/dev::mp2d \
+        psi4/label/dev::pybind11-headers \
         blas=*=mkl \
         mkl-include \
-        qcelemental \
-        qcengine \
-        pymdi \
-        adcc \
-        -c adcc \
-        -c conda-forge
+        networkx \
+        pytest \
+        pytest-xdist \
+        conda-forge::qcelemental \
+        conda-forge::qcengine \
+        conda-forge::pymdi \
+        adcc::adcc
+      source activate p4env
+      which python
       pip install git+https://github.com/i-pi/i-pi.git@master-py3
       conda list
     displayName: 'Build Environment'

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -29,7 +29,7 @@ jobs:
 
       clang_latest:
         CXX_COMPILER: 'clang++'
-        PYTHON_VER: '3.7'
+        PYTHON_VER: '3.8'
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'

--- a/doc/sphinxman/source/occ.rst
+++ b/doc/sphinxman/source/occ.rst
@@ -369,6 +369,8 @@ or may not be the default in |PSIfour| for available methods. (See
 details.) To call the OCC/DFOCC implementation of any method below in
 preference to the default module, issue ``set qc_module occ``.
 
+Starting in v1.4, MP2.5 and MP3 default to the density-fit algorithm. Set |globals__mp_type| to ``CONV`` to get previous behavior.
+
 .. _`table:occ_nonoo_calls`:
 
 .. table:: Conventional (non-OO) CC and MP capabilities of OCC/DFOCC modules

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental ATLEAST 0.15.1 QUIET)
+    find_python_module(qcelemental ATLEAST 0.16.0 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -19,7 +19,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.15.1.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.16.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcengine}))
     include(FindPythonModule)
-    find_python_module(qcengine ATLEAST 0.15.0 QUIET)
+    find_python_module(qcengine ATLEAST 0.16.0 QUIET)
 endif()
 
 if(${qcengine_FOUND})
@@ -21,7 +21,7 @@ else()
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCEngine/archive/v0.15.0.tar.gz
+        URL https://github.com/MolSSI/QCEngine/archive/v0.16.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -372,7 +372,7 @@ def select_mp3(name, **kwargs):
 
     """
     reference = core.get_option('SCF', 'REFERENCE')
-    mtd_type = core.get_global_option('MP_TYPE')
+    mtd_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
     module = core.get_global_option('QC_MODULE')
     # Considering only [df]occ/fnocc/detci
 
@@ -425,7 +425,7 @@ def select_mp3_gradient(name, **kwargs):
 
     """
     reference = core.get_option('SCF', 'REFERENCE')
-    mtd_type = core.get_global_option('MP_TYPE')
+    mtd_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
     module = core.get_global_option('QC_MODULE')
     all_electron = (core.get_global_option('FREEZE_CORE') == "FALSE")
     # Considering only [df]occ
@@ -522,7 +522,7 @@ def select_mp2p5(name, **kwargs):
 
     """
     reference = core.get_option('SCF', 'REFERENCE')
-    mtd_type = core.get_global_option('MP_TYPE')
+    mtd_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
     module = core.get_global_option('QC_MODULE')
     # Considering only [df]occ
 
@@ -553,7 +553,7 @@ def select_mp2p5_gradient(name, **kwargs):
 
     """
     reference = core.get_option('SCF', 'REFERENCE')
-    mtd_type = core.get_global_option('MP_TYPE')
+    mtd_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
     module = core.get_global_option('QC_MODULE')
     all_electron = (core.get_global_option('FREEZE_CORE') == "FALSE")
     # Considering only [df]occ
@@ -1697,8 +1697,7 @@ def run_dfocc(name, **kwargs):
         ['DFOCC', 'CHOLESKY'],
         ['DFOCC', 'CC_LAMBDA'])
 
-    def set_cholesky_from(mtd_type):
-        corl_type = core.get_global_option(mtd_type)
+    def set_cholesky_from(corl_type):
         if corl_type == 'DF':
             core.set_local_option('DFOCC', 'CHOLESKY', 'FALSE')
             proc_util.check_disk_df(name.upper(), optstash)
@@ -1715,38 +1714,44 @@ def run_dfocc(name, **kwargs):
         else:
             raise ValidationError(f"""Invalid type '{corl_type}' for DFOCC""")
 
-        return corl_type
-
     if name in ['mp2', 'omp2']:
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OMP2')
-        set_cholesky_from('MP2_TYPE')
-    elif name in ['mp2.5', 'omp2.5']:
+        corl_type = core.get_global_option('MP2_TYPE')
+    elif name in ['mp2.5']:
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OMP2.5')
-        set_cholesky_from('MP_TYPE')
-    elif name in ['mp3', 'omp3']:
+        corl_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
+    elif name in ['omp2.5']:
+        core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OMP2.5')
+        corl_type = core.get_global_option('MP_TYPE')
+    elif name in ['mp3']:
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OMP3')
-        set_cholesky_from('MP_TYPE')
+        corl_type = core.get_global_option('MP_TYPE') if core.has_global_option_changed("MP_TYPE") else "DF"
+    elif name in ['omp3']:
+        core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OMP3')
+        corl_type = core.get_global_option('MP_TYPE')
     elif name in ['lccd', 'olccd']:
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-OLCCD')
-        set_cholesky_from('CC_TYPE')
+        corl_type = core.get_global_option('CC_TYPE')
 
     elif name == 'ccd':
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-CCD')
-        set_cholesky_from('CC_TYPE')
+        corl_type = core.get_global_option('CC_TYPE')
     elif name == 'ccsd':
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-CCSD')
-        set_cholesky_from('CC_TYPE')
+        corl_type = core.get_global_option('CC_TYPE')
     elif name == 'ccsd(t)':
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-CCSD(T)')
-        set_cholesky_from('CC_TYPE')
+        corl_type = core.get_global_option('CC_TYPE')
     elif name == 'ccsd(at)':
         core.set_local_option('DFOCC', 'CC_LAMBDA', 'TRUE')
         core.set_local_option('DFOCC', 'WFN_TYPE', 'DF-CCSD(AT)')
-        set_cholesky_from('CC_TYPE')
+        corl_type = core.get_global_option('CC_TYPE')
     elif name == 'dfocc':
         pass
     else:
         raise ValidationError('Unidentified method %s' % (name))
+
+    set_cholesky_from(corl_type)
 
     # conventional vs. optimized orbitals
     if name in ['mp2', 'mp2.5', 'mp3', 'lccd',

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1764,6 +1764,9 @@ def run_dfocc(name, **kwargs):
     core.set_local_option('DFOCC', 'DO_SOS', 'FALSE')
     core.set_local_option('SCF', 'DF_INTS_IO', 'SAVE')
 
+    if name in ["mp2.5", "mp3"] and not core.has_global_option_changed("MP_TYPE"):
+        core.print_out(f"    Information: {name.upper()} default algorithm changed to DF in August 2020. Use `set mp_type conv` for previous behavior.\n")
+
     # Bypass the scf call if a reference wavefunction is given
     ref_wfn = kwargs.get('ref_wfn', None)
     if ref_wfn is None:
@@ -1849,6 +1852,10 @@ def run_dfocc_gradient(name, **kwargs):
     core.set_local_option('DFOCC', 'DO_SCS', 'FALSE')
     core.set_local_option('DFOCC', 'DO_SOS', 'FALSE')
     core.set_local_option('SCF', 'DF_INTS_IO', 'SAVE')
+
+    print(f'{name=} {core.has_global_option_changed("MP_TYPE")=}')
+    if name in ["mp2.5", "mp3"] and not core.has_global_option_changed("MP_TYPE"):
+        core.print_out(f"    Information: {name.upper()} default algorithm changed to DF in August 2020. Use `set mp_type conv` for previous behavior.\n")
 
     # Bypass the scf call if a reference wavefunction is given
     ref_wfn = kwargs.get('ref_wfn', None)

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1853,7 +1853,6 @@ def run_dfocc_gradient(name, **kwargs):
     core.set_local_option('DFOCC', 'DO_SOS', 'FALSE')
     core.set_local_option('SCF', 'DF_INTS_IO', 'SAVE')
 
-    print(f'{name=} {core.has_global_option_changed("MP_TYPE")=}')
     if name in ["mp2.5", "mp3"] and not core.has_global_option_changed("MP_TYPE"):
         core.print_out(f"    Information: {name.upper()} default algorithm changed to DF in August 2020. Use `set mp_type conv` for previous behavior.\n")
 

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -74,7 +74,6 @@ void DFOCC::common_init() {
     e3_scale = options_.get_double("E3_SCALE");
     tol_Eod = options_.get_double("E_CONVERGENCE");
     tol_t2 = options_.get_double("R_CONVERGENCE");
-    tol_pcg = options_.get_double("PCG_CONVERGENCE");
     reg_param = options_.get_double("REG_PARAM");
     tol_ldl = options_.get_double("CHOLESKY_TOLERANCE");
 
@@ -114,6 +113,15 @@ void DFOCC::common_init() {
 
     // title
     title();
+
+    //   Given default conjugate gradient convergence, set the criteria by what shoud
+    //   be necessary to achive the target energy convergence.
+    //   This is based solely on standard suite testing to achieve 1e-6 E & G with default convcrit.
+    if (options_["PCG_CONVERGENCE"].has_changed()) {
+        tol_pcg = options_.get_double("PCG_CONVERGENCE");
+    } else {
+        tol_pcg = 0.1 * tol_Eod;
+    }
 
     //   Given default orbital convergence, set the criteria by what should
     //   be necessary to achieve the target energy convergence.

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -120,7 +120,8 @@ void DFOCC::common_init() {
     if (options_["PCG_CONVERGENCE"].has_changed()) {
         tol_pcg = options_.get_double("PCG_CONVERGENCE");
     } else {
-        tol_pcg = 0.1 * tol_Eod;
+        tol_pcg = 0.01 * tol_t2;
+        outfile->Printf("\tFor this residual convergence, default PCG convergence is: %12.2e\n", tol_grad);
     }
 
     //   Given default orbital convergence, set the criteria by what should

--- a/psi4/src/psi4/occ/cepa_iterations.cc
+++ b/psi4/src/psi4/occ/cepa_iterations.cc
@@ -119,7 +119,7 @@ void OCCWave::cepa_iterations() {
             throw PSIEXCEPTION("LCCD iterations are diverging");
         }
 
-    } while (std::fabs(DE) >= tol_Eod || rms_t2 >= tol_t2);
+    } while (std::fabs(DE) >= (0.1 * tol_Eod) || rms_t2 >= tol_t2);
 
     // delete
     delete t2DiisManager;

--- a/psi4/src/psi4/occ/cepa_iterations.cc
+++ b/psi4/src/psi4/occ/cepa_iterations.cc
@@ -119,7 +119,8 @@ void OCCWave::cepa_iterations() {
             throw PSIEXCEPTION("LCCD iterations are diverging");
         }
 
-    } while (std::fabs(DE) >= (0.1 * tol_Eod) || rms_t2 >= tol_t2);
+    } while (std::fabs(DE) >= (0.5 * tol_Eod) || rms_t2 >= tol_t2);
+    // 0.5 scale battens down a touch tighter for spin components since tol_Eod can be satisfied by small energy increase
 
     // delete
     delete t2DiisManager;

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -347,7 +347,7 @@ void OCCWave::occ_iterations() {
             break;
         }
 
-        if (rms_wog < tol_grad && biggest_mograd < mograd_max && std::fabs(DE) < (0.1 * tol_Eod)) break;
+        if (rms_wog < tol_grad && biggest_mograd < mograd_max && std::fabs(DE) < tol_Eod) break;
 
         if (rms_wog >= DIVERGE) {
             throw PSIEXCEPTION("OCC iterations are diverging");

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -347,7 +347,7 @@ void OCCWave::occ_iterations() {
             break;
         }
 
-        if (rms_wog < tol_grad && biggest_mograd < mograd_max && std::fabs(DE) < tol_Eod) break;
+        if (rms_wog < tol_grad && biggest_mograd < mograd_max && std::fabs(DE) < (0.1 * tol_Eod)) break;
 
         if (rms_wog >= DIVERGE) {
             throw PSIEXCEPTION("OCC iterations are diverging");

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -146,8 +146,8 @@ void OCCWave::common_init() {
         } else {
             double temp;
             temp = (-0.9 * std::log10(tol_Eod)) - 1.6;
-            if (temp < 4.0) {
-                temp = 4.0;
+            if (temp < 6.0) {
+                temp = 6.0;
             }
             tol_grad = pow(10.0, -temp);
             // tol_grad = 100.0*tol_Eod;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -184,7 +184,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     See :ref:`Cross-module Redundancies <table:managedmethods>` for details. -*/
     options.add_str("MP2_TYPE", "DF", "DF CONV CD");
     /*- Algorithm to use for MPn ( $n>2$ ) computation (e.g., MP3 or MP2.5 or MP4(SDQ)).
-    See :ref:`Cross-module Redundancies <table:managedmethods>` for details. -*/
+    See :ref:`Cross-module Redundancies <table:managedmethods>` for details.
+    Since v1.4, default for non-orbital-optimized MP2.5 and MP3 is DF. -*/
     options.add_str("MP_TYPE", "CONV", "DF CONV CD");
     // The type of integrals to use in coupled cluster computations. DF activates density fitting for the largest
     // integral files, while CONV results in no approximations being made.

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2787,7 +2787,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Do apply DIIS extrapolation? -*/
         options.add_bool("DO_DIIS", true);
         /*- Do compute CC Lambda energy? In order to this option to be valid one should use "TPDM_ABCD_TYPE = COMPUTE"
-         * option. -*/
+        option. -*/
         options.add_bool("CCL_ENERGY", false);
         /*- Do compute OCC poles for ionization potentials? Only valid OMP2. -*/
         options.add_bool("IP_POLES", false);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2869,8 +2869,11 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("E3_SCALE", 0.25);
         /*- OO scaling factor used in MSD -*/
         options.add_double("OO_SCALE", 0.01);
-        /*- Convergence criterion for residual vector of preconditioned conjugate gradient method. -*/
-        options.add_double("PCG_CONVERGENCE", 1e-6);
+        /*- Convergence criterion for residual vector of preconditioned conjugate gradient method.
+        If this keyword is not set by the user, DFOCC will estimate and use a value required to achieve
+        |dfocc__r_convergence| residual convergence. The listed default will be used for the default value
+        of |dfocc__r_convergence|. -*/
+        options.add_double("PCG_CONVERGENCE", 1e-7);
         /*- Regularization parameter -*/
         options.add_double("REG_PARAM", 0.4);
         /*- tolerance for Cholesky decomposition of the ERI tensor -*/

--- a/tests/ci-multi/input.dat
+++ b/tests/ci-multi/input.dat
@@ -16,6 +16,7 @@ refmp4   = -25.2109921859091   #TEST
 set {
   basis cc-pVDZ
   docc [3, 0, 0, 0]
+  mp_type conv
 }
 
 ecisd  = energy('cisd')

--- a/tests/mp2p5-grad1/input.dat
+++ b/tests/mp2p5-grad1/input.dat
@@ -15,6 +15,7 @@ h 1 0.958 2 104.4776
 
 set {
   basis cc-pvdz
+  mp_type conv
 }
 
 grad = gradient('mp2.5')

--- a/tests/mp2p5-grad2/input.dat
+++ b/tests/mp2p5-grad2/input.dat
@@ -15,6 +15,7 @@ set {
   basis cc-pvdz
   reference uhf
   guess gwh
+  mp_type conv
 }
 
 grad = gradient('mp2.5')

--- a/tests/mp3-grad1/input.dat
+++ b/tests/mp3-grad1/input.dat
@@ -15,6 +15,7 @@ h 1 0.958 2 104.4776
 
 set {
   basis cc-pvdz
+  mp_type conv
 }
 
 grad = gradient('mp3')

--- a/tests/mp3-grad2/input.dat
+++ b/tests/mp3-grad2/input.dat
@@ -15,6 +15,7 @@ set {
   basis cc-pvdz
   reference uhf
   guess gwh
+  mp_type conv
 }
 
 grad = gradient('mp3')

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -35,7 +35,10 @@ def runner_asserter(inp, subject, method, basis, tnm):
     # ? precedence on next two
     scf_type = inp.get("corl_type", inp["keywords"].get("scf_type", "df"))  # hard-code of read_options.cc SCF_TYPE
     mp2_type = inp.get("corl_type", inp["keywords"].get("mp2_type", "df"))  # hard-code of read_options.cc MP2_TYPE
-    mp_type = inp.get("corl_type", inp["keywords"].get("mp_type", "conv"))  # hard-code of read_options.cc MP_TYPE
+    if method in ["mp2.5", "mp3"]:
+        mp_type = inp.get("corl_type", inp["keywords"].get("mp_type", "df"))  # hard-code of proc.py run_dfocc MP_TYPE
+    else:
+        mp_type = inp.get("corl_type", inp["keywords"].get("mp_type", "conv"))  # hard-code of read_options.cc MP_TYPE
     cc_type = inp.get("corl_type", inp["keywords"].get("cc_type", "conv"))  # hard-code of read_options.cc CC_TYPE
     corl_natural_values = {
         "hf": "df",  # dummy to assure df/cd/conv scf_type refs available

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -1,9 +1,9 @@
 import pytest
 from qcengine.programs.tests.standard_suite_contracts import (
-    # contractual_hf,
+    contractual_hf,
     contractual_mp2,
-    # contractual_mp2p5,
-    # contractual_mp3,
+    contractual_mp2p5,
+    contractual_mp3,
     contractual_lccd,
     contractual_lccsd,
     contractual_ccsd,

--- a/tests/pytests/standard_suite_runner.py
+++ b/tests/pytests/standard_suite_runner.py
@@ -76,15 +76,14 @@ def runner_asserter(inp, subject, method, basis, tnm):
 
     psi4.set_options(
         {
+            # reference generation conv crit
             # "guess": "sad",
             # "e_convergence": 10,
             # "d_convergence": 9,
             # "r_convergence": 9,
             # "pcg_convergence": 9,
 
-            # runtime conv crit, solely for occ/dfocc needs
-            "e_convergence": 7,
-            "pcg_convergence": 7,
+            # runtime conv crit
             "points": 5,
         }
     )

--- a/tests/pytests/test_detci_opdm.py
+++ b/tests/pytests/test_detci_opdm.py
@@ -2,7 +2,6 @@ import pytest
 import psi4
 import numpy as np
 
-@pytest.mark.xfail
 def test_pdms():
     h2o = psi4.geometry("""
         H
@@ -45,8 +44,7 @@ def test_pdms():
         ])
 
     # Test transition matrix
-    #assert psi4.compare_matrices(ref_tdm, wfn.get_opdm(1, 2, "A", True), 6, "TDM", equal_phase=True)
-    assert psi4.compare_matrices(ref_tdm, wfn.get_opdm(1, 2, "A", True), 6, "TDM")  # fails sometimes by a phase. replace with above when qcel v0.16  TODO v1.4
+    assert psi4.compare_matrices(ref_tdm, wfn.get_opdm(1, 2, "A", True), 6, "TDM", equal_phase=True)
     # Test the swapping the bra and the key produces the transpose matrix.
     assert psi4.compare_matrices(wfn.get_opdm(2, 1, "A", True), wfn.get_opdm(1, 2, "A", True).transpose(), 6, "TDM SWAP")
 

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -781,10 +781,10 @@ def test_mp2p5_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, req
         pytest.param({"keywords": {"reference": "rohf", "mp_type": "cd",                       "freeze_core": "false",                    }}, id="mp2.5 rohf    cd   ae: dd     ", marks=_nyi11),
 
         ###### default qc_module, mp_type
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="mp2.5  rhf         fc: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="mp2.5  rhf         fc: dd     ", marks=_nyi4 ),
         pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }}, id="mp2.5  uhf         fc: dd     ",             ),
         pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }}, id="mp2.5 rohf         fc: dd     ", marks=_nyi11),
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="mp2.5  rhf         ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="mp2.5  rhf         ae: dd     ", marks=_nyi4 ),
         pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }}, id="mp2.5  uhf         ae: dd     ",             ),
         pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }}, id="mp2.5 rohf         ae: dd     ", marks=_nyi11),
         # yapf: enable
@@ -945,10 +945,10 @@ def test_mp2p5_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, r
         pytest.param({"keywords": {"reference": "rohf", "mp_type": "cd",                       "freeze_core": "false",                    }, "marks": {1: _nyi3, 0: _nyi11},}, id="mp2.5 rohf    cd   ae: dd     ",),
 
         ###### default qc_module, mp_type
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi1},           }, id="mp2.5  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi1},           }, id="mp2.5  uhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi4, 0: _nyi4 },}, id="mp2.5  rhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                    },                                }, id="mp2.5  uhf         fc: dd     ",),
         pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "true",                    }, "marks": {1: _nyi2, 0: _nyi11},}, id="mp2.5 rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                   },                                }, id="mp2.5  rhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                   }, "marks": {1: _nyi4, 0: _nyi4 },}, id="mp2.5  rhf         ae: dd     ",),
         pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "false",                   },                                }, id="mp2.5  uhf         ae: dd     ",),
         pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "false",                   }, "marks": {1: _nyi2, 0: _nyi11},}, id="mp2.5 rohf         ae: dd     ",),
         # yapf: enable
@@ -1144,10 +1144,10 @@ def test_mp3_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
         pytest.param({"keywords": {"reference": "rohf", "mp_type": "cd",                       "freeze_core": "false",                    }}, id="mp3 rohf    cd   ae: dd     ", marks=_nyi11),
 
         ###### default qc_module, mp_type
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="mp3  rhf         fc: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "true",                     }}, id="mp3  rhf         fc: dd     ", marks=_nyi4 ),
         pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "true",                     }}, id="mp3  uhf         fc: dd     ",             ),
         pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "true",                     }}, id="mp3 rohf         fc: dd     ", marks=_nyi11),
-        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="mp3  rhf         ae: dd     ",             ),
+        pytest.param({"keywords": {"reference": "rhf",                                         "freeze_core": "false",                    }}, id="mp3  rhf         ae: dd     ", marks=_nyi4 ),
         pytest.param({"keywords": {"reference": "uhf",                                         "freeze_core": "false",                    }}, id="mp3  uhf         ae: dd     ",             ),
         pytest.param({"keywords": {"reference": "rohf",                                        "freeze_core": "false",                    }}, id="mp3 rohf         ae: dd     ", marks=_nyi11),
         # yapf: enable
@@ -1311,10 +1311,10 @@ def test_mp3_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, req
         pytest.param({"keywords": {"reference": "rohf", "mp_type": "cd",                       "freeze_core": "false",                    }, "marks": {1: _nyi3, 0: _nyi11},}, id="mp3 rohf    cd   ae: dd     ",),
 
         ###### default qc_module, mp_type
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi1},           }, id="mp3  rhf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi1},           }, id="mp3  uhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "true",                    }, "marks": {1: _nyi4, 0: _nyi4 },}, id="mp3  rhf         fc: dd     ",),
+        pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "true",                    },                                }, id="mp3  uhf         fc: dd     ",),
         pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "true",                    }, "marks": {1: _nyi2, 0: _nyi11},}, id="mp3 rohf         fc: dd     ",),
-        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                   },                                }, id="mp3  rhf         ae: dd     ",),
+        pytest.param({"keywords": {"reference": "rhf",                                          "freeze_core": "false",                   }, "marks": {1: _nyi4, 0: _nyi4 },}, id="mp3  rhf         ae: dd     ",),
         pytest.param({"keywords": {"reference": "uhf",                                          "freeze_core": "false",                   },                                }, id="mp3  uhf         ae: dd     ",),
         pytest.param({"keywords": {"reference": "rohf",                                         "freeze_core": "false",                   }, "marks": {1: _nyi2, 0: _nyi11},}, id="mp3 rohf         ae: dd     ",),
         # yapf: enable

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -2320,6 +2320,10 @@ def test_olccd_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, re
         pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd  rhf    conv ae: * occ  ",),
         pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd  uhf    conv ae: * occ  ",),
         pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    },              }, id="olccd rohf    conv ae: * occ  ",),
+        #
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    "ccl_energy": "true", "tpdm_abcd_type": "compute"},              }, id="olccd  rhf  v conv ae:   occ  ",),
+        pytest.param({"keywords": {"reference": "uhf",  "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    "ccl_energy": "true", "tpdm_abcd_type": "compute"},              }, id="olccd  uhf  v conv ae:   occ  ",),
+        pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv", "qc_module": "occ", "freeze_core": "false",                    "ccl_energy": "true", "tpdm_abcd_type": "compute"},              }, id="olccd rohf  v conv ae:   occ  ",),
         # ####
         # pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  rhf    df   fc:   dfocc",),
         # pytest.param({"keywords": {"reference": "uhf",  "cc_type": "df",   "qc_module": "occ", "freeze_core": "true",                     },}, id="olccd  uhf    df   fc:   dfocc",),

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -1862,12 +1862,12 @@ def test_lccsd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, re
         pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd  rhf disk/df   rr fnocc   ",),
         pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd  rhf   cd/df   rr fnocc   ",),
 
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",     },               }, id="ccsd  rhf   pk/df   rr occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "direct", },               }, id="ccsd  rhf drct/df   rr occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "df",     },               }, id="ccsd  rhf   df/df   rr occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "mem_df", }, "error": _p1, }, id="ccsd  rhf  mem/df   rr occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd  rhf disk/df   rr occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd  rhf   cd/df   rr occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",     },               }, id="ccsd  rhf   pk/df   rr dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "direct", },               }, id="ccsd  rhf drct/df   rr dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "df",     },               }, id="ccsd  rhf   df/df   rr dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "mem_df", }, "error": _p1, }, id="ccsd  rhf  mem/df   rr dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd  rhf disk/df   rr dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd  rhf   cd/df   rr dfocc   ",),
         # yapf: enable
     ],
 )
@@ -1927,20 +1927,20 @@ def test_ccsd_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, req
         pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "pk",}, "error": _p15,}, id="ccsd  rhf pk/cd ae:   fnocc   ",),
 
         ###### dfocc
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd  rhf    df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd  rhf    df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd  rhf    df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd  rhf    df ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd  rhf pk/df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd  rhf pk/df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd  rhf pk/df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd  rhf pk/df ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "cd",},               }, id="ccsd  rhf cd/df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",},               }, id="ccsd  rhf cd/df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "cd",},               }, id="ccsd  rhf cd/df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",},               }, id="ccsd  rhf cd/df ae:   dfocc   ",),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd  rhf    cd fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd  rhf    cd ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd  rhf    cd fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd  rhf    cd ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd  rhf pk/cd fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd  rhf pk/cd ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd  rhf pk/cd fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd  rhf pk/cd ae:   dfocc   ",),
         # yapf: enable
     ],
 )
@@ -2047,8 +2047,8 @@ def test_ccsd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, req
         pytest.param({"keywords": {"reference": "rohf", "cc_type": "conv", "qc_module": "ccenergy", "freeze_core": "false",},                    }, id="ccsd rohf  conv ae: * ccenergy",),
 
         ###### dfocc
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true", },                    }, id="ccsd  rhf    df fc: * occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",},                    }, id="ccsd  rhf    df ae: * occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true", },                    }, id="ccsd  rhf    df fc: * dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",},                    }, id="ccsd  rhf    df ae: * dfocc   ",),
         # yapf: enable
     ],
 )
@@ -2114,12 +2114,12 @@ def test_ccsd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
 #        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd_t_  rhf disk/df   rr fnocc   ",),
 #        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd_t_  rhf   cd/df   rr fnocc   ",),
 #
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",     },               }, id="ccsd_t_  rhf   pk/df   rr occ     ",),
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "direct", },               }, id="ccsd_t_  rhf drct/df   rr occ     ",),
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "df",     },               }, id="ccsd_t_  rhf   df/df   rr occ     ",),
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "mem_df", }, "error": _p1, }, id="ccsd_t_  rhf  mem/df   rr occ     ",),
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd_t_  rhf disk/df   rr occ     ",),
-#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd_t_  rhf   cd/df   rr occ     ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",     },               }, id="ccsd_t_  rhf   pk/df   rr dfocc   ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "direct", },               }, id="ccsd_t_  rhf drct/df   rr dfocc   ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "df",     },               }, id="ccsd_t_  rhf   df/df   rr dfocc   ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "mem_df", }, "error": _p1, }, id="ccsd_t_  rhf  mem/df   rr dfocc   ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "disk_df",},               }, id="ccsd_t_  rhf disk/df   rr dfocc   ",),
+#        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",     },               }, id="ccsd_t_  rhf   cd/df   rr dfocc   ",),
 #        # yapf: enable
 #    ],
 # )
@@ -2179,20 +2179,20 @@ def test_ccsd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
         pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "fnocc",    "freeze_core": "false", "scf_type": "pk",}, "error": _p15,}, id="ccsd_t_  rhf pk/cd ae:   fnocc   ",),
 
         ###### dfocc
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd_t_  rhf    df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd_t_  rhf    df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd_t_  rhf    df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd_t_  rhf    df ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/df ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "cd",},               }, id="ccsd_t_  rhf cd/df fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",},               }, id="ccsd_t_  rhf cd/df ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "cd",},               }, id="ccsd_t_  rhf cd/df fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "df",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "cd",},               }, id="ccsd_t_  rhf cd/df ae:   dfocc   ",),
         ####
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd_t_  rhf    cd fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd_t_  rhf    cd ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",                   },               }, id="ccsd_t_  rhf    cd fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false",                  },               }, id="ccsd_t_  rhf    cd ae:   dfocc   ",),
         ##
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/cd fc:   occ     ",),
-        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/cd ae:   occ     ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "true",  "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/cd fc:   dfocc   ",),
+        pytest.param({"keywords": {"reference": "rhf",  "cc_type": "cd",   "qc_module": "occ",      "freeze_core": "false", "scf_type": "pk",},               }, id="ccsd_t_  rhf pk/cd ae:   dfocc   ",),
         # yapf: enable
     ],
 )

--- a/tests/pytests/test_standard_suite.py
+++ b/tests/pytests/test_standard_suite.py
@@ -76,7 +76,6 @@ _nyi12 = pytest.mark.xfail(reason="cd scf gradients NYI", raises=psi4.Validation
 #  HF Energy
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -144,7 +143,6 @@ def test_hf_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reques
 #  HF Gradient
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -645,7 +643,6 @@ def test_mp2_gradient_default(inp, dertype, basis, subjects, clsd_open_pmols, re
 #  MP2.5 Energy
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
@@ -685,7 +682,6 @@ def test_mp2p5_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, re
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -747,7 +743,6 @@ def test_mp2p5_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, req
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz", marks=pytest.mark.quick),],
@@ -813,7 +808,6 @@ def test_mp2p5_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, re
 #  MP2.5 Gradient
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
@@ -861,7 +855,6 @@ def test_mp2p5_gradient_scftype(inp, dertype, basis, subjects, clsd_open_pmols, 
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -909,7 +902,6 @@ def test_mp2p5_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, r
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize(
     "dertype",
     [pytest.param(1, id="grd1", marks=pytest.mark.quick), pytest.param(0, id="grd0", marks=pytest.mark.long),],
@@ -983,7 +975,6 @@ def test_mp2p5_gradient_default(inp, dertype, basis, subjects, clsd_open_pmols, 
 #  MP3 Energy
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
@@ -1037,7 +1028,6 @@ def test_mp3_energy_scftype(inp, dertype, basis, subjects, clsd_open_pmols, requ
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -1110,7 +1100,6 @@ def test_mp3_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(0, id="ene0"),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz", marks=pytest.mark.quick),],
@@ -1176,7 +1165,6 @@ def test_mp3_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, requ
 #  MP3 Gradient
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
@@ -1225,7 +1213,6 @@ def test_mp3_gradient_scftype(inp, dertype, basis, subjects, clsd_open_pmols, re
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -1274,7 +1261,6 @@ def test_mp3_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, req
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize(
     "dertype",
     [pytest.param(1, id="grd1", marks=pytest.mark.quick), pytest.param(0, id="grd0", marks=pytest.mark.long),],
@@ -1525,7 +1511,6 @@ def test_lccd_energy_default(inp, dertype, basis, subjects, clsd_open_pmols, req
 #  LCCD Gradient
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects", [pytest.param("cc-pvdz", ["hf", "bh3p", "bh3p"], id="dz"),],
@@ -1574,7 +1559,6 @@ def test_lccd_gradient_scftype(inp, dertype, basis, subjects, clsd_open_pmols, r
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize("dertype", [pytest.param(1, id="grd1"), pytest.param(0, id="grd0", marks=pytest.mark.long),])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -1623,7 +1607,6 @@ def test_lccd_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, re
     runner_asserter(inpcopy, subject, method, basis, tnm)
 
 
-@pytest.mark.skip(reason="needs qcel v0.16.0")
 @pytest.mark.parametrize(
     "dertype",
     [pytest.param(1, id="grd1", marks=pytest.mark.quick), pytest.param(0, id="grd0", marks=pytest.mark.long),],

--- a/tests/pywrap-alias/input.dat
+++ b/tests/pywrap-alias/input.dat
@@ -13,6 +13,7 @@ set {
     scf_type pk  # no fitting bases for helium
     #df_scf_guess cc-pvdz-ri
     df_scf_guess false
+    mp_type conv
 }
 
 set scf {


### PR DESCRIPTION
## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] conventional only (not orbital optimized) MP2.5 and MP3 are now density-fit by default, fixes #1801 
- [x] note that this bifurcates the role of `mp_type`, with the above cases imposed in proc.py, leaving the keyword unchanged for others -- omp2.5, omp3, mp4, adc2
- [x] in occ, LCCD and OLCCD energies were often failing (to match to 1.e-6) with default convcrit. though there's a `abs(DE) < e_conv` test for iterations, the actual progressing of DE through the iterations has a lot of energy increases, so often a small energy increase satisfies the test. I reduced the energy test by an order of magnitude to allow a little more settling of iterations. obligatory @JonathonMisiewicz ping, who may be rightly appalled. it does fix up energy and 5-point findif gradient by energy convergence across the std suite.
- [x] in dfocc, most DF analytic gradients from MP2 to CCSD were failing with default convcrit w/o tightening pcg_convergence by an order of magnitude. so, I tied pcg_convergence to e_convergence if not specified. again, Jonathon's input welcome.
- [x] I maybe should write a warning to output if these methods run w/o mp_type specified so the change isn't wholly unmarked (besides release notes and docs)
- [x] bump qcel and qcng to v0.16

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
