### PR TITLE
precheck atoms for grids

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -307,6 +307,7 @@ install(FILES ../tests/pytests/__init__.py
               ../tests/pytests/test_psi4_qcschema.py
               ../tests/pytests/test_addons_qcschema.py
               ../tests/pytests/test_triplet.py
+              ../tests/pytests/test_raises.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)
 install(DIRECTORY ../tests/pytests/test_fchk_writer
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4/tests/)

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -163,4 +163,4 @@ void CDJK::print_header() const {
         outfile->Printf("    No. Cholesky vectors: %11li\n\n", ncholesky_);
     }
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -1897,4 +1897,4 @@ void DiskDFJK::block_wK(double** Qlmnp, double** Qrmnp, int naux) {
         timer_off("JK: wK2");
     }
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -580,4 +580,4 @@ void DiskJK::postiterations() {
     delete[] so2symblk_;
     delete[] so2index_;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/GTFockJK.cc
+++ b/psi4/src/psi4/libfock/GTFockJK.cc
@@ -37,7 +37,7 @@ struct MinimalInterface {
     void GetJ(std::vector<SharedMatrix>&) {}
     void GetK(std::vector<SharedMatrix>&) {}
 };
-}
+}  // namespace psi
 #endif
 
 #ifdef ENABLE_GTFOCK
@@ -54,5 +54,5 @@ void GTFockJK::compute_JK() {
     Impl_->GetK(K_ao_);
     Impl_->destroy_gtfock();
 }
-}
+}  // namespace psi
 #endif

--- a/psi4/src/psi4/libfock/MemDFJK.cc
+++ b/psi4/src/psi4/libfock/MemDFJK.cc
@@ -147,4 +147,4 @@ void MemDFJK::set_wcombine(bool wcombine) {
         dfh_->set_wcombine(wcombine); 
     }
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/PKJK.cc
+++ b/psi4/src/psi4/libfock/PKJK.cc
@@ -136,4 +136,4 @@ void PKJK::compute_JK() {
 }
 
 void PKJK::postiterations() {}
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -1064,5 +1064,5 @@ void IWLAsync_PK::flush() {
     write();
 }
 
-}  // End namespace pk
-}  // End namespace psi
+}  // namespace pk
+}  // namespace psi

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -1632,5 +1632,5 @@ void PKMgrInCore::form_J(std::vector<SharedMatrix> J, std::string exch, std::vec
 
 void PKMgrInCore::finalize_JK() { finalize_D(); }
 
-}  // End namespace pk
-}  // End namespace psi
+}  // namespace pk
+}  // namespace psi

