### PR TITLE
PK memory fixes

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -99,7 +99,7 @@ jobs:
         pybind11 \
         pymdi \
         -c conda-forge
-      conda install adcc -c adcc -c conda-forge
+      #conda install adcc -c adcc -c conda-forge
       pip install git+https://github.com/i-pi/i-pi.git@master-py3
       conda list
     displayName: 'Build Environment'
@@ -122,7 +122,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCMAKE_PREFIX_PATH=${CONDA}/envs/p4env \
         -DPYTHON_EXECUTABLE="${CONDA}/envs/p4env/bin/python" \
-        -DENABLE_adcc=ON \
+        -DENABLE_adcc=OFF \
         -DENABLE_CheMPS2=OFF \
         -DENABLE_dkh=ON \
         -DENABLE_libefp=ON \

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -815,6 +815,7 @@ void PKMgrReorder::prestripe_files() {
         // We need to keep the labels around in a vector
         label_J_.push_back(PKWorker::get_label_J(batch));
         AIO()->zero_disk(pk_file(), label_J_[batch], 1, batch_size);
+        AIO()->synchronize();
         label_K_.push_back(PKWorker::get_label_K(batch));
         AIO()->zero_disk(pk_file(), label_K_[batch], 1, batch_size);
     }

--- a/psi4/src/psi4/libfock/PKmanagers.h
+++ b/psi4/src/psi4/libfock/PKmanagers.h
@@ -160,7 +160,7 @@ class PKManager {
     size_t pk_size() const { return pk_size_; }
     size_t ntasks() const { return ntasks_; }
     size_t memory() const { return memory_; }
-    SharedPKWrkr buffer(int i) const { return iobuffers_[i]; }
+    SharedPKWrkr& buffer(int i) { return iobuffers_[i]; }
     double* D_glob_vecs(int i) const { return D_vec_[i]; }
     double* JK_glob_vecs(int i) const { return JK_vec_[i]; }
     std::shared_ptr<BasisSet> primary() const { return primary_; }


### PR DESCRIPTION
## Description
The PK(reordered, disk) algorithm was using twice as much memory as it should.
This is due to not deleting integral and disk-space buffers correctly:
 * During the pre-iterations the `batch size` buffer that prepares the disk space ("pre-striping", within `zero_disk`) and used during the SCF for processing the integrals on disk is not released. 
* The `buffer size` buffer that is used to calculate the integrals is not released after the computation is done

Both buffers are actually the same size and effectively lead to a doubling of the memory demand.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] memory leaks in PK(reordered, disk) algorithm addressed
- [x]  Likely solution to #1985 

## Questions
- [ ] Is there a better solution to `AIO->synchronize()` in-between the `zero_disk` operations?
- [ ] Will there be an issue with: https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libfock/PKmanagers.cc#L886  now that `buffer()` returns a reference?

## Checklist
- [x] ctest -L quick/dft pass
- [x] memory usage on `top` eyeballed like a hawk

## Status
- [x] Ready for review
- [ ] Ready for merge
