### PR TITLE
Skip Ghost-Nuclear interaction

### DIFF
--- a/psi4/src/psi4/libmints/extern.cc
+++ b/psi4/src/psi4/libmints/extern.cc
@@ -315,6 +315,10 @@ double ExternalPotential::computeNuclearEnergy(std::shared_ptr<Molecule> mol) {
         double yA = mol->y(A);
         double zA = mol->z(A);
         double ZA = mol->Z(A);
+        // skip Ghost interaction
+        if (ZA == 0) {
+            continue;
+        }
 
         for (size_t B = 0; B < charges_.size(); B++) {
             double ZB = std::get<0>(charges_[B]);

--- a/psi4/src/psi4/libmints/extern.cc
+++ b/psi4/src/psi4/libmints/extern.cc
@@ -315,23 +315,21 @@ double ExternalPotential::computeNuclearEnergy(std::shared_ptr<Molecule> mol) {
         double yA = mol->y(A);
         double zA = mol->z(A);
         double ZA = mol->Z(A);
-        // skip Ghost interaction
-        if (ZA == 0) {
-            continue;
-        }
 
-        for (size_t B = 0; B < charges_.size(); B++) {
-            double ZB = std::get<0>(charges_[B]);
-            double xB = convfac * std::get<1>(charges_[B]);
-            double yB = convfac * std::get<2>(charges_[B]);
-            double zB = convfac * std::get<3>(charges_[B]);
+        if (ZA > 0) { // skip Ghost interaction
+            for (size_t B = 0; B < charges_.size(); B++) {
+                double ZB = std::get<0>(charges_[B]);
+                double xB = convfac * std::get<1>(charges_[B]);
+                double yB = convfac * std::get<2>(charges_[B]);
+                double zB = convfac * std::get<3>(charges_[B]);
 
-            double dx = xA - xB;
-            double dy = yA - yB;
-            double dz = zA - zB;
-            double R = sqrt(dx * dx + dy * dy + dz * dz);
+                double dx = xA - xB;
+                double dy = yA - yB;
+                double dz = zA - zB;
+                double R = sqrt(dx * dx + dy * dy + dz * dz);
 
-            E += ZA * ZB / R;
+                E += ZA * ZB / R;
+            }
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10
-                  dft1-alt dft2 dft3 dft-omega dft-dens-cut docs-bases docs-dft explicit-am-basis extern1 extern2
+                  dft1-alt dft2 dft3 dft-omega dft-dens-cut docs-bases docs-dft explicit-am-basis extern1 extern2 extern3
                   fsapt1 fsapt2 fsapt-terms fsapt-allterms fsapt-ext isapt1 isapt2
                   fci-dipole fci-h2o fci-h2o-2 fci-h2o-fzcv fci-tdm fci-tdm-2
                   fci-coverage

--- a/tests/extern3/CMakeLists.txt
+++ b/tests/extern3/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(extern3 "psi;mp2;cart")

--- a/tests/extern3/input.dat
+++ b/tests/extern3/input.dat
@@ -1,0 +1,34 @@
+#! External potential calculation involving a TIP3P water and a QM water for DFMP2.
+#! Finite different test of the gradient is performed to validate forces.
+
+molecule water {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+# Define a TIP3P water as the external potential
+Chrgfield = QMMM()
+Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
+Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+
+set {
+    scf_type df
+    d_convergence 8
+    basis 6-31G*
+}
+
+fd_grad = gradient('mp2', molecule=water, dertype=0)
+fd_ener = psi4.variable('CURRENT ENERGY')
+an_grad = gradient('mp2', molecule=water)
+an_ener = psi4.variable('CURRENT ENERGY')
+
+compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
+compare_values(-76.2080976129895618, fd_ener, 6, 'Finite difference energy')  #TEST
+compare_values(-76.2080976129895618, an_ener, 6, 'Analytic energy')  #TEST

--- a/tests/extern3/input.dat
+++ b/tests/extern3/input.dat
@@ -1,34 +1,20 @@
-#! External potential calculation involving a TIP3P water and a QM water for DFMP2.
-#! Finite different test of the gradient is performed to validate forces.
+#! External potential calculation with one Ghost atom and one point charge at the same position.
 
-molecule water {
-  0 1
-  O  -0.778803000000  0.000000000000  1.132683000000
-  H  -0.666682000000  0.764099000000  1.706291000000
-  H  -0.666682000000  -0.764099000000  1.706290000000
-  symmetry c1
+molecule mol {
+  @N 0. 0. 1.
+  N 0. 0. 0.
   no_reorient
   no_com
+  symmetry c1
+  -7 1
 }
 
-# Define a TIP3P water as the external potential
+# Define point charge on top of first Ghost atom
 Chrgfield = QMMM()
-Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+Chrgfield.extern.addCharge(7.05, 0., 0., 1.)
 psi4.set_global_option_python('EXTERN', Chrgfield.extern)
 
-set {
-    scf_type df
-    d_convergence 8
-    basis 6-31G*
-}
-
-fd_grad = gradient('mp2', molecule=water, dertype=0)
-fd_ener = psi4.variable('CURRENT ENERGY')
-an_grad = gradient('mp2', molecule=water)
-an_ener = psi4.variable('CURRENT ENERGY')
-
-compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST
-compare_values(-76.2080976129895618, fd_ener, 6, 'Finite difference energy')  #TEST
-compare_values(-76.2080976129895618, an_ener, 6, 'Analytic energy')  #TEST
+set basis 6-31G
+set reference rhf
+e = energy('pbe')
+compare_values(-110.2168666458496773, e, 6, 'Total energy') #TEST


### PR DESCRIPTION
## Description
Fixes calculation of nuclear-nuclear interaction energy if a QM/MM point charge and a Ghost atom are at the same position as in the example below. Since a Ghost atom has no nuclear charge, it should not contribute. At any other position apart from the nuclear centers, it would not contribute. But since at this position, the distance between the Ghost and the atom is zero such that the current code wrongly produces a NaN energy.

Setups like this are relevant for [alchemical calculations](https://dx.doi.org/10.1103/PhysRevResearch.2.023220) where fractional nuclear charges are required.

```
molecule mol {
@N 0. 0. 1.
N 0. 0. 0.
no_reorient
no_com
symmetry c1
-7 1
}

Chrgfield = QMMM()
Chrgfield.extern.addCharge(7.05, 0., 0., 1.)
psi4.set_global_option_python('EXTERN', Chrgfield.extern)

set basis 6-31G
set reference rhf
e, wfn = energy('pbe', return_wfn=True)
```


## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.

## Questions

## Checklist
- [x] [All or relevant fraction of full tests run on local machine](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
