### PR TITLE
lagrangian saga continues. fixes mints8

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -257,7 +257,7 @@ def _core_wavefunction_to_file(wfn, filename=None):
             'Fb':       wfn.Fb().to_array()       if wfn.Fb()       else None,
             'H':        wfn.H().to_array()        if wfn.H()        else None,
             'S':        wfn.S().to_array()        if wfn.S()        else None,
-            'X':        wfn.X().to_array()        if wfn.X()        else None,
+            'X':        wfn.lagrangian().to_array() if wfn.lagrangian() else None,
             'aotoso':   wfn.aotoso().to_array()   if wfn.aotoso()   else None,
             'gradient': wfn.gradient().to_array() if wfn.gradient() else None,
             'hessian':  wfn.hessian().to_array()  if wfn.hessian()  else None

--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -121,7 +121,7 @@ def _mergedapis_compare_wavefunctions(expected, computed, *args, **kwargs):
     if expected.Fb():          compare_matrices(expected.Fb(), computed.Fb(), 'compare Fb', atol=atol, **kwargscopy)
     if expected.H():           compare_matrices(expected.H(), computed.H(), 'compare H', atol=atol, **kwargscopy)
     if expected.S():           compare_matrices(expected.S(), computed.S(), 'compare S', atol=atol, **kwargscopy)
-    if expected.X():           compare_matrices(expected.X(), computed.X(), 'compare X', atol=atol, **kwargscopy)
+    if expected.lagrangian():  compare_matrices(expected.lagrangian(), computed.lagrangian(), 'compare lagrangian', atol=atol, **kwargscopy)
     if expected.aotoso():      compare_matrices(expected.aotoso(), computed.aotoso(), 'compare aotoso', atol=atol, **kwargscopy)
     if expected.gradient():    compare_matrices(expected.gradient(), computed.gradient(), 'compare gradient', atol=atol, **kwargscopy)
     if expected.hessian():     compare_matrices(expected.hessian(), computed.hessian(), 'compare hessian', atol=atol, **kwargscopy)


### PR DESCRIPTION
## Description
can't have internal `.X()`s or the string deprcation warning triggers and mints8 fails.

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
