### PR TITLE
add orbital occupations to qcschema wavefunction

### DIFF
--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -313,6 +313,16 @@ def _convert_wavefunction(wfn, context=None):
 
         return arr
 
+    # get occupations in orbital-energy ordering
+    def sort_occs(noccpi, epsilon):
+        occs = []
+        for irrep, nocc in enumerate(noccpi):
+            for i, e in enumerate(epsilon[irrep]):
+                occs.append((e, int(i < nocc)))
+
+        occs.sort(key = lambda x : x[0])
+        return np.array([occ[1] for occ in occs])
+
     # Map back out what we can
     ret = {
         "basis": basis,
@@ -341,8 +351,8 @@ def _convert_wavefunction(wfn, context=None):
         "scf_fock_b": re2d(wfn.Fa_subset("AO")),
         "scf_eigenvalues_a": re1d(wfn.epsilon_a_subset("AO", "ALL")),
         "scf_eigenvalues_b": re1d(wfn.epsilon_b_subset("AO", "ALL")),
-        # "scf_occupations_a": np.hstack(wfn.occupation_a().nph),
-        # "scf_occupations_b": np.hstack(wfn.occupation_b().nph),
+        "scf_occupations_a": re1d(sort_occs((wfn.doccpi() + wfn.soccpi()).to_tuple(), wfn.epsilon_a().nph)),
+        "scf_occupations_b": re1d(sort_occs(wfn.doccpi().to_tuple(), wfn.epsilon_b().nph)),
     }
 
     return ret

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -30,7 +30,7 @@ def result_data_fixture():
         "keywords": {
             "scf_type": "df",
             "mp2_type": "df",
-            "scf_properties": ["mayer_indices"]
+            "scf_properties": ["mayer_indices"],
         }
     }
 
@@ -140,3 +140,28 @@ def test_qcschema_wavefunction_scf_orbitals(result_data_fixture):
 
     expected_keys = {'basis', 'restricted', 'scf_orbitals_a', 'scf_eigenvalues_a', 'orbitals_a', 'eigenvalues_a'}
     assert wfn.dict().keys() == expected_keys
+
+def test_qcschema_wavefunction_scf_occupations_gs(result_data_fixture):
+    result_data_fixture["protocols"] = {"wavefunction": "all"}
+    result_data_fixture["keywords"]["docc"] = [3, 0, 1, 1] # ground state
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
+    wfn = ret.wavefunction
+
+    ref_occupations_a = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
+    ref_occupied_energies_a = np.array([-20.55785069,  -1.31618596,  -0.6770761,  -0.49037545,  -0.55872283])
+
+    assert compare_arrays(ref_occupations_a, wfn.scf_occupations_a, 6, "Orbital Occupations")
+    assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
+
+def test_qcschema_wavefunction_scf_occupations_es(result_data_fixture):
+    result_data_fixture["protocols"] = {"wavefunction": "all"}
+    result_data_fixture["keywords"]["docc"] = [2, 1, 1, 1] # excited state
+    ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
+    wfn = ret.wavefunction
+
+    ref_occupations_a = np.array([1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
+    ref_occupied_energies_a = np.array([-20.86710716,  -1.38875044,  -0.77442913,  -0.6598582,    1.10374473])
+
+    assert compare_arrays(ref_occupations_a, ret.wavefunction.scf_occupations_a, 6, "Orbital Occupations")
+    assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
+


### PR DESCRIPTION
## Description
SCF orbital occupations are a required field for the wavefunction qcschema. This PR makes sure Psi4 populates the field. Addresses #1987 

## Todos
- [x] Add orbital occupations

## Status
- [x] Ready for review
- [ ] Ready for merge
