### PR TITLE
Fix diffuse external potential after L2 upgrade

### DIFF
--- a/psi4/src/psi4/libmints/extern.cc
+++ b/psi4/src/psi4/libmints/extern.cc
@@ -129,7 +129,6 @@ SharedMatrix ExternalPotential::computePotentialMatrix(std::shared_ptr<BasisSet>
         auto fact2 = std::make_shared<IntegralFactory>(aux, BasisSet::zero_ao_basis_set(), basis, basis);
         std::shared_ptr<TwoBodyAOInt> eri(fact2->eri());
 
-        const double *buffer = eri->buffer();
 
         double **Vp = V->pointer();
         double *dp = d->pointer();
@@ -145,6 +144,7 @@ SharedMatrix ExternalPotential::computePotentialMatrix(std::shared_ptr<BasisSet>
                     int Nstart = basis->shell(N).function_index();
 
                     eri->compute_shell(Q, 0, M, N);
+                    const double *buffer = eri->buffer();
 
                     for (int oq = 0, index = 0; oq < numQ; oq++) {
                         for (int om = 0; om < numM; om++) {


### PR DESCRIPTION
## Description
During the L2 upgrade, I missed the function that handles diffuse external multipoles.  In constructing a test case to avoid a repeat, I found some normalization problems (and a lack of gradients) which will be addressed in a followup PR.  H/T to @g-andres and his group for pointing the problem out.

## Todos
- [ ] Fixes energies with external diffuse potentials.

## Status
- [x] Ready for review
- [x] Ready for merge
