### PR TITLE
Remove more `dfocc` code duplication

### DIFF
--- a/psi4/src/psi4/dfocc/back_trans.cc
+++ b/psi4/src/psi4/dfocc/back_trans.cc
@@ -52,389 +52,7 @@ void DFOCC::back_trans() {
         GFao->back_transform(GF, CmoA);
 
         //=========================
-        // Seprable TPDM
-        //=========================
-        // OO Block Sep + OO block Ref
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->add(Gref);
-        Gref.reset();
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|On)", nQ_ref, noccA, nso_));
-        G->contract(false, true, nQ_ref * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("RefSep 3-Index TPDM (Q|nn)", nQ_ref, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 0.0);
-        G.reset();
-
-        // OV Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OV>", nQ_ref, noccA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|On)", nQ_ref, noccA, nso_));
-        G->contract(false, true, nQ_ref * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 1.0);
-        G.reset();
-
-        // VV Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VV>", nQ_ref, nvirA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|Vn)", nQ_ref, nvirA, nso_));
-        G->contract(false, true, nQ_ref * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
-        G.reset();
-
-        // symmetrize : This is necessary since we only consider OV block
-        Gao->symmetrize3(Gao);
-        Gao->write(psio_, PSIF_DFOCC_DENS, true, true);
-
-        /*
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF B (Q|mn)", nQ_ref, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|mn)", nQ_ref, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-        G = SharedTensor2d(new Tensor2d("2-Index RefSep TPDM (P|Q)", nQ_ref, nQ_ref));
-        G->gemm(false, true, cQso, Gao, 0.5, 0.0);
-        //G->gemm(false, true, cQso, Gao, 0.25, 0.0);
-        //G->gemm(false, true, Gao, cQso, 0.25, 1.0);
-        cQso.reset();
-        Gao.reset();
-        //G->write(psio_, PSIF_DFOCC_DENS);
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-        */
-
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF B (Q|mn)", nQ_ref, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|mn)", nQ_ref, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-
-        // Packed c_mn^Q
-        cQso2 = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|m>=n)", nQ_ref, ntri_so));
-        cQso2->symm_packed(cQso);
-        cQso.reset();
-
-        // LTM of G_mn^Q
-        Gao2 = SharedTensor2d(new Tensor2d("RefSep 3-Index TPDM (Q|n>=n)", nQ_ref, ntri_so));
-        Gao2->ltm(Gao);
-        Gao.reset();
-
-        // G_PQ = 1/2 \sum_{mn} c_mn^P G_mn^Q = 1/2 \sum_{m>=n} c_mn^P G_mn^Q (2 - \delta_{mn})
-        G = SharedTensor2d(new Tensor2d("2-Index RefSep TPDM (P|Q)", nQ_ref, nQ_ref));
-        G->gemm(false, true, cQso2, Gao2, 0.5, 0.0);
-        Gao2.reset();
-        cQso2.reset();
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        //=========================
-        // Correlation TPDM
-        //=========================
-        // OV Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
-        G->contract(false, true, nQ * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 0.0);
-        G.reset();
-
-        // symmetrize : This is necessary since we only consider OV block
-        Gao->symmetrize3(Gao);
-        Gao->write(psio_, PSIF_DFOCC_DENS, true, true);
-
-        /*
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC B (Q|mn)", nQ, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|mn)", nQ, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-        G = SharedTensor2d(new Tensor2d("2-Index Correlation TPDM (P|Q)", nQ, nQ));
-        G->gemm(false, true, cQso, Gao, 0.5, 0.0);
-        cQso.reset();
-        Gao.reset();
-        //G->write(psio_, PSIF_DFOCC_DENS);
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-        */
-
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC B (Q|mn)", nQ, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|mn)", nQ, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-
-        // Packed c_mn^Q
-        cQso2 = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|m>=n)", nQ, ntri_so));
-        cQso2->symm_packed(cQso);
-        cQso.reset();
-
-        // LTM of G_mn^Q
-        Gao2 = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|n>=n)", nQ, ntri_so));
-        Gao2->ltm(Gao);
-        Gao.reset();
-
-        // G_PQ = 1/2 \sum_{mn} c_mn^P G_mn^Q = 1/2 \sum_{m>=n} c_mn^P G_mn^Q (2 - \delta_{mn})
-        G = SharedTensor2d(new Tensor2d("2-Index Correlation TPDM (P|Q)", nQ, nQ));
-        G->gemm(false, true, cQso2, Gao2, 0.5, 0.0);
-        Gao2.reset();
-        cQso2.reset();
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-    }  // end if (reference_ == "RESTRICTED")
-
-    else if (reference_ == "UNRESTRICTED") {
-        //=========================
-        // OPDM back trans
-        //=========================
-        G1ao->back_transform(G1A, CmoA);
-        G1ao->back_transform(G1B, CmoB, 1.0, 1.0);
-
-        //=========================
-        // GFM back trans
-        //=========================
-        GFao->back_transform(GFA, CmoA);
-        GFao->back_transform(GFB, CmoB, 1.0, 1.0);
-
-        //=========================
-        // Seprable TPDM
-        //=========================
-        // OO Block sep + OO Block ref
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->add(Gref);
-        Gref.reset();
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|On)", nQ_ref, noccA, nso_));
-        G->contract(false, true, nQ_ref * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("RefSep 3-Index TPDM (Q|nn)", nQ_ref, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 0.0);
-        G.reset();
-
-        // oo Block sep + oo block ref
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|oo>", nQ_ref, noccB, noccB));
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|oo>", nQ_ref, noccB, noccB));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        Gmo->add(Gref);
-        Gref.reset();
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|on)", nQ_ref, noccB, nso_));
-        G->contract(false, true, nQ_ref * noccB, nso_, noccB, Gmo, CoccB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccB, G, 1.0, 1.0);
-        G.reset();
-
-        // OV Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OV>", nQ_ref, noccA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|On)", nQ_ref, noccA, nso_));
-        G->contract(false, true, nQ_ref * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 1.0);
-        G.reset();
-
-        // ov Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|ov>", nQ_ref, noccB, nvirB));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|on)", nQ_ref, noccB, nso_));
-        G->contract(false, true, nQ_ref * noccB, nso_, nvirB, Gmo, CvirB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccB, G, 2.0, 1.0);
-        G.reset();
-
-        // VV Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VV>", nQ_ref, nvirA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|Vn)", nQ_ref, nvirA, nso_));
-        G->contract(false, true, nQ_ref * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
-        G.reset();
-
-        // vv Block
-        Gmo = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|vv>", nQ_ref, nvirB, nvirB));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|vn)", nQ_ref, nvirB, nso_));
-        G->contract(false, true, nQ_ref * nvirB, nso_, nvirB, Gmo, CvirB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirB, G, 1.0, 1.0);
-        G.reset();
-
-        // symmetrize : This is necessary since we only consider OV block
-        Gao->symmetrize3(Gao);
-        Gao->write(psio_, PSIF_DFOCC_DENS, true, true);
-
-        /*
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF B (Q|mn)", nQ_ref, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|mn)", nQ_ref, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-        G = SharedTensor2d(new Tensor2d("2-Index RefSep TPDM (P|Q)", nQ_ref, nQ_ref));
-        G->gemm(false, true, cQso, Gao, 0.5, 0.0);
-        cQso.reset();
-        Gao.reset();
-        //G->write(psio_, PSIF_DFOCC_DENS);
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-        */
-
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF B (Q|mn)", nQ_ref, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|mn)", nQ_ref, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-
-        // Packed c_mn^Q
-        cQso2 = SharedTensor2d(new Tensor2d("DF_BASIS_SCF C (Q|m>=n)", nQ_ref, ntri_so));
-        cQso2->symm_packed(cQso);
-        cQso.reset();
-
-        // LTM of G_mn^Q
-        Gao2 = SharedTensor2d(new Tensor2d("RefSep 3-Index TPDM (Q|n>=n)", nQ_ref, ntri_so));
-        Gao2->ltm(Gao);
-        Gao.reset();
-
-        // G_PQ = 1/2 \sum_{mn} c_mn^P G_mn^Q = 1/2 \sum_{m>=n} c_mn^P G_mn^Q (2 - \delta_{mn})
-        G = SharedTensor2d(new Tensor2d("2-Index RefSep TPDM (P|Q)", nQ_ref, nQ_ref));
-        G->gemm(false, true, cQso2, Gao2, 0.5, 0.0);
-        Gao2.reset();
-        cQso2.reset();
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        //=========================
-        // Correlation TPDM
-        //=========================
-        // OV Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
-        G->contract(false, true, nQ * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 0.0);
-        G.reset();
-
-        // ov Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|ov>", nQ, noccB, nvirB));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|on)", nQ, noccB, nso_));
-        G->contract(false, true, nQ * noccB, nso_, nvirB, Gmo, CvirB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccB, G, 2.0, 1.0);
-        G.reset();
-
-        // symmetrize : This is necessary since we only consider OV block
-        Gao->symmetrize3(Gao);
-        Gao->write(psio_, PSIF_DFOCC_DENS, true, true);
-
-        /*
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC B (Q|mn)", nQ, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|mn)", nQ, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-        G = SharedTensor2d(new Tensor2d("2-Index Correlation TPDM (P|Q)", nQ, nQ));
-        G->gemm(false, true, cQso, Gao, 0.5, 0.0);
-        cQso.reset();
-        Gao.reset();
-        //G->write(psio_, PSIF_DFOCC_DENS);
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-        */
-
-        // 2-Index TPDM
-        bQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC B (Q|mn)", nQ, nso_, nso_));
-        bQso->read(psio_, PSIF_DFOCC_INTS, true, true);
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-        cQso = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|mn)", nQ, nso_, nso_));
-        cQso->gemm(true, false, Jmhalf, bQso, 1.0, 0.0);
-        bQso.reset();
-        Jmhalf.reset();
-
-        // Packed c_mn^Q
-        cQso2 = SharedTensor2d(new Tensor2d("DF_BASIS_CC C (Q|m>=n)", nQ, ntri_so));
-        cQso2->symm_packed(cQso);
-        cQso.reset();
-
-        // LTM of G_mn^Q
-        Gao2 = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|n>=n)", nQ, ntri_so));
-        Gao2->ltm(Gao);
-        Gao.reset();
-
-        // G_PQ = 1/2 \sum_{mn} c_mn^P G_mn^Q = 1/2 \sum_{m>=n} c_mn^P G_mn^Q (2 - \delta_{mn})
-        G = SharedTensor2d(new Tensor2d("2-Index Correlation TPDM (P|Q)", nQ, nQ));
-        G->gemm(false, true, cQso2, Gao2, 0.5, 0.0);
-        Gao2.reset();
-        cQso2.reset();
-        G->write_symm(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-    }  // else if (reference_ == "UNRESTRICTED")
-    timer_off("back_trans");
-    // outfile->Printf("\tBacktransformation is done.\n");
-    //
-}  // end back_trans
-
-//======================================================================
-//    CCSD: Back Trans
-//======================================================================
-void DFOCC::back_trans_cc() {
-    outfile->Printf("\tBacktransforming OPDM, TPDM, and GFM to the AO basis...\n");
-
-    SharedTensor2d Gmo, Gao, Gao2, G, Gref, Gsep, Gcorr, cQso2;
-    timer_on("back_trans");
-    if (reference_ == "RESTRICTED") {
-        //=========================
-        // OPDM back trans
-        //=========================
-        G1ao->back_transform(G1, CmoA);
-
-        //=========================
-        // GFM back trans
-        //=========================
-        GFao->back_transform(GF, CmoA);
-
-        //=========================
-        // Seprable TPDM
+        // Separable TPDM
         //=========================
         // OO Block Sep + OO block Ref
         Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
@@ -503,33 +121,35 @@ void DFOCC::back_trans_cc() {
         //=========================
         // Correlation TPDM
         //=========================
-        // OO Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
-        G->contract(false, true, nQ * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 0.0);
-        G.reset();
-
         // OV Block
         Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
         Gmo->read(psio_, PSIF_DFOCC_DENS);
         G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
         G->contract(false, true, nQ * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
         Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 1.0);
+        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
+        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 0.0);
         G.reset();
 
-        // VV Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|Vn)", nQ, nvirA, nso_));
-        G->contract(false, true, nQ * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
-        G.reset();
+        if (wfn_type_ != "DF-OMP2") {
+            // OO Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
+            Gmo->read(psio_, PSIF_DFOCC_DENS);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
+            G->contract(false, true, nQ * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 1.0);
+            G.reset();
+
+            // VV Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
+            Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|Vn)", nQ, nvirA, nso_));
+            G->contract(false, true, nQ * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
+            G.reset();
+        }
 
         // symmetrize : This is necessary since we only consider OV block
         Gao->symmetrize3(Gao);
@@ -579,7 +199,7 @@ void DFOCC::back_trans_cc() {
         GFao->back_transform(GFB, CmoB, 1.0, 1.0);
 
         //=========================
-        // Seprable TPDM
+        // Separable TPDM
         //=========================
         // OO Block sep + OO Block ref
         Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
@@ -679,32 +299,14 @@ void DFOCC::back_trans_cc() {
         //=========================
         // Correlation TPDM
         //=========================
-        // OO Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
-        G->contract(false, true, nQ * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
-        Gmo.reset();
-        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 0.0);
-        G.reset();
-
-        // oo Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|oo>", nQ, noccB, noccB));
-        Gmo->read(psio_, PSIF_DFOCC_DENS);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|on)", nQ, noccB, nso_));
-        G->contract(false, true, nQ * noccB, nso_, noccB, Gmo, CoccB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccB, G, 1.0, 1.0);
-        G.reset();
-
         // OV Block
         Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
         Gmo->read(psio_, PSIF_DFOCC_DENS);
         G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
         G->contract(false, true, nQ * noccA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
         Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 1.0);
+        Gao = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|nn)", nQ, nso_, nso_));
+        Gao->contract233(false, false, nso_, nso_, CoccA, G, 2.0, 0.0);
         G.reset();
 
         // ov Block
@@ -716,23 +318,43 @@ void DFOCC::back_trans_cc() {
         Gao->contract233(false, false, nso_, nso_, CoccB, G, 2.0, 1.0);
         G.reset();
 
-        // VV Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|Vn)", nQ, nvirA, nso_));
-        G->contract(false, true, nQ * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
-        G.reset();
+        if (wfn_type_ != "DF-OMP2") {
+            // OO Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
+            Gmo->read(psio_, PSIF_DFOCC_DENS);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|On)", nQ, noccA, nso_));
+            G->contract(false, true, nQ * noccA, nso_, noccA, Gmo, CoccA, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CoccA, G, 1.0, 1.0);
+            G.reset();
 
-        // vv Block
-        Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|vv>", nQ, nvirB, nvirB));
-        Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|vn)", nQ, nvirB, nso_));
-        G->contract(false, true, nQ * nvirB, nso_, nvirB, Gmo, CvirB, 1.0, 0.0);
-        Gmo.reset();
-        Gao->contract233(false, false, nso_, nso_, CvirB, G, 1.0, 1.0);
-        G.reset();
+            // oo Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|oo>", nQ, noccB, noccB));
+            Gmo->read(psio_, PSIF_DFOCC_DENS);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|on)", nQ, noccB, nso_));
+            G->contract(false, true, nQ * noccB, nso_, noccB, Gmo, CoccB, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CoccB, G, 1.0, 1.0);
+            G.reset();
+
+            // VV Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
+            Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|Vn)", nQ, nvirA, nso_));
+            G->contract(false, true, nQ * nvirA, nso_, nvirA, Gmo, CvirA, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CvirA, G, 1.0, 1.0);
+            G.reset();
+
+            // vv Block
+            Gmo = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|vv>", nQ, nvirB, nvirB));
+            Gmo->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G = SharedTensor2d(new Tensor2d("3-Index Correlation TPDM (Q|vn)", nQ, nvirB, nso_));
+            G->contract(false, true, nQ * nvirB, nso_, nvirB, Gmo, CvirB, 1.0, 0.0);
+            Gmo.reset();
+            Gao->contract233(false, false, nso_, nso_, CvirB, G, 1.0, 1.0);
+            G.reset();
+        }
 
         // symmetrize : This is necessary since we only consider OV block
         Gao->symmetrize3(Gao);

--- a/psi4/src/psi4/dfocc/dfgrad.cc
+++ b/psi4/src/psi4/dfocc/dfgrad.cc
@@ -51,13 +51,8 @@ void DFOCC::dfgrad() {
     title_grad();
     outfile->Printf("\tAnalytic gradients computation is starting...\n");
 
-    if (wfn_type_ == "DF-OMP2") {
-        tpdm_tilde();
-        back_trans();
-    } else {
-        tpdm_tilde_cc();
-        back_trans_cc();
-    }
+    tpdm_tilde();
+    back_trans();
 
     //===========================================================================================
     //============================ Gradient =====================================================

--- a/psi4/src/psi4/dfocc/dfocc.h
+++ b/psi4/src/psi4/dfocc/dfocc.h
@@ -76,8 +76,6 @@ class DFOCC : public Wavefunction {
     // void combine_ref_sep_tpdm();
     void tpdm_tilde();
     void back_trans();
-    void tpdm_tilde_cc();
-    void back_trans_cc();
     void dfgrad();
     void oei_grad(std::map<std::string, SharedMatrix>&);
     void tei_grad(std::string aux_type, std::map<std::string, SharedMatrix>&);

--- a/psi4/src/psi4/dfocc/tpdm_tilde.cc
+++ b/psi4/src/psi4/dfocc/tpdm_tilde.cc
@@ -58,7 +58,7 @@ void DFOCC::tpdm_tilde() {
         G.reset();
 
         //=========================
-        // Seprable TPDM
+        // Separable TPDM
         //=========================
         // OO Block
         G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
@@ -118,6 +118,26 @@ void DFOCC::tpdm_tilde() {
         G2->write(psio_, PSIF_DFOCC_DENS);
         G2.reset();
 
+        if (wfn_type_ != "DF-OMP2") {
+            // OO Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS);
+            G.reset();
+
+            // VV Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS, true, true);
+            G.reset();
+        }
+
         // Free J-1/2
         Jmhalf.reset();
 
@@ -150,7 +170,7 @@ void DFOCC::tpdm_tilde() {
         G.reset();
 
         //=========================
-        // Seprable TPDM
+        // Separable TPDM
         //=========================
         // OO Block
         G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
@@ -258,291 +278,43 @@ void DFOCC::tpdm_tilde() {
         G2->write(psio_, PSIF_DFOCC_DENS);
         G2.reset();
 
-        // Free J-1/2
-        Jmhalf.reset();
+        if (wfn_type_ != "DF-OMP2") {
+            // OO Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS);
+            G.reset();
 
-    }  // else if (reference_ == "UNRESTRICTED")
-    timer_off("tpdm_tilde");
-}  // end tpdm_tilde
+            // VV Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS, true, true);
+            G.reset();
 
-//======================================================================
-//    CCSD: Gamma Tilde
-//======================================================================
-void DFOCC::tpdm_tilde_cc() {
-    outfile->Printf("\tForming Gamma^tilde...\n");
+            // oo Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|oo>", nQ, noccB, noccB));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS);
+            G.reset();
 
-    SharedTensor2d G, G2, Gref, Gsep, Gcorr;
-    timer_on("tpdm_tilde");
-    if (reference_ == "RESTRICTED") {
-        //=========================
-        // Reference TPDM
-        //=========================
-        // Read J-1/2
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-
-        G = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM (Q|OO)", nQ_ref, noccA, noccA));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gref, 1.0, 0.0);
-        Gref.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        //=========================
-        // Seprable TPDM
-        //=========================
-        // OO Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|OO)", nQ_ref, noccA, noccA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // OV Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OV>", nQ_ref, noccA, nvirA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|OV)", nQ_ref, noccA, nvirA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // VO Block
-        G2 = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VO>", nQ_ref, nvirA, noccA));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // VV Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VV>", nQ_ref, nvirA, nvirA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|VV)", nQ_ref, nvirA, nvirA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
-
-        // Free J-1/2
-        Jmhalf.reset();
-
-        //=========================
-        // Correlation TPDM
-        //=========================
-        // Read J-1/2
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-
-        // OO Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // OV Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // VO Block
-        G2 = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VO>", nQ, nvirA, noccA));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // VV Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
-
-        // Free J-1/2
-        Jmhalf.reset();
-
-    }  // end if (reference_ == "RESTRICTED")
-
-    else if (reference_ == "UNRESTRICTED") {
-        //=========================
-        // Reference TPDM
-        //=========================
-        // Read J-1/2
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_SCF Jmhalf <P|Q>", nQ_ref, nQ_ref));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-
-        // OO Block
-        G = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM (Q|OO)", nQ_ref, noccA, noccA));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gref, 1.0, 0.0);
-        Gref.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // oo Block
-        G = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM <Q|oo>", nQ_ref, noccB, noccB));
-        Gref = SharedTensor2d(new Tensor2d("Reference 3-Index TPDM (Q|oo)", nQ_ref, noccB, noccB));
-        Gref->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gref, 1.0, 0.0);
-        Gref.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        //=========================
-        // Seprable TPDM
-        //=========================
-        // OO Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OO>", nQ_ref, noccA, noccA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|OO)", nQ_ref, noccA, noccA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // oo Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|oo>", nQ_ref, noccB, noccB));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|oo)", nQ_ref, noccB, noccB));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // OV Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|OV>", nQ_ref, noccA, nvirA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|OV)", nQ_ref, noccA, nvirA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // VO Block
-        G2 = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VO>", nQ_ref, nvirA, noccA));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // ov Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|ov>", nQ_ref, noccB, nvirB));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|ov)", nQ_ref, noccB, nvirB));
-        Gsep->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // vo Block
-        G2 = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|vo>", nQ_ref, nvirB, noccB));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // VV Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|VV>", nQ_ref, nvirA, nvirA));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|VV)", nQ_ref, nvirA, nvirA));
-        Gsep->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
-
-        // vv Block
-        G = SharedTensor2d(new Tensor2d("3-Index Separable TPDM <Q|vv>", nQ_ref, nvirB, nvirB));
-        Gsep = SharedTensor2d(new Tensor2d("3-Index Separable TPDM (Q|vv)", nQ_ref, nvirB, nvirB));
-        Gsep->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gsep, 1.0, 0.0);
-        Gsep.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
-
-        // Free J-1/2
-        Jmhalf.reset();
-
-        //=========================
-        // Correlation TPDM
-        //=========================
-        // Read J-1/2
-        Jmhalf = SharedTensor2d(new Tensor2d("DF_BASIS_CC Jmhalf <P|Q>", nQ, nQ));
-        Jmhalf->read(psio_, PSIF_DFOCC_INTS);
-
-        // OO Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OO>", nQ, noccA, noccA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // OV Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|OV>", nQ, noccA, nvirA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // VO Block
-        G2 = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VO>", nQ, nvirA, noccA));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // VV Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|VV>", nQ, nvirA, nvirA));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
-
-        // oo Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|oo>", nQ, noccB, noccB));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        G.reset();
-
-        // ov Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|ov>", nQ, noccB, nvirB));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|ov)", nQ, noccB, nvirB));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-
-        // vo Block
-        G2 = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|vo>", nQ, nvirB, noccB));
-        G2->swap_3index_col(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        G2.reset();
-
-        // vv Block
-        G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|vv>", nQ, nvirB, nvirB));
-        Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB));
-        Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
-        G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
-        Gcorr.reset();
-        G->write(psio_, PSIF_DFOCC_DENS, true, true);
-        G.reset();
+            // vv Block
+            G = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM <Q|vv>", nQ, nvirB, nvirB));
+            Gcorr = SharedTensor2d(new Tensor2d("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB));
+            Gcorr->read(psio_, PSIF_DFOCC_DENS, true, true);
+            G->gemm(true, false, Jmhalf, Gcorr, 1.0, 0.0);
+            Gcorr.reset();
+            G->write(psio_, PSIF_DFOCC_DENS, true, true);
+            G.reset();
+        }
 
         // Free J-1/2
         Jmhalf.reset();


### PR DESCRIPTION
## Description
This PR eliminates 600+ duplicate lines of code from `dfocc`, as well as two functions. This cleans up a near-future PR of mine.

Obligatory @loriab ping.

## Todos
- [x] `dfocc` repeats itself a little bit less

## Checklist
- [x] `ctest -L df$` and `test_standard_suite.py` pass

## Status
- [x] Ready for review
- [x] Ready for merge
