### PR TITLE
OEI libtrans Cleanup

### DIFF
--- a/psi4/include/psi4/psifiles.h
+++ b/psi4/include/psi4/psifiles.h
@@ -363,11 +363,8 @@
 #define PSIF_MO_A_OEI            "MO-basis Alpha One-electron Ints"
 #define PSIF_MO_B_OEI            "MO-basis Beta One-electron Ints"
 #define PSIF_MO_FZC              "MO-basis Frozen-Core Operator"
-#define PSIF_MO_FOCK             "MO-basis Fock Matrix"
 #define PSIF_MO_A_FZC            "MO-basis Alpha Frozen-Core Oper"
 #define PSIF_MO_B_FZC            "MO-basis Beta Frozen-Core Oper"
-#define PSIF_MO_A_FOCK           "MO-basis Alpha Fock Matrix"
-#define PSIF_MO_B_FOCK           "MO-basis Beta Fock Matrix"
 
 // More macros
 #define PSIF_AO_OPDM_TRIANG      "AO-basis OPDM triang"

--- a/psi4/include/psi4/psifiles.h
+++ b/psi4/include/psi4/psifiles.h
@@ -359,9 +359,6 @@
 #define PSIF_MO_DFDB_Y           "AO-basis dF/dBy Ints"
 #define PSIF_MO_DFDB_Z           "AO-basis dF/dBz Ints"
 
-#define PSIF_MO_OEI              "MO-basis One-electron Ints"
-#define PSIF_MO_A_OEI            "MO-basis Alpha One-electron Ints"
-#define PSIF_MO_B_OEI            "MO-basis Beta One-electron Ints"
 #define PSIF_MO_FZC              "MO-basis Frozen-Core Operator"
 #define PSIF_MO_A_FZC            "MO-basis Alpha Frozen-Core Oper"
 #define PSIF_MO_B_FZC            "MO-basis Beta Frozen-Core Oper"

