### PR TITLE
minor patches for fnocc and dfocc

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -860,6 +860,11 @@ def return_energy_components():
                             'mp2': 'MP2 TOTAL ENERGY',
                            'ccsd': 'CCSD TOTAL ENERGY',
                         'ccsd(t)': 'CCSD(T) TOTAL ENERGY'}
+    VARH['ccsd(at)'] = {
+                             'hf': 'HF TOTAL ENERGY',
+                            'mp2': 'MP2 TOTAL ENERGY',
+                           'ccsd': 'CCSD TOTAL ENERGY',
+                       'ccsd(at)': 'CCSD(AT) TOTAL ENERGY'}
     VARH['bccd(t)'] = {
                              'hf': 'HF TOTAL ENERGY',
                             'mp2': 'MP2 TOTAL ENERGY',

--- a/psi4/src/psi4/dfocc/ccsd_triples.cc
+++ b/psi4/src/psi4/dfocc/ccsd_triples.cc
@@ -2174,6 +2174,12 @@ void DFOCC::ccsdl_canonic_triples_disk() {
     SharedTensor2d V, J1, J2, J3, Jt;
     SharedTensor1d Eijk;
     long int Nijk;
+    
+    // progress counter
+    std::time_t stop, start = std::time(nullptr);
+    long int ind = 0;
+    double step_print = 10.0;
+    double next_print = step_print;
 
     // Find number of unique ijk combinations (i>=j>=k)
     Nijk = naoccA * (naoccA + 1) * (naoccA + 2) / 6;
@@ -2539,6 +2545,15 @@ void DFOCC::ccsdl_canonic_triples_disk() {
                             sum += (value * factor) / Dijkabc;
                         }
                     }
+                }
+                // progress counter
+                ind += 1;
+                double percent = static_cast<double>(ind) / static_cast<double>(Nijk) * 100.0;
+                if (percent >= next_print) {
+                    stop = std::time(nullptr);
+                    next_print += step_print;
+                    outfile->Printf("              %5.1lf  %8d s\n", percent,
+                                    static_cast<int>(stop) - static_cast<int>(start));
                 }
 
             }  // k

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -121,7 +121,7 @@ void DFOCC::common_init() {
         tol_pcg = options_.get_double("PCG_CONVERGENCE");
     } else {
         tol_pcg = 0.01 * tol_t2;
-        outfile->Printf("\tFor this residual convergence, default PCG convergence is: %12.2e\n", tol_grad);
+        outfile->Printf("\tFor this residual convergence, default PCG convergence is: %12.2e\n", tol_pcg);
     }
 
     //   Given default orbital convergence, set the criteria by what should

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -720,10 +720,7 @@ void DFCoupledCluster::AllocateMemory() {
     Ca = reference_wavefunction_->Ca()->pointer();
 
     // one-electron integrals
-    //    auto mints = std::make_shared<MintsHelper>(basisset_, options_, 0);
-    auto mints = std::make_shared<MintsHelper>(reference_wavefunction_);
-    H = mints->so_kinetic();
-    H->add(mints->so_potential());
+    H = reference_wavefunction_->H()->clone();
 
     if (t2_on_disk) {
         auto psio = std::make_shared<PSIO>();

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -1039,9 +1039,7 @@ void DFFrozenNO::BuildFock(long int nQ, double* Qso, double* F) {
 
     // transform H
     // one-electron integrals
-    auto mints = std::make_shared<MintsHelper>(basisset_, options_, 0);
-    SharedMatrix H = mints->so_kinetic();
-    H->add(mints->so_potential());
+    auto H = reference_wavefunction_->H()->clone();
 
     long int max = nQ > nso * nso ? nQ : nso * nso;
     double* temp2 = (double*)malloc(max * sizeof(double));


### PR DESCRIPTION
## Description

<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] adds `CCSD(AT)` to cbs driver
- [x] progress counter for `(AT)`part.
- [x] fix for #1957 
- [x] fix for printing wrong variable in `dfocc`


## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
