### PR TITLE
Optimize linalg::triplet matrix multiply

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -306,6 +306,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_fchk_writer.py
               ../tests/pytests/test_psi4_qcschema.py
               ../tests/pytests/test_addons_qcschema.py
+	      ../tests/pytests/test_triplet.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 install(DIRECTORY ../tests/pytests/test_fchk_writer
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -306,7 +306,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_fchk_writer.py
               ../tests/pytests/test_psi4_qcschema.py
               ../tests/pytests/test_addons_qcschema.py
-	      ../tests/pytests/test_triplet.py
+              ../tests/pytests/test_triplet.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 install(DIRECTORY ../tests/pytests/test_fchk_writer
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3404,26 +3404,43 @@ SharedMatrix doublet(const SharedMatrix &A, const SharedMatrix &B, bool transA, 
 SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedMatrix &C, bool transA, bool transB,
                      bool transC) {
 
-    int dim1 = transA ? A->ncol() : A->nrow();
-    int dim2 = transA ? A->nrow() : A->ncol();
-    int dim3 = transB ? B->ncol() : B->nrow();
-    int dim4 = transB ? B->nrow() : B->ncol();
-    int dim5 = transC ? C->ncol() : C->nrow();
-    int dim6 = transC ? C->nrow() : C->ncol();
+    int nirrep = A->nirrep();
+    
+    if (nirrep != B->nirrep() || nirrep != C->nirrep()) {
+        throw PsiException("Input Matrices A, B, and C do not have the same number of irreps.", __FILE__, __LINE__);
+    }
 
-    // Checks validity of Matrix Multiply, don't want calculation to suddenly fail halfway through
-    if (dim2 != dim3 || dim4 != dim5) {
-        throw PsiException("Input matrices are of invalid size", __FILE__, __LINE__);
+    // cost1 = cost of (AB)C
+    // cost2 = cost of A(BC)
+    int cost1 = 0;
+    int cost2 = 0;
+
+    for (int h = 0; h < nirrep; h++) {
+
+        int dim1 = transA ? A->colspi(h) : A->rowspi(h);
+        int dim2 = transA ? A->rowspi(h) : A->colspi(h);
+        int dim3 = transB ? B->colspi(h) : B->rowspi(h);
+        int dim4 = transB ? B->rowspi(h) : B->colspi(h);
+        int dim5 = transC ? C->colspi(h) : C->rowspi(h);
+        int dim6 = transC ? C->rowspi(h) : C->colspi(h);
+        // Checks validity of Matrix Multiply, don't want calculation to suddenly fail halfway through
+        if (dim2 != dim3 || dim4 != dim5) {
+            throw PsiException("Input matrices are of invalid size", __FILE__, __LINE__);
+        }
+
+        // Cost of (AB)C compared to A(BC) per irrep
+        // A = dim1 * dim2, B = dim3 * dim4, C = dim5 * dim6
+        // (AB)C cost = dim1 * (dim2 == dim3) * dim4 + dim1 * (dim4 == dim5) * dim6
+        // A(BC) cost = (dim3 == dim2) * (dim4 == dim5) * dim6 + dim1 * (dim2 == dim3) * dim6
+        cost1 += dim1 * dim4 * (dim2 + dim6);
+        cost2 += dim2 * dim6 * (dim1 + dim4);
+
     }
 
     SharedMatrix T;
     SharedMatrix S;
 
-    // Cost of (AB)C compared to A(BC)
-    // A = dim1 * dim2, B = dim3 * dim4, C = dim5 * dim6
-    // (AB)C cost = dim1 * (dim2 == dim3) * dim4 + dim1 * (dim4 == dim5) * dim6
-    // A(BC) cost = (dim3 == dim2) * (dim4 == dim5) * dim6 + dim1 * (dim2 == dim3) * dim6
-    if (dim1 * dim4 * (dim2 + dim6) <= dim2 * dim6 * (dim1 + dim4)) {
+    if (cost1 <= cost2) {
         T = doublet(A, B, transA, transB);
         S = doublet(T, C, false, transC);
     } else {

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3420,7 +3420,7 @@ SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedM
     int cost1 = 0;
     int cost2 = 0;
 
-    for (int h = 0; h < nirrep; h++) {
+    for (int h = 0; h < A->nirrep(); h++) {
 
         int dim1 = transA ? A->colspi(h) : A->rowspi(h);
         int dim2 = transA ? A->rowspi(h) : A->colspi(h);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3404,6 +3404,17 @@ SharedMatrix doublet(const SharedMatrix &A, const SharedMatrix &B, bool transA, 
 SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedMatrix &C, bool transA, bool transB,
                      bool transC) {
 
+    bool same_symmetry = (A->symmetry() == B->symmetry() && A->symmetry() == C->symmetry());
+
+    SharedMatrix T;
+    SharedMatrix S;
+
+    if (!same_symmetry) {
+	T = doublet(A, B, transA, transB);
+        S = doublet(T, C, false, transC);
+	return S;
+    }
+
     int nirrep = A->nirrep();
     
     if (nirrep != B->nirrep() || nirrep != C->nirrep()) {
@@ -3436,9 +3447,6 @@ SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedM
         cost2 += dim2 * dim6 * (dim1 + dim4);
 
     }
-
-    SharedMatrix T;
-    SharedMatrix S;
 
     if (cost1 <= cost2) {
         T = doublet(A, B, transA, transB);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3410,7 +3410,7 @@ SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedM
     SharedMatrix S;
 
     if (!same_symmetry) {
-	T = doublet(A, B, transA, transB);
+        T = doublet(A, B, transA, transB);
         S = doublet(T, C, false, transC);
         return S;
     }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3412,13 +3412,7 @@ SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedM
     if (!same_symmetry) {
 	T = doublet(A, B, transA, transB);
         S = doublet(T, C, false, transC);
-	return S;
-    }
-
-    int nirrep = A->nirrep();
-    
-    if (nirrep != B->nirrep() || nirrep != C->nirrep()) {
-        throw PsiException("Input Matrices A, B, and C do not have the same number of irreps.", __FILE__, __LINE__);
+        return S;
     }
 
     // cost1 = cost of (AB)C

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -3403,8 +3403,49 @@ SharedMatrix doublet(const SharedMatrix &A, const SharedMatrix &B, bool transA, 
 
 SharedMatrix triplet(const SharedMatrix &A, const SharedMatrix &B, const SharedMatrix &C, bool transA, bool transB,
                      bool transC) {
-    SharedMatrix T = doublet(A, B, transA, transB);
-    SharedMatrix S = doublet(T, C, false, transC);
+
+    int dim1 = A->nrow();
+    int dim2 = A->ncol();
+    int dim3 = B->nrow();
+    int dim4 = B->ncol();
+    int dim5 = C->nrow();
+    int dim6 = C->ncol();
+
+    int temp = 0;
+
+    if (transA) {
+        temp = dim1;
+        dim1 = dim2;
+        dim2 = temp;
+    }
+
+    if (transB) {
+        temp = dim3;
+        dim3 = dim4;
+        dim4 = temp;
+    }
+
+    if (transC) {
+        temp = dim5;
+        dim5 = dim6;
+        dim6 = temp;
+    }
+
+    if (dim2 != dim3 || dim4 != dim5) {
+        throw new PsiException("Input matrices are of invalid size", __FILE__, __LINE__);
+    }
+
+    SharedMatrix T;
+    SharedMatrix S;
+
+    if (dim1 * dim4 * (dim2 + dim6) <= dim2 * dim6 * (dim1 + dim4)) {
+        T = doublet(A, B, transA, transB);
+        S = doublet(T, C, false, transC);
+    } else {
+        T = doublet(B, C, transB, transC);
+        S = doublet(A, T, transA, false);
+    }
+
     return S;
 }
 

--- a/tests/pytests/test_triplet.py
+++ b/tests/pytests/test_triplet.py
@@ -6,9 +6,9 @@ import psi4
 
 @pytest.mark.quick
 def test_triplet_speedup():
-    a = np.random.rand(10000, 10);
-    b = np.random.rand(10, 10000);
-    c = np.random.rand(10000, 10);
+    a = np.random.rand(10000, 10)
+    b = np.random.rand(10, 10000)
+    c = np.random.rand(10000, 10)
 
     A = psi4.core.Matrix.from_array(a)
     B = psi4.core.Matrix.from_array(b)
@@ -28,9 +28,9 @@ def test_triplet_speedup():
 
 @pytest.mark.quick
 def test_triplet_normal_case():
-    a = np.random.rand(500, 500);
-    b = np.random.rand(500, 500);
-    c = np.random.rand(500, 500);
+    a = np.random.rand(500, 500)
+    b = np.random.rand(500, 500)
+    c = np.random.rand(500, 500)
 
     A = psi4.core.Matrix.from_array(a)
     B = psi4.core.Matrix.from_array(b)
@@ -42,3 +42,39 @@ def test_triplet_normal_case():
     S = psi4.core.doublet(S, C, False, False)
 
     assert psi4.compare_matrices(R, S, 8, "linalg::triplet avg_case test")
+
+@pytest.mark.quick
+def test_triplet_with_irreps():
+    A = psi4.core.Matrix.from_array([np.random.rand(10000, 5), np.random.rand(5, 10000), np.random.rand(10000, 5)])
+    B = psi4.core.Matrix.from_array([np.random.rand(5, 10000), np.random.rand(10000, 5), np.random.rand(5, 10000)]) 
+    C = psi4.core.Matrix.from_array([np.random.rand(10000, 5), np.random.rand(5, 10000), np.random.rand(10000, 5)])
+
+    start = time.time()
+    R = psi4.core.triplet(A, B, C, False, False, False)
+    time1 = time.time() - start
+
+    start = time.time()
+    S = psi4.core.doublet(A, B, False, False)
+    S = psi4.core.doublet(S, C, False, False)
+    time2 = time.time() - start
+
+    assert (time1 < time2)
+    assert psi4.compare_matrices(R, S, 8, "linalg::triplet irrep test")
+
+@pytest.mark.quick
+def test_triplet_with_transpose():
+    A = psi4.core.Matrix.from_array([np.random.rand(5, 10000), np.random.rand(10000, 5), np.random.rand(5, 10000)])
+    B = psi4.core.Matrix.from_array([np.random.rand(5, 10000), np.random.rand(10000, 5), np.random.rand(5, 10000)])
+    C = psi4.core.Matrix.from_array([np.random.rand(10000, 5), np.random.rand(5, 10000), np.random.rand(10000, 5)])
+
+    start = time.time()
+    R = psi4.core.triplet(A, B, C, True, False, False)
+    time1 = time.time() - start
+
+    start = time.time()
+    S = psi4.core.doublet(A, B, True, False)
+    S = psi4.core.doublet(S, C, False, False)
+    time2 = time.time() - start
+
+    assert (time1 < time2)
+    assert psi4.compare_matrices(R, S, 8, "linalg::triplet transpose test")

--- a/tests/pytests/test_triplet.py
+++ b/tests/pytests/test_triplet.py
@@ -6,9 +6,9 @@ import psi4
 
 @pytest.mark.quick
 def test_triplet_speedup():
-    a = np.random.rand(1000, 100);
-    b = np.random.rand(100, 1000);
-    c = np.random.rand(1000, 100);
+    a = np.random.rand(10000, 10);
+    b = np.random.rand(10, 10000);
+    c = np.random.rand(10000, 10);
 
     A = psi4.core.Matrix.from_array(a)
     B = psi4.core.Matrix.from_array(b)

--- a/tests/pytests/test_triplet.py
+++ b/tests/pytests/test_triplet.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+import time
+
+import psi4
+
+@pytest.mark.quick
+def test_triplet_speedup():
+    a = np.random.rand(1000, 100);
+    b = np.random.rand(100, 1000);
+    c = np.random.rand(1000, 100);
+
+    A = psi4.core.Matrix.from_array(a)
+    B = psi4.core.Matrix.from_array(b)
+    C = psi4.core.Matrix.from_array(c)
+
+    start = time.time()
+    R = psi4.core.triplet(A, B, C, False, False, False)
+    time1 = time.time() - start
+
+    start = time.time()
+    S = psi4.core.doublet(A, B, False, False)
+    S = psi4.core.doublet(S, C, False, False)
+    time2 = time.time() - start
+
+    assert (time1 < time2)
+    assert psi4.compare_matrices(R, S, 5, "linalg::triplet speedup test")
+
+@pytest.mark.quick
+def test_triplet_normal_case():
+    a = np.random.rand(500, 500);
+    b = np.random.rand(500, 500);
+    c = np.random.rand(500, 500);
+
+    A = psi4.core.Matrix.from_array(a)
+    B = psi4.core.Matrix.from_array(b)
+    C = psi4.core.Matrix.from_array(c)
+
+    R = psi4.core.triplet(A, B, C, False, False, False)
+
+    S = psi4.core.doublet(A, B, False, False)
+    S = psi4.core.doublet(S, C, False, False)
+
+    assert psi4.compare_matrices(R, S, 8, "linalg::triplet avg_case test")

--- a/tests/pytests/test_triplet.py
+++ b/tests/pytests/test_triplet.py
@@ -24,7 +24,7 @@ def test_triplet_speedup():
     time2 = time.time() - start
 
     assert (time1 < time2)
-    assert psi4.compare_matrices(R, S, 5, "linalg::triplet speedup test")
+    assert psi4.compare_matrices(R, S, 8, "linalg::triplet speedup test")
 
 @pytest.mark.quick
 def test_triplet_normal_case():


### PR DESCRIPTION
## Description
linalg::triplet currently does matrix multiplication in the same order (AB)C. Sometimes, A(BC) may be more efficient, per observation of @zachglick 

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] More efficient linalg::triplet call

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