--- a/psi4/src/psi4/libfock/apps.cc
+++ b/psi4/src/psi4/libfock/apps.cc
@@ -1506,4 +1506,4 @@ double RTDDFT::compute_energy() {
 
     return 0.0;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -105,7 +105,7 @@ bool brianBuildingNLCGrid = false;
 
 using namespace psi;
 
-namespace {
+namespace psi {
 
 // clang-format off
 double GetBSRadius(unsigned Z) {
@@ -2549,7 +2549,7 @@ void StandardGridMgr::makeCubatureGridFromPruneSpec(PruneSpec const &spec, int r
         int groupCount = 0;
         for (groupCount = 0; spec.group[groupCount].npts != 0; groupCount++) {
         }
-        
+
         brianStoreGridDataInto->resize(groupCount);
     }
 #endif
@@ -2565,7 +2565,7 @@ void StandardGridMgr::makeCubatureGridFromPruneSpec(PruneSpec const &spec, int r
             for (int i_rep = 0; i_rep < spec.group[i_grp].nreps; i_rep++) {
                 (*brianStoreGridDataInto)[i_grp].radialPoints[i_rep] = {r[k_rad + i_rep], wr[k_rad + i_rep]};
             }
-            
+
             (*brianStoreGridDataInto)[i_grp].angularPoints.resize(numAngPoints);
             for (int i_ang = 0; i_ang < numAngPoints; i_ang++) {
                 // we compensate for an extra factor of 4*pi in Psi4's angular grid generation
@@ -3582,7 +3582,7 @@ OrientationMgr::OrientationMgr(std::shared_ptr<Molecule> mol) {
     rotation_ = Q;
 }
 
-}  // namespace
+}  // namespace psi
 
 namespace psi {
 
@@ -3665,7 +3665,7 @@ int RadialPruneMgr::TreutlerShellPruning(int ri, int Z, int radial_pts) {
     // H, He always 1 smaller
     if (Z <= 2) {
         pruned_order = nominal_order_ - 1;
-    }; 
+    };
 
     int region1 = 7;  // 5, as in the paper, is too small. 7 appears to favored also by other programs.
     int region2 = 11;
@@ -3696,7 +3696,7 @@ int RadialPruneMgr::ShellPruning(int ri, int Z, int radial_pts) {
     // H, He always reduced by 1
     if (Z <= 2) {
         pruned_order = nominal_order_ - 1;
-    };  
+    };
 
     // dvide BS shell into 4 equal regions
     double nr = (double)radial_pts / 4.0;
@@ -3737,18 +3737,28 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
         radial_grids_.resize(molecule_->natom());
         spherical_grids_.resize(molecule_->natom());
     }
-    
+
 #ifdef USING_BrianQC
     std::vector<std::vector<double>> atomRotations(molecule_->natom());
     std::vector<std::vector<BrianBlock>> atomBlocks(molecule_->natom());
 #endif
+
+    // Check grid per-atom first so throws happen outside threaded block
+    for (int A = 0; A < molecule_->natom(); A++) {
+        int Z = molecule_->true_atomic_number(A);
+
+        if (opt.namedGrid != -1) {  // Using a named grid
+            assert(opt.namedGrid == 0 || opt.namedGrid == 1);
+            int npts = (opt.namedGrid == 0) ? StandardGridMgr::GetSG0size(Z) : StandardGridMgr::GetSG1size(Z);
+        }
+    }
 
 // Iterate over atoms
 #pragma omp parallel for schedule(static)
     for (int A = 0; A < molecule_->natom(); A++) {
         int Z = molecule_->true_atomic_number(A);
         double stratmannCutoff = nuc.GetStratmannCutoff(A);
-        
+
 #ifdef USING_BrianQC
         if (brianEnable and brianEnableDFT) {
             std::shared_ptr<Matrix> rotationMatrix = orientation_->transpose();
@@ -3766,7 +3776,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
             radial_grids_[A] = RadialGrid::build("Unknown", opt.nradpts, r.data(), wr.data(), alpha, Z);
             std::vector<std::shared_ptr<SphericalGrid>> spheres;
             spherical_grids_[A] = spheres;
-            
+
             int currentBlockIndex = -1;
             for (int i = 0; i < opt.nradpts; i++) {
                 int numAngPts = 0;
@@ -3781,19 +3791,19 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                 }
                 assert(numAngPts > 0);
                 const MassPoint *anggrid = LebedevGridMgr::findGridByNPoints(numAngPts);
-                
+
 #ifdef USING_BrianQC
                 if (brianEnable and brianEnableDFT) {
                     if (currentBlockIndex == -1 or atomBlocks[A][currentBlockIndex].angularPoints.size() != numAngPts) {
                         atomBlocks[A].push_back(BrianBlock());
                         currentBlockIndex++;
-                        
+
                         for (int j = 0; j < numAngPts; j++) {
                             // we compensate for an extra factor of 4*pi in Psi4's angular grid generation
                             atomBlocks[A][currentBlockIndex].angularPoints.push_back({anggrid[j].x, anggrid[j].y, anggrid[j].z, anggrid[j].w / (4.0 * M_PI)});
                         }
                     }
-                    
+
                     atomBlocks[A][currentBlockIndex].radialPoints.push_back({r[i], wr[i]});
                 }
 #endif
@@ -3831,7 +3841,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
             }
         }
     }
-    
+
 #ifdef USING_BrianQC
     // TODO: do the same for the other version of buildGridFromOptions below
     if (brianEnable and brianEnableDFT) {
@@ -3839,14 +3849,14 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
         brianInt atomBlockOffset = 0;
         brianInt radialOffset = 0;
         brianInt angularOffset = 0;
-        
+
         for (int A = 0; A < molecule_->natom(); A++) {
             brianGrid.atomRotationMatrices.insert(brianGrid.atomRotationMatrices.end(), atomRotations[A].begin(), atomRotations[A].end());
-            
+
             brianGrid.atomBlockCounts.push_back(atomBlocks[A].size());
             brianGrid.atomBlockOffsets.push_back(atomBlockOffset);
             for (int blockIndex = 0; blockIndex < atomBlocks[A].size(); blockIndex++) {
-                
+
                 brianGrid.blockRadialCounts.push_back(atomBlocks[A][blockIndex].radialPoints.size());
                 brianGrid.blockRadialOffsets.push_back(radialOffset);
                 for (int radialIndex = 0; radialIndex < atomBlocks[A][blockIndex].radialPoints.size(); radialIndex++)
@@ -3855,7 +3865,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                     brianGrid.radialWeights.push_back(atomBlocks[A][blockIndex].radialPoints[radialIndex].w);
                 }
                 radialOffset += atomBlocks[A][blockIndex].radialPoints.size();
-                
+
                 brianGrid.blockAngularCounts.push_back(atomBlocks[A][blockIndex].angularPoints.size());
                 brianGrid.blockAngularOffsets.push_back(angularOffset);
                 for (int angularIndex = 0; angularIndex < atomBlocks[A][blockIndex].angularPoints.size(); angularIndex++)
@@ -3867,10 +3877,10 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                 }
                 angularOffset += atomBlocks[A][blockIndex].angularPoints.size();
             }
-            
+
             atomBlockOffset += atomBlocks[A].size();
         }
-        
+
         if (brianBuildingNLCGrid) {
             brianCOMSetNLCGrid(&brianCookie,
                 brianGrid.atomBlockCounts.data(),
@@ -4565,7 +4575,7 @@ void NaiveGridBlocker::block() {
 
     ::memcpy((void *)x_, (void *)x_ref_, sizeof(double) * npoints_);
     ::memcpy((void *)y_, (void *)y_ref_, sizeof(double) * npoints_);
-    ::memcpy((void *)z_, (void *)z_ref_, sizeof(double) * npoints_); 
+    ::memcpy((void *)z_, (void *)z_ref_, sizeof(double) * npoints_);
     ::memcpy((void *)w_, (void *)w_ref_, sizeof(double) * npoints_);
     ::memcpy((void *)index_, (void *)index_ref_, sizeof(int) * npoints_);
 
@@ -4904,15 +4914,15 @@ std::shared_ptr<RadialGrid> RadialGrid::build_treutler(int npoints, double alpha
     // // Treutler/Ahlrichs 1995 mapping parameters
     // clang-format off
     static const std::vector<double> TreutlerEta =  { 1.0,
-      0.800, 0.900,                                                                
-      1.800, 1.400,                      1.300, 1.100, 0.900, 0.900, 0.900, 0.900, 
-      1.400, 1.300,                      1.300, 1.200, 1.100, 1.000, 1.000, 1.000, 
-      1.500, 1.400,1.300, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.100, 1.100, 1.100,1.100, 1.000, 0.900, 0.900, 0.900, 0.900,     
-      2.000, 1.700,1.500, 1.500, 1.350, 1.350, 1.250, 1.200, 1.250, 1.300, 1.500, 1.500, 1.300, 1.200, 1.200, 1.150, 1.150, 1.150,     
-      2.500, 2.200,                                                                
-             2.500, 1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,                                                                             
-      1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 
-      2.500, 2.100,                                                                
+      0.800, 0.900,
+      1.800, 1.400,                                                                       1.300, 1.100, 0.900, 0.900, 0.900, 0.900,
+      1.400, 1.300,                                                                       1.300, 1.200, 1.100, 1.000, 1.000, 1.000,
+      1.500, 1.400, 1.300, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.100, 1.100, 1.100, 1.100, 1.000, 0.900, 0.900, 0.900, 0.900,
+      2.000, 1.700, 1.500, 1.500, 1.350, 1.350, 1.250, 1.200, 1.250, 1.300, 1.500, 1.500, 1.300, 1.200, 1.200, 1.150, 1.150, 1.150,
+      2.500, 2.200,
+             2.500, 1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
+             1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500,
+      2.500, 2.100,
              3.685,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
     };
 

--- a/psi4/src/psi4/libfock/hamiltonian.cc
+++ b/psi4/src/psi4/libfock/hamiltonian.cc
@@ -1723,4 +1723,4 @@ std::vector<std::pair<SharedMatrix, SharedMatrix> > USTABHamiltonian::unpack_pai
 
     return t1;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -629,4 +629,4 @@ void JK::set_wcombine(bool wcombine) {
     }
 }
 void JK::finalize() { postiterations(); }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/points.cc
+++ b/psi4/src/psi4/libfock/points.cc
@@ -830,4 +830,4 @@ void BasisFunctions::print(std::string out, int print) const {
     printer->Printf("\n\n");
 }
 
-}  // Namespace psi
+}  // namespace psi

--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -2800,4 +2800,4 @@ void DLUSolver::subspaceCollapse() {
         }
     }
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfock/soscf.cc
+++ b/psi4/src/psi4/libfock/soscf.cc
@@ -1440,4 +1440,4 @@ void IncoreSOMCSCF::set_eri_tensors(SharedMatrix aaaa, SharedMatrix aaar) {
     eri_tensor_set_ = true;
 }  // End DiskSOMCSCF object
 
-}  // Namespace psi
+}  // namespace psi

