### PR TITLE
Build Treutler grid if asked to do so.

### DIFF
--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -4857,7 +4857,7 @@ std::shared_ptr<RadialGrid> RadialGrid::build(const std::string &scheme, int npo
     if (scheme == "BECKE") {
         return RadialGrid::build_becke(npoints, alpha, Z);
     } else if (scheme == "TREUTLER") {
-        return RadialGrid::build_becke(npoints, alpha, Z);
+        return RadialGrid::build_treutler(npoints, alpha, Z);
     } else {
         throw PSIEXCEPTION("RadialGrid::build: Unrecognized radial grid.");
     }


### PR DESCRIPTION
## Description
Fixes a bug where a Becke grid is used instead of Treutler in case a Treutler grid was requested.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
