### PR TITLE
Mark Lagrangian and X as deprecated

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -752,7 +752,7 @@ def _multipole_plumper(compressed, order):
     -------
     complete : ndarray
         Multipole array, order-dimensional Cartesian array expanded to complete components.
-        
+
     """
     shape = tuple([3] * order)
     complete = np.zeros(shape)
@@ -987,6 +987,17 @@ def _core_wavefunction_set_frequencies(cls, val):
 core.Wavefunction.frequencies = _core_wavefunction_frequencies
 core.Wavefunction.legacy_frequencies = _core_wavefunction_legacy_frequencies
 core.Wavefunction.set_frequencies = _core_wavefunction_set_frequencies
+
+
+def _core_wavefunction_X(cls):
+    warnings.warn(
+        "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.4 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+    return cls.lagrangian()
+
+
+core.Wavefunction.X = _core_wavefunction_X
 
 ## Psi4 v1.3 Export Deprecations
 

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -997,16 +997,7 @@ def _core_wavefunction_X(cls):
     return cls.lagrangian()
 
 
-def _core_wavefunction_Lagrangian(cls):
-    warnings.warn(
-        "Using `psi4.core.Wavefunction.Lagrangian` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.5 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
-    return cls.lagrangian()
-
-
 core.Wavefunction.X = _core_wavefunction_X
-core.Wavefunction.Lagrangian = _core_wavefunction_Lagrangian
 
 ## Psi4 v1.3 Export Deprecations
 

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -991,13 +991,22 @@ core.Wavefunction.set_frequencies = _core_wavefunction_set_frequencies
 
 def _core_wavefunction_X(cls):
     warnings.warn(
-        "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.5 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+    return cls.lagrangian()
+
+
+def _core_wavefunction_Lagrangian(cls):
+    warnings.warn(
+        "Using `psi4.core.Wavefunction.Lagrangian` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.5 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.lagrangian()
 
 
 core.Wavefunction.X = _core_wavefunction_X
+core.Wavefunction.Lagrangian = _core_wavefunction_Lagrangian
 
 ## Psi4 v1.3 Export Deprecations
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -155,8 +155,8 @@ void export_wavefunction(py::module& m) {
         .def("epsilon_a_subset", &Wavefunction::epsilon_a_subset, "Returns the requested Alpha Eigenvalues subset.")
         .def("epsilon_b_subset", &Wavefunction::epsilon_b_subset, "Returns the requested Beta Eigenvalues subset.")
         .def("X", &Wavefunction::X, "Returns the Lagrangian Matrix.")
-        .def("lagrangian", &Wavefunction::lagrangian, "Returns the Lagrangian Matrix.")
-        .def("set_lagrangian", &Wavefunction::set_lagrangian, "Sets the orbital Lagrangian matrix.")
+        .def("lagrangian", &Wavefunction::Lagrangian, "Returns the Lagrangian Matrix.")
+        .def("set_lagrangian", &Wavefunction::set_Lagrangian, "Sets the orbital Lagrangian matrix.")
         .def("basis_projection", &Wavefunction::basis_projection,
              "Projects a orbital matrix from one basis to another.")
         .def("H", &Wavefunction::H, "Returns the 'Core' Matrix (Potential + Kinetic) Integrals.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -154,9 +154,8 @@ void export_wavefunction(py::module& m) {
         .def("epsilon_b", &Wavefunction::epsilon_b, "Returns the Beta Eigenvalues.")
         .def("epsilon_a_subset", &Wavefunction::epsilon_a_subset, "Returns the requested Alpha Eigenvalues subset.")
         .def("epsilon_b_subset", &Wavefunction::epsilon_b_subset, "Returns the requested Beta Eigenvalues subset.")
-        .def("X", &Wavefunction::X, "Returns the Lagrangian Matrix.")
-        .def("lagrangian", &Wavefunction::Lagrangian, "Returns the Lagrangian Matrix.")
-        .def("set_lagrangian", &Wavefunction::set_Lagrangian, "Sets the orbital Lagrangian matrix.")
+        .def("lagrangian", &Wavefunction::lagrangian, "Returns the Lagrangian Matrix.")
+        .def("set_lagrangian", &Wavefunction::set_lagrangian, "Sets the orbital Lagrangian matrix.")
         .def("basis_projection", &Wavefunction::basis_projection,
              "Projects a orbital matrix from one basis to another.")
         .def("H", &Wavefunction::H, "Returns the 'Core' Matrix (Potential + Kinetic) Integrals.")

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -494,7 +494,7 @@ SharedMatrix Deriv::compute(DerivCalcType deriv_calc_type) {
         tpdm_ref_contr_ = factory_->create_shared_matrix("Reference two-electron contribution to gradient", natom_, 3);
 
         // Here we need to extract the reference contributions
-        SharedMatrix X_ref = ref_wfn->lagrangian();
+        SharedMatrix X_ref = ref_wfn->Lagrangian();
         SharedMatrix Da_ref = ref_wfn->Da();
 
         for (size_t cd = 0; cd < cdsalcs_.ncd(); ++cd) {

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -437,7 +437,7 @@ SharedMatrix Deriv::compute(DerivCalcType deriv_calc_type) {
     // Try and grab the OPDM and lagrangian from the wavefunction
     SharedMatrix Da = wfn_->Da();
     SharedMatrix Db = wfn_->Db();
-    SharedMatrix X = wfn_->X();
+    SharedMatrix X = wfn_->lagrangian();
 
     // The current wavefunction's reference wavefunction, nullptr for SCF/DFT
     std::shared_ptr<Wavefunction> ref_wfn = wfn_->reference_wavefunction();
@@ -494,7 +494,7 @@ SharedMatrix Deriv::compute(DerivCalcType deriv_calc_type) {
         tpdm_ref_contr_ = factory_->create_shared_matrix("Reference two-electron contribution to gradient", natom_, 3);
 
         // Here we need to extract the reference contributions
-        SharedMatrix X_ref = ref_wfn->Lagrangian();
+        SharedMatrix X_ref = ref_wfn->lagrangian();
         SharedMatrix Da_ref = ref_wfn->Da();
 
         for (size_t cd = 0; cd < cdsalcs_.ncd(); ++cd) {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1235,7 +1235,7 @@ SharedMatrix Wavefunction::Fa() const { return Fa_; }
 
 SharedMatrix Wavefunction::Fb() const { return Fb_; }
 
-SharedMatrix Wavefunction::lagrangian() const { return Lagrangian_; }
+SharedMatrix Wavefunction::Lagrangian() const { return Lagrangian_; }
 
 SharedVector Wavefunction::epsilon_a() const { return epsilon_a_; }
 

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1235,8 +1235,6 @@ SharedMatrix Wavefunction::Fa() const { return Fa_; }
 
 SharedMatrix Wavefunction::Fb() const { return Fb_; }
 
-SharedMatrix Wavefunction::Lagrangian() const { return Lagrangian_; }
-
 SharedVector Wavefunction::epsilon_a() const { return epsilon_a_; }
 
 SharedVector Wavefunction::epsilon_b() const { return epsilon_b_; }
@@ -1245,7 +1243,9 @@ const SharedMatrix Wavefunction::Da() const { return Da_; }
 
 SharedMatrix Wavefunction::Db() const { return Db_; }
 
-SharedMatrix Wavefunction::X() const { return Lagrangian_; }
+SharedMatrix Wavefunction::lagrangian() const { return Lagrangian_; }
+
+void Wavefunction::set_lagrangian(SharedMatrix X) { Lagrangian_ = X; }
 
 void Wavefunction::set_energy(double ene) { set_scalar_variable("CURRENT ENERGY", ene); }
 

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -573,11 +573,11 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
                                   std::shared_ptr<BasisSet> new_basis);
 
     /// Returns the SO basis Lagrangian
-    SharedMatrix lagrangian() const;
+    SharedMatrix Lagrangian() const;
     /// Returns the Lagrangian in SO basis for the wavefunction
     SharedMatrix X() const;
     /// Set Lagrangian matrix in SO basis
-    void set_lagrangian(SharedMatrix X) { Lagrangian_ = X; }
+    void set_Lagrangian(SharedMatrix X) { Lagrangian_ = X; }
 
     /// Returns the gradient
     SharedMatrix gradient() const;

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -573,11 +573,14 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
                                   std::shared_ptr<BasisSet> new_basis);
 
     /// Returns the SO basis Lagrangian
-    SharedMatrix Lagrangian() const;
-    /// Returns the Lagrangian in SO basis for the wavefunction
-    SharedMatrix X() const;
+    SharedMatrix lagrangian() const;
     /// Set Lagrangian matrix in SO basis
-    void set_Lagrangian(SharedMatrix X) { Lagrangian_ = X; }
+    void set_lagrangian(SharedMatrix X);
+    /// Returns the SO basis Lagrangian
+    PSI_DEPRECATED(
+        "Using `Wavefunction.Lagrangian` instead of `Wavefunction.lagrangian` is deprecated,"
+        " and in 1.4 it will stop working")
+    SharedMatrix Lagrangian() const { return lagrangian(); }
 
     /// Returns the gradient
     SharedMatrix gradient() const;

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -579,8 +579,13 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Returns the SO basis Lagrangian
     PSI_DEPRECATED(
         "Using `Wavefunction.Lagrangian` instead of `Wavefunction.lagrangian` is deprecated,"
-        " and in 1.4 it will stop working")
+        " and in 1.5 it will stop working")
     SharedMatrix Lagrangian() const { return lagrangian(); }
+    /// Returns the SO basis Lagrangian (duplicated one)
+    PSI_DEPRECATED(
+        "Using `Wavefunction.X` instead of `Wavefunction.lagrangian` is deprecated,"
+        " and in 1.5 it will stop working")
+    SharedMatrix X() const { return lagrangian(); }
 
     /// Returns the gradient
     SharedMatrix gradient() const;


### PR DESCRIPTION
## Description
This PR follows the change of PR #2064.

To avoid compilation errors for any downstream packages, `Lagrangian()` and `X()` in the `Wavefunction` class have been marked deprecated instead of removing them.

Future code should use lowercase `lagrangian()` and `set_lagrangian()` to obtain and set the orbital Lagrangian matrix (both C++ and Python), respectively.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
