### PR TITLE
prints electron count on quadrature grid

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -531,6 +531,12 @@ PSI Variables by Alpha
    The total electronic energy [H] and correlation energy component [H]
    for the full configuration interaction level of theory.
 
+.. psivar:: GRID ELECTRONS TOTAL
+   GRID ELECTRONS ALPHA
+   GRID ELECTRONS BETA
+
+   The number of electrons integrated by the xc quadrature grid.
+
 .. psivar:: HF TOTAL ENERGY
 
    The total electronic energy [H] for the Hartree--Fock method, without

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -561,6 +561,25 @@ def scf_finalize_energy(self):
 
     core.print_out("\n  ==> Post-Iterations <==\n\n")
 
+    if self.V_potential():
+        quad = self.V_potential().quadrature_values()
+        rho_a = quad['RHO_A']/2 if self.same_a_b_dens() else quad['RHO_A']
+        rho_b = quad['RHO_B']/2 if self.same_a_b_dens() else quad['RHO_B']
+        rho_ab = (rho_a + rho_b)
+        self.set_variable("GRID ELECTRONS TOTAL",rho_ab)
+        self.set_variable("GRID ELECTRONS ALPHA",rho_a)
+        self.set_variable("GRID ELECTRONS BETA",rho_b)
+        dev_a = rho_a - self.nalpha()
+        dev_b = rho_b - self.nbeta()
+        core.print_out(f"   electrons on quadrature grid:\n")
+        if self.same_a_b_dens():
+            core.print_out(f"      NTotal = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
+        else:
+            core.print_out(f"      Nalpha   = {rho_a:15.10f} ; deviation = {dev_a:.3e}\n")
+            core.print_out(f"      Nbeta    = {rho_b:15.10f} ; deviation = {dev_b:.3e}\n")
+            core.print_out(f"      NTotal   = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
+        if ((dev_b+dev_a) > 0.1):
+            core.print_out("   WARNING: large deviation in the electron count on grid detected. Check grid size!")
     self.check_phases()
     self.compute_spin_contamination()
     self.frac_renormalize()

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -571,13 +571,13 @@ def scf_finalize_energy(self):
         self.set_variable("GRID ELECTRONS BETA",rho_b)
         dev_a = rho_a - self.nalpha()
         dev_b = rho_b - self.nbeta()
-        core.print_out(f"   electrons on quadrature grid:\n")
+        core.print_out(f"   Electrons on quadrature grid:\n")
         if self.same_a_b_dens():
-            core.print_out(f"      NTotal = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
+            core.print_out(f"      Ntotal   = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
         else:
             core.print_out(f"      Nalpha   = {rho_a:15.10f} ; deviation = {dev_a:.3e}\n")
             core.print_out(f"      Nbeta    = {rho_b:15.10f} ; deviation = {dev_b:.3e}\n")
-            core.print_out(f"      NTotal   = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
+            core.print_out(f"      Ntotal   = {rho_ab:15.10f} ; deviation = {dev_b+dev_a:.3e} \n\n")
         if ((dev_b+dev_a) > 0.1):
             core.print_out("   WARNING: large deviation in the electron count on grid detected. Check grid size!")
     self.check_phases()


### PR DESCRIPTION
## Description
The number of electrons as integrated on the DFT quadrature is printed as "Post-Iterations" quantity.

Current formatting:
```
Energy and wave function converged.


  ==> Post-Iterations <==

   electrons on quadrature grid:
      NTotal =    2.0000000000 ; deviation = -7.638e-14

    Orbital Energies [Eh]
    ---------------------

--
   electrons on quadrature grid:
      Nalpha   =    5.9997499893 ; deviation = -2.500e-04
      Nbeta    =    4.9997504300 ; deviation = -2.496e-04
      NTotal   =   10.9995004192 ; deviation = -4.996e-04

   @Spin Contamination Metric:   2.559910084E-05
```

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [x] NTotal/Nalpha/Nbeta electrons are printed as obtained from the grid as a health check
- [x] adds `psivars`: `GRID ELECTRONS TOTAL/ALPHA/BETA`

## Questions
- [ ] Open to suggestions and opinions for naming and formatting. Especially regarding printing of decimals.

## Checklist
- [x] psivars doc string
- [ ] Tests?


## Status
- [x] Ready for review
- [x] Ready for merge