--- a/psi4/src/psi4/libfock/wrapper.cc
+++ b/psi4/src/psi4/libfock/wrapper.cc
@@ -85,5 +85,5 @@ SharedWavefunction libfock(SharedWavefunction ref_wfn, Options& options) {
     return wfn;
     //    return Success;
 }
-}
-}
+}  // namespace libfock
+}  // namespace psi

--- a/tests/pytests/test_raises.py
+++ b/tests/pytests/test_raises.py
@@ -1,0 +1,25 @@
+import pytest
+import psi4
+
+
+pytestmark = [pytest.mark.quick]
+
+def test_dft_grid_threaded_raise():
+    dimer = psi4.geometry("""
+      1 1
+      K -4.067042 -1.894214 0.002270
+    """)
+    
+    psi4.set_options({
+        "dft_grid_name": "SG1",
+        "dft_vv10_radial_points": 50,
+        "dft_vv10_spherical_points": 194,
+        "dft_nuclear_scheme": "treutler",
+        "dft_radial_scheme": "EM",
+        "basis": "def2-TZVPPD",
+    })
+    
+    with pytest.raises(RuntimeError) as e:
+        ene = psi4.energy("wB97M-V")
+
+    assert "There is no SG-1 grid defined for the requested atomic number" in str(e.value)


### PR DESCRIPTION
## Description
It looks like errors like #2080 happen when `throw` called from within threaded code in C++. From non-threaded code, Pybind11 catches them and turns them into nicely behaved `RuntimeError`s but from threaded, it just segfaults. This PR averts a few, but there could be far more throughout codebase

closes #2080 

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] cleans up namespace markings in libfock. also adds `namespace psi` into a formerly anonymous namespace
- [x] pre-clears SG0 and SG1 atoms before entering the threaded grid build proper. the non-SG0 and SG1 block had some throws, too, but I couldn't trigger them.

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
