### PR TITLE
solved memory bug in libtrans when bucketSize exceeds an int

### DIFF
--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -106,6 +106,7 @@ PSI_API long int **init_long_int_matrix(int rows, int cols);
 PSI_API void free_long_int_matrix(long int **array);
 PSI_API void zero_long_int_matrix(long int **array, int rows, int cols);
 PSI_API void print_long_int_mat(long int **a, int m, int n, std::string out);
+PSI_API size_t *init_size_t_array(int size);
 
 /* Functions in block_matrix.c */
 PSI_API double **block_matrix(size_t n, size_t m, bool mlock = false);

--- a/psi4/src/psi4/libciomr/long_int_array.cc
+++ b/psi4/src/psi4/libciomr/long_int_array.cc
@@ -69,4 +69,28 @@ long int *init_long_int_array(int size) {
     memset(array, 0, sizeof(long int) * size);
     return (array);
 }
+
+/*!
+** init_size_t_array(): Allocates memory for one-D array of size_t of
+**  dimension
+** 'size' and returns pointer to 1st element.  Zeroes all elements.
+**
+** \param size = length of array to allocate
+**
+** Returns: pointer to new array
+**
+** Added by RAK, 2020
+** \ingroup CIOMR
+*/
+PSI_API size_t *init_size_t_array(int size) {
+    size_t *array;
+
+    if ((array = (size_t *)malloc(sizeof(size_t) * size)) == nullptr) {
+        outfile->Printf("init_size_t_array:  trouble allocating memory \n");
+        outfile->Printf("size = %d\n", size);
+        exit(PSI_RETURN_FAILURE);
+    }
+    memset(array, 0, sizeof(size_t) * size);
+    return (array);
+}
 }

--- a/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
@@ -40,6 +40,20 @@
 
 using namespace psi;
 
+
+size_t *init_size_t_array(int size) {
+    size_t *array;
+
+    if ((array = (size_t *)malloc(sizeof(size_t) * size)) == nullptr) {
+        outfile->Printf("init_size_t_array:  trouble allocating memory \n");
+        outfile->Printf("size = %d\n", size);
+        exit(PSI_RETURN_FAILURE);
+    }
+    memset(array, 0, sizeof(size_t) * size);
+    return (array);
+}
+
+
 /**
  * Presort the (restricted) MO TPDM into DPD buffers to prepare it
  * for the the transformation.
@@ -77,8 +91,11 @@ void IntegralTransform::presort_mo_tpdm_restricted() {
     bucketOffset[0] = init_int_array(nirreps_);
     int **bucketRowDim = (int **)malloc(sizeof(int *));
     bucketRowDim[0] = init_int_array(nirreps_);
-    int **bucketSize = (int **)malloc(sizeof(int *));
-    bucketSize[0] = init_int_array(nirreps_);
+    //int **bucketSize = (int **)malloc(sizeof(int *));
+    //bucketSize[0] = init_int_array(nirreps_);
+    size_t **bucketSize = (size_t **) malloc(sizeof(size_t *));
+    bucketSize[0] = init_size_t_array(nirreps_);
+
 
     /* Figure out how many passes we need and where each p,q goes */
     int nBuckets = 1;
@@ -115,13 +132,17 @@ void IntegralTransform::presort_mo_tpdm_restricted() {
                 bucketRowDim[nBuckets - 1] = init_int_array(nirreps_);
                 bucketRowDim[nBuckets - 1][h] = 1;
 
-                p = static_cast<int **>(realloc(static_cast<void *>(bucketSize), nBuckets * sizeof(int *)));
-                if (p == nullptr) {
+                //p = static_cast<int **>(realloc(static_cast<void *>(bucketSize), nBuckets * sizeof(int *)));
+                size_t **P = static_cast<size_t **>(realloc(static_cast<void *>(bucketSize),
+                                                    nBuckets * sizeof(size_t *)));
+
+                if (P == nullptr) {
                     throw PsiException("file_build: allocation error", __FILE__, __LINE__);
                 } else {
-                    bucketSize = p;
+                    bucketSize = P;
                 }
-                bucketSize[nBuckets - 1] = init_int_array(nirreps_);
+                //bucketSize[nBuckets - 1] = init_int_array(nirreps_);
+                bucketSize[nBuckets - 1] = init_size_t_array(nirreps_);
                 bucketSize[nBuckets - 1][h] = rowLength;
             }
             int p = I.params->roworb[h][row][0];

--- a/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
@@ -40,20 +40,6 @@
 
 using namespace psi;
 
-
-size_t *init_size_t_array(int size) {
-    size_t *array;
-
-    if ((array = (size_t *)malloc(sizeof(size_t) * size)) == nullptr) {
-        outfile->Printf("init_size_t_array:  trouble allocating memory \n");
-        outfile->Printf("size = %d\n", size);
-        exit(PSI_RETURN_FAILURE);
-    }
-    memset(array, 0, sizeof(size_t) * size);
-    return (array);
-}
-
-
 /**
  * Presort the (restricted) MO TPDM into DPD buffers to prepare it
  * for the the transformation.


### PR DESCRIPTION
## Description
Fix memory bug in libtrans for large cases.

## Todos
- [X] bucketSize was overflowing int storage causing psio write error

## Status
- [X] Ready to merge
