### PR TITLE
CC response vars to wfn: polar, optrot, quadrupole

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -289,6 +289,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_gradients.py
               ../tests/pytests/test_mdi.py
               ../tests/pytests/test_weird_basis.py
+              ../tests/pytests/test_ccresponse.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 
     # <<<  install psi4 share/ & include/  >>>

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3008,7 +3008,7 @@ def run_cc_property(name, **kwargs):
     if n_one > 0:
         # call oe prop for GS density
         oe = core.OEProp(ccwfn)
-        oe.set_title("CC")
+        oe.set_title(name.upper())
         for oe_name in one:
             oe.add(oe_name.upper())
         oe.compute()

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -589,7 +589,6 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         mtd = json_data["model"]["method"].upper()
 
         # Dipole/quadrupole still special case
-        # CC* dipole/quadrupole use umbrella qcvars
         if "dipole" in kwargs["properties"]:
             ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
         if "quadrupole" in kwargs["properties"]:

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -589,10 +589,17 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         mtd = json_data["model"]["method"].upper()
 
         # Dipole/quadrupole still special case
+        # CC* dipole/quadrupole use umbrella qcvars
         if "dipole" in kwargs["properties"]:
-            ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
+            if "CC" in mtd:
+                ret["dipole"] = _serial_translation(psi_props["CC DIPOLE"], json=json_serialization)
+            else:
+                ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
         if "quadrupole" in kwargs["properties"]:
-            ret["quadrupole"] = _serial_translation(psi_props[mtd + " QUADRUPOLE"], json=json_serialization)
+            if "CC" in mtd:
+                ret["quadrupole"] = _serial_translation(psi_props["CC QUADRUPOLE"], json=json_serialization)
+            else:
+                ret["quadrupole"] = _serial_translation(psi_props[mtd + " QUADRUPOLE"], json=json_serialization)
         ret.update(_convert_variables(wfn.variables(), context="properties", json=json_serialization))
 
         json_data["return_result"] = ret

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -591,15 +591,9 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         # Dipole/quadrupole still special case
         # CC* dipole/quadrupole use umbrella qcvars
         if "dipole" in kwargs["properties"]:
-            if "CC" in mtd:
-                ret["dipole"] = _serial_translation(psi_props["CC DIPOLE"], json=json_serialization)
-            else:
-                ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
+            ret["dipole"] = _serial_translation(psi_props[mtd + " DIPOLE"], json=json_serialization)
         if "quadrupole" in kwargs["properties"]:
-            if "CC" in mtd:
-                ret["quadrupole"] = _serial_translation(psi_props["CC QUADRUPOLE"], json=json_serialization)
-            else:
-                ret["quadrupole"] = _serial_translation(psi_props[mtd + " QUADRUPOLE"], json=json_serialization)
+            ret["quadrupole"] = _serial_translation(psi_props[mtd + " QUADRUPOLE"], json=json_serialization)
         ret.update(_convert_variables(wfn.variables(), context="properties", json=json_serialization))
 
         json_data["return_result"] = ret

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -74,7 +74,6 @@ void local_init();
 void local_done();
 
 void polar(std::shared_ptr<Wavefunction> ref_wfn);
-/*void optrot(std::shared_ptr<Molecule> molecule);*/
 void optrot(std::shared_ptr<Wavefunction> ref_wfn);
 void roa(std::shared_ptr<Wavefunction> ref_wfn);
 
@@ -128,7 +127,6 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
     preppert(ref_wfn->basisset());
 
     if (params.prop == "POLARIZABILITY") polar(ref_wfn);
-/*    if (params.prop == "ROTATION") optrot(ref_wfn->molecule()); */
     if (params.prop == "ROTATION") optrot(ref_wfn);
     if (params.prop == "ROA_TENSOR") roa(ref_wfn);
 

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -76,7 +76,7 @@ void local_done();
 void polar(std::shared_ptr<Wavefunction> ref_wfn);
 /*void optrot(std::shared_ptr<Molecule> molecule);*/
 void optrot(std::shared_ptr<Wavefunction> ref_wfn);
-void roa();
+void roa(std::shared_ptr<Wavefunction> ref_wfn);
 
 void preppert(std::shared_ptr<BasisSet> primary);
 
@@ -130,7 +130,7 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
     if (params.prop == "POLARIZABILITY") polar(ref_wfn);
 /*    if (params.prop == "ROTATION") optrot(ref_wfn->molecule()); */
     if (params.prop == "ROTATION") optrot(ref_wfn);
-    if (params.prop == "ROA_TENSOR") roa();
+    if (params.prop == "ROA_TENSOR") roa(ref_wfn);
 
     if (params.local) local_done();
 

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -73,7 +73,7 @@ void lambda_residuals();
 void local_init();
 void local_done();
 
-void polar();
+void polar(std::shared_ptr<Wavefunction> ref_wfn);
 void optrot(std::shared_ptr<Molecule> molecule);
 void roa();
 
@@ -126,7 +126,7 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
 
     preppert(ref_wfn->basisset());
 
-    if (params.prop == "POLARIZABILITY") polar();
+    if (params.prop == "POLARIZABILITY") polar(ref_wfn);
     if (params.prop == "ROTATION") optrot(ref_wfn->molecule());
     if (params.prop == "ROA_TENSOR") roa();
 

--- a/psi4/src/psi4/cc/ccresponse/ccresponse.cc
+++ b/psi4/src/psi4/cc/ccresponse/ccresponse.cc
@@ -74,7 +74,8 @@ void local_init();
 void local_done();
 
 void polar(std::shared_ptr<Wavefunction> ref_wfn);
-void optrot(std::shared_ptr<Molecule> molecule);
+/*void optrot(std::shared_ptr<Molecule> molecule);*/
+void optrot(std::shared_ptr<Wavefunction> ref_wfn);
 void roa();
 
 void preppert(std::shared_ptr<BasisSet> primary);
@@ -127,7 +128,8 @@ PsiReturnType ccresponse(std::shared_ptr<Wavefunction> ref_wfn, Options &options
     preppert(ref_wfn->basisset());
 
     if (params.prop == "POLARIZABILITY") polar(ref_wfn);
-    if (params.prop == "ROTATION") optrot(ref_wfn->molecule());
+/*    if (params.prop == "ROTATION") optrot(ref_wfn->molecule()); */
+    if (params.prop == "ROTATION") optrot(ref_wfn);
     if (params.prop == "ROA_TENSOR") roa();
 
     if (params.local) local_done();

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -78,6 +78,7 @@
 #include "psi4/libpsio/psio.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/molecule.h"
+#include "psi4/libmints/wavefunction.h"
 #include "psi4/psi4-dec.h"
 
 #include "MOInfo.h"
@@ -95,7 +96,7 @@ void compute_X(const char *pert, int irrep, double omega);
 void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep, double omega_x, const char *pert_y,
              int y_irrep, double omega_y);
 
-void optrot(std::shared_ptr<Molecule> molecule) {
+void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     double ***tensor_rl, ***tensor_pl, ***tensor_rp, **tensor0;
     double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;
     char **cartcomp, pert[32], pert_x[32], pert_y[32];
@@ -104,6 +105,8 @@ void optrot(std::shared_ptr<Molecule> molecule) {
     double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod, **delta;
     char lbl1[32], lbl2[32], lbl3[32];
     int compute_rl = 0, compute_pl = 0;
+    std::shared_ptr<Molecule> molecule;
+    molecule = ref_wfn->molecule();
 
     /* Booleans for convenience */
     if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -87,6 +87,7 @@
 #define EXTERN
 #include "globals.h"
 #include "psi4/physconst.h"
+#include "psi4/libmints/matrix.h"
 
 namespace psi {
 namespace ccresponse {
@@ -184,15 +185,27 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             psio_read_entry(PSIF_CC_INFO, lbl1, (char *)tensor0[0], 9 * sizeof(double));
         }
 
-        if (params.wfn == "CC2")
+        std::stringstream tag_tensor0;
+        if (params.wfn == "CC2") {
             outfile->Printf("\n     CC2 Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-        else if (params.wfn == "CCSD")
+            tag_tensor0 << "CC2 OPTICAL ROTATION TENSOR (VEL) @ 0";
+        }
+        else if (params.wfn == "CCSD") {
             outfile->Printf("\n    CCSD Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
+            tag_tensor0 << "CCSD OPTICAL ROTATION TENSOR (VEL) @ 0";
+        }
 
         outfile->Printf("  -------------------------------------------------------------------------\n");
         outfile->Printf("   Evaluated at omega = 0.00 E_h (Inf nm, 0.0 eV, 0.0 cm-1)\n");
         outfile->Printf("  -------------------------------------------------------------------------\n");
         mat_print(tensor0, 3, 3, "outfile");
+        auto tensor_mat0 = std::make_shared<Matrix>(3, 3);
+        for (int m = 0; m < 3; m++) {
+            for (int n = 0; n < 3; n++) {
+                tensor_mat0->set(m,n,tensor0[m][n]);
+            }
+        }
+        ref_wfn->set_array_variable(tag_tensor0.str(),tensor_mat0);
     }
 
     for (i = 0; i < params.nomega; i++) {
@@ -419,10 +432,15 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         prefactor *= 288.0e-30 * pc_pi * pc_pi * pc_na * bohr2a4;
 
         if (compute_rl) {
-            if (params.wfn == "CC2")
+            std::stringstream tag_tensor_rl;
+            if (params.wfn == "CC2") {
                 outfile->Printf("\n            CC2 Optical Rotation Tensor (Length Gauge):\n");
-            else if (params.wfn == "CCSD")
+                tag_tensor_rl << "CC2 OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+            }
+            else if (params.wfn == "CCSD") {
                 outfile->Printf("\n           CCSD Optical Rotation Tensor (Length Gauge):\n");
+                tag_tensor_rl << "CCSD OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+            }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
             outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
@@ -430,6 +448,13 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                             pc_hartree2wavenumbers * params.omega[i]);
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_rl[i], 3, 3, "outfile");
+            auto tensor_mat_rl = std::make_shared<Matrix>(3, 3);
+            for (int m = 0; m < 3; m++) {
+                for (int n = 0; n < 3; n++) {
+                    tensor_mat_rl->set(m,n,tensor_rl[i][m][n]);
+                }
+            }
+            ref_wfn->set_array_variable(tag_tensor_rl.str(),tensor_mat_rl);
 
             TrG_rl = -(tensor_rl[i][0][0] + tensor_rl[i][1][1] + tensor_rl[i][2][2]) / (3.0 * params.omega[i]);
 
@@ -458,10 +483,15 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         }
 
         if (compute_pl) {
-            if (params.wfn == "CC2")
+            std::stringstream tag_tensor_pl;
+            if (params.wfn == "CC2") {
                 outfile->Printf("\n          CC2 Optical Rotation Tensor (Velocity Gauge):\n");
-            else if (params.wfn == "CCSD")
+                tag_tensor_pl << "CC2 OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+            }
+            else if (params.wfn == "CCSD") {
                 outfile->Printf("\n         CCSD Optical Rotation Tensor (Velocity Gauge):\n");
+                tag_tensor_pl << "CCSD OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+            }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
             outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
@@ -469,6 +499,13 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                             pc_hartree2wavenumbers * params.omega[i]);
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
+            auto tensor_mat_pl = std::make_shared<Matrix>(3, 3);
+            for (int m = 0; m < 3; m++) {
+                for (int n = 0; n < 3; n++) {
+                    tensor_mat_pl->set(m,n,tensor_pl[i][m][n]);
+                }
+            }
+            ref_wfn->set_array_variable(tag_tensor_pl.str(),tensor_mat_pl);
 
             TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2]) / (3.0 * params.omega[i]);
             TrG_pl /= params.omega[i];
@@ -500,10 +537,15 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             for (j = 0; j < 3; j++)
                 for (k = 0; k < 3; k++) tensor_pl[i][j][k] -= tensor0[j][k];
 
-            if (params.wfn == "CC2")
+            std::stringstream tag_tensor_pl2;
+            if (params.wfn == "CC2") {
                 outfile->Printf("\n        CC2 Optical Rotation Tensor (Modified Velocity Gauge):\n");
-            else if (params.wfn == "CCSD")
+                tag_tensor_pl2 << "CC2 OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+            }
+            else if (params.wfn == "CCSD") {
                 outfile->Printf("\n        CCSD Optical Rotation Tensor (Modified Velocity Gauge):\n");
+                tag_tensor_pl2 << "CCSD OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+            }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
             outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
@@ -511,6 +553,13 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                             pc_hartree2wavenumbers * params.omega[i]);
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
+            auto tensor_mat_pl2 = std::make_shared<Matrix>(3, 3);
+            for (int m = 0; m < 3; m++) {
+                for (int n = 0; n < 3; n++) {
+                    tensor_mat_pl2->set(m,n,tensor_pl[i][m][n]);
+                }
+            }
+            ref_wfn->set_array_variable(tag_tensor_pl2.str(),tensor_mat_pl2);
 
             /* compute the specific rotation */
             TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2]) / (3.0 * params.omega[i]);

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -106,8 +106,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod, **delta;
     char lbl1[32], lbl2[32], lbl3[32];
     int compute_rl = 0, compute_pl = 0;
-    std::shared_ptr<Molecule> molecule;
-    molecule = ref_wfn->molecule();
+    auto molecule = ref_wfn->molecule();
 
     /* Booleans for convenience */
     if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;
@@ -200,11 +199,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         outfile->Printf("  -------------------------------------------------------------------------\n");
         mat_print(tensor0, 3, 3, "outfile");
         auto tensor_mat0 = std::make_shared<Matrix>(3, 3);
-        for (int m = 0; m < 3; m++) {
-            for (int n = 0; n < 3; n++) {
-                tensor_mat0->set(m,n,tensor0[m][n]);
-            }
-        }
+        tensor_mat0->set(tensor0);
         ref_wfn->set_array_variable(tag_tensor0.str(),tensor_mat0);
     }
 
@@ -452,11 +447,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_rl[i], 3, 3, "outfile");
             auto tensor_mat_rl = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_rl->set(m,n,tensor_rl[i][m][n]);
-                }
-            }
+            tensor_mat_rl->set(tensor_rl[i]);
             ref_wfn->set_array_variable(tag_tensor_rl.str(),tensor_mat_rl);
 
             TrG_rl = -(tensor_rl[i][0][0] + tensor_rl[i][1][1] + tensor_rl[i][2][2]) / (3.0 * params.omega[i]);
@@ -467,7 +458,6 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
             if (params.wfn == "CC2") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
                 ref_wfn->set_scalar_variable(tag.str(),rotation_rl[i]);
@@ -500,11 +490,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
             auto tensor_mat_pl = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_pl->set(m,n,tensor_pl[i][m][n]);
-                }
-            }
+            tensor_mat_pl->set(tensor_pl[i]);
             ref_wfn->set_array_variable(tag_tensor_pl.str(),tensor_mat_pl);
 
             TrG_pl = -(tensor_pl[i][0][0] + tensor_pl[i][1][1] + tensor_pl[i][2][2]) / (3.0 * params.omega[i]);
@@ -547,11 +533,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
             auto tensor_mat_pl2 = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_pl2->set(m,n,tensor_pl[i][m][n]);
