### PR TITLE
pybind11 v2.6, cbs dedup, enable_xhost

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -97,7 +97,7 @@ jobs:
         psi4/label/dev::snsmp2 \
         psi4/label/dev::fockci \
         psi4/label/dev::mp2d \
-        psi4/label/dev::pybind11-headers \
+        psi4/label/trial::pybind11-headers \
         blas=*=mkl \
         mkl-include \
         networkx \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,8 +131,13 @@ option_with_print(ENABLE_AUTO_BLAS "Enables CMake to auto-detect BLAS" ON)
 option_with_print(ENABLE_AUTO_LAPACK "Enables CMake to auto-detect LAPACK" ON)
 option_with_print(ENABLE_PLUGIN_TESTING "Test the plugin templates build and run" OFF)
 option_with_print(ENABLE_CYTHONIZE "Compile each python file rather than plaintext (requires cython) !experimental!" OFF)
+if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
                   "-xHost" "-march=native" "/arch:AVX2")
+else()
+option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
+                  "-march=native" "-xHost" "/arch:AVX2")
+endif()
 option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
                   "-ftest-coverage")
 option_with_flags(ENABLE_BOUNDS_CHECK "Enables bounds check in Fortran" OFF

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz
+        URL https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1522,7 +1522,7 @@ def cbs(func, label, **kwargs):
         dups = -1
         for indx_job, job in enumerate(JOBS):
             if (job['f_wfn'] == mc['f_wfn']) and (job['f_basis'] == mc['f_basis']) and \
-               (job['f_options'] == mc['f_options']) and (job['f_options'] != False):
+               (job['f_options'] == mc['f_options']):
                 dups += 1
                 if dups >= 1:
                     del JOBS[indx_job]

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1524,7 +1524,7 @@ def scf_helper(name, post_scf=True, **kwargs):
     # PE preparation
     if core.get_option('SCF', 'PE'):
         if not solvent._have_pe:
-            raise ValidationError("Could not find cppe module.")
+            raise ModuleNotFoundError('Python module cppe not found. Solve by installing it: `conda install -c psi4 pycppe`')
         use_c1 = True
         core.print_out("""  PE does not make use of molecular symmetry: """
                        """further calculations in C1 point group.\n""")

--- a/psi4/share/psi4/plugin/ambit/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/ambit/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/aointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/aointegrals/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/basic/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/basic/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/dfmp2/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/dfmp2/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/mointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/mointegrals/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/scf/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/scf/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/sointegrals/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/sointegrals/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 

--- a/psi4/share/psi4/plugin/wavefunction/CMakeLists.txt.template
+++ b/psi4/share/psi4/plugin/wavefunction/CMakeLists.txt.template
@@ -28,7 +28,7 @@
 # @END LICENSE
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(@plugin@ CXX)
 


### PR DESCRIPTION
## Description
misc

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] let plugins work with pybind11 v2.6.0
- [x] there was extra testing in the == of cbs() tasks when options was involved (e.g., delta(ae - fc)). but I don't understand it, and it was preventing deduplication. so fixed it
- [x] Susi noticed trouble with ENABLE_XHOST in that the two options directed at Intel and GCC are valid cross-options. this is a workaround

## Status
- [x] Ready for review
- [x] Ready for merge
