### PR TITLE
cleaner print for module level errors

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -351,13 +351,18 @@ except Exception as exception:
 
     in_str = "Printing out the relevant lines from the Psithon --> Python processed input file:\n"
     lines = content.splitlines()
-    suspect_lineno = traceback.extract_tb(exc_traceback)[1].lineno - 1  # -1 for 0 indexing
-    first_line = max(0, suspect_lineno - 5)  # Try to show five lines back...
-    last_line = min(len(lines), suspect_lineno + 6)  # Try to show five lines forward
-    for lineno in range(first_line, last_line):
-        mark = "--> " if lineno == suspect_lineno else "    "
-        in_str += mark + lines[lineno] + "\n"
-    psi4.core.print_out(in_str)
+    try:
+        suspect_lineno = traceback.extract_tb(exc_traceback)[1].lineno - 1  # -1 for 0 indexing
+    except IndexError:
+        # module error where lineno useless (e.g., `print "asdf"`)
+        pass
+    else:
+        first_line = max(0, suspect_lineno - 5)  # Try to show five lines back...
+        last_line = min(len(lines), suspect_lineno + 6)  # Try to show five lines forward
+        for lineno in range(first_line, last_line):
+            mark = "--> " if lineno == suspect_lineno else "    "
+            in_str += mark + lines[lineno] + "\n"
+        psi4.core.print_out(in_str)
 
     # extact expection message and print it in a box for attention.
     ex = ','.join(traceback.format_exception_only(type(exception), exception))


### PR DESCRIPTION
## Description

Fixes special case of traceback printing where only lineno available is from `exec(content)`, which is useless. This fixes #1920 . We don't get Jonathon's nice `-->` offending line printing, but at least we don't get a new error. I've tried it on `print("asdf")` and some more common mistakes.

```
Traceback (most recent call last):
  File "/psi/gits/hrw-py39/objdir39/stage/bin/psi4", line 337, in <module>
    exec(content)

  File "<string>", line 26
    print "asdf"
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("asdf")?

Printing out the relevant lines from the Psithon --> Python processed input file:


!----------------------------------------------------------------------!
!                                                                      !
!  Missing parentheses in call to 'print'. Did you mean print("asdf")? !
!                                                                      !
!----------------------------------------------------------------------!
```

## Status
- [x] Ready for review
- [x] Ready for merge