-                }
-            }
+            tensor_mat_pl2->set(tensor_pl[i]);
             ref_wfn->set_array_variable(tag_tensor_pl2.str(),tensor_mat_pl2);
 
             /* compute the specific rotation */

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -188,11 +188,11 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         std::stringstream tag_tensor0;
         if (params.wfn == "CC2") {
             outfile->Printf("\n     CC2 Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-            tag_tensor0 << "CC2 OPTICAL ROTATION TENSOR (VEL) @ 0";
+            tag_tensor0 << "CC2 OPTICAL ROTATION TENSOR (VEL) @ 0NM";
         }
         else if (params.wfn == "CCSD") {
             outfile->Printf("\n    CCSD Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-            tag_tensor0 << "CCSD OPTICAL ROTATION TENSOR (VEL) @ 0";
+            tag_tensor0 << "CCSD OPTICAL ROTATION TENSOR (VEL) @ 0NM";
         }
 
         outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -433,13 +433,16 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
         if (compute_rl) {
             std::stringstream tag_tensor_rl;
+            /* grab omega in nm, rounded to nearest int */
+            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
+
             if (params.wfn == "CC2") {
                 outfile->Printf("\n            CC2 Optical Rotation Tensor (Length Gauge):\n");
-                tag_tensor_rl << "CC2 OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+                tag_tensor_rl << "CC2 OPTICAL ROTATION TENSOR (LEN) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n           CCSD Optical Rotation Tensor (Length Gauge):\n");
-                tag_tensor_rl << "CCSD OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+                tag_tensor_rl << "CCSD OPTICAL ROTATION TENSOR (LEN) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -462,35 +465,32 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\n   Specific rotation using length-gauge electric-dipole Rosenfeld tensor.\n");
             outfile->Printf("\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_rl[i]);
 
-            /* grab omega in nm, rounded to nearest int */
-            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
-
             if (params.wfn == "CC2") {
                 std::stringstream tag;
                 std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
-                tag_au << "CC2 SPECIFIC ROTATION (LEN) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_rl[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_rl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
-                tag_au << "CCSD SPECIFIC ROTATION (LEN) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_rl[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_rl[i]);
             }
         }
 
         if (compute_pl) {
             std::stringstream tag_tensor_pl;
+            /* grab omega in nm, rounded to nearest int */
+            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
+
             if (params.wfn == "CC2") {
                 outfile->Printf("\n          CC2 Optical Rotation Tensor (Velocity Gauge):\n");
-                tag_tensor_pl << "CC2 OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+                tag_tensor_pl << "CC2 OPTICAL ROTATION TENSOR (VEL) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n         CCSD Optical Rotation Tensor (Velocity Gauge):\n");
-                tag_tensor_pl << "CCSD OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+                tag_tensor_pl << "CCSD OPTICAL ROTATION TENSOR (VEL) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -514,23 +514,16 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\n   Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.\n");
             outfile->Printf("\t[alpha]_(%5.3f) = %10.5f deg/[dm (g/cm^3)]\n", params.omega[i], rotation_pl[i]);
 
-            /* grab omega in nm, rounded to nearest int */
-            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
-
             if (params.wfn == "CC2") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
-                tag_au << "CC2 SPECIFIC ROTATION (VEL) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_pl[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_pl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
-                tag_au << "CCSD SPECIFIC ROTATION (VEL) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_pl[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_pl[i]);
             }
 
             /* subtract the zero-frequency beta tensor */
@@ -540,11 +533,11 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor_pl2;
             if (params.wfn == "CC2") {
                 outfile->Printf("\n        CC2 Optical Rotation Tensor (Modified Velocity Gauge):\n");
-                tag_tensor_pl2 << "CC2 OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+                tag_tensor_pl2 << "CC2 OPTICAL ROTATION TENSOR (MVG) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n        CCSD Optical Rotation Tensor (Modified Velocity Gauge):\n");
-                tag_tensor_pl2 << "CCSD OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+                tag_tensor_pl2 << "CCSD OPTICAL ROTATION TENSOR (MVG) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -571,18 +564,14 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
             if (params.wfn == "CC2") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
-                tag_au << "CC2 SPECIFIC ROTATION (MVG) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_mod[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_mod[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
-                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
-                tag_au << "CCSD SPECIFIC ROTATION (MVG) @ " << params.omega[i];
-                ref_wfn->set_scalar_variable(tag_au.str(),rotation_mod[i]);
+                ref_wfn->set_scalar_variable(tag.str(),rotation_mod[i]);
             }
         }
 

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -442,12 +442,18 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
             if (params.wfn == "CC2") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
+                tag_au << "CC2 SPECIFIC ROTATION (LEN) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_rl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
+                tag_au << "CCSD SPECIFIC ROTATION (LEN) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_rl[i]);
             }
         }
 
@@ -476,12 +482,18 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
             if (params.wfn == "CC2") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
+                tag_au << "CC2 SPECIFIC ROTATION (VEL) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_pl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
+                tag_au << "CCSD SPECIFIC ROTATION (VEL) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_pl[i]);
             }
 
             /* subtract the zero-frequency beta tensor */
@@ -510,12 +522,18 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 
             if (params.wfn == "CC2") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
+                tag_au << "CC2 SPECIFIC ROTATION (MVG) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_mod[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
+                std::stringstream tag_au;
                 tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
+                tag_au << "CCSD SPECIFIC ROTATION (MVG) @ " << params.omega[i];
+                ref_wfn->set_scalar_variable(tag_au.str(),rotation_mod[i]);
             }
         }
 

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -460,12 +460,10 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 std::stringstream tag;
                 tag << "CC2 SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_rl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
                 tag << "CCSD SPECIFIC ROTATION (LEN) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_rl[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_rl[i]);
             }
         }
 
@@ -504,12 +502,10 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 std::stringstream tag;
                 tag << "CC2 SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_pl[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
                 tag << "CCSD SPECIFIC ROTATION (VEL) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_pl[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_pl[i]);
             }
 
             /* subtract the zero-frequency beta tensor */
@@ -548,12 +544,10 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 std::stringstream tag;
                 tag << "CC2 SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_mod[i]);
             } else if (params.wfn == "CCSD") {
                 std::stringstream tag;
                 tag << "CCSD SPECIFIC ROTATION (MVG) @ " << om_nm << "NM";
                 Process::environment.globals[tag.str()] = rotation_mod[i];
-                ref_wfn->set_scalar_variable(tag.str(),rotation_mod[i]);
             }
         }
 

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -146,7 +146,6 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor;
             tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
             Process::environment.globals[tag.str()] = trace[i] / 3.0;
-            ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
             tag_tensor << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
             tensor_mat->set(tensor[i]);
@@ -156,7 +155,6 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor;
             tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
             Process::environment.globals[tag.str()] = trace[i] / 3.0;
-            ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
             tag_tensor << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
             tensor_mat->set(tensor[i]);

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -143,13 +143,11 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
         }
         if (params.wfn == "CC2") {
             std::stringstream tag;
-            std::stringstream tag_au;
             std::stringstream tag_tensor;
             tag << "CC2 DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
             Process::environment.globals[tag.str()] = trace[i] / 3.0;
-            tag_au << "CC2 DIPOLE POLARIZABILITY @ " << params.omega[i];
-            ref_wfn->set_scalar_variable(tag_au.str(),trace[i] / 3.0);
-            tag_tensor << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << params.omega[i];
+            ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
+            tag_tensor << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
             for (int m = 0; m < 3; m++) {
                 for (int n = 0; n < 3; n++) {
@@ -159,13 +157,11 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             ref_wfn->set_array_variable(tag_tensor.str(),tensor_mat);
         } else if (params.wfn == "CCSD") {
             std::stringstream tag;
-            std::stringstream tag_au;
             std::stringstream tag_tensor;
             tag << "CCSD DIPOLE POLARIZABILITY @ " << omega_nm_rd << "NM";
             Process::environment.globals[tag.str()] = trace[i] / 3.0;
-            tag_au << "CCSD DIPOLE POLARIZABILITY @ " << params.omega[i];
-            ref_wfn->set_scalar_variable(tag_au.str(),trace[i] / 3.0);
-            tag_tensor << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << params.omega[i];
+            ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
+            tag_tensor << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
             for (int m = 0; m < 3; m++) {
                 for (int n = 0; n < 3; n++) {

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -149,11 +149,7 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
             tag_tensor << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat->set(m,n,tensor[i][m][n]);
-                }
-            }
+            tensor_mat->set(tensor[i]);
             ref_wfn->set_array_variable(tag_tensor.str(),tensor_mat);
         } else if (params.wfn == "CCSD") {
             std::stringstream tag;
@@ -163,11 +159,7 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             ref_wfn->set_scalar_variable(tag.str(),trace[i] / 3.0);
             tag_tensor << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << omega_nm_rd << "NM";
             auto tensor_mat = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat->set(m,n,tensor[i][m][n]);
-                }
-            }
+            tensor_mat->set(tensor[i]);
             ref_wfn->set_array_variable(tag_tensor.str(),tensor_mat);
         }
     }

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -160,11 +160,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         outfile->Printf("  -------------------------------------------------------------------------\n");
         mat_print(tensor0, 3, 3, "outfile");
         auto tensor_mat0 = std::make_shared<Matrix>(3, 3);
-        for (int m = 0; m < 3; m++) {
-            for (int n = 0; n < 3; n++) {
-                tensor_mat0->set(m,n,tensor0[m][n]);
-            }
-        }
+        tensor_mat0->set(tensor0);
         ref_wfn->set_array_variable(tag_tensor0.str(),tensor_mat0);
     }
 
@@ -461,11 +457,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         outfile->Printf("  -------------------------------------------------------------------------\n");
         mat_print(tensor_rr[i], 3, 3, "outfile");
         auto tensor_mat_rr = std::make_shared<Matrix>(3, 3);
-        for (int m = 0; m < 3; m++) {
-            for (int n = 0; n < 3; n++) {
-                tensor_mat_rr->set(m,n,tensor_rr[i][m][n]);
-            }
-        }
+        tensor_mat_rr->set(tensor_rr[i]);
         ref_wfn->set_array_variable(tag_polar.str(),tensor_mat_rr);
 
         if (compute_rl) {
@@ -486,11 +478,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_rl[i], 3, 3, "outfile");
             auto tensor_mat_rl = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_rl->set(m,n,tensor_rl[i][m][n]);
-                }
-            }
+            tensor_mat_rl->set(tensor_rl[i]);
             ref_wfn->set_array_variable(tag_tensor_rl.str(),tensor_mat_rl);
         }
 
@@ -512,11 +500,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
             auto tensor_mat_pl = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_pl->set(m,n,tensor_pl[i][m][n]);
-                }
-            }
+            tensor_mat_pl->set(tensor_pl[i]);
             ref_wfn->set_array_variable(tag_tensor_pl.str(),tensor_mat_pl);
 
             /* subtract the zero-frequency beta tensor */
@@ -540,11 +524,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("  -------------------------------------------------------------------------\n");
             mat_print(tensor_pl[i], 3, 3, "outfile");
             auto tensor_mat_pl2 = std::make_shared<Matrix>(3, 3);
-            for (int m = 0; m < 3; m++) {
-                for (int n = 0; n < 3; n++) {
-                    tensor_mat_pl2->set(m,n,tensor_pl[i][m][n]);
-                }
-            }
+            tensor_mat_pl2->set(tensor_pl[i]);
             ref_wfn->set_array_variable(tag_tensor_pl2.str(),tensor_mat_pl2);
         }
 
@@ -567,15 +547,14 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                         pc_hartree2wavenumbers * params.omega[i]);
         outfile->Printf("  -------------------------------------------------------------------------\n");
         for (alpha = 0; alpha < 3; alpha++) mat_print(tensor_rQ[i][alpha], 3, 3, "outfile");
-        auto quad_mat = new SharedMatrix[3];
         for (alpha = 0; alpha < 3; alpha++) {
-            quad_mat[alpha] = std::make_shared<Matrix>(3, 3);
+            auto tmp = std::make_shared<Matrix>(3, 3);
             for (int m = 0; m < 3; m++) {
                 for (int n = 0; n < 3; n++) {
-                    quad_mat[alpha]->set(m,n,tensor_rQ[i][alpha][m][n]);
+                    tmp->set(m,n,tensor_rQ[i][alpha][m][n]);
                 }
             }
-            ref_wfn->set_array_variable(tag_quad[alpha].str(),quad_mat[alpha]);
+            ref_wfn->set_array_variable(tag_quad[alpha].str(),tmp);
         }
 
     } /* loop i over nomega */

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libqt/qt.h"
@@ -75,6 +76,9 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
     /* Booleans for convenience */
     if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;
     if (params.gauge == "VELOCITY" || params.gauge == "BOTH") compute_pl = 1;
+
+    /* grab omega in nm, rounded to nearest int */
+    long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
 
     cartcomp = (char **)malloc(3 * sizeof(char *));
     cartcomp[0] = strdup("X");
@@ -144,11 +148,11 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         std::stringstream tag_tensor0;
         if (params.wfn == "CC2") {
             outfile->Printf("\n     CC2 Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-            tag_tensor0 << "CC2 OPTICAL ROTATION TENSOR (VEL) @ 0";
+            tag_tensor0 << "CC2 OPTICAL ROTATION TENSOR (VEL) @ 0NM";
         }
         else if (params.wfn == "CCSD") {
             outfile->Printf("\n    CCSD Optical Rotation Tensor (Velocity Gauge): %s\n", lbl1);
-            tag_tensor0 << "CCSD OPTICAL ROTATION TENSOR (VEL) @ 0";
+            tag_tensor0 << "CCSD OPTICAL ROTATION TENSOR (VEL) @ 0NM";
         }
 
         outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -443,12 +447,12 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         std::stringstream tag_polar;
         if (params.wfn == "CC2") {
             outfile->Printf("\n                 CC2 Dipole Polarizability [(e^2 a0^2)/E_h]:\n");
-            tag_polar << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << params.omega[i];
+            tag_polar << "CC2 DIPOLE POLARIZABILITY TENSOR @ " << om_nm << "NM";
         }
         else {
             outfile->Printf("\n                 CCSD Dipole Polarizability [(e^2 a0^2)/E_h]:\n");
         outfile->Printf("  -------------------------------------------------------------------------\n");
-            tag_polar << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << params.omega[i];
+            tag_polar << "CCSD DIPOLE POLARIZABILITY TENSOR @ " << om_nm << "NM";
         }
 
         outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],