--- a/psi4/src/export_trans.cc
+++ b/psi4/src/export_trans.cc
@@ -125,8 +125,6 @@ void export_trans(py::module& m) {
     int_trans_bind.def("initialize", &IntegralTransform::initialize, "Initialize an IntegralTransform")
         .def("presort_so_tei", &IntegralTransform::presort_so_tei, "docstring")
         .def("update_orbitals", &IntegralTransform::update_orbitals, "docstring")
-        .def("transform_oei", &IntegralTransform::transform_oei, "Transform one-electron integrals", "s1"_a, "s2"_a,
-             "labels"_a)
         .def("transform_tei", &IntegralTransform::transform_tei, "Transform two-electron integrals", "s1"_a, "s2"_a,
              "s3"_a, "s4"_a, "half_trans"_a = IntegralTransform::HalfTrans::MakeAndNuke)
         .def("transform_tei_first_half", &IntegralTransform::transform_tei_first_half,

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -81,13 +81,10 @@ namespace detci {
 void CIWavefunction::transform_ci_integrals() {
     outfile->Printf("\n   ==> Transforming CI integrals <==\n\n");
     // Grab orbitals
-    SharedMatrix Cdrc = get_orbitals("DRC");
-    SharedMatrix Cact = get_orbitals("ACT");
-    SharedMatrix Cvir = get_orbitals("VIR");
-    SharedMatrix Cfzv = get_orbitals("FZV");
-
-    // Build up active space
-    std::vector<std::shared_ptr<MOSpace>> spaces;
+    auto Cdrc = get_orbitals("DRC");
+    auto Cact = get_orbitals("ACT");
+    auto Cvir = get_orbitals("VIR");
+    auto Cfzv = get_orbitals("FZV");
 
     // Indices should be empty
     std::vector<int> indices(CalcInfo_->num_ci_orbs, 0);
@@ -102,14 +99,13 @@ void CIWavefunction::transform_ci_integrals() {
     }
 
     auto act_space = std::make_shared<MOSpace>('X', orbitals, indices);
-    spaces.push_back(act_space);
+    std::vector<std::shared_ptr<MOSpace>> spaces {act_space};
 
     IntegralTransform* ints =
         new IntegralTransform(H_, Cdrc, Cact, Cvir, Cfzv, spaces, IntegralTransform::TransformationType::Restricted,
                               IntegralTransform::OutputType::DPDOnly, IntegralTransform::MOOrdering::PitzerOrder,
                               IntegralTransform::FrozenOrbitals::OccAndVir, true);
     ints_ = std::shared_ptr<IntegralTransform>(ints);
-    ints_->set_build_mo_fock(false);
     ints_->set_memory(Process::environment.get_memory() * 0.8);
 
     // Incase we do two ci runs

--- a/psi4/src/psi4/libtrans/README.txt
+++ b/psi4/src/psi4/libtrans/README.txt
@@ -1,0 +1,16 @@
+General Notes About the Code
+
+1. While the primary purpose of the code is transformations between the AO and MO bases, 
+   some codes (mrcc, detci, and especially cc) request that all tasks involving frozen core
+   orbitals be either done by libtrans or converted into effective quantities free of frozen
+   core orbitals - that way, they don't need to worry about frozen core orbtials at all, and
+   the calculation retains all the simplicity of one where core electrons simply don't exist.
+   In particular, libtrans has the following responsibilities:
+   * Computing all energy contributions involving frozen core orbitals only and putting that
+     result into frozen_core_energy_. Used to sanity-check the HF energy.
+   * Constructing the "frozen-core operator", which is the core hamiltonian for non-frozen orbitals
+     plus the Couloumb and exchange contributions terms arising from the electric field of
+     the frozen core orbitals. Used to sanity check the correlated energy by computing it from
+     density matrices.
+   * Constructing the contribution to the (one-electron) density matrix solely due to frozen
+     core orbitals. This may needed for property calculations later.

--- a/psi4/src/psi4/libtrans/README.txt
+++ b/psi4/src/psi4/libtrans/README.txt
@@ -5,12 +5,10 @@ General Notes About the Code
    orbitals be either done by libtrans or converted into effective quantities free of frozen
    core orbitals - that way, they don't need to worry about frozen core orbtials at all, and
    the calculation retains all the simplicity of one where core electrons simply don't exist.
-   In particular, libtrans has the following responsibilities:
+   In particular, libtrans:integraltransform_sort_so_tei.cc has the following responsibilities:
    * Computing all energy contributions involving frozen core orbitals only and putting that
      result into frozen_core_energy_. Used to sanity-check the HF energy.
    * Constructing the "frozen-core operator", which is the core hamiltonian for non-frozen orbitals
      plus the Couloumb and exchange contributions terms arising from the electric field of
      the frozen core orbitals. Used to sanity check the correlated energy by computing it from
      density matrices.
-   * Constructing the contribution to the (one-electron) density matrix solely due to frozen
-     core orbitals. This may needed for property calculations later.

--- a/psi4/src/psi4/libtrans/README.txt
+++ b/psi4/src/psi4/libtrans/README.txt
@@ -1,14 +1,13 @@
 General Notes About the Code
 
 1. While the primary purpose of the code is transformations between the AO and MO bases, 
-   some codes (mrcc, detci, and especially cc) request that all tasks involving frozen core
+   some codes (mrcc, detci, and especially cc) request that tasks involving frozen core
    orbitals be either done by libtrans or converted into effective quantities free of frozen
-   core orbitals - that way, they don't need to worry about frozen core orbtials at all, and
+   core orbitals - that way, they don't need to worry about frozen core orbitals at all, and
    the calculation retains all the simplicity of one where core electrons simply don't exist.
    In particular, libtrans:integraltransform_sort_so_tei.cc has the following responsibilities:
    * Computing all energy contributions involving frozen core orbitals only and putting that
      result into frozen_core_energy_. Used to sanity-check the HF energy.
    * Constructing the "frozen-core operator", which is the core hamiltonian for non-frozen orbitals
      plus the Couloumb and exchange contributions terms arising from the electric field of
-     the frozen core orbitals. Used to sanity check the correlated energy by computing it from
-     density matrices.
+     the frozen core orbitals. Think of it as halfway between the core Hamiltonian and the Fock operator.

--- a/psi4/src/psi4/libtrans/integraltransform.cc
+++ b/psi4/src/psi4/libtrans/integraltransform.cc
@@ -84,7 +84,6 @@ IntegralTransform::IntegralTransform(std::shared_ptr<Wavefunction> wfn, SpaceVec
       keepDpdMoTpdm_(true),
       keepHtInts_(true),
       keepHtTpdm_(true),
-      buildMOFock_(true),
       tpdmAlreadyPresorted_(false),
       soIntTEIFile_(PSIF_SO_TEI) {
     // Implement set/get functions to customize any of this stuff.  Delayed initialization
@@ -161,7 +160,6 @@ IntegralTransform::IntegralTransform(SharedMatrix H, SharedMatrix c, SharedMatri
       keepDpdMoTpdm_(true),
       keepHtInts_(true),
       keepHtTpdm_(true),
-      buildMOFock_(true),
       tpdmAlreadyPresorted_(false),
       soIntTEIFile_(PSIF_SO_TEI) {
     memory_ = Process::environment.get_memory();

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -148,9 +148,6 @@ class PSI_API IntegralTransform {
     void initialize();
     void presort_so_tei();
     void update_orbitals();
-    void transform_T_plus_V(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2);
-    void transform_oei(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                       const std::array<std::string, 4> &labels);
     void transform_tei(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
                        const std::shared_ptr<MOSpace> s3, const std::shared_ptr<MOSpace> s4,
                        HalfTrans = HalfTrans::MakeAndNuke);
@@ -257,10 +254,6 @@ class PSI_API IntegralTransform {
     void setup_tpdm_buffer(const dpdbuf4 *D);
     void sort_so_tpdm(const dpdbuf4 *B, int irrep, size_t first_row, size_t num_rows, bool first_run);
 
-    void transform_oei_restricted(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                                  const std::vector<double> &soInts, std::string label);
-    void transform_oei_unrestricted(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                                    const std::vector<double> &soInts, std::string A_label, std::string B_label);
     void trans_one(int m, int n, double *input, double *output, double **C, int soOffset, int *order,
                    bool backtransform = false, double scale = 0.0);
 

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -174,8 +174,6 @@ class PSI_API IntegralTransform {
     void set_write_dpd_so_tpdm(bool t_f) { write_dpd_so_tpdm_ = t_f; }
     /// Set the level of printing used during transformations (0 -> 6)
     void set_print(int n) { print_ = n; }
-    /// Whether to build the Fock matrix in the MO basis during integral presort
-    void set_build_mo_fock(bool t_f) { buildMOFock_ = t_f; }
     /// Sets the orbitals to the given C matrix. This is a hack for MCSCF wavefunctions.
     /// Use with caution.
     void set_orbitals(SharedMatrix C);
@@ -264,7 +262,10 @@ class PSI_API IntegralTransform {
     std::vector<size_t> tpdm_buffer_sizes_;
     // The buffer used in sorting the SO basis tpdm
     double *tpdm_buffer_;
-    // Frozen core energy
+    // Energy due solely to frozen core orbitals. Some modules request libtrans compute this so
+    // that they don't have to concern themselves with core orbitals at all. In those cases,
+    // contributions due to the valence orbitals feeling the electric field of the core orbitals
+    // are accounted for by writing a "frozen core operator" to disk.
     double frozen_core_energy_;
     // The wavefunction object, containing the orbital infomation
     std::shared_ptr<Wavefunction> wfn_;
@@ -412,8 +413,6 @@ class PSI_API IntegralTransform {
     bool useDPD_;
     // Has this object already pre-sorted?
     bool tpdmAlreadyPresorted_;
-    // Whether to form the MO basis Fock matrix during TEI presort
-    bool buildMOFock_;
     // This keeps track of which labels have been assigned by other spaces
     std::map<char, int> labelsUsed_;
 };

--- a/psi4/src/psi4/libtrans/integraltransform_functors.h
+++ b/psi4/src/psi4/libtrans/integraltransform_functors.h
@@ -39,7 +39,7 @@
 
 namespace psi {
 
-class FrozenCoreAndFockRestrictedFunctor {
+class FrozenCoreRestrictedFunctor {
    private:
     /// The frozen core density matrix (stored as a lower triangular array)
     const double *FzD_;
@@ -229,7 +229,7 @@ class FrozenCoreUnrestrictedFunctor {
      * @param Fza: The alpha frozen core operator (stored as a lower triangular array)
      * @param Fzb: The beta frozen core operator (stored as a lower triangular array)
      */
-    FrozenCoreAndFockUnrestrictedFunctor(const double *FzDa, const double *FzDb, double *Fza, double *Fzb)
+    FrozenCoreUnrestrictedFunctor(const double *FzDa, const double *FzDb, double *Fza, double *Fzb)
         : FzDa_(FzDa), FzDb_(FzDb), Fza_(Fza), Fzb_(Fzb) {}
 
     void operator()(int pabs, int qabs, int rabs, int sabs, int psym, int prel, int qsym, int qrel, int rsym, int rrel,

--- a/psi4/src/psi4/libtrans/integraltransform_functors.h
+++ b/psi4/src/psi4/libtrans/integraltransform_functors.h
@@ -222,7 +222,7 @@ class FrozenCoreUnrestrictedFunctor {
 
    public:
     /*
-     * Generates the fock and frozen core operators, given the density matrices as input
+     * Generates the frozen core operators, given the density matrices as input
      *
      * @param FzDa: The alpha frozen core density matrix (stored as a lower triangular array)
      * @param FzDb: The beta frozen core density matrix (stored as a lower triangular array)

--- a/psi4/src/psi4/libtrans/integraltransform_functors.h
+++ b/psi4/src/psi4/libtrans/integraltransform_functors.h
@@ -41,12 +41,8 @@ namespace psi {
 
 class FrozenCoreAndFockRestrictedFunctor {
    private:
-    /// The density matrix (stored as a lower triangular array)
-    const double *D_;
     /// The frozen core density matrix (stored as a lower triangular array)
     const double *FzD_;
-    /// The Fock matrix (stored as a lower triangular array)
-    double *F_;
     /// The frozen core operator (stored as a lower triangular array)
     double *Fz_;
     /// Some temporary arrays for handling permutations
@@ -56,13 +52,11 @@ class FrozenCoreAndFockRestrictedFunctor {
     /*
      * Generates the fock and frozen core operators, given the density matrices as input
      *
-     * @param D: The density matrix (stored as a lower triangular array)
      * @param FzD: The frozen core density matrix (stored as a lower triangular array)
-     * @param F: The Fock matrix (stored as a lower triangular array)
      * @param Fz: The frozen core operator (stored as a lower triangular array)
      */
-    FrozenCoreAndFockRestrictedFunctor(const double *D, const double *FzD, double *F, double *Fz)
-        : D_(D), FzD_(FzD), F_(F), Fz_(Fz) {}
+    FrozenCoreRestrictedFunctor(const double *FzD, double *Fz)
+        : FzD_(FzD), Fz_(Fz) {}
 
     void operator()(int pabs, int qabs, int rabs, int sabs, int psym, int prel, int qsym, int qrel, int rsym, int rrel,
                     int ssym, int srel, double value) {
@@ -76,10 +70,8 @@ class FrozenCoreAndFockRestrictedFunctor {
         int ad = INDEX(a, d);
 
         Fz_[cd] += 2.0 * FzD_[ab] * value;
-        F_[cd] += 2.0 * D_[ab] * value;
         if (b >= c) {
             Fz_[bc] -= FzD_[ad] * value;
-            F_[bc] -= D_[ad] * value;
         }
 
         a = al[1] = qabs;
@@ -93,11 +85,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -114,11 +104,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -135,11 +123,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -156,11 +142,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -177,11 +161,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -198,11 +180,9 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
 
@@ -219,30 +199,20 @@ class FrozenCoreAndFockRestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fz_[cd] += 2.0 * FzD_[ab] * value;
-                F_[cd] += 2.0 * D_[ab] * value;
             }
             if (b >= c) {
                 Fz_[bc] -= FzD_[ad] * value;
-                F_[bc] -= D_[ad] * value;
             }
         }
     }
 };
 
-class FrozenCoreAndFockUnrestrictedFunctor {
+class FrozenCoreUnrestrictedFunctor {
    private:
-    /// The alpha density matrix (stored as a lower triangular array)
-    const double *Da_;
-    /// The beta density matrix (stored as a lower triangular array)
-    const double *Db_;
     /// The alpha frozen core density matrix (stored as a lower triangular array)
     const double *FzDa_;
     /// The beta frozen core density matrix (stored as a lower triangular array)
     const double *FzDb_;
-    /// The alpha Fock matrix (stored as a lower triangular array)
-    double *Fa_;
-    /// The beta Fock matrix (stored as a lower triangular array)
-    double *Fb_;
     /// The alpha frozen core operator (stored as a lower triangular array)
     double *Fza_;
     /// The beta frozen core operator (stored as a lower triangular array)
@@ -254,18 +224,13 @@ class FrozenCoreAndFockUnrestrictedFunctor {
     /*
      * Generates the fock and frozen core operators, given the density matrices as input
      *
-     * @param Da: The alpha density matrix (stored as a lower triangular array)
-     * @param Db: The beta density matrix (stored as a lower triangular array)
      * @param FzDa: The alpha frozen core density matrix (stored as a lower triangular array)
      * @param FzDb: The beta frozen core density matrix (stored as a lower triangular array)
-     * @param Fa: The alpha Fock matrix (stored as a lower triangular array)
-     * @param Fa: The beta Fock matrix (stored as a lower triangular array)
      * @param Fza: The alpha frozen core operator (stored as a lower triangular array)
      * @param Fzb: The beta frozen core operator (stored as a lower triangular array)
      */
-    FrozenCoreAndFockUnrestrictedFunctor(const double *Da, const double *Db, const double *FzDa, const double *FzDb,
-                                         double *Fa, double *Fb, double *Fza, double *Fzb)
-        : Da_(Da), Db_(Db), FzDa_(FzDa), FzDb_(FzDb), Fa_(Fa), Fb_(Fb), Fza_(Fza), Fzb_(Fzb) {}
+    FrozenCoreAndFockUnrestrictedFunctor(const double *FzDa, const double *FzDb, double *Fza, double *Fzb)
+        : FzDa_(FzDa), FzDb_(FzDb), Fza_(Fza), Fzb_(Fzb) {}
 
     void operator()(int pabs, int qabs, int rabs, int sabs, int psym, int prel, int qsym, int qrel, int rsym, int rrel,
                     int ssym, int srel, double value) {
@@ -279,13 +244,9 @@ class FrozenCoreAndFockUnrestrictedFunctor {
         int ad = INDEX(a, d);
         Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
         Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-        Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
-        Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
         if (b >= c) {
             Fza_[bc] -= FzDa_[ad] * value;
-            Fa_[bc] -= Da_[ad] * value;
             Fzb_[bc] -= FzDb_[ad] * value;
-            Fb_[bc] -= Db_[ad] * value;
         }
 
         a = al[1] = qabs;
@@ -299,15 +260,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -324,15 +281,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -349,15 +302,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -374,15 +323,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -399,15 +344,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -424,15 +365,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
 
@@ -449,15 +386,11 @@ class FrozenCoreAndFockUnrestrictedFunctor {
             ad = INDEX(a, d);
             if (c >= d) {
                 Fza_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fa_[cd] += (Da_[ab] + Db_[ab]) * value;
                 Fzb_[cd] += (FzDa_[ab] + FzDb_[ab]) * value;
-                Fb_[cd] += (Da_[ab] + Db_[ab]) * value;
             }
             if (b >= c) {
                 Fza_[bc] -= FzDa_[ad] * value;
-                Fa_[bc] -= Da_[ad] * value;
                 Fzb_[bc] -= FzDb_[ad] * value;
-                Fb_[bc] -= Db_[ad] * value;
             }
         }
     }
@@ -550,8 +483,8 @@ class NullFunctor {
 
 template <class DPDFunctor, class FockFunctor>
 void iwl_integrals(IWL *iwl, DPDFunctor &dpd, FockFunctor &fock) {
-    Label *lblptr = iwl->labels();
-    Value *valptr = iwl->values();
+    auto lblptr = iwl->labels();
+    auto valptr = iwl->values();
     int labelIndex, p, q, r, s;
     double value;
     bool lastBuffer;

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -47,7 +47,6 @@ void IntegralTransform::common_initialize() {
     bbIntName_ = "";
 
     keepHtInts_ = false;
-    buildMOFock_ = true;
 
     nTriSo_ = nso_ * (nso_ + 1) / 2;
     nTriMo_ = nmo_ * (nmo_ + 1) / 2;

--- a/psi4/src/psi4/libtrans/integraltransform_oei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_oei.cc
@@ -33,144 +33,10 @@
 #include <string>
 #include <vector>
 
-#include "psi4/psifiles.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
-#include "psi4/libmints/matrix.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/libiwl/iwl.hpp"
 
 using namespace psi;
-
-/**
- * Transforms the kinetic energy plus nuclear attraction one-electron
- * integrals.  This function is currently limited to IWL input and output and
- * Pitzer ordering, regardless of how the parameters passed to the constructor.
- *
- * @param s1 - the MOSpace for the bra
- * @param s2 - the MOSpace for the ket
- *
- * N.B. This need not be called if a two-electron transformation is performed, as
- * the sort_so_tei routine will perform this transformation in addition to the
- * Fock matrix construction.
- */
-void IntegralTransform::transform_T_plus_V(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2) {
-    check_initialized();
-
-//    wfn_->mintshelper()->so_kinetic();
-
-    //
-    // This code is never called
-    std::vector<double> soInts(nTriSo_), T(nTriSo_);
-//    if (print_ > 4) outfile->Printf("The SO basis kinetic energy integrals\n");
-//    IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_T, T.data(), nTriSo_, 0, print_ > 4, "outfile");
-//    if (print_ > 4) outfile->Printf("The SO basis nuclear attraction integrals\n");
-//    IWL::read_one(psio_.get(), PSIF_OEI, PSIF_SO_V, soInts.data(), nTriSo_, 0, print_ > 4, "outfile");
-//    // Add the nuclear and kinetic energy integrals
-//    std::transform(soInts.begin(), soInts.end(), T.begin(), soInts.begin(), std::plus<double>());
-
-
-
-
-    if (transformationType_ == TransformationType::Restricted) {
-        transform_oei_restricted(s1, s2, soInts, PSIF_MO_OEI);
-    } else {
-        transform_oei_unrestricted(s1, s2, soInts, PSIF_MO_A_OEI, PSIF_MO_B_OEI);
-    }
-}
-
-/**
- * Transforms the one-electron integrals.  This function is currently limited to
- * IWL input and output and Pitzer ordering, regardless of how the parameters passed
- * to the constructor.
- *
- * @param s1 - the MOSpace for the bra
- * @param s2 - the MOSpace for the ket
- * @param labels - array with the labels of the OEI to be transformed
- *
- * @note The labels array is assumed to have the labels for the OEI in this
- * order:
- * 0. labels[0] is the AO integrals label,
- * 1. labels[1] is the MO integrals label, for the restricted case
- * 2. labels[2] is the alpha MO integrals label, for the unrestricted case
- * 3. labels[3] is the beta MO integrals label, for the unrestricted case
- */
-void IntegralTransform::transform_oei(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                                      const std::array<std::string, 4> &labels) {
-    check_initialized();
-    std::vector<double> soInts(nTriSo_);
-    if (print_ > 4) outfile->Printf("Grabbing " + labels[0] + "\n");
-    IWL::read_one(psio_.get(), PSIF_OEI, labels[0].c_str(), soInts.data(), nTriSo_, 0, print_ > 4, "outfile");
-    if (transformationType_ == TransformationType::Restricted) {
-        transform_oei_restricted(s1, s2, soInts, labels[1].c_str());
-    } else {
-        transform_oei_unrestricted(s1, s2, soInts, labels[2].c_str(), labels[3].c_str());
-    }
-}
-
-/**
- * Perform restricted transformation of the one-electron integrals. This function is currently limited to
- * IWL input and output and Pitzer ordering, regardless of how the parameters passed
- * to the constructor.
- *
- * @param s1 - the MOSpace for the bra
- * @param s2 - the MOSpace for the ket
- * @param soInts - buffer with the SO-basis integrals to be transformed
- * @param label - MO label
- */
-void IntegralTransform::transform_oei_restricted(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                                                 const std::vector<double> &soInts, std::string label) {
-    std::vector<double> moInts(nTriMo_);
-    std::vector<int> order(nmo_);
-    // We want to keep Pitzer ordering, so this is just an identity mapping
-    std::iota(order.begin(), order.end(), 0);
-    for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-        double **pCa = Ca_->pointer(h);
-        trans_one(sopi_[h], mopi_[h], const_cast<double *>(soInts.data()), moInts.data(), pCa, soOffset,
-                  &(order[moOffset]));
-        soOffset += sopi_[h];
-        moOffset += mopi_[h];
-    }
-    if (print_ > 4) {
-        outfile->Printf("The MO basis " + label + "\n");
-        print_array(moInts.data(), nmo_, "outfile");
-    }
-    IWL::write_one(psio_.get(), PSIF_OEI, label.c_str(), nTriMo_, moInts.data());
-}
-
-void IntegralTransform::transform_oei_unrestricted(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
-                                                   const std::vector<double> &soInts, std::string A_label,
-                                                   std::string B_label) {
-    std::vector<double> moInts(nTriMo_);
-    std::vector<int> order(nmo_);
-    // We want to keep Pitzer ordering, so this is just an identity mapping
-    std::iota(order.begin(), order.end(), 0);
-    for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-        double **pCa = Ca_->pointer(h);
-        trans_one(sopi_[h], mopi_[h], const_cast<double *>(soInts.data()), moInts.data(), pCa, soOffset,
-                  &(order[moOffset]));
-        soOffset += sopi_[h];
-        moOffset += mopi_[h];
-    }
-    if (print_ > 4) {
-        outfile->Printf("The MO basis alpha " + A_label + "\n");
-        print_array(moInts.data(), nmo_, "outfile");
-    }
-    IWL::write_one(psio_.get(), PSIF_OEI, A_label.c_str(), nTriMo_, moInts.data());
-
-    for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-        double **pCb = Cb_->pointer(h);
-        trans_one(sopi_[h], mopi_[h], const_cast<double *>(soInts.data()), moInts.data(), pCb, soOffset,
-                  &(order[moOffset]));
-        soOffset += sopi_[h];
-        moOffset += mopi_[h];
-    }
-    if (print_ > 4) {
-        outfile->Printf("The MO basis beta " + B_label + "\n");
-        print_array(moInts.data(), nmo_, "outfile");
-    }
-    IWL::write_one(psio_.get(), PSIF_OEI, B_label.c_str(), nTriMo_, moInts.data());
-}
 
 /**
  * Transforms a packed symmetric matrix.
@@ -193,9 +59,9 @@ void IntegralTransform::trans_one(int m, int n, double *input, double *output, d
                                   bool backtransform, double scale) {
     // TODO the order argument is actually not used right now.  I don't know that anybody will need it
     // so I haven't bothered so far...
-    int dim = (m > n) ? m : n;
-    double **TMP0 = block_matrix(dim, dim);
-    double **TMP1 = block_matrix(dim, dim);
+    int dim = std::max(m, n);
+    auto TMP0 = block_matrix(dim, dim);
+    auto TMP1 = block_matrix(dim, dim);
 
     for (int p = 0; p < m; ++p) {
         for (int q = 0; q <= p; ++q) {

--- a/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_so_tei.cc
@@ -183,14 +183,14 @@ void IntegralTransform::presort_so_tei() {
         return;
     }
 
-    /// Construct OEI parts of frozen core and Fock operators
+    /// Initialize frozen core density
     auto aFzcD = std::vector<double>(nTriSo_); // Density matrix from core orbitals only
     std::vector<double> bFzcD, bFzcOp;
     if (transformationType_ != TransformationType::Restricted) {
         bFzcD = std::vector<double>(nTriSo_);
     }
 
-    // Form the Density matrices
+    // Set frozen core density
     for (int h = 0, soOffset = 0; h < nirreps_; ++h) {
         auto pCa = Ca_->pointer(h);
         auto pCb = Cb_->pointer(h);
@@ -206,7 +206,7 @@ void IntegralTransform::presort_so_tei() {
         soOffset += sopi_[h];
     }
 
-    // Copy the OEI into the Frozen Core and Fock operators
+    // Copy the OEI into the frozen core operator
     auto aoH = H_->to_lower_triangle();
     std::vector<double> aFzcOp(aoH, aoH + nTriSo_); // The frozen core operator. Not complete yet.
     if (transformationType_ != TransformationType::Restricted) {
@@ -350,7 +350,7 @@ void IntegralTransform::presort_so_tei() {
     // We want to keep Pitzer ordering, so this is just an identity mapping
     std::vector<int> order(nmo_);
     std::iota(std::begin(order), std::end(order), 0);
-    if (print_) outfile->Printf("\tTransforming the one-electron integrals and constructing Fock matrices\n");
+    if (print_) outfile->Printf("\tConstructing frozen core operators\n");
     if (transformationType_ == TransformationType::Restricted) {
         // Compute frozen core energy
         size_t pq = 0;
@@ -362,18 +362,6 @@ void IntegralTransform::presort_so_tei() {
                 frozen_core_energy_ += prefact * aFzcD[pq] * (aoH[pq] + aFzcOp[pq]);
             }
         }
-
-        for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-            auto pCa = Ca_->pointer(h);
-            trans_one(sopi_[h], mopi_[h], aoH, moInts, pCa, soOffset, &(order[moOffset]));
-            soOffset += sopi_[h];
-            moOffset += mopi_[h];
-        }
-        if (print_ > 4) {
-            outfile->Printf("The MO basis one-electron integrals\n");
-            print_array(moInts, nmo_, "outfile");
-        }
-        IWL::write_one(psio_.get(), PSIF_OEI, PSIF_MO_OEI, nTriMo_, moInts);
 
         for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
             auto pCa = Ca_->pointer(h);
@@ -397,30 +385,6 @@ void IntegralTransform::presort_so_tei() {
                 frozen_core_energy_ += prefact * bFzcD[pq] * (aoH[pq] + bFzcOp[pq]);
             }
         }
-
-        for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-            auto pCa = Ca_->pointer(h);
-            trans_one(sopi_[h], mopi_[h], aoH, moInts, pCa, soOffset, &(order[moOffset]));
-            soOffset += sopi_[h];
-            moOffset += mopi_[h];
-        }
-        if (print_ > 4) {
-            outfile->Printf("The MO basis alpha one-electron integrals\n");
-            print_array(moInts, nmo_, "outfile");
-        }
-        IWL::write_one(psio_.get(), PSIF_OEI, PSIF_MO_A_OEI, nTriMo_, moInts);
-
-        for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
-            auto pCb = Cb_->pointer(h);
-            trans_one(sopi_[h], mopi_[h], aoH, moInts, pCb, soOffset, &(order[moOffset]));
-            soOffset += sopi_[h];
-            moOffset += mopi_[h];
-        }
-        if (print_ > 4) {
-            outfile->Printf("The MO basis beta one-electron integrals\n");
-            print_array(moInts, nmo_, "outfile");
-        }
-        IWL::write_one(psio_.get(), PSIF_OEI, PSIF_MO_B_OEI, nTriMo_, moInts);
 
         for (int h = 0, moOffset = 0, soOffset = 0; h < nirreps_; ++h) {
             auto pCa = Ca_->pointer(h);

--- a/psi4/src/psi4/occ/trans_ints_rhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_rhf.cc
@@ -173,11 +173,8 @@ void OCCWave::trans_ints_rhf() {
     }
 
     else if (orb_opt_ == "FALSE") {
-        for (int h = 0; h < nirrep_; ++h) {
-            for (int i = 0; i < occpiA[h]; ++i) FockA->set(h, i, i, epsilon_a_->get(h, i));
-            for (int a = 0; a < virtpiA[h]; ++a)
-                FockA->set(h, a + occpiA[h], a + occpiA[h], epsilon_a_->get(h, a + occpiA[h]));
-        }
+        // Assume that the Fock matrix is up-to-date.
+        FockA = Fa_subset("MO");
     }
 
     timer_on("Build Denominators");

--- a/psi4/src/psi4/occ/trans_ints_rhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_rhf.cc
@@ -174,7 +174,8 @@ void OCCWave::trans_ints_rhf() {
 
     else if (orb_opt_ == "FALSE") {
         // Assume that the Fock matrix is up-to-date.
-        FockA = Fa_subset("MO");
+        FockA = Fa_->clone();
+        FockA->transform(Ca_);
     }
 
     timer_on("Build Denominators");

--- a/psi4/src/psi4/occ/trans_ints_uhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_uhf.cc
@@ -735,24 +735,10 @@ void OCCWave::trans_ints_uhf() {
         timer_off("Build Fock");
     }
 
-    else if (orb_opt_ == "FALSE" || reference == "ROHF") {
-        double *mo_ints = init_array(ntri);
-        IWL::read_one(psio_.get(), PSIF_OEI, PSIF_MO_A_FOCK, mo_ints, ntri, 0, 0, "outfile");
-        FockA->set(mo_ints);
-        IWL::read_one(psio_.get(), PSIF_OEI, PSIF_MO_B_FOCK, mo_ints, ntri, 0, 0, "outfile");
-        FockB->set(mo_ints);
-        free(mo_ints);
-    }
-
-    else if (orb_opt_ == "FALSE" && reference != "ROHF") {
-        for (int h = 0; h < nirrep_; ++h) {
-            for (int i = 0; i < occpiA[h]; ++i) FockA->set(h, i, i, epsilon_a_->get(h, i));
-            for (int i = 0; i < occpiB[h]; ++i) FockB->set(h, i, i, epsilon_b_->get(h, i));
-            for (int a = 0; a < virtpiA[h]; ++a)
-                FockA->set(h, a + occpiA[h], a + occpiA[h], epsilon_a_->get(h, a + occpiA[h]));
-            for (int a = 0; a < virtpiB[h]; ++a)
-                FockB->set(h, a + occpiB[h], a + occpiB[h], epsilon_b_->get(h, a + occpiB[h]));
-        }
+    else if (orb_opt_ == "FALSE") {
+        // Assume that the Fock matrix is up-to-date.
+        FockA = Fa_subset("MO");
+        FockB = Fb_subset("MO");
     }
 
     timer_on("Build Denominators");

--- a/psi4/src/psi4/occ/trans_ints_uhf.cc
+++ b/psi4/src/psi4/occ/trans_ints_uhf.cc
@@ -737,8 +737,10 @@ void OCCWave::trans_ints_uhf() {
 
     else if (orb_opt_ == "FALSE") {
         // Assume that the Fock matrix is up-to-date.
-        FockA = Fa_subset("MO");
-        FockB = Fb_subset("MO");
+        FockA = Fa_->clone();
+        FockA->transform(Ca_);
+        FockB = Fb_->clone();
+        FockB->transform(Cb_);
     }
 
     timer_on("Build Denominators");

--- a/tests/dft-ghost/input.dat
+++ b/tests/dft-ghost/input.dat
@@ -11,4 +11,4 @@ H          0.919541811311     0.097469656245     2.500000000000
 
 cam_energy = energy('cam-b3lyp/def2-svp')
 
-compare_values(-76.3298204862400667, cam_energy, 7, "Ghost CAM-B3LYP Energy") #TEST
+compare_values(-76.3298204862400667, cam_energy, 6, "Ghost CAM-B3LYP Energy") #TEST


### PR DESCRIPTION
## Description
This PR does some miscellaneous cleanup of the OEI part of `libtrans` and will probably lead to another series of smaller PRs involving `libtrans`. The focus of this PR is to take away from `libtrans` responsibility for creating unused or barely used one-electron objects.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] Remove unused OEI functions from `libtrans`
- [x] Remove creation of Fock matrices from being the responsibility of `libtrans`
- [x] Add a readme file explaining why `libtrans` is bothering with a frozen core operator.

## Checklist
- [x] `pytest test_standard_suite.py` and all C-tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
