### PR TITLE
PE-SCF nuclear gradients

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2402,6 +2402,14 @@ def run_scf_gradient(name, **kwargs):
         grad.add(ecpgradmat)
         grad.print_atom_vector()
         ref_wfn.set_print(old_print)
+    
+    if hasattr(ref_wfn, "pe_state"):
+        core.print_out("\n\n Adding PE gradient terms. \n")
+        Dt = ref_wfn.Da().clone()
+        Dt.add(ref_wfn.Db())
+        pe_grad = ref_wfn.pe_state.nuclear_gradient_scf(Dt)
+        grad.add(pe_grad)
+        grad.print_atom_vector()
 
     ref_wfn.set_gradient(grad)
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -996,6 +996,8 @@ void export_mints(py::module& m) {
              "Vector AO EFP multipole integrals", "origin"_a = std::vector<double>{0, 0, 0}, "deriv"_a = 0)
         .def("ao_multipole_potential", &MintsHelper::ao_multipole_potential, "Vector AO multipole potential integrals",
              "origin"_a = std::vector<double>{0, 0, 0}, "max_k"_a = 0, "deriv"_a = 0)
+        .def("ao_multipole_potential_gradient", &MintsHelper::ao_multipole_potential_gradient, "Nuclear gradient of multipole potentials",
+             "Dt"_a, "moments"_a, "origin"_a = std::vector<double>{0, 0, 0}, "max_k"_a = 0)
         .def("electric_field", &MintsHelper::electric_field, "Vector electric field integrals",
              "origin"_a = std::vector<double>{0, 0, 0}, "deriv"_a = 0)
         .def("induction_operator", &MintsHelper::induction_operator,
@@ -1521,6 +1523,8 @@ void export_mints(py::module& m) {
         .def("clear", &ExternalPotential::clear, "Reset the field to zero (eliminates all entries)")
         .def("computePotentialMatrix", &ExternalPotential::computePotentialMatrix,
              "Compute the external potential matrix in the given basis set", "basis"_a)
+        .def("computePotentialGradients", &ExternalPotential::computePotentialGradients,
+             "Compute the gradients due to the external potential", "basis"_a, "Dt"_a)
         .def("print_out", &ExternalPotential::py_print, "Print python print helper to the outfile");
 
     typedef std::shared_ptr<Localizer> (*localizer_with_type)(const std::string&, std::shared_ptr<BasisSet>,

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -291,6 +291,7 @@ class PSI_API MintsHelper {
     // AO EFP Multipole Potential Integrals
     std::vector<SharedMatrix> ao_multipole_potential(const std::vector<double>& origin = {0., 0., 0.}, int max_k = 0,
                                                      int deriv = 0);
+    SharedMatrix ao_multipole_potential_gradient(SharedMatrix Dt, const std::vector<double>& moments, const std::vector<double>& origin = {0., 0., 0.}, int max_k = 0);
     /// Electric Field Integrals
     std::vector<SharedMatrix> electric_field(const std::vector<double>& origin = {0., 0., 0.}, int deriv = 0);
     /// Induction Operator for dipole moments at given sites

--- a/psi4/src/psi4/libmints/multipolepotential.cc
+++ b/psi4/src/psi4/libmints/multipolepotential.cc
@@ -49,25 +49,34 @@ MultipolePotentialInt::MultipolePotentialInt(std::vector<SphericalTransform> &sp
                                              std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, int max_k,
                                              int deriv)
     : OneBodyAOInt(spherical_transforms, bs1, bs2, deriv),
-      mvi_recur_(bs1->max_am(), bs2->max_am(), max_k),
       max_k_(max_k) {
+
+    if (deriv == 0) {
+        mvi_recur_ = new ObaraSaikaTwoCenterMultipolePotentialRecursion(bs1->max_am(), bs2->max_am(), max_k);
+    } else if (deriv == 1) {
+        mvi_recur_ = new ObaraSaikaTwoCenterMultipolePotentialRecursion(bs1->max_am() + 1, bs2->max_am() + 1, max_k);
+    } else {
+        throw FeatureNotImplemented("LibMints", "MultipolePotentialInts called with deriv > 1", __FILE__, __LINE__);
+     }
     int maxam1 = bs1_->max_am();
     int maxam2 = bs2_->max_am();
 
     int maxnao1 = INT_NCART(maxam1);
     int maxnao2 = INT_NCART(maxam2);
 
-    if (deriv > 3) {
-        throw FeatureNotImplemented("LibMints", "MultipolePotentialInts called with deriv > 0", __FILE__, __LINE__);
-    }
-
     if (max_k > 3) {
         throw FeatureNotImplemented("LibMints", "MultipolePotentialInts called with max_k > 3", __FILE__, __LINE__);
     }
 
     int nchunks = number_of_chunks(max_k_);
+    if (deriv == 1) {
+        set_chunks(3 * natom_ * nchunks);
+        maxnao1 *= 3 * natom_;
+    } else {
+        set_chunks(nchunks);
+    }
+
     buffer_ = new double[nchunks * maxnao1 * maxnao2];
-    set_chunks(nchunks);
 }
 
 MultipolePotentialInt::~MultipolePotentialInt() { delete[] buffer_; }
@@ -110,30 +119,30 @@ void MultipolePotentialInt::compute_pair(const GaussianShell &s1, const Gaussian
     bool have_octupole = have_moment(3, max_k_);
 
     // Charge
-    double ***q = mvi_recur_.q();
+    double ***q = mvi_recur_->q();
     // Dipole
-    double ***x = mvi_recur_.x();
-    double ***y = mvi_recur_.y();
-    double ***z = mvi_recur_.z();
+    double ***x = mvi_recur_->x();
+    double ***y = mvi_recur_->y();
+    double ***z = mvi_recur_->z();
     // Quadrupole
-    double ***xx = mvi_recur_.xx();
-    double ***yy = mvi_recur_.yy();
-    double ***zz = mvi_recur_.zz();
-    double ***xy = mvi_recur_.xy();
-    double ***xz = mvi_recur_.xz();
-    double ***yz = mvi_recur_.yz();
+    double ***xx = mvi_recur_->xx();
+    double ***yy = mvi_recur_->yy();
+    double ***zz = mvi_recur_->zz();
+    double ***xy = mvi_recur_->xy();
+    double ***xz = mvi_recur_->xz();
+    double ***yz = mvi_recur_->yz();
 
     // Octupole
-    double ***xxx = mvi_recur_.xxx();
-    double ***yyy = mvi_recur_.yyy();
-    double ***zzz = mvi_recur_.zzz();
-    double ***xxy = mvi_recur_.xxy();
-    double ***xxz = mvi_recur_.xxz();
-    double ***xyy = mvi_recur_.xyy();
-    double ***yyz = mvi_recur_.yyz();
-    double ***xzz = mvi_recur_.xzz();
-    double ***yzz = mvi_recur_.yzz();
-    double ***xyz = mvi_recur_.xyz();
+    double ***xxx = mvi_recur_->xxx();
+    double ***yyy = mvi_recur_->yyy();
+    double ***zzz = mvi_recur_->zzz();
+    double ***xxy = mvi_recur_->xxy();
+    double ***xxz = mvi_recur_->xxz();
+    double ***xyy = mvi_recur_->xyy();
+    double ***yyz = mvi_recur_->yyz();
+    double ***xzz = mvi_recur_->xzz();
+    double ***yzz = mvi_recur_->yzz();
+    double ***xyz = mvi_recur_->xyz();
 
     double Cx = origin_[0];
     double Cy = origin_[1];
@@ -169,7 +178,7 @@ void MultipolePotentialInt::compute_pair(const GaussianShell &s1, const Gaussian
             PC[2] = P[2] - Cz;
 
             // Get recursive
-            mvi_recur_.compute(PA, PB, PC, gamma, am1, am2);
+            mvi_recur_->compute(PA, PB, PC, gamma, am1, am2);
 
             // Gather contributions.
             ao12 = 0;
@@ -222,4 +231,247 @@ void MultipolePotentialInt::compute_pair(const GaussianShell &s1, const Gaussian
             }
         }
     }
+}
+
+void MultipolePotentialInt::compute_pair_deriv1(const GaussianShell &s1, const GaussianShell &s2) {
+    int ao12;
+    int am1 = s1.am();
+    int am2 = s2.am();
+    int nprim1 = s1.nprimitive();
+    int nprim2 = s2.nprimitive();
+    const int ncenteri = s1.ncenter();
+    const int ncenterj = s2.ncenter();
+    double A[3], B[3];
+    A[0] = s1.center()[0];
+    A[1] = s1.center()[1];
+    A[2] = s1.center()[2];
+    B[0] = s2.center()[0];
+    B[1] = s2.center()[1];
+    B[2] = s2.center()[2];
+
+    int izm1 = 1;
+    int iym1 = am1 + 1 + 1;
+    int ixm1 = iym1 * iym1;
+    int jzm1 = 1;
+    int jym1 = am2 + 1 + 1;
+    int jxm1 = jym1 * jym1;
+
+    // Not sure if these are needed.
+    const size_t size = s1.ncartesian() * s2.ncartesian();
+    const int center_i = ncenteri * 3 * size;
+    const int center_j = ncenterj * 3 * size;
+
+    // compute intermediates
+    double AB2 = 0.0;
+    AB2 += (A[0] - B[0]) * (A[0] - B[0]);
+    AB2 += (A[1] - B[1]) * (A[1] - B[1]);
+    AB2 += (A[2] - B[2]) * (A[2] - B[2]);
+
+    size_t n_elements = static_cast<size_t>(number_of_chunks(max_k_) * size);
+    memset(buffer_, 0, 3 * natom_ * n_elements * sizeof(double));
+
+    bool have_dipole = have_moment(1, max_k_);
+    bool have_quadrupole = have_moment(2, max_k_);
+    bool have_octupole = have_moment(3, max_k_);
+
+    // Charge
+    double ***q = mvi_recur_->q();
+    // Dipole
+    double ***x = mvi_recur_->x();
+    double ***y = mvi_recur_->y();
+    double ***z = mvi_recur_->z();
+    // Quadrupole
+    double ***xx = mvi_recur_->xx();
+    double ***yy = mvi_recur_->yy();
+    double ***zz = mvi_recur_->zz();
+    double ***xy = mvi_recur_->xy();
+    double ***xz = mvi_recur_->xz();
+    double ***yz = mvi_recur_->yz();
+
+    // Octupole
+    double ***xxx = mvi_recur_->xxx();
+    double ***yyy = mvi_recur_->yyy();
+    double ***zzz = mvi_recur_->zzz();
+    double ***xxy = mvi_recur_->xxy();
+    double ***xxz = mvi_recur_->xxz();
+    double ***xyy = mvi_recur_->xyy();
+    double ***yyz = mvi_recur_->yyz();
+    double ***xzz = mvi_recur_->xzz();
+    double ***yzz = mvi_recur_->yzz();
+    double ***xyz = mvi_recur_->xyz();
+
+    double Cx = origin_[0];
+    double Cy = origin_[1];
+    double Cz = origin_[2];
+
+    for (int p1 = 0; p1 < nprim1; ++p1) {
+        double a1 = s1.exp(p1);
+        double c1 = s1.coef(p1);
+        for (int p2 = 0; p2 < nprim2; ++p2) {
+            double a2 = s2.exp(p2);
+            double c2 = s2.coef(p2);
+            double gamma = a1 + a2;
+            double oog = 1.0 / gamma;
+
+            double PA[3], PB[3];
+            double P[3];
+
+            P[0] = (a1 * A[0] + a2 * B[0]) * oog;
+            P[1] = (a1 * A[1] + a2 * B[1]) * oog;
+            P[2] = (a1 * A[2] + a2 * B[2]) * oog;
+            PA[0] = P[0] - A[0];
+            PA[1] = P[1] - A[1];
+            PA[2] = P[2] - A[2];
+            PB[0] = P[0] - B[0];
+            PB[1] = P[1] - B[1];
+            PB[2] = P[2] - B[2];
+
+            double over_pf = exp(-a1 * a2 * AB2 * oog) * sqrt(M_PI * oog) * M_PI * oog * c1 * c2;
+            double PC[3];
+
+            PC[0] = P[0] - Cx;
+            PC[1] = P[1] - Cy;
+            PC[2] = P[2] - Cz;
+
+            // Get recursive
+            mvi_recur_->compute(PA, PB, PC, gamma, am1 + 1, am2 + 1);
+
+            // Gather contributions.
+            ao12 = 0;
+            for (int ii = 0; ii <= am1; ++ii) {
+                int l1 = am1 - ii;
+                for (int jj = 0; jj <= ii; ++jj) {
+                    int m1 = ii - jj;
+                    int n1 = jj;
+
+                    for (int kk = 0; kk <= am2; ++kk) {
+                        int l2 = am2 - kk;
+                        for (int ll = 0; ll <= kk; ++ll) {
+                            int m2 = kk - ll;
+                            int n2 = ll;
+
+                            // Compute location in the recursion
+                            int iind = l1 * ixm1 + m1 * iym1 + n1 * izm1;
+                            int jind = l2 * jxm1 + m2 * jym1 + n2 * jzm1;
+                            
+                            double Z = moments_[0];
+                            double pfac = over_pf * Z;
+
+                            // x
+                            double temp = 2.0 * a1 * q[iind + ixm1][jind][0];
+                            if (l1) temp -= l1 * q[iind - ixm1][jind][0];
+                            buffer_[center_i + (0 * size) + ao12] -= temp * pfac;
+
+                            temp = 2.0 * a2 * q[iind][jind + jxm1][0];
+                            if (l2) temp -= l2 * q[iind][jind - jxm1][0];
+                            buffer_[center_j + (0 * size) + ao12] -= temp * pfac;
+
+                            // y
+                            temp = 2.0 * a1 * q[iind + iym1][jind][0];
+                            if (m1) temp -= m1 * q[iind - iym1][jind][0];
+                            buffer_[center_i + (1 * size) + ao12] -= temp * pfac;
+
+                            temp = 2.0 * a2 * q[iind][jind + jym1][0];
+                            if (m2) temp -= m2 * q[iind][jind - jym1][0];
+                            buffer_[center_j + (1 * size) + ao12] -= temp * pfac;
+
+                            // z
+                            temp = 2.0 * a1 * q[iind + izm1][jind][0];
+                            if (n1) temp -= n1 * q[iind - izm1][jind][0];
+                            buffer_[center_i + (2 * size) + ao12] -= temp * pfac;
+
+                            temp = 2.0 * a2 * q[iind][jind + jzm1][0];
+                            if (n2) temp -= n2 * q[iind][jind - jzm1][0];
+                            buffer_[center_j + (2 * size) + ao12] -= temp * pfac;
+
+                            int off;
+                            if (have_dipole) {
+                                off = 1;
+                                const std::vector<double ***> dips{x, y, z};
+                                for (int cc = 0; cc < 3; ++cc) {
+                                    double*** dip = dips[cc];
+                                    // x
+                                    temp = 2.0 * a1 * dip[iind + ixm1][jind][0];
+                                    if (l1) temp -= l1 * dip[iind - ixm1][jind][0];
+                                    buffer_[center_i + (0 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * dip[iind][jind + jxm1][0];
+                                    if (l2) temp -= l2 * dip[iind][jind - jxm1][0];
+                                    buffer_[center_j + (0 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    // y
+                                    temp = 2.0 * a1 * dip[iind + iym1][jind][0];
+                                    if (m1) temp -= m1 * dip[iind - iym1][jind][0];
+                                    buffer_[center_i + (1 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * dip[iind][jind + jym1][0];
+                                    if (m2) temp -= m2 * dip[iind][jind - jym1][0];
+                                    buffer_[center_j + (1 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    // z
+                                    temp = 2.0 * a1 * dip[iind + izm1][jind][0];
+                                    if (n1) temp -= n1 * dip[iind - izm1][jind][0];
+                                    buffer_[center_i + (2 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * dip[iind][jind + jzm1][0];
+                                    if (n2) temp -= n2 * dip[iind][jind - jzm1][0];
+                                    buffer_[center_j + (2 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+                                }
+                            }
+                            // could also be done in one go (charges, dipoles, quadrupoles etc.)
+                            if (have_quadrupole) {
+                                off = 4;
+                                const std::vector<double ***> quads{xx, xy, xz, yy, yz, zz};
+                                for (int cc = 0; cc < 6; ++cc) {
+                                    double*** quad = quads[cc];
+                                    // x
+                                    temp = 2.0 * a1 * quad[iind + ixm1][jind][0];
+                                    if (l1) temp -= l1 * quad[iind - ixm1][jind][0];
+                                    buffer_[center_i + (0 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * quad[iind][jind + jxm1][0];
+                                    if (l2) temp -= l2 * quad[iind][jind - jxm1][0];
+                                    buffer_[center_j + (0 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    // y
+                                    temp = 2.0 * a1 * quad[iind + iym1][jind][0];
+                                    if (m1) temp -= m1 * quad[iind - iym1][jind][0];
+                                    buffer_[center_i + (1 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * quad[iind][jind + jym1][0];
+                                    if (m2) temp -= m2 * quad[iind][jind - jym1][0];
+                                    buffer_[center_j + (1 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    // z
+                                    temp = 2.0 * a1 * quad[iind + izm1][jind][0];
+                                    if (n1) temp -= n1 * quad[iind - izm1][jind][0];
+                                    buffer_[center_i + (2 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+
+                                    temp = 2.0 * a2 * quad[iind][jind + jzm1][0];
+                                    if (n2) temp -= n2 * quad[iind][jind - jzm1][0];
+                                    buffer_[center_j + (2 * size) + ao12] -= temp * over_pf * moments_[cc + off];
+                                }
+                            }
+                            ao12++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+void MultipolePotentialInt::compute_shell_deriv1(int sh1, int sh2) {
+    const GaussianShell &s1 = bs1_->shell(sh1);
+    const GaussianShell &s2 = bs2_->shell(sh2);
+
+    // Call the child's compute_pair method, results better be in buffer_.
+    compute_pair_deriv1(s1, s2);
+
+    // Normalize for angular momentum
+    normalize_am(s1, s2, nchunk_);
+
+    // Pure angular momentum (6d->5d, ...) transformation
+    if (!force_cartesian_) pure_transform(s1, s2, nchunk_);
 }

--- a/psi4/src/psi4/libmints/multipolepotential.h
+++ b/psi4/src/psi4/libmints/multipolepotential.h
@@ -51,13 +51,16 @@ class SphericalTransform;
  */
 class MultipolePotentialInt : public OneBodyAOInt {
     // OS Recursion for this type of potential integral
-    ObaraSaikaTwoCenterMultipolePotentialRecursion mvi_recur_;
+    ObaraSaikaTwoCenterMultipolePotentialRecursion* mvi_recur_;
 
     // maximum multipole order to compute
     int max_k_;
 
+    std::vector<double> moments_;
+
     //! Computes the electric field between two gaussian shells.
     void compute_pair(const GaussianShell&, const GaussianShell&) override;
+    void compute_pair_deriv1(const GaussianShell&, const GaussianShell&) override;
 
    public:
     //! Constructor. Do not call directly use an IntegralFactory.
@@ -65,6 +68,9 @@ class MultipolePotentialInt : public OneBodyAOInt {
                           int max_k = 0, int deriv = 0);
     //! Virtual destructor
     ~MultipolePotentialInt() override;
+    void compute_shell_deriv1(int sh1, int sh2) override;
+
+    void set_moments(const std::vector<double>& moments) { moments_ = moments; }
 };
 
 }  // namespace psi


### PR DESCRIPTION
## Description
This PR implements analytical nuclear gradients for Polarizable Embedding (PE).

I've been messing with some integral routines, so now `ao_multipole_potential` and `ao_multipole_potential_gradient`
exist. I think we can also reconcile this and make it consistent (pass all moments and coordinates) throughout...

I'm creating this PR as a preliminary draft for now so we can better coordinate.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] PE-SCF gradients
- [ ] some sort of dispersion/repulsion for optimizations (D3, LJ, ...)
- [ ] Release and bump `cppe`
- [ ] add tests once new `cppe` is out
- [ ] consistent top-level integral routines

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