@@ -468,11 +472,11 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor_rl;
             if (params.wfn == "CC2") {
                 outfile->Printf("\n            CC2 Optical Rotation Tensor (Length Gauge):\n");
-                tag_tensor_rl << "CC2 OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+                tag_tensor_rl << "CC2 OPTICAL ROTATION TENSOR (LEN) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n           CCSD Optical Rotation Tensor (Length Gauge):\n");
-                tag_tensor_rl << "CCSD OPTICAL ROTATION TENSOR (LEN) @ " << params.omega[i];
+                tag_tensor_rl << "CCSD OPTICAL ROTATION TENSOR (LEN) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -494,11 +498,11 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor_pl;
             if (params.wfn == "CC2") {
                 outfile->Printf("\n          CC2 Optical Rotation Tensor (Velocity Gauge):\n");
-                tag_tensor_pl << "CC2 OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+                tag_tensor_pl << "CC2 OPTICAL ROTATION TENSOR (VEL) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n         CCSD Optical Rotation Tensor (Velocity Gauge):\n");
-                tag_tensor_pl << "CCSD OPTICAL ROTATION TENSOR (VEL) @ " << params.omega[i];
+                tag_tensor_pl << "CCSD OPTICAL ROTATION TENSOR (VEL) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -522,11 +526,11 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             std::stringstream tag_tensor_pl2;
             if (params.wfn == "CC2") {
                 outfile->Printf("\n        CC2 Optical Rotation Tensor (Modified Velocity Gauge):\n");
-                tag_tensor_pl2 << "CC2 OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+                tag_tensor_pl2 << "CC2 OPTICAL ROTATION TENSOR (MVG) @ " << om_nm << "NM";
             }
             else if (params.wfn == "CCSD") {
                 outfile->Printf("\n        CCSD Optical Rotation Tensor (Modified Velocity Gauge):\n");
-                tag_tensor_pl2 << "CCSD OPTICAL ROTATION TENSOR (MVG) @ " << params.omega[i];
+                tag_tensor_pl2 << "CCSD OPTICAL ROTATION TENSOR (MVG) @ " << om_nm << "NM";
             }
 
             outfile->Printf("  -------------------------------------------------------------------------\n");
@@ -547,15 +551,15 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         std::stringstream* tag_quad = new std::stringstream[3];
         if (params.wfn == "CC2") {
             outfile->Printf("\n    CC2 Electric-Dipole/Quadrupole Polarizability [(e^2 a0^2)/E_h]:\n");
-            tag_quad[0] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ " << params.omega[i];
-            tag_quad[1] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ " << params.omega[i];
-            tag_quad[2] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ " << params.omega[i];
+            tag_quad[0] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ " << om_nm << "NM";
+            tag_quad[1] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ " << om_nm << "NM";
+            tag_quad[2] << "CC2 QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ " << om_nm << "NM";
         }
         else {
             outfile->Printf("\n    CCSD Electric-Dipole/Quadrupole Polarizability [(e^2 a0^2)/E_h]:\n");
-            tag_quad[0] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ " << params.omega[i];
-            tag_quad[1] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ " << params.omega[i];
-            tag_quad[2] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ " << params.omega[i];
+            tag_quad[0] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ " << om_nm << "NM";
+            tag_quad[1] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ " << om_nm << "NM";
+            tag_quad[2] << "CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ " << om_nm << "NM";
         }
         outfile->Printf("  -------------------------------------------------------------------------\n");
         outfile->Printf("   Evaluated at omega = %8.6f E_h (%6.2f nm, %5.3f eV, %8.2f cm-1)\n", params.omega[i],

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -544,7 +544,6 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             ref_wfn->set_array_variable(tag_tensor_pl2.str(),tensor_mat_pl2);
         }
 
-/*        std::stringstream tag_tensor_quad; */
         std::stringstream* tag_quad = new std::stringstream[3];
         if (params.wfn == "CC2") {
             outfile->Printf("\n    CC2 Electric-Dipole/Quadrupole Polarizability [(e^2 a0^2)/E_h]:\n");
@@ -564,8 +563,6 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                         pc_hartree2wavenumbers * params.omega[i]);
         outfile->Printf("  -------------------------------------------------------------------------\n");
         for (alpha = 0; alpha < 3; alpha++) mat_print(tensor_rQ[i][alpha], 3, 3, "outfile");
-/*        auto* quad_mat = new std::make_shared<Matrix>(3, 3)[3]; 
-        auto quad_mat = new std::make_shared<Matrix>[3]; */
         auto quad_mat = new SharedMatrix[3];
         for (alpha = 0; alpha < 3; alpha++) {
             quad_mat[alpha] = std::make_shared<Matrix>(3, 3);

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -28,20 +28,20 @@ cc_energy, wfn = properties('eom-cc2', properties=['dipole','quadrupole'],return
 
 
 gs_refs = {
-        "CC DIPOLE X":                 0.0000,
-        "CC DIPOLE Y":                 0.0000,
-        "CC DIPOLE Z":                 2.8972,
-        "CC QUADRUPOLE XX":          -11.6671,
-        "CC QUADRUPOLE XY":           -1.4071,
-        "CC QUADRUPOLE XZ":            0.0000,
-        "CC QUADRUPOLE YY":          -11.0457,
-        "CC QUADRUPOLE YZ":            0.0000,
-        "CC QUADRUPOLE ZZ":           -9.3692
+        "EOM-CC2 DIPOLE X":                 0.0000,
+        "EOM-CC2 DIPOLE Y":                 0.0000,
+        "EOM-CC2 DIPOLE Z":                 2.8972,
+        "EOM-CC2 QUADRUPOLE XX":          -11.6671,
+        "EOM-CC2 QUADRUPOLE XY":           -1.4071,
+        "EOM-CC2 QUADRUPOLE XZ":            0.0000,
+        "EOM-CC2 QUADRUPOLE YY":          -11.0457,
+        "EOM-CC2 QUADRUPOLE YZ":            0.0000,
+        "EOM-CC2 QUADRUPOLE ZZ":           -9.3692
         }
-pole = [gs_refs["CC DIPOLE " + cart] for cart in "XYZ"]  #TEST
-gs_refs["CC DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
-pole = [gs_refs["CC QUADRUPOLE " + cart] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
-gs_refs["CC QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
+pole = [gs_refs["EOM-CC2 DIPOLE " + cart] for cart in "XYZ"]  #TEST
+gs_refs["EOM-CC2 DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
+pole = [gs_refs["EOM-CC2 QUADRUPOLE " + cart] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
+gs_refs["EOM-CC2 QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
 root_refs = {
         "CC ROOT 1 DIPOLE X":          0.0000,
@@ -101,7 +101,8 @@ with warnings.catch_warnings():
 
 
     # Checking that the wfn.Da/Db have been set by ccdensity
-    oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST CC")
+    oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST EOM-CC2")
+    print(psi4.variables())
     for tag,refval in gs_refs.items():
         oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
         compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -102,7 +102,6 @@ with warnings.catch_warnings():
 
     # Checking that the wfn.Da/Db have been set by ccdensity
     oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST EOM-CC2")
-    print(psi4.variables())
     for tag,refval in gs_refs.items():
         oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
         compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST

--- a/tests/cc46/output.ref
+++ b/tests/cc46/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.4a2.dev1064 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {propvars} 54c5210 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Sunday, 25 October 2020 05:13PM
 
-    Process ID:  12921
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 91691
+    Host:       Mash.local
+    PSIDATADIR: /Users/mash/installed/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -29,6 +42,9 @@
 
 --------------------------------------------------------------------------
 #! EOM-CC2/cc-pVDZ on H2O2 with two excited states in each irrep
+
+d2au = 1 / constants.dipmom_au2debye  #TEST
+q2au = d2au / constants.bohr2angstroms  #TEST
 
 molecule h2o2 {
   0 1
@@ -43,20 +59,33 @@ set {
   freeze_core true
   roots_per_irrep [2, 2]
 }
+set cclambda {
+  r_convergence 4
+}
+set cceom {
+  r_convergence 4
+  e_convergence 5
+}
 
-cc_energy, wfn = property('eom-cc2', properties=['oscillator_strength'],return_wfn=True)
+cc_energy, wfn = properties('eom-cc2', properties=['dipole','quadrupole'],return_wfn=True)
+
 
 gs_refs = {
-        "CC DIPOLE X":                 0.0000,
-        "CC DIPOLE Y":                 0.0000,
-        "CC DIPOLE Z":                 2.8972,
-        "CC QUADRUPOLE XX":          -11.6671,
-        "CC QUADRUPOLE XY":           -1.4071,
-        "CC QUADRUPOLE XZ":            0.0000,
-        "CC QUADRUPOLE YY":          -11.0457,
-        "CC QUADRUPOLE YZ":            0.0000,
-        "CC QUADRUPOLE ZZ":           -9.3692
+        "EOM-CC2 DIPOLE X":                 0.0000,
+        "EOM-CC2 DIPOLE Y":                 0.0000,
+        "EOM-CC2 DIPOLE Z":                 2.8972,
+        "EOM-CC2 QUADRUPOLE XX":          -11.6671,
+        "EOM-CC2 QUADRUPOLE XY":           -1.4071,
+        "EOM-CC2 QUADRUPOLE XZ":            0.0000,
+        "EOM-CC2 QUADRUPOLE YY":          -11.0457,
+        "EOM-CC2 QUADRUPOLE YZ":            0.0000,
+        "EOM-CC2 QUADRUPOLE ZZ":           -9.3692
         }
+pole = [gs_refs["EOM-CC2 DIPOLE " + cart] for cart in "XYZ"]  #TEST
+gs_refs["EOM-CC2 DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
+pole = [gs_refs["EOM-CC2 QUADRUPOLE " + cart] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
+gs_refs["EOM-CC2 QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
+
 root_refs = {
         "CC ROOT 1 DIPOLE X":          0.0000,
         "CC ROOT 1 DIPOLE Y":          0.0000,
@@ -95,38 +124,49 @@ root_refs = {
         "CC ROOT 4 QUADRUPOLE YZ":     0.0000,
         "CC ROOT 4 QUADRUPOLE ZZ":   -15.3582
 }
-
-# check ground state
-for tag,refval in gs_refs.items():
-    compare_values(psi4.get_variable(tag),refval,4, tag)                          #TEST
-
-# check eom roots
-for tag,refval in root_refs.items():
-    compare_values(psi4.get_variable(tag),refval,4, tag)                          #TEST
+for root in range(1, 5):
+    pole = [root_refs[f"CC ROOT {root} DIPOLE {cart}"] for cart in "XYZ"]  #TEST
+    root_refs[f"CC ROOT {root} DIPOLE"] = np.array(pole).reshape((3,)) * d2au  #TEST
+    pole = [root_refs[f"CC ROOT {root} QUADRUPOLE {cart}"] for cart in ["XX", "XY", "XZ", "XY", "YY", "YZ", "XZ", "YZ", "ZZ"]]  #TEST
+    root_refs[f"CC ROOT {root} QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
 
-# Checking that the wfn.Da/Db have been set by ccdensity
-oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST CC")
-for tag,refval in gs_refs.items():
-    oeprop_val = psi4.get_variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
-    compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+
+    # check ground state
+    for tag,refval in gs_refs.items():  #TEST
+        compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
+
+    # check eom roots
+    for tag,refval in root_refs.items():  #TEST
+        compare_values(psi4.variable(tag),refval,4, tag)                          #TEST
+
+
+    # Checking that the wfn.Da/Db have been set by ccdensity
+    oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST EOM-CC2")
+    print(psi4.variables())
+    for tag,refval in gs_refs.items():
+        oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
+        compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:44 2017
+*** tstart() called on Mash.local
+*** at Sun Oct 25 17:13:23 2020
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1-2 entry O          line   198 file /Users/mash/installed/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/mash/installed/psi4/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -140,16 +180,16 @@ for tag,refval in gs_refs.items():
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.695000000000    -0.049338350190    15.994914619560
-           O          0.000000000000     0.695000000000    -0.049338350190    15.994914619560
-           H          0.388142264171    -0.895248563098     0.783035421467     1.007825032070
-           H         -0.388142264171     0.895248563098     0.783035421467     1.007825032070
+         O            0.000000000000    -0.695000000000    -0.049338350197    15.994914619570
+         O            0.000000000000     0.695000000000    -0.049338350197    15.994914619570
+         H            0.388142264171    -0.895248563098     0.783035421459     1.007825032230
+         H           -0.388142264171     0.895248563098     0.783035421459     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380680327
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531042538
 
   Charge       = 0
   Multiplicity = 1
@@ -178,17 +218,6 @@ for tag,refval in gs_refs.items():
     Spherical Harmonics?: true
     Max angular momentum: 2
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   Using in-core PK algorithm.
@@ -206,44 +235,60 @@ for tag,refval in gs_refs.items():
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.1047221517E-02.
+  Reciprocal condition number of the overlap matrix is 8.7919776090E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83527118424107   -1.50835e+02   7.61669e-02 
-   @RHF iter   1:  -150.75300393196329    8.22673e-02   8.92814e-03 
-   @RHF iter   2:  -150.77674264680309   -2.37387e-02   2.23904e-03 DIIS
-   @RHF iter   3:  -150.77866726940414   -1.92462e-03   8.11583e-04 DIIS
-   @RHF iter   4:  -150.77908304190515   -4.15773e-04   3.09116e-04 DIIS
-   @RHF iter   5:  -150.77917159812222   -8.85562e-05   9.19744e-05 DIIS
-   @RHF iter   6:  -150.77918361494824   -1.20168e-05   1.37015e-05 DIIS
-   @RHF iter   7:  -150.77918386184561   -2.46897e-07   2.97198e-06 DIIS
-   @RHF iter   8:  -150.77918387199850   -1.01529e-08   5.75950e-07 DIIS
-   @RHF iter   9:  -150.77918387232643   -3.27930e-10   1.51394e-07 DIIS
-   @RHF iter  10:  -150.77918387235522   -2.87912e-11   4.48580e-08 DIIS
-   @RHF iter  11:  -150.77918387235846   -3.24007e-12   9.89275e-09 DIIS
-   @RHF iter  12:  -150.77918387235854   -8.52651e-14   1.77899e-09 DIIS
-   @RHF iter  13:  -150.77918387235860   -5.68434e-14   2.61634e-10 DIIS
-   @RHF iter  14:  -150.77918387235869   -8.52651e-14   6.83680e-11 DIIS
+   @RHF iter SAD:  -150.13109142562018   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505706   -5.98853e-01   1.20798e-02 DIIS
+   @RHF iter   2:  -150.77474437542571   -4.48002e-02   3.93712e-03 DIIS
+   @RHF iter   3:  -150.77873318371888   -3.98881e-03   9.84955e-04 DIIS
+   @RHF iter   4:  -150.77914057631511   -4.07393e-04   2.78194e-04 DIIS
+   @RHF iter   5:  -150.77918121284821   -4.06365e-05   4.89104e-05 DIIS
+   @RHF iter   6:  -150.77918362636723   -2.41352e-06   1.25533e-05 DIIS
+   @RHF iter   7:  -150.77918384928179   -2.22915e-07   3.89267e-06 DIIS
+   @RHF iter   8:  -150.77918387131746   -2.20357e-08   8.15950e-07 DIIS
+   @RHF iter   9:  -150.77918387210676   -7.89299e-10   1.49862e-07 DIIS
+   @RHF iter  10:  -150.77918387212907   -2.23110e-11   3.10700e-08 DIIS
+   @RHF iter  11:  -150.77918387213026   -1.19371e-12   6.60374e-09 DIIS
+   @RHF iter  12:  -150.77918387213015    1.13687e-13   1.38275e-09 DIIS
+   @RHF iter  13:  -150.77918387213032   -1.70530e-13   3.05355e-10 DIIS
+   @RHF iter  14:  -150.77918387213020    1.13687e-13   6.33760e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -268,48 +313,43 @@ for tag,refval in gs_refs.items():
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235869
+  @RHF Final Energy:  -150.77918387213020
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806803268
-    One-Electron Energy =                -284.0698921465232161
-    Two-Electron Energy =                  95.0367398934842100
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723586579
+    Nuclear Repulsion Energy =             38.2539685310425384
+    One-Electron Energy =                -284.0698924306335584
+    Two-Electron Energy =                  95.0367400274608087
+    Total Energy =                       -150.7791838721302042
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:45 2017
+*** tstop() called on Mash.local at Sun Oct 25 17:13:24 2020
 Module time:
-	user time   =       0.55 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.55 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -331,12 +371,12 @@ Total time:
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 117651 non-zero two-electron integrals.
+      Computed 117357 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:45 2017
+*** tstart() called on Mash.local
+*** at Sun Oct 25 17:13:24 2020
 
 
 	Wfn Parameters:
@@ -359,7 +399,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -395,7 +435,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295891
+	Frozen core energy     =   -132.27484829822765
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -409,34 +449,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838068033
-	SCF energy                   =   -150.77918387235869
-	One-electron energy          =   -101.99691957132264
-	Two-electron energy          =     45.23861556124284
-	Reference energy             =   -150.77918387235837
+	Nuclear Rep. energy          =     38.25396853104254
+	SCF energy                   =   -150.77918387213020
+	One-electron energy          =   -101.99691974244963
+	Two-electron energy          =     45.23861563750454
+	Reference energy             =   -150.77918387213020
 
-*** tstop() called on psinet at Mon May 15 15:34:45 2017
+*** tstop() called on Mash.local at Sun Oct 25 17:13:24 2020
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.74 seconds =       0.01 minutes
+	user time   =       0.56 seconds =       0.01 minutes
 	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:45 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380680327
-    SCF energy          (wfn)     = -150.779183872358686
-    Reference energy    (file100) = -150.779183872358374
+    Nuclear Rep. energy (wfn)     =   38.253968531042538
+    SCF energy          (wfn)     = -150.779183872130204
+    Reference energy    (file100) = -150.779183872130204
 
     Input parameters:
     -----------------
@@ -464,76 +500,63 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054135753
+MP2 correlation energy -0.3802563047353464
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305413575    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.380254802722189    2.350e-02    0.006281    0.014957    0.014957    0.143419
-     2        -0.382926539245087    6.976e-03    0.007604    0.017580    0.017580    0.146255
-     3        -0.383312067134338    2.742e-03    0.008393    0.018848    0.018848    0.146676
-     4        -0.383283495426497    9.595e-04    0.008568    0.018859    0.018859    0.146729
-     5        -0.383286625218999    3.462e-04    0.008637    0.018841    0.018841    0.146745
-     6        -0.383290105628154    9.323e-05    0.008642    0.018836    0.018836    0.146748
-     7        -0.383289932289576    3.248e-05    0.008643    0.018835    0.018835    0.146748
-     8        -0.383289793502010    1.255e-05    0.008643    0.018835    0.018835    0.146748
-     9        -0.383289823387463    3.458e-06    0.008643    0.018835    0.018835    0.146748
-    10        -0.383289826363971    1.544e-06    0.008643    0.018835    0.018835    0.146748
-    11        -0.383289836414563    4.659e-07    0.008643    0.018835    0.018835    0.146748
-    12        -0.383289840450544    1.935e-07    0.008643    0.018835    0.018835    0.146748
-    13        -0.383289840923770    7.060e-08    0.008643    0.018835    0.018835    0.146748
+     0        -0.380256304735346    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.380254802043474    2.350e-02    0.006281    0.014957    0.014957    0.143419
+     2        -0.382926538506984    6.976e-03    0.007604    0.017580    0.017580    0.146255
+     3        -0.383312066377083    2.742e-03    0.008393    0.018848    0.018848    0.146676
+     4        -0.383283494671415    9.595e-04    0.008568    0.018859    0.018859    0.146729
+     5        -0.383286624463541    3.462e-04    0.008637    0.018841    0.018841    0.146745
+     6        -0.383290104872595    9.323e-05    0.008642    0.018836    0.018836    0.146748
+     7        -0.383289931534046    3.248e-05    0.008643    0.018835    0.018835    0.146748
+     8        -0.383289792746475    1.255e-05    0.008643    0.018835    0.018835    0.146748
+     9        -0.383289822631932    3.458e-06    0.008643    0.018835    0.018835    0.146748
+    10        -0.383289825608433    1.544e-06    0.008643    0.018835    0.018835    0.146748
+    11        -0.383289835659024    4.659e-07    0.008643    0.018835    0.018835    0.146748
+    12        -0.383289839695005    1.935e-07    0.008643    0.018835    0.018835    0.146748
+    13        -0.383289840168230    7.060e-08    0.008643    0.018835    0.018835    0.146748
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0109554494
-              6  14        -0.0098594082
-              2   7        -0.0085098717
+              5  14        -0.0109554489
+              6  14        -0.0098594077
+              2   7        -0.0085098715
               2   9        -0.0082148274
-              2   4         0.0076053348
-              5  17         0.0075277221
+              2   4         0.0076053346
+              5  17         0.0075277218
               1   0        -0.0069350391
-              1   8        -0.0069268907
+              1   8        -0.0069268906
               1   3         0.0063772897
-              2   3        -0.0057368808
+              2   3        -0.0057368806
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0557781569
+      2   2  15  15        -0.0557781564
       1   1  15  15        -0.0278636304
-      1   2  15  15         0.0272969982
-      2   1  15  15         0.0272969982
-      2   2  14  15         0.0270427379
-      2   2  15  14         0.0270427379
-      3   3  17  17        -0.0218529151
-      2   3  15  17         0.0214876848
-      3   2  17  15         0.0214876848
-      2   6  15   2         0.0208245684
+      1   2  15  15         0.0272969980
+      2   1  15  15         0.0272969980
+      2   2  14  15         0.0270427369
+      2   2  15  14         0.0270427369
+      3   3  17  17        -0.0218529145
+      2   3  15  17         0.0214876843
+      3   2  17  15         0.0214876843
+      2   6  15   2         0.0208245681
 
-    SCF energy       (wfn)                    = -150.779183872358686
-    Reference energy (file100)                = -150.779183872358374
+    SCF energy       (wfn)                    = -150.779183872130204
+    Reference energy (file100)                = -150.779183872130204
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987529232
-    Same-spin MP2 correlation energy          =   -0.097557317884343
-    MP2 correlation energy                    =   -0.380256305413575
-      * MP2 total energy                      = -151.159440177771955
-    CC2 correlation energy                    =   -0.383289840923770
-      * CC2 total energy                      = -151.162473713282139
-
-
-*** tstop() called on psinet at Mon May 15 15:34:46 2017
-Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.95 seconds =       0.02 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:46 2017
+    Opposite-spin MP2 correlation energy      =   -0.282698986958634
+    Same-spin MP2 correlation energy          =   -0.097557317776712
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735346
+      * MP2 total energy                      = -151.159440176865559
+    CC2 correlation energy                    =   -0.383289840168230
+      * CC2 total energy                      = -151.162473712298436
 
 
 			**************************
@@ -543,28 +566,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:46 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:46 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
-	SCF energy          (wfn)     = -150.779183872358686
-	Reference energy    (file100) = -150.779183872358374
-	CC2 energy          (file100) =   -0.383289840923770
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
+	SCF energy          (wfn)     = -150.779183872130204
+	Reference energy    (file100) = -150.779183872130204
+	CC2 energy          (file100) =   -0.383289840168230
 
 	Input parameters:
 	-----------------
@@ -597,6 +606,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total  161.9378511804
+Fmi   dot Fmi   total    6.2584666936
+Fme   dot Fme   total    0.0000109623
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    0.0000000000
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A
 Symmetry of excited state: A
 Symmetry of right eigenvector: A
@@ -604,74 +621,74 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3908373749   3.91e-01    5.95e-01      N
-                     2   0.4695339537   4.70e-01    6.54e-01      N
+                     1   0.3908373750   3.91e-01    5.95e-01      N
+                     2   0.4695339570   4.70e-01    6.54e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2550709555  -1.36e-01    5.03e-02      N
-                     2   0.3388817700  -1.31e-01    5.92e-02      N
+                     1   0.2550709558  -1.36e-01    5.03e-02      N
+                     2   0.3388817734  -1.31e-01    5.92e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2512135764  -3.86e-03    5.79e-02      N
-                     2   0.3366653957  -2.22e-03    2.88e-02      N
+                     1   0.2512135767  -3.86e-03    5.79e-02      N
+                     2   0.3366653992  -2.22e-03    2.88e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2495571334  -1.66e-03    1.70e-02      N
-                     2   0.3362551544  -4.10e-04    9.73e-03      N
+                     1   0.2495571338  -1.66e-03    1.70e-02      N
+                     2   0.3362551579  -4.10e-04    9.73e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2493271705  -2.30e-04    8.41e-03      N
-                     2   0.3361310598  -1.24e-04    7.17e-03      N
+                     1   0.2493271709  -2.30e-04    8.41e-03      N
+                     2   0.3361310633  -1.24e-04    7.17e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2492941420  -3.30e-05    3.41e-03      N
-                     2   0.3360872096  -4.39e-05    4.32e-03      N
+                     1   0.2492941424  -3.30e-05    3.41e-03      N
+                     2   0.3360872131  -4.39e-05    4.32e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2492869292  -7.21e-06    1.18e-03      N
-                     2   0.3360728191  -1.44e-05    1.37e-03      N
+                     1   0.2492869296  -7.21e-06    1.18e-03      N
+                     2   0.3360728226  -1.44e-05    1.37e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2492852002  -1.73e-06    5.37e-04      N
-                     2   0.3360714949  -1.32e-06    6.32e-04      N
+                     1   0.2492852006  -1.73e-06    5.37e-04      N
+                     2   0.3360714984  -1.32e-06    6.32e-04      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2492849759  -2.24e-07    1.15e-04      N
-                     2   0.3360706413  -8.54e-07    2.07e-04      N
+                     1   0.2492849763  -2.24e-07    1.15e-04      N
+                     2   0.3360706448  -8.54e-07    2.07e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2492849835   7.56e-09    3.72e-05      Y
-                     2   0.3360710565   4.15e-07    9.93e-05      Y
+                     1   0.2492849839   7.56e-09    3.72e-05      Y
+                     2   0.3360710600   4.15e-07    9.93e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CC2 R0 for root 0 =  -0.00222257629
-EOM CC2 R0 for root 1 =   0.01570026618
+EOM CC2 R0 for root 0 =   0.00222257638
+EOM CC2 R0 for root 1 =  -0.01570026544
 
 Final Energetic Summary for Converged Roots of Irrep A
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      6.783    54711.7   0.2492849835  -150.913188729793
+EOM State 1      6.783    54711.7   0.2492849839  -150.913188728388
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         3 >   0      :        5a >     6a :    0.6769441198
-         3 >   1      :        5a >     7a :   -0.0595076033
-         2 >   0      :        4a >     6a :    0.0329571007
-         2 >   0      :        4b >     5b :    0.0296933452
-         1 >   0      :        3b >     5b :   -0.0289994530
+         3 >   0      :        5a >     6a :   -0.6769441201
+         3 >   1      :        5a >     7a :    0.0595076031
+         2 >   0      :        4a >     6a :   -0.0329570998
+         2 >   0      :        4b >     5b :   -0.0296933451
+         1 >   0      :        3b >     5b :    0.0289994534
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   1   0     :     4a     3b >     6b     6a :    0.0443379564
-        1   2 >   0   1     :     3b     4a >     6a     6b :    0.0443379564
-        1   3 >   0   0     :     3a     5a >     6a     6a :    0.0340050213
-        3   1 >   0   0     :     5a     3a >     6a     6a :    0.0340050213
-        1   1 >   1   0     :     3a     3b >     6b     6a :   -0.0280579786
-EOM State 2      9.145    73759.1   0.3360710565  -150.826402656773
+        2   1 >   1   0     :     4a     3b >     6b     6a :   -0.0443379561
+        1   2 >   0   1     :     3b     4a >     6a     6b :   -0.0443379561
+        1   3 >   0   0     :     3a     5a >     6a     6a :   -0.0340050211
+        3   1 >   0   0     :     5a     3a >     6a     6a :   -0.0340050211
+        1   1 >   1   0     :     3a     3b >     6b     6a :    0.0280579786
+EOM State 2      9.145    73759.1   0.3360710600  -150.826402652286
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :        4b >     5b :    0.5493306307
-         2 >   1      :        4b >     6b :   -0.3949868944
-         1 >   0      :        3b >     5b :   -0.0790971374
-         1 >   1      :        3b >     6b :    0.0624887087
-         2 >   2      :        4b >     7b :   -0.0486861428
+         2 >   0      :        4b >     5b :   -0.5493306327
+         2 >   1      :        4b >     6b :    0.3949868924
+         1 >   0      :        3b >     5b :    0.0790971351
+         1 >   1      :        3b >     6b :   -0.0624887066
+         2 >   2      :        4b >     7b :    0.0486861435
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   1     :     4a     4a >     5b     6b :   -0.0333764588
-        2   2 >   1   0     :     4a     4a >     6b     5b :   -0.0333764588
-        2   2 >   1   1     :     4a     4a >     6b     6b :    0.0322443347
-        2   2 >   0   0     :     4a     4a >     5b     5b :    0.0274807095
-        2   3 >   1   0     :     4a     5a >     6b     5b :   -0.0270848057
+        2   2 >   0   1     :     4a     4a >     5b     6b :    0.0333764586
+        2   2 >   1   0     :     4a     4a >     6b     5b :    0.0333764586
+        2   2 >   1   1     :     4a     4a >     6b     6b :   -0.0322443346
+        2   2 >   0   0     :     4a     4a >     5b     5b :   -0.0274807089
+        2   3 >   1   0     :     4a     5a >     6b     5b :    0.0270848053
 
 Symmetry of excited state: B
 Symmetry of right eigenvector: B
@@ -679,48 +696,48 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3840582303   3.84e-01    6.54e-01      N
-                     2   0.4526989243   4.53e-01    5.76e-01      N
+                     1   0.3840582331   3.84e-01    6.54e-01      N
+                     2   0.4526989255   4.53e-01    5.76e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2558809035  -1.28e-01    5.67e-02      N
-                     2   0.3343922181  -1.18e-01    4.56e-02      N
+                     1   0.2558809064  -1.28e-01    5.67e-02      N
+                     2   0.3343922193  -1.18e-01    4.56e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2540437637  -1.84e-03    2.36e-02      N
-                     2   0.3320770040  -2.32e-03    3.79e-02      N
+                     1   0.2540437667  -1.84e-03    2.36e-02      N
+                     2   0.3320770052  -2.32e-03    3.79e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2537339901  -3.10e-04    1.15e-02      N
-                     2   0.3313054066  -7.72e-04    1.65e-02      N
+                     1   0.2537339932  -3.10e-04    1.15e-02      N
+                     2   0.3313054078  -7.72e-04    1.65e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535244965  -2.09e-04    9.53e-03      N
-                     2   0.3306781090  -6.27e-04    2.35e-02      N
+                     1   0.2535244995  -2.09e-04    9.53e-03      N
+                     2   0.3306781101  -6.27e-04    2.35e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534711522  -5.33e-05    3.80e-03      N
-                     2   0.3302326490  -4.45e-04    1.68e-02      N
+                     1   0.2534711552  -5.33e-05    3.80e-03      N
+                     2   0.3302326501  -4.45e-04    1.68e-02      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534604016  -1.08e-05    9.31e-04      N
-                     2   0.3300578563  -1.75e-04    6.48e-03      N
+                     1   0.2534604046  -1.08e-05    9.31e-04      N
+                     2   0.3300578574  -1.75e-04    6.48e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534596593  -7.42e-07    3.82e-04      N
-                     2   0.3300118556  -4.60e-05    4.16e-03      N
+                     1   0.2534596623  -7.42e-07    3.82e-04      N
+                     2   0.3300118567  -4.60e-05    4.16e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534593919  -2.67e-07    1.19e-04      N
-                     2   0.3300025053  -9.35e-06    1.49e-03      N
+                     1   0.2534593949  -2.67e-07    1.19e-04      N
+                     2   0.3300025064  -9.35e-06    1.49e-03      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534596113   2.19e-07    5.85e-05      Y
-                     2   0.3300027430   2.38e-07    6.71e-04      N
+                     1   0.2534596143   2.19e-07    5.85e-05      Y
+                     2   0.3300027441   2.38e-07    6.71e-04      N
 Iter=11   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534596622   5.09e-08    3.77e-05      Y
-                     2   0.3300022064  -5.37e-07    3.40e-04      N
+                     1   0.2534596653   5.09e-08    3.77e-05      Y
+                     2   0.3300022075  -5.37e-07    3.40e-04      N
 Iter=12   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534596363  -2.60e-08    2.73e-05      Y
-                     2   0.3300020493  -1.57e-07    1.49e-04      N
+                     1   0.2534596393  -2.60e-08    2.73e-05      Y
+                     2   0.3300020504  -1.57e-07    1.49e-04      N
 Iter=13   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2534596216  -1.47e-08    2.53e-05      Y
-                     2   0.3300021901   1.41e-07    4.34e-05      Y
+                     1   0.2534596246  -1.47e-08    2.53e-05      Y
+                     2   0.3300021913   1.41e-07    4.34e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot -150.8324715231
+Energy written to CC_INFO:Etot -150.8324715210
 States per irrep written to CC_INFO.
 EOM CC2 R0 for root 0 =   0.00000000000
 EOM CC2 R0 for root 1 =   0.00000000000
@@ -728,67 +745,53 @@ EOM CC2 R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3      6.897    55627.9   0.2534596216  -150.909014091713
+EOM State 3      6.897    55628.0   0.2534596246  -150.909014087719
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         3 >   0      :        5a >     5b :    0.5559553930
-         3 >   1      :        5a >     6b :   -0.3960782667
-         3 >   2      :        5a >     7b :   -0.0499449086
-         2 >   0      :        4a >     5b :    0.0429227406
-         2 >   1      :        4a >     6b :   -0.0384589505
+         3 >   0      :        5a >     5b :    0.5559553950
+         3 >   1      :        5a >     6b :   -0.3960782640
+         3 >   2      :        5a >     7b :   -0.0499449095
+         2 >   0      :        4a >     5b :    0.0429227395
+         2 >   1      :        4a >     6b :   -0.0384589495
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   1   0     :     4a     3b >     6b     5b :    0.0371373084
-        1   2 >   0   1     :     3b     4a >     5b     6b :    0.0371373084
-        2   1 >   1   1     :     4a     3b >     6b     6b :   -0.0245531258
-        1   2 >   1   1     :     3b     4a >     6b     6b :   -0.0245531258
-        1   1 >   1   0     :     3a     3b >     6b     5b :   -0.0232122367
-EOM State 4      8.980    72427.1   0.3300021901  -150.832471523139
+        2   1 >   1   0     :     4a     3b >     6b     5b :    0.0371373083
+        1   2 >   0   1     :     3b     4a >     5b     6b :    0.0371373083
+        2   1 >   1   1     :     4a     3b >     6b     6b :   -0.0245531255
+        1   2 >   1   1     :     3b     4a >     6b     6b :   -0.0245531255
+        1   1 >   1   0     :     3a     3b >     6b     5b :   -0.0232122368
+EOM State 4      8.980    72427.1   0.3300021913  -150.832471521039
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :        4b >     6a :   -0.6052370986
-         3 >   1      :        5a >     6b :   -0.2475063000
-         3 >   0      :        5a >     5b :   -0.1457632867
-         1 >   0      :        3b >     6a :    0.1181548816
+         2 >   0      :        4b >     6a :   -0.6052371029
+         3 >   1      :        5a >     6b :   -0.2475062952
+         3 >   0      :        5a >     5b :   -0.1457632798
+         1 >   0      :        3b >     6a :    0.1181548788
          2 >   1      :        4b >     7a :    0.0541862646
  RIjAb (libdpd indices)     : (cscf notation)
-        1   2 >   0   0     :     3a     4b >     6a     6a :   -0.0336279067
-        2   1 >   0   0     :     4b     3a >     6a     6a :   -0.0336279067
-        2   3 >   1   0     :     4a     5a >     6b     6a :    0.0261191895
-        3   2 >   0   1     :     5a     4a >     6a     6b :    0.0261191895
-        2   2 >   0   1     :     4a     4a >     6a     6b :    0.0256988254
+        1   2 >   0   0     :     3a     4b >     6a     6a :   -0.0336279068
+        2   1 >   0   0     :     4b     3a >     6a     6a :   -0.0336279068
+        2   3 >   1   0     :     4a     5a >     6b     6a :    0.0261191894
+        3   2 >   0   1     :     5a     4a >     6a     6b :    0.0261191894
+        2   2 >   0   1     :     4a     4a >     6a     6b :    0.0256988256
 
 	Putting into environment energy for root of R irrep 2 and root 2.
-	Putting into environment CURRENT ENERGY:             -150.8324715231
+	Putting into environment CURRENT ENERGY:             -150.8324715210
 
 	Total # of sigma evaluations: 43
-
-*** tstop() called on psinet at Mon May 15 15:34:47 2017
-Module time:
-	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.50 seconds =       0.03 minutes
-	system time =       0.63 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
-
 
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358686
-	Reference energy    (CC_INFO) = -150.779183872358374
-	CC2 energy          (CC_INFO) =   -0.383289840923770
-	Total CC2 energy    (CC_INFO) = -151.162473713282139
+	SCF energy          (wfn)     = -150.779183872130204
+	Reference energy    (CC_INFO) = -150.779183872130204
+	CC2 energy          (CC_INFO) =   -0.383289840168230
+	Total CC2 energy    (CC_INFO) = -151.162473712298436
 
 	Input parameters:
 	-----------------
@@ -801,13 +804,13 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
-	  2   0     1         No       0.2492849835  -0.0022225763
-	  3   0     2         No       0.3360710565   0.0157002662
-	  4   1     1         No       0.2534596216   0.0000000000
-	  5   1     2         No       0.3300021901   0.0000000000
+	  2   0     1         No       0.2492849839   0.0022225764
+	  3   0     2         No       0.3360710600  -0.0157002654
+	  4   1     1         No       0.2534596246   0.0000000000
+	  5   1     2         No       0.3300021913   0.0000000000
 	Labels for eigenvector 1:
 	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
 	Labels for eigenvector 2:
@@ -826,39 +829,39 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.383295397523609    0.000e+00
-	   1        -0.383117231009968    1.890e-03
-	   2        -0.383117283442559    3.947e-04
-	   3        -0.383115579312551    1.797e-04
-	   4        -0.383115422154071    4.040e-05
+	   0        -0.383295396774477    0.000e+00
+	   1        -0.383117230271462    1.890e-03
+	   2        -0.383117282703843    3.947e-04
+	   3        -0.383115578573767    1.797e-04
+	   4        -0.383115421415290    4.040e-05
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0106463740
-	          6  14        -0.0091194433
-	          2   7        -0.0085628903
-	          2   9        -0.0085251020
-	          2   4         0.0077482228
-	          5  17         0.0076072550
-	          1   8        -0.0069596903
+	          5  14        -0.0106463734
+	          6  14        -0.0091194428
+	          2   7        -0.0085628901
+	          2   9        -0.0085251019
+	          2   4         0.0077482227
+	          5  17         0.0076072547
+	          1   8        -0.0069596902
 	          1   3         0.0064424743
 	          1   0        -0.0061372490
-	          2   3        -0.0058820193
+	          2   3        -0.0058820191
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0557426326
+	  2   2  15  15        -0.0557426321
 	  1   1  15  15        -0.0278679434
-	  1   2  15  15         0.0272992996
-	  2   1  15  15         0.0272992996
-	  2   2  14  15         0.0269862860
-	  2   2  15  14         0.0269862860
-	  3   3  17  17        -0.0218489577
-	  2   3  15  17         0.0214817640
-	  3   2  17  15         0.0214817640
-	  2   6  15   2         0.0208259404
+	  1   2  15  15         0.0272992994
+	  2   1  15  15         0.0272992994
+	  2   2  14  15         0.0269862851
+	  2   2  15  14         0.0269862851
+	  3   3  17  17        -0.0218489571
+	  2   3  15  17         0.0214817635
+	  3   2  17  15         0.0214817635
+	  2   6  15   2         0.0208259402
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89784163857
+	Overlap <L|e^T> =        0.89784163932
 	Symmetry of left-hand state: A
 	Symmetry of left-hand eigenvector: A
 	Initial overlap of initial guess <L|R> =    0.9999893877
@@ -868,97 +871,97 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         0.000184859590071    4.040e-05
-	   1        -0.000394334733634    5.434e-03
-	   2        -0.000419946669462    1.122e-03
-	   3        -0.000424832613214    6.025e-04
-	   4        -0.000424385067403    2.685e-04
-	   5        -0.000423228379582    6.867e-05
+	   0        -0.000184859687987    4.040e-05
+	   1         0.000394334660440    5.434e-03
+	   2         0.000419946597533    1.122e-03
+	   3         0.000424832541554    6.025e-04
+	   4         0.000424384995692    2.685e-04
+	   5         0.000423228307893    6.867e-05
 
 	Initial  <L|R>  =        1.0013709669
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9356992868
-	L2 * R2 =        0.0643007132
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9356992873
+	L2 * R2 =        0.0643007127
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.000422648941864
+	Pseudoenergy or Norm of normalized L =    0.000422648870295
 
 	Largest LIA Amplitudes:
-	          3   0         0.6775309237
-	          3   1        -0.0574129663
-	          2   0         0.0336132960
-	          6  14         0.0289609187
-	          5  14        -0.0288654001
-	          5  15        -0.0284686210
-	          6  15         0.0248025695
-	          3   2         0.0195013546
-	          1   0         0.0156515004
-	          3   5        -0.0152554947
+	          3   0        -0.6775309240
+	          3   1         0.0574129661
+	          2   0        -0.0336132951
+	          6  14        -0.0289609187
+	          5  14         0.0288654005
+	          5  15         0.0284686207
+	          6  15        -0.0248025690
+	          3   2        -0.0195013545
+	          1   0        -0.0156514999
+	          3   5         0.0152554950
 
 	Largest LIjAb Amplitudes:
-	  2   5  15   0         0.0437058322
-	  5   2   0  15         0.0437058322
-	  1   3   0   0         0.0336630504
-	  3   1   0   0         0.0336630504
-	  1   5  15   0        -0.0281256635
-	  5   1   0  15        -0.0281256635
-	  3   5  17   0        -0.0264675171
-	  5   3   0  17        -0.0264675171
-	  2   6  15   0        -0.0258689807
-	  6   2   0  15        -0.0258689807
+	  2   5  15   0        -0.0437058320
+	  5   2   0  15        -0.0437058320
+	  1   3   0   0        -0.0336630502
+	  3   1   0   0        -0.0336630502
+	  1   5  15   0         0.0281256635
+	  5   1   0  15         0.0281256635
+	  3   5  17   0         0.0264675167
+	  5   3   0  17         0.0264675167
+	  2   6  15   0         0.0258689803
+	  6   2   0  15         0.0258689803
 
 	Iterations converged.
 
 	Symmetry of left-hand state: A
 	Symmetry of left-hand eigenvector: A
-	Initial overlap of initial guess <L|R> =    0.9994932809
+	Initial overlap of initial guess <L|R> =    0.9994932810
 	Checking overlap of initial guess <L|R> =    1.0000000000
 
 	          Solving Lambda Equations
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.000356035873323    6.867e-05
-	   1         0.003886346791675    8.449e-03
-	   2         0.004060365727192    1.814e-03
-	   3         0.004094767416211    1.468e-03
-	   4         0.004106813220961    9.549e-04
-	   5         0.004105090693516    6.755e-04
-	   6         0.004108844486358    3.875e-04
-	   7         0.004111502255702    1.022e-04
-	   8         0.004111731725971    3.783e-05
+	   0         0.000356035560160    6.867e-05
+	   1        -0.003886346916677    8.449e-03
+	   2        -0.004060365843960    1.814e-03
+	   3        -0.004094767531292    1.468e-03
+	   4        -0.004106813334108    9.549e-04
+	   5        -0.004105090806505    6.755e-04
+	   6        -0.004108844599483    3.875e-04
+	   7        -0.004111502368927    1.022e-04
+	   8        -0.004111731839161    3.783e-05
 
 	Initial  <L|R>  =        1.0029562034
 	Normalizing L...
-	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9495230235
-	L2 * R2 =        0.0504769765
+	L0 * R0 =       -0.0000000000
+	L1 * R1 =        0.9495230237
+	L2 * R2 =        0.0504769763
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    0.004099612437687
+	Pseudoenergy or Norm of normalized L =   -0.004099612550595
 
 	Largest LIA Amplitudes:
-	          6  14         0.5539432983
-	          6  15        -0.3898889507
-	          5  14        -0.0808013631
-	          5  15         0.0623775270
-	          6  16        -0.0464459953
-	          6  17        -0.0319155388
-	          6  19         0.0262756656
-	          2   0         0.0174108685
-	          1   0         0.0158338978
-	          6  22        -0.0148816436
+	          6  14        -0.5539433003
+	          6  15         0.3898889487
+	          5  14         0.0808013608
+	          5  15        -0.0623775249
+	          6  16         0.0464459961
+	          6  17         0.0319155392
+	          6  19        -0.0262756652
+	          2   0        -0.0174108698
+	          1   0        -0.0158338982
+	          6  22         0.0148816436
 
 	Largest LIjAb Amplitudes:
-	  2   2  14  15        -0.0322037151
-	  2   2  15  14        -0.0322037151
-	  2   2  15  15         0.0307939089
-	  2   3  15  14        -0.0269247561
-	  3   2  14  15        -0.0269247561
-	  2   2  14  14         0.0263700014
-	  1   1  15  15        -0.0224733906
-	  1   2  14  15        -0.0224341962
-	  2   1  15  14        -0.0224341962
-	  1   3  15  14         0.0218648871
+	  2   2  14  15         0.0322037149
+	  2   2  15  14         0.0322037149
+	  2   2  15  15        -0.0307939087
+	  2   3  15  14         0.0269247557
+	  3   2  14  15         0.0269247557
+	  2   2  14  14        -0.0263700009
+	  1   1  15  15         0.0224733905
+	  1   2  14  15         0.0224341962
+	  2   1  15  14         0.0224341962
+	  1   3  15  14        -0.0218648868
 
 	Iterations converged.
 
@@ -972,46 +975,46 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    3.783e-05
-	   1         1.001633291232293    9.597e-03
-	   2         1.001662894045342    1.700e-03
-	   3         1.001924277354292    1.339e-03
-	   4         1.002158902965928    8.362e-04
-	   5         1.002345075480473    6.067e-04
-	   6         1.002525032276687    3.279e-04
-	   7         1.002568515930572    1.053e-04
-	   8         1.002569484877644    2.792e-05
+	   1         1.001633291199736    9.597e-03
+	   2         1.001662894018486    1.700e-03
+	   3         1.001924277330674    1.339e-03
+	   4         1.002158902947036    8.362e-04
+	   5         1.002345075476355    6.067e-04
+	   6         1.002525032276909    3.279e-04
+	   7         1.002568515932536    1.053e-04
+	   8         1.002569484879428    2.792e-05
 
 	Initial  <L|R>  =        1.0024637063
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9523863299
-	L2 * R2 =        0.0476136701
+	L1 * R1 =        0.9523863300
+	L2 * R2 =        0.0476136700
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000105518634054
+	Pseudoenergy or Norm of normalized L =    1.000105518631739
 
 	Largest LIA Amplitudes:
-	          3  14         0.5608054681
-	          3  15        -0.3903094611
-	          3  16        -0.0481938500
-	          2  14         0.0436659457
-	          2  15        -0.0382769329
-	          3  17        -0.0295148480
-	          3  19         0.0277646527
-	          6   0         0.0215586280
-	          3  18        -0.0206189735
+	          3  14         0.5608054701
+	          3  15        -0.3903094585
+	          3  16        -0.0481938508
+	          2  14         0.0436659445
+	          2  15        -0.0382769319
+	          3  17        -0.0295148486
+	          3  19         0.0277646522
+	          6   0         0.0215586294
+	          3  18        -0.0206189725
 	          3  22        -0.0170276896
 
 	Largest LIjAb Amplitudes:
-	  2   5  15  14         0.0367732836
-	  5   2  14  15         0.0367732836
-	  2   5  15  15        -0.0238142361
-	  5   2  15  15        -0.0238142361
-	  1   5  15  14        -0.0234557720
-	  5   1  14  15        -0.0234557720
-	  2   6  15  14        -0.0216091724
-	  6   2  14  15        -0.0216091724
-	  2   5  14  14        -0.0200651345
-	  5   2  14  14        -0.0200651345
+	  2   5  15  14         0.0367732835
+	  5   2  14  15         0.0367732835
+	  2   5  15  15        -0.0238142358
+	  5   2  15  15        -0.0238142358
+	  1   5  15  14        -0.0234557721
+	  5   1  14  15        -0.0234557721
+	  2   6  15  14        -0.0216091721
+	  6   2  14  15        -0.0216091721
+	  2   5  14  14        -0.0200651339
+	  5   2  14  14        -0.0200651339
 
 	Iterations converged.
 
@@ -1025,43 +1028,43 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    2.792e-05
-	   1         1.001485570002263    8.504e-03
-	   2         1.001228669359107    1.292e-03
-	   3         1.001359002587072    6.220e-04
-	   4         1.001389500918903    2.924e-04
-	   5         1.001387144048820    8.506e-05
+	   1         1.001485569955021    8.504e-03
+	   2         1.001228669323444    1.292e-03
+	   3         1.001359002549709    6.220e-04
+	   4         1.001389500881277    2.924e-04
+	   5         1.001387144011818    8.506e-05
 
-	Initial  <L|R>  =        1.0013413078
+	Initial  <L|R>  =        1.0013413077
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9442287214
-	L2 * R2 =        0.0557712786
+	L1 * R1 =        0.9442287215
+	L2 * R2 =        0.0557712785
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000045774897963
+	Pseudoenergy or Norm of normalized L =    1.000045774895705
 
 	Largest LIA Amplitudes:
-	          6   0        -0.6060566913
-	          3  15        -0.2449993672
-	          3  14        -0.1490687797
-	          5   0         0.1189052965
-	          6   1         0.0523094948
-	          2  15        -0.0434270107
-	          3  19         0.0268395977
-	          3  16         0.0264173968
-	          1  14        -0.0255012928
-	          5   1        -0.0186605944
+	          6   0        -0.6060566956
+	          3  15        -0.2449993625
+	          3  14        -0.1490687727
+	          5   0         0.1189052937
+	          6   1         0.0523094947
+	          2  15        -0.0434270101
+	          3  19         0.0268395974
+	          3  16         0.0264173955
+	          1  14        -0.0255012930
+	          5   1        -0.0186605940
 
 	Largest LIjAb Amplitudes:
 	  1   6   0   0        -0.0331078074
 	  6   1   0   0        -0.0331078074
-	  2   3  15   0         0.0256112173
-	  3   2   0  15         0.0256112173
-	  2   2   0  15         0.0248985130
-	  2   2  15   0         0.0248985130
-	  1   2   0  15         0.0238802052
-	  2   1  15   0         0.0238802052
-	  6   6   0  18         0.0205741935
-	  6   6  18   0         0.0205741935
+	  2   3  15   0         0.0256112172
+	  3   2   0  15         0.0256112172
+	  2   2   0  15         0.0248985133
+	  2   2  15   0         0.0248985133
+	  1   2   0  15         0.0238802053
+	  2   1  15   0         0.0238802053
+	  6   6   0  18         0.0205741938
+	  6   6  18   0         0.0205741938
 
 	Iterations converged.
 
@@ -1069,7 +1072,7 @@ Total time:
 
                  1            2            3            4            5
 
-    1    1.0000000    0.0000000    0.0000000  -99.0000000  -99.0000000
+    1    1.0000000   -0.0000000   -0.0000000  -99.0000000  -99.0000000
     2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000
     3    0.0000000    0.0000001    1.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
@@ -1080,55 +1083,41 @@ Total time:
 
                  1            2            3            4            5
 
-    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000
+    1    1.0000000    0.0000000    0.0000000  -99.0000000  -99.0000000
     2    0.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000
-    3    0.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000
-    4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
-    5  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
+    3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000
+    4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
+    5  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000
 
 
 
 	Projections for excited state, irrep A, root 0:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000055030
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9365732895
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0634212089
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9365732900
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0634212083
 	Sum of above             =    1.0000000013
-	Approx. excitation level =    1.0634157072
+	Approx. excitation level =    1.0634157067
 
 	Projections for excited state, irrep A, root 1:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0002520770
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9490670391
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0506808904
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9490670393
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0506808902
 	Sum of above             =    1.0000000065
-	Approx. excitation level =    1.0504288199
+	Approx. excitation level =    1.0504288198
 
 	Projections for excited state, irrep A, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9520831060
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0479168943
+	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9520831061
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0479168942
 	Sum of above             =    1.0000000002
-	Approx. excitation level =    1.0479168945
+	Approx. excitation level =    1.0479168944
 
 	Projections for excited state, irrep A, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9449312354
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0550687639
+	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9449312355
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0550687638
 	Sum of above             =    0.9999999992
-	Approx. excitation level =    1.0550687631
-
-*** tstop() called on psinet at Mon May 15 15:34:47 2017
-Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.63 seconds =       0.03 minutes
-	system time =       0.74 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
-
+	Approx. excitation level =    1.0550687630
 
 			**************************
 			*                        *
@@ -1152,312 +1141,82 @@ Total time:
 	Xi connected     = Yes
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
-	SCF energy          (wfn)     = -150.779183872358686
-	Reference energy    (file100) = -150.779183872358374
-	CC2 energy          (CC_INFO) =   -0.383289840923770
-	Total CC2 energy    (CC_INFO) = -151.162473713282139
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
+	SCF energy          (wfn)     = -150.779183872130204
+	Reference energy    (file100) = -150.779183872130204
+	CC2 energy          (CC_INFO) =   -0.383289840168230
+	Total CC2 energy    (CC_INFO) = -151.162473712298436
 	Number of States = 5
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0  A    0.0000000000   1.00000000
-	   No     1  A    0.2492849835  -0.00222258
-	   No     2  A    0.3360710565   0.01570027
-	   No     1  B    0.2534596216   0.00000000
-	   No     2  B    0.3300021901   0.00000000
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.3278
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.1398     Total:     1.1398
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.8972     Total:     2.8972
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -11.6671     YY:   -11.0457     ZZ:    -9.3692
-    XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.9731     YY:    -0.3517     ZZ:     1.3248
-    XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.07569  4.07569  0.00000 -0.15138
-       2     O     4.07569  4.07569  0.00000 -0.15138
-       3     H     0.42431  0.42431  0.00000  0.15138
-       4     H     0.42431  0.42431  0.00000  0.15138
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.968
-  HONO-1 :    4  B    1.966
-  HONO-0 :    5  A    1.943
-  LUNO+0 :    5  B    0.050
-  LUNO+1 :    6  A    0.023
-  LUNO+2 :    6  B    0.022
-  LUNO+3 :    7  B    0.019
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 1 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -2.0235
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.5558     Total:     0.5558
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -1.4128     Total:     1.4128
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -13.9067     YY:   -13.2865     ZZ:   -16.4603
-    XY:     0.2628     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.6444     YY:     1.2647     ZZ:    -1.9091
-    XY:     0.2628     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.86040  3.86040  0.00000  0.27919
-       2     O     3.86040  3.86040  0.00000  0.27919
-       3     H     0.63960  0.63960  0.00000 -0.27919
-       4     H     0.63960  0.63960  0.00000 -0.27919
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.975
-  HONO-1 :    4  B    1.959
-  HONO-0 :    5  A    1.035
-  LUNO+0 :    6  A    0.988
-  LUNO+1 :    5  B    0.024
-  LUNO+2 :    6  B    0.018
-  LUNO+3 :    7  A    0.006
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 2 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.7768
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.6908     Total:     0.6908
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.7559     Total:     1.7559
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -12.1976     YY:   -13.9980     ZZ:    -9.7604
-    XY:    -0.9808     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.2122     YY:    -2.0126     ZZ:     2.2249
-    XY:    -0.9808     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.03239  4.03239  0.00000 -0.06477
-       2     O     4.03239  4.03239  0.00000 -0.06477
-       3     H     0.46761  0.46761  0.00000  0.06477
-       4     H     0.46761  0.46761  0.00000  0.06477
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.979
-  HONO-1 :    5  A    1.967
-  HONO-0 :    4  B    1.028
-  LUNO+0 :    5  B    0.993
-  LUNO+1 :    6  B    0.017
-  LUNO+2 :    6  A    0.007
-  LUNO+3 :    7  B    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 3 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.6875
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.7802     Total:     0.7802
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.9830     Total:     1.9830
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -11.5842     YY:   -13.9751     ZZ:   -10.6229
-    XY:    -0.4562     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.4765     YY:    -1.9144     ZZ:     1.4378
-    XY:    -0.4562     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.01840  4.01840  0.00000 -0.03680
-       2     O     4.01840  4.01840  0.00000 -0.03680
-       3     H     0.48160  0.48160  0.00000  0.03680
-       4     H     0.48160  0.48160  0.00000  0.03680
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.981
-  HONO-1 :    4  B    1.969
-  HONO-0 :    5  A    1.025
-  LUNO+0 :    5  B    0.991
-  LUNO+1 :    6  B    0.016
-  LUNO+2 :    6  A    0.007
-  LUNO+3 :    7  B    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 4 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.9944
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.5267     Total:     0.5267
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -1.3387     Total:     1.3387
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -14.2850     YY:   -13.5795     ZZ:   -15.3582
-    XY:    -0.0453     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.1226     YY:     0.8281     ZZ:    -0.9507
-    XY:    -0.0453     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.88224  3.88224  0.00000  0.23552
-       2     O     3.88224  3.88224  0.00000  0.23552
-       3     H     0.61776  0.61776  0.00000 -0.23552
-       4     H     0.61776  0.61776  0.00000 -0.23552
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.979
-  HONO-1 :    5  A    1.803
-  HONO-0 :    4  B    1.202
-  LUNO+0 :    6  A    0.816
-  LUNO+1 :    5  B    0.188
-  LUNO+2 :    6  B    0.017
-  LUNO+3 :    7  A    0.006
-
+	   No     1  A    0.2492849839   0.00222258
+	   No     2  A    0.3360710600  -0.01570027
+	   No     1  B    0.2534596246   0.00000000
+	   No     2  B    0.3300021913   0.00000000
 Doing transition
 
 	Oscillator Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00604453
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.00469777
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.00604453
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.00469778
 	Dipole Strength          0.00002840 
 	Oscillator Strength      0.00000472 
-	Einstein A Coefficient   9.42242882e+03 
-	Einstein B Coefficient   3.45482218e+15 
+	Einstein A Coefficient   9.42243487e+03 
+	Einstein B Coefficient   3.45482395e+15 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00604453
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.32011208
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31184179
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.00469777
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.00604453
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.32011208
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.31184179
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.00469778
 
 	Rotational Strength (au)                 -0.00169995
-	Rotational Strength (10^-40 esu^2 cm^2)  -0.80142816
+	Rotational Strength (10^-40 esu^2 cm^2)  -0.80142842
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.01650481
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.32011208
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31184179
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.01642554
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.01650481
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.32011208
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.31184179
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.01642554
 
 	Rotational Strength (au)                 -0.02087081
-	Rotational Strength (10^-40 esu^2 cm^2)  -9.83940868
+	Rotational Strength (10^-40 esu^2 cm^2)  -9.83940883
 Doing transition
 Doing transition
 
 	Oscillator Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.21035901
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.21838458
-	Dipole Strength          0.04593916 
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.21035901
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.21838459
+	Dipole Strength          0.04593917 
 	Oscillator Strength      0.01029255 
-	Einstein A Coefficient   3.73504686e+07 
-	Einstein B Coefficient   5.58925481e+18 
+	Einstein A Coefficient   3.73504707e+07 
+	Einstein B Coefficient   5.58925424e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.21035901
-	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.19595003
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.18974388
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.21838458
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.21035901
+	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.19595003
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.18974388
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.21838459
 
 	Rotational Strength (au)                  0.04132850
-	Rotational Strength (10^-40 esu^2 cm^2)  19.48405249
+	Rotational Strength (10^-40 esu^2 cm^2)  19.48405259
 
 	Velocity-Gauge Rotational Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.10727746
-	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.19595003
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.18974388
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.11156369
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.10727747
+	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.19595003
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.18974388
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.11156369
 
 	Rotational Strength (au)                  0.06276879
-	Rotational Strength (10^-40 esu^2 cm^2)  29.59194185
+	Rotational Strength (10^-40 esu^2 cm^2)  29.59194194
 Doing transition
 Doing transition
 
@@ -1467,8 +1226,8 @@ Doing transition
 	<n|mu_e|0>              -0.09990700 	 -0.06592845 	  0.00000000
 	Dipole Strength          0.01401554 
 	Oscillator Strength      0.00236825 
-	Einstein A Coefficient   4.88827779e+06 
-	Einstein B Coefficient   1.70522119e+18 
+	Einstein A Coefficient   4.88827803e+06 
+	Einstein B Coefficient   1.70522099e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1  B
@@ -1479,49 +1238,49 @@ Doing transition
 	<n|mu_e|0>*             -0.09990700 	 -0.06592845 	  0.00000000
 
 	Rotational Strength (au)                 -0.00581702
-	Rotational Strength (10^-40 esu^2 cm^2)  -2.74239695
+	Rotational Strength (10^-40 esu^2 cm^2)  -2.74239708
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.08741322 	 -0.01015862 	  0.00000000
+	<0|mu_e|n>              -0.08741322 	 -0.01015863 	  0.00000000
 	<n|mu_m|0>               0.08654109 	 -0.04057903 	  0.00000000
 	<0|mu_m|n>*              0.08445379 	 -0.03869748 	  0.00000000
 	<n|mu_e|0>*             -0.09147011 	 -0.00985726 	  0.00000000
 
 	Rotational Strength (au)                 -0.02859658
-	Rotational Strength (10^-40 esu^2 cm^2)  -13.48167070
+	Rotational Strength (10^-40 esu^2 cm^2)  -13.48167076
 Doing transition
 Doing transition
 
 	Oscillator Strength for 2  B
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.15192758 	  0.14719604 	  0.00000000
-	<n|mu_e|0>               0.15458930 	  0.15339002 	  0.00000000
+	<n|mu_e|0>               0.15458929 	  0.15339002 	  0.00000000
 	Dipole Strength          0.04606478 
 	Oscillator Strength      0.01013432 
-	Einstein A Coefficient   3.54600310e+07 
-	Einstein B Coefficient   5.60453818e+18 
+	Einstein A Coefficient   3.54600297e+07 
+	Einstein B Coefficient   5.60453722e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2  B
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.15192758 	  0.14719604 	  0.00000000
-	<n|mu_m|0>               0.36663204 	  0.13685806 	  0.00000000
-	<0|mu_m|n>*              0.35828526 	  0.13325274 	  0.00000000
-	<n|mu_e|0>*              0.15458930 	  0.15339002 	  0.00000000
+	<n|mu_m|0>               0.36663205 	  0.13685806 	  0.00000000
+	<0|mu_m|n>*              0.35828527 	  0.13325273 	  0.00000000
+	<n|mu_e|0>*              0.15458929 	  0.15339002 	  0.00000000
 
-	Rotational Strength (au)                  0.07583660
-	Rotational Strength (10^-40 esu^2 cm^2)  35.75267278
+	Rotational Strength (au)                  0.07583659
+	Rotational Strength (10^-40 esu^2 cm^2)  35.75267230
 
 	Velocity-Gauge Rotational Strength for 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.12039903 	  0.04647697 	  0.00000000
-	<n|mu_m|0>               0.36663204 	  0.13685806 	  0.00000000
-	<0|mu_m|n>*              0.35828526 	  0.13325274 	  0.00000000
+	<0|mu_e|n>               0.12039902 	  0.04647697 	  0.00000000
+	<n|mu_m|0>               0.36663205 	  0.13685806 	  0.00000000
+	<0|mu_m|n>*              0.35828527 	  0.13325273 	  0.00000000
 	<n|mu_e|0>*              0.12317046 	  0.04847774 	  0.00000000
 
 	Rotational Strength (au)                  0.15316995
-	Rotational Strength (10^-40 esu^2 cm^2)  72.21098562
+	Rotational Strength (10^-40 esu^2 cm^2)  72.21098486
 Doing transition
 Doing transition
 
@@ -1529,9 +1288,9 @@ Doing transition
 
 	                   Excitation Energy          OS       RS        RS     Einstein A
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
-	 1  A   6.783   54711.7   182.8   0.249285   0.0000  -0.0017  -0.0209  9.422429E+03
+	 1  A   6.783   54711.7   182.8   0.249285   0.0000  -0.0017  -0.0209  9.422435E+03
 	 2  A   9.145   73759.1   135.6   0.336071   0.0103   0.0413   0.0628  3.735047E+07
-	 1  B   6.897   55627.9   179.8   0.253460   0.0024  -0.0058  -0.0286  4.888278E+06
+	 1  B   6.897   55628.0   179.8   0.253460   0.0024  -0.0058  -0.0286  4.888278E+06
 	 2  B   8.980   72427.1   138.1   0.330002   0.0101   0.0758   0.1532  3.546003E+07
 
 Doing transition
@@ -1565,8 +1324,8 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.02865102
 	Dipole Strength          0.00082836 
 	Oscillator Strength      0.00004793 
-	Einstein A Coefficient   1.15980920e+04 
-	Einstein B Coefficient   1.00783080e+17 
+	Einstein A Coefficient   1.15980926e+04 
+	Einstein B Coefficient   1.00783061e+17 
 
 	Length-Gauge Rotational Strength for 1  A to 2  A Transition
 	                              X    	       Y    	       Z
@@ -1576,7 +1335,7 @@ Doing transition
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.02865102
 
 	Rotational Strength (au)                 -0.00033794
-	Rotational Strength (10^-40 esu^2 cm^2)  -0.15932179
+	Rotational Strength (10^-40 esu^2 cm^2)  -0.15932180
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
@@ -1586,7 +1345,7 @@ Doing transition
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.00600580
 
 	Rotational Strength (au)                 -0.00092134
-	Rotational Strength (10^-40 esu^2 cm^2)  -0.43435973
+	Rotational Strength (10^-40 esu^2 cm^2)  -0.43435975
 
 	*** Computing <1 A|X{pq}}|1 B> (LEFT) Transition Density ***
 
@@ -1604,32 +1363,32 @@ Doing transition
 
 	Oscillator Strength for 1  A to 1  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.41794240 	  0.82952628 	  0.00000000
-	<n|mu_e|0>              -0.42243291 	  0.84107572 	  0.00000000
-	Dipole Strength          0.87424704 
+	<0|mu_e|n>               0.41794241 	 -0.82952629 	  0.00000000
+	<n|mu_e|0>               0.42243293 	 -0.84107574 	  0.00000000
+	Dipole Strength          0.87424708 
 	Oscillator Strength      0.00243311 
-	Einstein A Coefficient   1.36241776e+03 
-	Einstein B Coefficient   1.06366531e+20 
+	Einstein A Coefficient   1.36242032e+03 
+	Einstein B Coefficient   1.06366519e+20 
 
 	Length-Gauge Rotational Strength for 1  A to 1  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.41794240 	  0.82952628 	  0.00000000
-	<q|mu_m|p>              -0.06012807 	 -0.03792748 	  0.00000000
-	<p|mu_m|q>*             -0.06049596 	 -0.03759064 	  0.00000000
-	<q|mu_e|p>*             -0.42243291 	  0.84107572 	  0.00000000
+	<p|mu_e|q>               0.41794241 	 -0.82952629 	  0.00000000
+	<q|mu_m|p>               0.06012807 	  0.03792748 	  0.00000000
+	<p|mu_m|q>*              0.06049596 	  0.03759064 	  0.00000000
+	<q|mu_e|p>*              0.42243293 	 -0.84107574 	  0.00000000
 
 	Rotational Strength (au)                 -0.00619643
-	Rotational Strength (10^-40 esu^2 cm^2)  -2.92126780
+	Rotational Strength (10^-40 esu^2 cm^2)  -2.92126772
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.01060144 	 -0.04430474 	  0.00000000
-	<q|mu_m|p>              -0.06012807 	 -0.03792748 	  0.00000000
-	<p|mu_m|q>*             -0.06049596 	 -0.03759064 	  0.00000000
-	<q|mu_e|p>*             -0.01124558 	 -0.04351728 	  0.00000000
+	<p|mu_e|q>               0.01060144 	  0.04430474 	  0.00000000
+	<q|mu_m|p>               0.06012807 	  0.03792748 	  0.00000000
+	<p|mu_m|q>*              0.06049596 	  0.03759064 	  0.00000000
+	<q|mu_e|p>*              0.01124558 	  0.04351728 	  0.00000000
 
-	Rotational Strength (au)                  0.55501404
-	Rotational Strength (10^-40 esu^2 cm^2)  261.65778420
+	Rotational Strength (au)                  0.55501372
+	Rotational Strength (10^-40 esu^2 cm^2)  261.65763313
 
 	*** Computing <1 B|X{pq}}|2 A> (LEFT) Transition Density ***
 
@@ -1647,32 +1406,32 @@ Doing transition
 
 	Oscillator Strength for 1  B to 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.07809921 	 -0.57035851 	  0.00000000
-	<n|mu_e|0>               0.08136070 	 -0.57392609 	  0.00000000
-	Dipole Strength          0.33369783 
+	<0|mu_e|n>              -0.07809921 	  0.57035850 	  0.00000000
+	<n|mu_e|0>              -0.08136070 	  0.57392608 	  0.00000000
+	Dipole Strength          0.33369782 
 	Oscillator Strength      0.01837817 
-	Einstein A Coefficient   4.02989305e+06 
-	Einstein B Coefficient   4.05998296e+19 
+	Einstein A Coefficient   4.02989286e+06 
+	Einstein B Coefficient   4.05998219e+19 
 
 	Length-Gauge Rotational Strength for 1  B to 2  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.07809921 	 -0.57035851 	  0.00000000
-	<q|mu_m|p>               0.02628093 	 -0.36530383 	  0.00000000
-	<p|mu_m|q>*              0.03292278 	 -0.36649695 	  0.00000000
-	<q|mu_e|p>*              0.08136070 	 -0.57392609 	  0.00000000
+	<p|mu_e|q>              -0.07809921 	  0.57035850 	  0.00000000
+	<q|mu_m|p>              -0.02628093 	  0.36530383 	  0.00000000
+	<p|mu_m|q>*             -0.03292278 	  0.36649695 	  0.00000000
+	<q|mu_e|p>*             -0.08136070 	  0.57392608 	  0.00000000
 
 	Rotational Strength (au)                  0.21171372
-	Rotational Strength (10^-40 esu^2 cm^2)  99.81106746
+	Rotational Strength (10^-40 esu^2 cm^2)  99.81106622
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.01575043 	 -0.05707094 	  0.00000000
-	<q|mu_m|p>               0.02628093 	 -0.36530383 	  0.00000000
-	<p|mu_m|q>*              0.03292278 	 -0.36649695 	  0.00000000
-	<q|mu_e|p>*              0.01881561 	 -0.05385495 	  0.00000000
+	<p|mu_e|q>              -0.01575043 	  0.05707094 	  0.00000000
+	<q|mu_m|p>              -0.02628093 	  0.36530383 	  0.00000000
+	<p|mu_m|q>*             -0.03292278 	  0.36649695 	  0.00000000
+	<q|mu_e|p>*             -0.01881561 	  0.05385495 	  0.00000000
 
 	Rotational Strength (au)                  0.25189797
-	Rotational Strength (10^-40 esu^2 cm^2)  118.75566987
+	Rotational Strength (10^-40 esu^2 cm^2)  118.75566882
 
 	*** Computing <1 A|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1690,32 +1449,32 @@ Doing transition
 
 	Oscillator Strength for 1  A to 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.30118907 	 -0.19608443 	  0.00000000
-	<n|mu_e|0>               0.30196658 	 -0.20101180 	  0.00000000
-	Dipole Strength          0.13036432 
-	Oscillator Strength      0.00701510 
-	Einstein A Coefficient   1.46850944e+06 
-	Einstein B Coefficient   1.58609632e+19 
+	<0|mu_e|n>              -0.30118906 	  0.19608440 	  0.00000000
+	<n|mu_e|0>              -0.30196656 	  0.20101178 	  0.00000000
+	Dipole Strength          0.13036430 
+	Oscillator Strength      0.00701509 
+	Einstein A Coefficient   1.46850925e+06 
+	Einstein B Coefficient   1.58609588e+19 
 
 	Length-Gauge Rotational Strength for 1  A to 2  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.30118907 	 -0.19608443 	  0.00000000
-	<q|mu_m|p>               0.00288867 	  0.34276532 	  0.00000000
-	<p|mu_m|q>*              0.00255011 	  0.34434395 	  0.00000000
-	<q|mu_e|p>*              0.30196658 	 -0.20101180 	  0.00000000
+	<p|mu_e|q>              -0.30118906 	  0.19608440 	  0.00000000
+	<q|mu_m|p>              -0.00288867 	 -0.34276532 	  0.00000000
+	<p|mu_m|q>*             -0.00255011 	 -0.34434395 	  0.00000000
+	<q|mu_e|p>*             -0.30196656 	  0.20101178 	  0.00000000
 
-	Rotational Strength (au)                 -0.06739403
-	Rotational Strength (10^-40 esu^2 cm^2)  -31.77247878
+	Rotational Strength (au)                 -0.06739402
+	Rotational Strength (10^-40 esu^2 cm^2)  -31.77247605
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00222421 	 -0.01226942 	  0.00000000
-	<q|mu_m|p>               0.00288867 	  0.34276532 	  0.00000000
-	<p|mu_m|q>*              0.00255011 	  0.34434395 	  0.00000000
-	<q|mu_e|p>*              0.00133679 	 -0.02764035 	  0.00000000
+	<p|mu_e|q>              -0.00222421 	  0.01226942 	  0.00000000
+	<q|mu_m|p>              -0.00288867 	 -0.34276532 	  0.00000000
+	<p|mu_m|q>*             -0.00255011 	 -0.34434395 	  0.00000000
+	<q|mu_e|p>*             -0.00133679 	  0.02764035 	  0.00000000
 
-	Rotational Strength (au)                 -0.08494773
-	Rotational Strength (10^-40 esu^2 cm^2)  -40.04805820
+	Rotational Strength (au)                 -0.08494772
+	Rotational Strength (10^-40 esu^2 cm^2)  -40.04805602
 
 	*** Computing <2 B|X{pq}}|2 A> (LEFT) Transition Density ***
 
@@ -1733,32 +1492,32 @@ Doing transition
 
 	Oscillator Strength for 2  B to 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.37889824 	 -0.79523559 	  0.00000000
-	<n|mu_e|0>               0.38276990 	 -0.80810758 	  0.00000000
-	Dipole Strength          0.78766675 
+	<0|mu_e|n>              -0.37889825 	  0.79523561 	  0.00000000
+	<n|mu_e|0>              -0.38276991 	  0.80810760 	  0.00000000
+	Dipole Strength          0.78766679 
 	Oscillator Strength      0.00318683 
-	Einstein A Coefficient   3.77124607e+03 
-	Einstein B Coefficient   9.58326140e+19 
+	Einstein A Coefficient   3.77125063e+03 
+	Einstein B Coefficient   9.58326048e+19 
 
 	Length-Gauge Rotational Strength for 2  B to 2  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.37889824 	 -0.79523559 	  0.00000000
-	<q|mu_m|p>               0.03642031 	  0.02940742 	  0.00000000
-	<p|mu_m|q>*              0.03785298 	  0.02952481 	  0.00000000
-	<q|mu_e|p>*              0.38276990 	 -0.80810758 	  0.00000000
+	<p|mu_e|q>              -0.37889825 	  0.79523561 	  0.00000000
+	<q|mu_m|p>              -0.03642031 	 -0.02940742 	  0.00000000
+	<p|mu_m|q>*             -0.03785299 	 -0.02952481 	  0.00000000
+	<q|mu_e|p>*             -0.38276991 	  0.80810760 	  0.00000000
 
 	Rotational Strength (au)                 -0.00947824
-	Rotational Strength (10^-40 esu^2 cm^2)  -4.46845307
+	Rotational Strength (10^-40 esu^2 cm^2)  -4.46845273
 
 	Velocity-Gauge Rotational Strength for 2  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00776061 	  0.03525611 	  0.00000000
-	<q|mu_m|p>               0.03642031 	  0.02940742 	  0.00000000
-	<p|mu_m|q>*              0.03785298 	  0.02952481 	  0.00000000
-	<q|mu_e|p>*              0.00863196 	  0.03123939 	  0.00000000
+	<p|mu_e|q>              -0.00776061 	 -0.03525611 	  0.00000000
+	<q|mu_m|p>              -0.03642031 	 -0.02940742 	  0.00000000
+	<p|mu_m|q>*             -0.03785299 	 -0.02952481 	  0.00000000
+	<q|mu_e|p>*             -0.00863196 	 -0.03123938 	  0.00000000
 
-	Rotational Strength (au)                  0.21161424
-	Rotational Strength (10^-40 esu^2 cm^2)  99.76416830
+	Rotational Strength (au)                  0.21161417
+	Rotational Strength (10^-40 esu^2 cm^2)  99.76413194
 
 	*** Computing <1 B|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1780,8 +1539,8 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.32578797
 	Dipole Strength          0.10732712 
 	Oscillator Strength      0.00547673 
-	Einstein A Coefficient   1.03095143e+06 
-	Einstein B Coefficient   1.30581093e+19 
+	Einstein A Coefficient   1.03095133e+06 
+	Einstein B Coefficient   1.30581073e+19 
 
 	Length-Gauge Rotational Strength for 1  B to 2  B Transition
 	                              X    	       Y    	       Z
@@ -1791,7 +1550,7 @@ Doing transition
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.32578797
 
 	Rotational Strength (au)                  0.00294209
-	Rotational Strength (10^-40 esu^2 cm^2)   1.38702786
+	Rotational Strength (10^-40 esu^2 cm^2)   1.38702780
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
@@ -1801,15 +1560,15 @@ Doing transition
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.01828047
 
 	Rotational Strength (au)                  0.00244451
-	Rotational Strength (10^-40 esu^2 cm^2)   1.15245053
+	Rotational Strength (10^-40 esu^2 cm^2)   1.15245049
 
 	                   Ground State -> Excited State Transitions
 
 	                   Excitation Energy          OS       RS        RS     Einstein A
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
-	 1  A   6.783   54711.7   182.8   0.249285   0.0000  -0.0017  -0.0209  9.422429E+03
+	 1  A   6.783   54711.7   182.8   0.249285   0.0000  -0.0017  -0.0209  9.422435E+03
 	 2  A   9.145   73759.1   135.6   0.336071   0.0103   0.0413   0.0628  3.735047E+07
-	 1  B   6.897   55627.9   179.8   0.253460   0.0024  -0.0058  -0.0286  4.888278E+06
+	 1  B   6.897   55628.0   179.8   0.253460   0.0024  -0.0058  -0.0286  4.888278E+06
 	 2  B   8.980   72427.1   138.1   0.330002   0.0101   0.0758   0.1532  3.546003E+07
 
 
@@ -1818,101 +1577,324 @@ Doing transition
 	                        Excitation Energy          OS       RS        RS     Einstein A
 	Transition   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
 	  1A->2A   2.362   19047.3   525.0   0.086786   0.0000  -0.0003  -0.0009  1.159809E+04
-	  1A->1B   0.114     916.2 10914.3   0.004175   0.0024  -0.0062   0.5550  1.362418E+03
+	  1A->1B   0.114     916.2 10914.3   0.004175   0.0024  -0.0062   0.5550  1.362420E+03
 	  1B->2A   2.248   18131.1   551.5   0.082611   0.0184   0.2117   0.2519  4.029893E+06
 	  1A->2B   2.196   17715.4   564.5   0.080717   0.0070  -0.0674  -0.0849  1.468509E+06
-	  2B->2A   0.165    1332.0  7507.7   0.006069   0.0032  -0.0095   0.2116  3.771246E+03
-	  1B->2B   2.083   16799.1   595.3   0.076543   0.0055   0.0029   0.0024  1.030951E+06
+	  2B->2A   0.165    1332.0  7507.7   0.006069   0.0032  -0.0095   0.2116  3.771251E+03
+	  1B->2B   2.083   16799.2   595.3   0.076543   0.0055   0.0029   0.0024  1.030951E+06
 
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
-Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.99 seconds =       0.03 minutes
-	system time =       0.89 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
-	CC QUADRUPOLE ZZ..................................................PASSED
-	CC QUADRUPOLE XZ..................................................PASSED
-	CC QUADRUPOLE XX..................................................PASSED
-	CC QUADRUPOLE XY..................................................PASSED
-	CC QUADRUPOLE YY..................................................PASSED
-	CC QUADRUPOLE YZ..................................................PASSED
-	CC DIPOLE Z.......................................................PASSED
-	CC DIPOLE X.......................................................PASSED
-	CC DIPOLE Y.......................................................PASSED
-	CC ROOT 2 QUADRUPOLE ZZ...........................................PASSED
-	CC ROOT 2 QUADRUPOLE YZ...........................................PASSED
-	CC ROOT 2 QUADRUPOLE XZ...........................................PASSED
-	CC ROOT 2 QUADRUPOLE XY...........................................PASSED
-	CC ROOT 2 QUADRUPOLE XX...........................................PASSED
-	CC ROOT 1 DIPOLE X................................................PASSED
-	CC ROOT 1 DIPOLE Y................................................PASSED
-	CC ROOT 1 DIPOLE Z................................................PASSED
-	CC ROOT 4 DIPOLE X................................................PASSED
-	CC ROOT 3 QUADRUPOLE XZ...........................................PASSED
-	CC ROOT 3 QUADRUPOLE XX...........................................PASSED
-	CC ROOT 3 QUADRUPOLE XY...........................................PASSED
-	CC ROOT 3 QUADRUPOLE YY...........................................PASSED
-	CC ROOT 4 QUADRUPOLE XX...........................................PASSED
-	CC ROOT 3 QUADRUPOLE YZ...........................................PASSED
-	CC ROOT 4 QUADRUPOLE YZ...........................................PASSED
-	CC ROOT 3 QUADRUPOLE ZZ...........................................PASSED
-	CC ROOT 2 DIPOLE Y................................................PASSED
-	CC ROOT 2 DIPOLE X................................................PASSED
-	CC ROOT 4 DIPOLE Y................................................PASSED
-	CC ROOT 2 DIPOLE Z................................................PASSED
-	CC ROOT 4 DIPOLE Z................................................PASSED
-	CC ROOT 4 QUADRUPOLE XY...........................................PASSED
-	CC ROOT 4 QUADRUPOLE ZZ...........................................PASSED
-	CC ROOT 1 QUADRUPOLE YZ...........................................PASSED
-	CC ROOT 4 QUADRUPOLE YY...........................................PASSED
-	CC ROOT 1 QUADRUPOLE ZZ...........................................PASSED
-	CC ROOT 1 QUADRUPOLE YY...........................................PASSED
-	CC ROOT 2 QUADRUPOLE YY...........................................PASSED
-	CC ROOT 3 DIPOLE Z................................................PASSED
-	CC ROOT 3 DIPOLE X................................................PASSED
-	CC ROOT 3 DIPOLE Y................................................PASSED
-	CC ROOT 1 QUADRUPOLE XX...........................................PASSED
-	CC ROOT 1 QUADRUPOLE XY...........................................PASSED
-	CC ROOT 1 QUADRUPOLE XZ...........................................PASSED
-	CC ROOT 4 QUADRUPOLE XZ...........................................PASSED
 
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties computed using the EOM-CC2 density matrix
 
-Properties computed using the CCDENSITY-SET-WFN-TEST CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.3278
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.1398     Total:     1.1398
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.8972     Total:     2.8972
 
-  Quadrupole Moment: (Debye Ang)
+  Quadrupole Moment: [D A]
     XX:   -11.6671     YY:   -11.0457     ZZ:    -9.3692
     XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
 
-  Traceless Quadrupole Moment: (Debye Ang)
+  Traceless Quadrupole Moment: [D A]
     XX:    -0.9731     YY:    -0.3517     ZZ:     1.3248
     XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
 
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE ZZ...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE XZ...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE XX...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE XY...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE YY...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC QUADRUPOLE YZ...........................PASSED
-	CCDENSITY-SET-WFN-TEST CC DIPOLE Z................................PASSED
-	CCDENSITY-SET-WFN-TEST CC DIPOLE X................................PASSED
-	CCDENSITY-SET-WFN-TEST CC DIPOLE Y................................PASSED
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.07569  4.07569  0.00000 -0.15138
+       2     O     4.07569  4.07569  0.00000 -0.15138
+       3     H     0.42431  0.42431  0.00000  0.15138
+       4     H     0.42431  0.42431  0.00000  0.15138
+
+   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    4  A    1.968
+  HONO-1 :    4  B    1.966
+  HONO-0 :    5  A    1.943
+  LUNO+0 :    5  B    0.050
+  LUNO+1 :    6  A    0.023
+  LUNO+2 :    6  B    0.022
+  LUNO+3 :    7  B    0.019
+
+
+Properties computed using the CC ROOT 1 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4677
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -2.0235
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.5558     Total:     0.5558
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.4128     Total:     1.4128
+
+  Quadrupole Moment: [D A]
+    XX:   -13.9067     YY:   -13.2865     ZZ:   -16.4603
+    XY:     0.2628     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     0.6444     YY:     1.2647     ZZ:    -1.9091
+    XY:     0.2628     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     3.86040  3.86040  0.00000  0.27919
+       2     O     3.86040  3.86040  0.00000  0.27919
+       3     H     0.63960  0.63960  0.00000 -0.27919
+       4     H     0.63960  0.63960  0.00000 -0.27919
+
+   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    4  A    1.975
+  HONO-1 :    4  B    1.959
+  HONO-0 :    5  A    1.035
+  LUNO+0 :    6  A    0.988
+  LUNO+1 :    5  B    0.024
+  LUNO+2 :    6  B    0.018
+  LUNO+3 :    7  A    0.006
+
+
+Properties computed using the CC ROOT 2 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4677
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7768
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.6908     Total:     0.6908
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.7559     Total:     1.7559
+
+  Quadrupole Moment: [D A]
+    XX:   -12.1976     YY:   -13.9980     ZZ:    -9.7604
+    XY:    -0.9808     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -0.2122     YY:    -2.0126     ZZ:     2.2249
+    XY:    -0.9808     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.03239  4.03239  0.00000 -0.06477
+       2     O     4.03239  4.03239  0.00000 -0.06477
+       3     H     0.46761  0.46761  0.00000  0.06477
+       4     H     0.46761  0.46761  0.00000  0.06477
+
+   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    4  A    1.979
+  HONO-1 :    5  A    1.967
+  HONO-0 :    4  B    1.028
+  LUNO+0 :    5  B    0.993
+  LUNO+1 :    6  B    0.017
+  LUNO+2 :    6  A    0.007
+  LUNO+3 :    7  B    0.005
+
+
+Properties computed using the CC ROOT 3 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4677
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.6875
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7802     Total:     0.7802
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.9830     Total:     1.9830
+
+  Quadrupole Moment: [D A]
+    XX:   -11.5842     YY:   -13.9751     ZZ:   -10.6229
+    XY:    -0.4562     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     0.4765     YY:    -1.9144     ZZ:     1.4378
+    XY:    -0.4562     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.01840  4.01840  0.00000 -0.03680
+       2     O     4.01840  4.01840  0.00000 -0.03680
+       3     H     0.48160  0.48160  0.00000  0.03680
+       4     H     0.48160  0.48160  0.00000  0.03680
+
+   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    4  A    1.981
+  HONO-1 :    4  B    1.969
+  HONO-0 :    5  A    1.025
+  LUNO+0 :    5  B    0.991
+  LUNO+1 :    6  B    0.016
+  LUNO+2 :    6  A    0.007
+  LUNO+3 :    7  B    0.005
+
+
+Properties computed using the CC ROOT 4 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4677
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.9944
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.5267     Total:     0.5267
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.3387     Total:     1.3387
+
+  Quadrupole Moment: [D A]
+    XX:   -14.2850     YY:   -13.5795     ZZ:   -15.3582
+    XY:    -0.0453     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     0.1226     YY:     0.8281     ZZ:    -0.9507
+    XY:    -0.0453     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     3.88224  3.88224  0.00000  0.23552
+       2     O     3.88224  3.88224  0.00000  0.23552
+       3     H     0.61776  0.61776  0.00000 -0.23552
+       4     H     0.61776  0.61776  0.00000 -0.23552
+
+   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    4  A    1.979
+  HONO-1 :    5  A    1.803
+  HONO-0 :    4  B    1.202
+  LUNO+0 :    6  A    0.816
+  LUNO+1 :    5  B    0.188
+  LUNO+2 :    6  B    0.017
+  LUNO+3 :    7  A    0.006
+
+    EOM-CC2 DIPOLE X......................................................................PASSED
+    EOM-CC2 DIPOLE Y......................................................................PASSED
+    EOM-CC2 DIPOLE Z......................................................................PASSED
+    EOM-CC2 QUADRUPOLE XX.................................................................PASSED
+    EOM-CC2 QUADRUPOLE XY.................................................................PASSED
+    EOM-CC2 QUADRUPOLE XZ.................................................................PASSED
+    EOM-CC2 QUADRUPOLE YY.................................................................PASSED
+    EOM-CC2 QUADRUPOLE YZ.................................................................PASSED
+    EOM-CC2 QUADRUPOLE ZZ.................................................................PASSED
+    EOM-CC2 DIPOLE........................................................................PASSED
+    EOM-CC2 QUADRUPOLE....................................................................PASSED
+    CC ROOT 1 DIPOLE X....................................................................PASSED
+    CC ROOT 1 DIPOLE Y....................................................................PASSED
+    CC ROOT 1 DIPOLE Z....................................................................PASSED
+    CC ROOT 1 QUADRUPOLE XX...............................................................PASSED
+    CC ROOT 1 QUADRUPOLE XY...............................................................PASSED
+    CC ROOT 1 QUADRUPOLE XZ...............................................................PASSED
+    CC ROOT 1 QUADRUPOLE YY...............................................................PASSED
+    CC ROOT 1 QUADRUPOLE YZ...............................................................PASSED
+    CC ROOT 1 QUADRUPOLE ZZ...............................................................PASSED
+    CC ROOT 2 DIPOLE X....................................................................PASSED
+    CC ROOT 2 DIPOLE Y....................................................................PASSED
+    CC ROOT 2 DIPOLE Z....................................................................PASSED
+    CC ROOT 2 QUADRUPOLE XX...............................................................PASSED
+    CC ROOT 2 QUADRUPOLE XY...............................................................PASSED
+    CC ROOT 2 QUADRUPOLE XZ...............................................................PASSED
+    CC ROOT 2 QUADRUPOLE YY...............................................................PASSED
+    CC ROOT 2 QUADRUPOLE YZ...............................................................PASSED
+    CC ROOT 2 QUADRUPOLE ZZ...............................................................PASSED
+    CC ROOT 3 DIPOLE X....................................................................PASSED
+    CC ROOT 3 DIPOLE Y....................................................................PASSED
+    CC ROOT 3 DIPOLE Z....................................................................PASSED
+    CC ROOT 3 QUADRUPOLE XX...............................................................PASSED
+    CC ROOT 3 QUADRUPOLE XY...............................................................PASSED
+    CC ROOT 3 QUADRUPOLE XZ...............................................................PASSED
+    CC ROOT 3 QUADRUPOLE YY...............................................................PASSED
+    CC ROOT 3 QUADRUPOLE YZ...............................................................PASSED
+    CC ROOT 3 QUADRUPOLE ZZ...............................................................PASSED
+    CC ROOT 4 DIPOLE X....................................................................PASSED
+    CC ROOT 4 DIPOLE Y....................................................................PASSED
+    CC ROOT 4 DIPOLE Z....................................................................PASSED
+    CC ROOT 4 QUADRUPOLE XX...............................................................PASSED
+    CC ROOT 4 QUADRUPOLE XY...............................................................PASSED
+    CC ROOT 4 QUADRUPOLE XZ...............................................................PASSED
+    CC ROOT 4 QUADRUPOLE YY...............................................................PASSED
+    CC ROOT 4 QUADRUPOLE YZ...............................................................PASSED
+    CC ROOT 4 QUADRUPOLE ZZ...............................................................PASSED
+    CC ROOT 1 DIPOLE......................................................................PASSED
+    CC ROOT 1 QUADRUPOLE..................................................................PASSED
+    CC ROOT 2 DIPOLE......................................................................PASSED
+    CC ROOT 2 QUADRUPOLE..................................................................PASSED
+    CC ROOT 3 DIPOLE......................................................................PASSED
+    CC ROOT 3 QUADRUPOLE..................................................................PASSED
+    CC ROOT 4 DIPOLE......................................................................PASSED
+    CC ROOT 4 QUADRUPOLE..................................................................PASSED
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the CCDENSITY-SET-WFN-TEST EOM-CC2 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4677
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.3278
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.1398     Total:     1.1398
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.8972     Total:     2.8972
+
+  Quadrupole Moment: [D A]
+    XX:   -11.6671     YY:   -11.0457     ZZ:    -9.3692
+    XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -0.9731     YY:    -0.3517     ZZ:     1.3248
+    XY:    -1.4071     XZ:     0.0000     YZ:     0.0000
+
+    CCDENSITY-SET-WFN-TEST EOM-CC2 DIPOLE X...............................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 DIPOLE Y...............................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 DIPOLE Z...............................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE XX..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE XY..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE XZ..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE YY..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE YZ..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE ZZ..........................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 DIPOLE.................................................PASSED
+    CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE.............................................PASSED
+
+    Psi4 stopped on: Sunday, 25 October 2020 05:13PM
+    Psi4 wall time for execution: 0:00:02.79
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc46/output.ref
+++ b/tests/cc46/output.ref
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Sunday, 25 October 2020 05:13PM
+    Psi4 started on: Tuesday, 27 October 2020 03:19PM
 
-    Process ID: 91691
+    Process ID: 60663
     Host:       Mash.local
     PSIDATADIR: /Users/mash/installed/psi4/share/psi4
     Memory:     500.0 MiB
@@ -145,14 +145,13 @@ with warnings.catch_warnings():
 
     # Checking that the wfn.Da/Db have been set by ccdensity
     oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="CCDENSITY-SET-WFN-TEST EOM-CC2")
-    print(psi4.variables())
     for tag,refval in gs_refs.items():
         oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
         compare_values(oeprop_val,refval,4,"CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
 --------------------------------------------------------------------------
 
 *** tstart() called on Mash.local
-*** at Sun Oct 25 17:13:23 2020
+*** at Tue Oct 27 15:19:57 2020
 
    => Loading Basis Set <=
 
@@ -342,14 +341,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on Mash.local at Sun Oct 25 17:13:24 2020
+*** tstop() called on Mash.local at Tue Oct 27 15:19:58 2020
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -376,7 +375,7 @@ Total time:
 
 
 *** tstart() called on Mash.local
-*** at Sun Oct 25 17:13:24 2020
+*** at Tue Oct 27 15:19:58 2020
 
 
 	Wfn Parameters:
@@ -455,14 +454,14 @@ Total time:
 	Two-electron energy          =     45.23861563750454
 	Reference energy             =   -150.77918387213020
 
-*** tstop() called on Mash.local at Sun Oct 25 17:13:24 2020
+*** tstop() called on Mash.local at Tue Oct 27 15:19:58 2020
 Module time:
 	user time   =       0.05 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
@@ -1894,7 +1893,7 @@ Properties computed using the CCDENSITY-SET-WFN-TEST EOM-CC2 density matrix
     CCDENSITY-SET-WFN-TEST EOM-CC2 DIPOLE.................................................PASSED
     CCDENSITY-SET-WFN-TEST EOM-CC2 QUADRUPOLE.............................................PASSED
 
-    Psi4 stopped on: Sunday, 25 October 2020 05:13PM
-    Psi4 wall time for execution: 0:00:02.79
+    Psi4 stopped on: Tuesday, 27 October 2020 03:20PM
+    Psi4 wall time for execution: 0:00:03.00
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/pytests/test_ccresponse.py
+++ b/tests/pytests/test_ccresponse.py
@@ -1,0 +1,115 @@
+import numpy as np
+import psi4
+
+def test_cc_polaroptrot():
+    # cc29 + polarizabilities + tensors
+    mol = psi4.geometry("""
+        O     -0.028962160801    -0.694396279686    -0.049338350190
+        O      0.028962160801     0.694396279686    -0.049338350190
+        H      0.350498145881    -0.910645626300     0.783035421467
+        H     -0.350498145881     0.910645626300     0.783035421467
+        symmetry c1
+        noreorient
+        """)
+    
+    psi4.set_options({"basis":"cc-pVDZ"})
+    omega = [589, 355, 'nm']
+    psi4.set_options({'gauge': 'both', 'omega': omega, 'freeze_core': True, 'r_convergence': 10})
+
+    e,wfn = psi4.properties('CCSD',properties=["polarizability","rotation"],return_wfn=True)
+
+    pol_589      =      8.92296  #TEST
+    pol_355      =      9.16134  #TEST
+    rotlen_589   =    -76.93388  #TEST
+    rotvel_589   =    850.24712  #TEST
+    rotmvg_589   =   -179.08820  #TEST
+    rotlen_355   =   -214.73273  #TEST
+    rotvel_355   =    384.88786  #TEST
+    rotmvg_355   =   -644.44746  #TEST
+
+    polt_589 = np.array([[ 5.44184081e+00, -8.30270852e-01,  9.39878004e-14],
+     [-8.30270852e-01,  1.27518991e+01, -6.94720506e-14],
+     [ 9.39878004e-14, -6.94720506e-14,  8.57516214e+00]])
+    polt_355 = np.array([[ 5.57913165e+00, -8.66951957e-01,  1.02575190e-13],
+     [-8.66951957e-01,  1.31256109e+01, -7.71806997e-14],
+     [ 1.02575190e-13, -7.71806997e-14,  8.77928702e+00]])
+    rottvel_0 = np.array([[ 3.63702792e-01, -3.62754886e-01, -3.37227243e-14],
+     [-1.16320923e-01,  1.20784891e-02,  1.76483272e-14],
+     [ 1.90062651e-14, -2.33369227e-15, -3.92022202e-01]])
+    rottlen_589 = np.array([[ 1.41679366e-01, -7.07140738e-02, -2.26060131e-14],
+     [-2.72710108e-01,  1.28928522e-03,  1.01578936e-14],
+     [ 3.74236371e-14,  3.88522300e-15, -1.27276912e-01]])
+    rottvel_589 = np.array([[ 3.75624000e-01, -3.74245928e-01, -3.61489832e-14],
+     [-1.39409385e-01,  1.26867931e-02,  1.94630079e-14],
+     [ 2.33993608e-14, -1.61361648e-15, -4.01726048e-01]])
+    rottmvg_589 = np.array([[ 1.19212077e-02, -1.14910412e-02, -2.42625886e-15],
+     [-2.30884623e-02,  6.08303937e-04,  1.81468070e-15],
+     [ 4.39309571e-15,  7.20075789e-16, -9.70384612e-03]])
+
+    assert psi4.compare_values(pol_589,   wfn.variable("CCSD DIPOLE POLARIZABILITY @ 589NM"),  3, "CCSD polarizability @ 589nm") #TEST
+    assert psi4.compare_values(pol_355,   wfn.variable("CCSD DIPOLE POLARIZABILITY @ 355NM"),  3, "CCSD polarizability @ 355nm") #TEST
+    assert psi4.compare_values(rotlen_589,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
+    assert psi4.compare_values(rotvel_589,   wfn.variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
+    assert psi4.compare_values(rotmvg_589,   wfn.variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
+    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
+    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+
+    assert psi4.compare_values(polt_589, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 589NM"),  3, "CCSD polarizability tensor @ 589nm") #TEST
+    assert psi4.compare_values(polt_355, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 355NM"),  3, "CCSD polarizability tensor @ 355nm") #TEST
+    assert psi4.compare_arrays(rottvel_0, wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 0NM"), 3, "CCSD optrot tensor @ 0NM in velocity guage") #TEST
+    assert psi4.compare_arrays(rottlen_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in length guage") #TEST 
+    assert psi4.compare_arrays(rottvel_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in velocity guage") #TEST
+    assert psi4.compare_arrays(rottmvg_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in modified velocity guage") #TEST 
+
+
+def test_cc_roa():
+    # three tensors for ROA (polar, optrot, and dip-quad)
+    mol = psi4.geometry("""
+        O     -0.028962160801    -0.694396279686    -0.049338350190
+        O      0.028962160801     0.694396279686    -0.049338350190
+        H      0.350498145881    -0.910645626300     0.783035421467
+        H     -0.350498145881     0.910645626300     0.783035421467
+        symmetry c1
+        noreorient
+        """)
+    
+    psi4.set_options({"basis":"cc-pVDZ"})
+    omega = [589, 'nm']
+    psi4.set_options({'gauge': 'both', 'omega': omega, 'freeze_core': True, 'r_convergence': 10})
+
+    e,wfn = psi4.properties('CCSD',properties=["roa_tensor"],return_wfn=True)
+
+    polt_589 = np.array([[ 5.44184081e+00, -8.30270852e-01,  9.39878004e-14],
+     [-8.30270852e-01,  1.27518991e+01, -6.94720506e-14],
+     [ 9.39878004e-14, -6.94720506e-14,  8.57516214e+00]])
+    rottvel_0 = np.array([[ 3.63702792e-01, -3.62754886e-01, -3.37227243e-14],
+     [-1.16320923e-01,  1.20784891e-02,  1.76483272e-14],
+     [ 1.90062651e-14, -2.33369227e-15, -3.92022202e-01]])
+    rottlen_589 = np.array([[ 1.41679366e-01, -7.07140738e-02, -2.26060131e-14],
+     [-2.72710108e-01,  1.28928522e-03,  1.01578936e-14],
+     [ 3.74236371e-14,  3.88522300e-15, -1.27276912e-01]])
+    rottvel_589 = np.array([[ 3.75624000e-01, -3.74245928e-01, -3.61489832e-14],
+     [-1.39409385e-01,  1.26867931e-02,  1.94630079e-14],
+     [ 2.33993608e-14, -1.61361648e-15, -4.01726048e-01]])
+    rottmvg_589 = np.array([[ 1.19212077e-02, -1.14910412e-02, -2.42625886e-15],
+     [-2.30884623e-02,  6.08303937e-04,  1.81468070e-15],
+     [ 4.39309571e-15,  7.20075789e-16, -9.70384612e-03]])
+    quad0 = np.array([[-2.52229282e-14, -4.33846468e-13,  3.90176525e+00],
+     [-4.33846468e-13, -6.81906994e-15, -5.83659009e+00],
+     [ 3.90176525e+00, -5.83659009e+00,  3.18177152e-14]])
+    quad1 = np.array([[ 1.20834634e-13,  6.99638702e-14, -2.37995874e+00],
+     [ 6.99638702e-14, -1.17603861e-13,  6.85651590e+00],
+     [-2.37995874e+00,  6.85651590e+00, -3.99609068e-15]])
+    quad2 = np.array([[-4.55024365e+00, -5.30335671e+00,  1.65990108e-13],
+     [-5.30335671e+00, -1.35415335e+00, -8.75522529e-13],
+     [ 1.65990108e-13, -8.75522529e-13,  5.90439700e+00]])
+
+    assert psi4.compare_values(polt_589, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 589NM"),  3, "CCSD polarizability tensor @ 589nm") #TEST
+    assert psi4.compare_arrays(rottvel_0, wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 0NM"), 3, "CCSD optrot tensor @ 0NM in velocity guage") #TEST
+    assert psi4.compare_arrays(rottlen_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in length guage") #TEST 
+    assert psi4.compare_arrays(rottvel_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in velocity guage") #TEST
+    assert psi4.compare_arrays(rottmvg_589, wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 589NM"), 3, "CCSD optrot tensor @ 589NM in modified velocity guage") #TEST 
+    assert psi4.compare_values(quad0, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ 589NM"),  3, "CCSD quadrupole tensor 0 @ 589nm") #TEST
+    assert psi4.compare_values(quad1, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ 589NM"),  3, "CCSD quadrupole tensor 1 @ 589nm") #TEST
+    assert psi4.compare_values(quad1, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ 589NM"),  3, "CCSD quadrupole tensor 1 @ 589nm") #TEST

--- a/tests/pytests/test_ccresponse.py
+++ b/tests/pytests/test_ccresponse.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 import psi4
 
-pytestmark = [pytest.mark.cc]
-
 def test_cc_polaroptrot():
     # cc29 + polarizabilities + tensors
     mol = psi4.geometry("""

--- a/tests/pytests/test_ccresponse.py
+++ b/tests/pytests/test_ccresponse.py
@@ -1,5 +1,8 @@
 import numpy as np
+import pytest
 import psi4
+
+pytestmark = [pytest.mark.cc]
 
 def test_cc_polaroptrot():
     # cc29 + polarizabilities + tensors

--- a/tests/pytests/test_ccresponse.py
+++ b/tests/pytests/test_ccresponse.py
@@ -12,6 +12,17 @@ def test_cc_polaroptrot():
         symmetry c1
         noreorient
         """)
+
+    mw = sum([mol.mass(i) for i in range(0,4)])
+    c = psi4.constants.c
+    h = psi4.constants.h
+    h2j = psi4.constants.hartree2J
+    Na = psi4.constants.na
+    me = psi4.constants.me
+    hbar = psi4.constants.hbar 
+    prefactor = -72E6 * hbar**2 * Na / c**2 / me**2 / mw / 3.0
+    au_589 = c * h * 1E9 / h2j / 589
+    au_355 = c * h * 1E9 / h2j / 355
     
     psi4.set_options({"basis":"cc-pVDZ"})
     omega = [589, 355, 'nm']
@@ -28,33 +39,42 @@ def test_cc_polaroptrot():
     rotvel_355   =    384.88786  #TEST
     rotmvg_355   =   -644.44746  #TEST
 
+    polr_589     =  np.trace(wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 589NM").to_array()) / 3.0                 #RESULT 
+    polr_355     =  np.trace(wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 355NM").to_array()) / 3.0                 #RESULT
+    rotlenr_589  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM").to_array()) * prefactor * au_589 #RESULT 
+    rotvelr_589  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 589NM").to_array()) * prefactor          #RESULT 
+    rotmvgr_589  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 589NM").to_array()) * prefactor          #RESULT 
+    rotlenr_355  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM").to_array()) * prefactor * au_355 #RESULT 
+    rotvelr_355  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 355NM").to_array()) * prefactor          #RESULT 
+    rotmvgr_355  =  np.trace(wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 355NM").to_array()) * prefactor          #RESULT 
+
     polt_589 = np.array([[ 5.44184081e+00, -8.30270852e-01,  9.39878004e-14],
      [-8.30270852e-01,  1.27518991e+01, -6.94720506e-14],
-     [ 9.39878004e-14, -6.94720506e-14,  8.57516214e+00]])
+     [ 9.39878004e-14, -6.94720506e-14,  8.57516214e+00]]) #TEST
     polt_355 = np.array([[ 5.57913165e+00, -8.66951957e-01,  1.02575190e-13],
      [-8.66951957e-01,  1.31256109e+01, -7.71806997e-14],
-     [ 1.02575190e-13, -7.71806997e-14,  8.77928702e+00]])
+     [ 1.02575190e-13, -7.71806997e-14,  8.77928702e+00]]) #TEST
     rottvel_0 = np.array([[ 3.63702792e-01, -3.62754886e-01, -3.37227243e-14],
      [-1.16320923e-01,  1.20784891e-02,  1.76483272e-14],
-     [ 1.90062651e-14, -2.33369227e-15, -3.92022202e-01]])
+     [ 1.90062651e-14, -2.33369227e-15, -3.92022202e-01]]) #TEST
     rottlen_589 = np.array([[ 1.41679366e-01, -7.07140738e-02, -2.26060131e-14],
      [-2.72710108e-01,  1.28928522e-03,  1.01578936e-14],
-     [ 3.74236371e-14,  3.88522300e-15, -1.27276912e-01]])
+     [ 3.74236371e-14,  3.88522300e-15, -1.27276912e-01]]) #TEST
     rottvel_589 = np.array([[ 3.75624000e-01, -3.74245928e-01, -3.61489832e-14],
      [-1.39409385e-01,  1.26867931e-02,  1.94630079e-14],
-     [ 2.33993608e-14, -1.61361648e-15, -4.01726048e-01]])
+     [ 2.33993608e-14, -1.61361648e-15, -4.01726048e-01]]) #TEST
     rottmvg_589 = np.array([[ 1.19212077e-02, -1.14910412e-02, -2.42625886e-15],
      [-2.30884623e-02,  6.08303937e-04,  1.81468070e-15],
-     [ 4.39309571e-15,  7.20075789e-16, -9.70384612e-03]])
+     [ 4.39309571e-15,  7.20075789e-16, -9.70384612e-03]]) #TEST
 
-    assert psi4.compare_values(pol_589,   wfn.variable("CCSD DIPOLE POLARIZABILITY @ 589NM"),  3, "CCSD polarizability @ 589nm") #TEST
-    assert psi4.compare_values(pol_355,   wfn.variable("CCSD DIPOLE POLARIZABILITY @ 355NM"),  3, "CCSD polarizability @ 355nm") #TEST
-    assert psi4.compare_values(rotlen_589,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
-    assert psi4.compare_values(rotvel_589,   wfn.variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
-    assert psi4.compare_values(rotmvg_589,   wfn.variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
-    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
-    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
-    assert psi4.compare_values(rotlen_355,   wfn.variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+    assert psi4.compare_values(pol_589, polr_589,  3, "CCSD polarizability @ 589nm") #TEST
+    assert psi4.compare_values(pol_355, polr_355,  3, "CCSD polarizability @ 355nm") #TEST
+    assert psi4.compare_values(rotlen_589, rotlenr_589,  3, "CCSD rotation @ 589nm in length gauge") #TEST
+    assert psi4.compare_values(rotvel_589, rotvelr_589,  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
+    assert psi4.compare_values(rotmvg_589, rotmvgr_589,  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
+    assert psi4.compare_values(rotlen_355, rotlenr_355,  3, "CCSD rotation @ 355nm in length gauge") #TEST
+    assert psi4.compare_values(rotvel_355, rotvelr_355,  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+    assert psi4.compare_values(rotmvg_355, rotmvgr_355,  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
 
     assert psi4.compare_values(polt_589, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 589NM"),  3, "CCSD polarizability tensor @ 589nm") #TEST
     assert psi4.compare_values(polt_355, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 355NM"),  3, "CCSD polarizability tensor @ 355nm") #TEST


### PR DESCRIPTION
## Description
Adds the tensors generated from the CC response code to the reference wave function, eventually to be included in the JSON output for a [QCEng](https://github.com/molssi/qcengine) run. Also patched CC-level dipoles and (static) quadrupoles in `proc.py` to be consistent with other naming conventions, allowing them to pass through `schema_wrapper.py`. This means that all (ground state, static) CC one-electron properties should follow the naming convention used on wfn. Old excited state (EOM) and dynamic property variables remain unchanged. 

Updates to the schema wrapper to allow the other tensors though are coming in a separate PR. 

## Todos
- [x] Electric dipole polarizability tensor
- [x] Optical rotation (electric-dipole/magnetic-dipole) tensor
- [x] Electric dipole-quadrupole polarizability tensor (stored as three 3x3 components) (calculated through `roa.cc`)
- [x] Patch CC dipole and (static) quadrupole QCVars
- [x] New pytest for all new QCVars
- [x] Update `cc46` to adhere to new ground state `psi4.core.variables()` names

## Questions
- [x] `tests/pytests/test_qcschema.py` doesn't include any properties (yet). Are the existing returns of dipoles / quadrupoles in `schema_wrapper` tested anywhere? @loriab 

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests) `ctest -L cc` comes clean.
- [x] New pytest `test_ccresponse.py` comes clean.

## Status
- [x] Ready for review
- [x] Ready for merge
