### PR TITLE
Eliminate gradient globals from `dfocc`

### DIFF
--- a/psi4/src/psi4/dfocc/dfocc.h
+++ b/psi4/src/psi4/dfocc/dfocc.h
@@ -79,8 +79,8 @@ class DFOCC : public Wavefunction {
     void tpdm_tilde_cc();
     void back_trans_cc();
     void dfgrad();
-    void oei_grad();
-    void tei_grad(std::string aux_type);
+    void oei_grad(std::map<std::string, SharedMatrix>&);
+    void tei_grad(std::string aux_type, std::map<std::string, SharedMatrix>&);
     void gfock_oo();
     void gfock_vo();
     void gfock_ov();
@@ -594,10 +594,6 @@ class DFOCC : public Wavefunction {
     std::shared_ptr<DIISManager> ccsdDiisManagerBB;
     std::shared_ptr<DIISManager> ccsdDiisManagerAB;
     std::shared_ptr<DIISManager> ccsdlDiisManager;
-
-    // Gradients
-    std::map<std::string, SharedMatrix> gradients;
-    std::vector<std::string> gradient_terms;
 
     int natom;
     int nmo;      // Number of MOs

--- a/psi4/src/psi4/dfocc/oei_grad.cc
+++ b/psi4/src/psi4/dfocc/oei_grad.cc
@@ -28,14 +28,10 @@
 
 /** Standard library includes */
 #include <fstream>
-#include "psi4/psifiles.h"
-#include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/molecule.h"
-#include "psi4/libmints/basisset.h"
-#include "psi4/libmints/integral.h"
 #include "psi4/libmints/mintshelper.h"
 #include "dfocc.h"
 
@@ -49,7 +45,7 @@ using namespace psi;
 namespace psi {
 namespace dfoccwave {
 
-void DFOCC::oei_grad() {
+void DFOCC::oei_grad(std::map<std::string, SharedMatrix>& gradients) {
     /********************************************************************************************/
     /************************** Gradient ********************************************************/
     /********************************************************************************************/
@@ -60,6 +56,7 @@ void DFOCC::oei_grad() {
     /************************** Nuclear Gradient ************************************************/
     /********************************************************************************************/
     // => Nuclear Gradient <= //
+    // TODO: Where should external potentials be added?
     gradients["Nuclear"] = SharedMatrix(molecule_->nuclear_repulsion_energy_deriv1(dipole_field_strength_).clone());
     gradients["Nuclear"]->set_name("Nuclear Gradient");
     gradients["Nuclear"]->print_atom_vector();
@@ -92,8 +89,6 @@ void DFOCC::oei_grad() {
     /****************************************************************************************/
     /****************************************************************************************/
     /****************************************************************************************/
-
-    // outfile->Printf("\toei_grad is done. \n");
 }
 }  // namespace dfoccwave
 }  // namespace psi

--- a/psi4/src/psi4/dfocc/tei_grad.cc
+++ b/psi4/src/psi4/dfocc/tei_grad.cc
@@ -28,8 +28,6 @@
 
 /** Standard library includes */
 #include <fstream>
-#include "psi4/psifiles.h"
-#include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/integral.h"
@@ -49,7 +47,7 @@ using namespace psi;
 namespace psi {
 namespace dfoccwave {
 
-void DFOCC::tei_grad(std::string aux_type) {
+void DFOCC::tei_grad(std::string aux_type, std::map<std::string, SharedMatrix>& gradients) {
     //===========================================================================================
     //============================== Two-electron Gradient ======================================
     //===========================================================================================


### PR DESCRIPTION
## Description
Part of the DF Gradient refactor. It's become clear that Rob's implementation of the DF-MP2 gradients can't be generalized without incurring a performance hit, so the scope of the project now is to generalize what `dfocc` does out of `dfocc` so other modules (like `dct`) can use it. The current step of that is to make the procedure independent of `dfocc` globals.

While I was at it, I got rid of unneeded headers and did some other minor code cleanup.

## Todos
- [x] Some `dfocc` cleanup

## Checklist
- [x] `ctest -L df$` and `test_standard_suite.py` pass

## Status
- [x] Ready for review
- [x] Ready for merge
