### PR TITLE
Better visible PSIO errors

### DIFF
--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -36,6 +36,8 @@
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/psi4-dec.h"
 
 namespace psi {
 
@@ -50,89 +52,85 @@ namespace psi {
  */
 void psio_error(size_t unit, size_t errval) {
     int i;
-
     fprintf(stderr, "PSIO_ERROR: unit = %zu, errval = %zu\n", unit, errval);
     /* Try to save the TOCs for all open units */
     /* psio_tocwrite() does not call psio_error() so this is OK */
     for (i = 0; i < PSIO_MAXUNIT; i++) psio_tocwrite(i);
-
+    auto msg = new char[800];
     switch (errval) {
         case PSIO_ERROR_INIT:
-            fprintf(stderr, "PSIO_ERROR: %d (I/O inititalization failed)\n", PSIO_ERROR_INIT);
+            sprintf(msg,"PSIO_ERROR: %d (I/O inititalization failed)\n", PSIO_ERROR_INIT);
             break;
         case PSIO_ERROR_DONE:
-            fprintf(stderr, "PSIO_ERROR: %d (I/O cleanup failed)\n", PSIO_ERROR_DONE);
+            sprintf(msg,"PSIO_ERROR: %d (I/O cleanup failed)\n", PSIO_ERROR_DONE);
             break;
         case PSIO_ERROR_MAXVOL:
-            fprintf(stderr, "PSIO_ERROR: %d (maximum number of volumes exceeded)\n", PSIO_ERROR_MAXVOL);
+            sprintf(msg,"PSIO_ERROR: %d (maximum number of volumes exceeded)\n", PSIO_ERROR_MAXVOL);
             break;
         case PSIO_ERROR_NOVOLPATH:
-            fprintf(stderr, "PSIO_ERROR: %d (no volume path given)\n", PSIO_ERROR_NOVOLPATH);
+            sprintf(msg,"PSIO_ERROR: %d (no volume path given)\n", PSIO_ERROR_NOVOLPATH);
             break;
         case PSIO_ERROR_IDENTVOLPATH:
-            fprintf(stderr, "PSIO_ERROR: %d (two identical volume paths)\n", PSIO_ERROR_IDENTVOLPATH);
+            sprintf(msg,"PSIO_ERROR: %d (two identical volume paths)\n", PSIO_ERROR_IDENTVOLPATH);
             break;
         case PSIO_ERROR_OPEN:
-            fprintf(stderr, "PSIO_ERROR: %d (open call failed)\n", PSIO_ERROR_OPEN);
-            fprintf(stderr, "PSIO_ERROR:\n");
-            fprintf(stderr, "PSIO_ERROR: Check the location of your scratch directory which can be\n");
-            fprintf(stderr, "PSIO_ERROR: specified via the $PSI_SCRATCH environment variable or in\n");
-            fprintf(stderr, "PSIO_ERROR: the $HOME/.psi4rc file.\n");
-            fprintf(stderr, "PSIO_ERROR:\n");
-            fprintf(stderr, "PSIO_ERROR: Please note that the scratch directory must exist and be\n");
-            fprintf(stderr, "PSIO_ERROR: writable by Psi4\n");
+            sprintf(msg,"PSIO_ERROR: %d (open call failed)\n\n"
+                        " Check the location of your scratch directory which can be\n"
+                        " specified via the $PSI_SCRATCH environment variable or in\n"
+                        " the $HOME/.psi4rc file.\n\n"
+                        " Please note that the scratch directory must exist and be\n"
+                        " writable by Psi4\n", PSIO_ERROR_OPEN);
             break;
         case PSIO_ERROR_REOPEN:
-            fprintf(stderr, "PSIO_ERROR: %d (file is already open)\n", PSIO_ERROR_REOPEN);
+            sprintf(msg,"PSIO_ERROR: %d (file is already open)\n", PSIO_ERROR_REOPEN);
             break;
         case PSIO_ERROR_CLOSE:
-            fprintf(stderr, "PSIO_ERROR: %d (file close failed)\n", PSIO_ERROR_CLOSE);
+            sprintf(msg,"PSIO_ERROR: %d (file close failed)\n", PSIO_ERROR_CLOSE);
             break;
         case PSIO_ERROR_RECLOSE:
-            fprintf(stderr, "PSIO_ERROR: %d (file is already closed)\n", PSIO_ERROR_RECLOSE);
+            sprintf(msg,"PSIO_ERROR: %d (file is already closed)\n", PSIO_ERROR_RECLOSE);
             break;
         case PSIO_ERROR_OSTAT:
-            fprintf(stderr, "PSIO_ERROR: %d (invalid status flag for file open)\n", PSIO_ERROR_OSTAT);
+            sprintf(msg,"PSIO_ERROR: %d (invalid status flag for file open)\n", PSIO_ERROR_OSTAT);
             break;
         case PSIO_ERROR_LSEEK:
-            fprintf(stderr, "PSIO_ERROR: %d (lseek failed)\n", PSIO_ERROR_LSEEK);
+            sprintf(msg,"PSIO_ERROR: %d (lseek failed)\n", PSIO_ERROR_LSEEK);
             break;
         case PSIO_ERROR_NOTOCENT:
-            fprintf(stderr, "PSIO_ERROR: %d (no such TOC entry)\n", PSIO_ERROR_NOTOCENT);
+            sprintf(msg,"PSIO_ERROR: %d (no such TOC entry)\n", PSIO_ERROR_NOTOCENT);
+            // sprintf(msg,"PSIO_ERROR: %d (no such TOC entry)\n", PSIO_ERROR_NOTOCENT);
             break;
         case PSIO_ERROR_TOCENTSZ:
-            fprintf(stderr, "PSIO_ERROR: %d (TOC entry size mismatch)\n", PSIO_ERROR_TOCENTSZ);
+            sprintf(msg,"PSIO_ERROR: %d (TOC entry size mismatch)\n", PSIO_ERROR_TOCENTSZ);
             break;
         case PSIO_ERROR_KEYLEN:
-            fprintf(stderr, "PSIO_ERROR: %d (TOC key too long)\n", PSIO_ERROR_KEYLEN);
+            sprintf(msg,"PSIO_ERROR: %d (TOC key too long)\n", PSIO_ERROR_KEYLEN);
             break;
         case PSIO_ERROR_BLKSIZ:
-            fprintf(stderr, "PSIO_ERROR: %d (Requested blocksize invalid)\n", PSIO_ERROR_BLKSIZ);
+            sprintf(msg,"PSIO_ERROR: %d (Requested blocksize invalid)\n", PSIO_ERROR_BLKSIZ);
             break;
         case PSIO_ERROR_BLKSTART:
-            fprintf(stderr, "PSIO_ERROR: %d (Incorrect block start address)\n", PSIO_ERROR_BLKSTART);
+            sprintf(msg,"PSIO_ERROR: %d (Incorrect block start address)\n", PSIO_ERROR_BLKSTART);
             break;
         case PSIO_ERROR_BLKEND:
-            fprintf(stderr, "PSIO_ERROR: %d (Incorrect block end address)\n", PSIO_ERROR_BLKEND);
+            sprintf(msg,"PSIO_ERROR: %d (Incorrect block end address)\n", PSIO_ERROR_BLKEND);
             break;
         case PSIO_ERROR_WRITE:
-            fprintf(stderr, "PSIO_ERROR: %d (error writing to file)\n", PSIO_ERROR_WRITE);
+            sprintf(msg,"PSIO_ERROR: %d (error writing to file)\n", PSIO_ERROR_WRITE);
             break;
         case PSIO_ERROR_MAXUNIT:
-            fprintf(stderr, "PSIO_ERROR: %d (Maximum unit number exceeded)\n", PSIO_ERROR_MAXUNIT);
-            fprintf(stderr, "Open failed because unit %zu exceeds ", unit);
-            fprintf(stderr, "PSIO_MAXUNIT = %d.\n", PSIO_MAXUNIT);
+            sprintf(msg,"PSIO_ERROR: %d (Maximum unit number exceeded)\n"
+                        " Open failed because unit %zu exceeds "
+                        " PSIO_MAXUNIT = %d.\n",PSIO_ERROR_MAXUNIT, unit, PSIO_MAXUNIT);
             break;
         case PSIO_ERROR_UNOPENED:
-            fprintf(stderr, "PSIO_ERROR: %d (File not opened)\n", PSIO_ERROR_UNOPENED);
-            fprintf(stderr, "You need to open file %zu before you attempt this operation,\n", unit);
-            fprintf(stderr, "If you're a user, contact developers immediately. This is a bug.\n");
-            fprintf(stderr, "If you're a developer, get yourself some coffee.\n");
+            sprintf(msg,"PSIO_ERROR: %d (File not opened)\n" 
+                        " You need to open file %zu before you attempt this operation,\n"
+                        " If you're a user, contact developers immediately. This is a bug.\n"
+                        " If you're a developer, get yourself some coffee.\n", PSIO_ERROR_UNOPENED,  unit);
             break;
     }
-    fflush(stderr);
-    throw PSIEXCEPTION("PSIO Error");
-    // exit(PSIO::_error_exit_code_);
+    throw PSIEXCEPTION(msg);
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -76,10 +76,10 @@ void psio_error(size_t unit, size_t errval) {
         case PSIO_ERROR_OPEN:
             sprintf(msg,"PSIO_ERROR: %d (open call failed)\n\n"
                         " Check the location of your scratch directory which can be\n"
-                        " specified via the $PSI_SCRATCH environment variable or in\n"
-                        " the $HOME/.psi4rc file.\n\n"
-                        " Please note that the scratch directory must exist and be\n"
-                        " writable by Psi4\n", PSIO_ERROR_OPEN);
+                        " specified via the $PSI_SCRATCH environment variable.\n"
+                        " A local (non-network) scratch disk is strongly preferred.\n\n"
+                        " Please note that the scratch directory must exist, be\n"
+                        " writable by Psi4, and have available space.\n", PSIO_ERROR_OPEN);
             break;
         case PSIO_ERROR_REOPEN:
             sprintf(msg,"PSIO_ERROR: %d (file is already open)\n", PSIO_ERROR_REOPEN);


### PR DESCRIPTION
## Description
Redirects the PSIO errors from `stderr` to exception message (stderr and normal output).
Essentially addressing #2019 and #1965.

Example print:

```
!----------------------------------------------------------------------------------!
!                                                                                  !
! Fatal Error: PSIO_ERROR: 5 (open call failed)                                    !
!  Check the location of your scratch directory which can be                       !
!  specified via the $PSI_SCRATCH environment variable or in                       !
!  the $HOME/.psi4rc file.                                                         !
!  Please note that the scratch directory must exist and be                        !
!  writable by Psi4                                                                !
! Error occurred in file: /Users/kruse/qc/psi4/psi4/src/psi4/libpsio/error.cc on   !
!     line: 133                                                                    !
! The most recent 2 function calls were:                                           !
!                                                                                  !
!----------------------------------------------------------------------------------!
```


## Feature
- [x] PSIO errors to stderr and normal output

## Checklist
- [x] limited manual testing by deleting files
- tests not applicable 

## Status
- [x] Ready for review
- [x] Ready for merge
