### PR TITLE
miscellaneous updates

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1733,10 +1733,12 @@ def cbs(func, label, **kwargs):
     if len(metadata) > 2:
         dc = 3
         for delta in metadata[2:]:
+            deltaE_total = GRAND_NEED[dc]['d_energy'] - GRAND_NEED[dc + 1]['d_energy']
             tables += """     %6s %20s %1s %-27s %2s %16.8f   %-s\n""" % (
                 GRAND_NEED[dc]['d_stage'], GRAND_NEED[dc]['d_wfn'] + ' - ' + GRAND_NEED[dc + 1]['d_wfn'], '/',
-                GRAND_NEED[dc]['d_basis'], '', GRAND_NEED[dc]['d_energy'] - GRAND_NEED[dc + 1]['d_energy'],
+                GRAND_NEED[dc]['d_basis'], '', deltaE_total,
                 GRAND_NEED[dc]['d_scheme'].__name__)
+            core.set_variable(f"{GRAND_NEED[dc]['d_stage'].upper()} TOTAL ENERGY", deltaE_total)
             dc += 2
 
     tables += """     %6s %20s %1s %-27s %2s %16.8f   %-s\n""" % ('total', 'CBS', '', '', '', finalenergy, '')

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1738,7 +1738,7 @@ def cbs(func, label, **kwargs):
                 GRAND_NEED[dc]['d_stage'], GRAND_NEED[dc]['d_wfn'] + ' - ' + GRAND_NEED[dc + 1]['d_wfn'], '/',
                 GRAND_NEED[dc]['d_basis'], '', deltaE_total,
                 GRAND_NEED[dc]['d_scheme'].__name__)
-            core.set_variable(f"{GRAND_NEED[dc]['d_stage'].upper()} TOTAL ENERGY", deltaE_total)
+            core.set_variable(f"CBS {GRAND_NEED[dc]['d_stage'].upper()} TOTAL ENERGY", deltaE_total)
             dc += 2
 
     tables += """     %6s %20s %1s %-27s %2s %16.8f   %-s\n""" % ('total', 'CBS', '', '', '', finalenergy, '')

--- a/psi4/src/psi4/cc/cctriples/ET_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_RHF.cc
@@ -98,8 +98,8 @@ double ET_RHF() {
         if (virtpi[h] > max_a) max_a = virtpi[h];
     long int thread_mem_estimate = 4 * max_a * max_a * max_a;
 
-    outfile->Printf("    Memory available in words        : %15ld\n", mem_avail);
-    outfile->Printf("    ~Words needed per explicit thread: %15ld\n", thread_mem_estimate);
+    outfile->Printf("    Memory available in words               : %15ld\n", mem_avail);
+    outfile->Printf("    Approx. words needed per explicit thread: %15ld\n", thread_mem_estimate);
 
     // subtract at least 1/2 for non-abc quantities (mainly 2 ijab's + other buffers)
     double tval = (double)mem_avail / (double)thread_mem_estimate;

--- a/tests/cbs-delta-energy/input.dat
+++ b/tests/cbs-delta-energy/input.dat
@@ -39,5 +39,7 @@ compare_values(ccsd_t_energy_delta, ccsd_t_energy, 6, 'CCSD(T) Energy Call vs De
 cbs1_energy = energy('MP2/cc-pV[DT]Z + D:CCSD(T)/cc-pVDZ')
 compare_values(-100.383956631, cbs1_energy, 6, 'MP2/cc-pV[DT]Z + D:CCSD(T)/cc-pVDZ Energy')  #TEST
 
+compare_values(-0.00689863, variable('CBS DELTA1 TOTAL ENERGY'), 6, 'CBS Delta Variable Check')  #TEST
+
 # Need higher angular momentum to do more
 


### PR DESCRIPTION
## Description
collection of small changes (see below)

You can calculate the contribution of any delta correction using the db function:
```
dcbs=[{"wfn": "hf", "basis": "cc-pvdz"}, {"wfn": "mp2", "basis": "cc-pVDZ"}, {"wfn": "ccsd(t)","wfn_lo":"ccsd", "basis": "minix"}]
db(cbs,'hbc6',cp='on',cbs_metadata=dcbs,subset='small',tabulate=['CBS DELTA1 TOTAL ENERGY'])
```

## Features
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x]  Delta correction `CBS {stage name} TOTAL ENERGY` variable from `cbs` function. E.g. `CBS DELTA1 TOTAL ENERGY`
- [x] removes a random `~`. Interferes with geometry optimizer print.

## Checklist
- [x] Tests added for any new features

## Status
- [x] Ready for review
- [x] Ready for merge
