### PR TITLE
Create and Python-expose functions for the DF deriv integrals

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -82,7 +82,7 @@ jobs:
         python=$PYTHON_VER \
         psi4/label/dev::gau2grid=2 \
         psi4/label/dev::libint2 \
-        psi4/label/dev::libxc \
+        psi4/label/dev::libxc=4 \
         psi4/label/dev::ambit \
         psi4/label/dev::chemps2 \
         psi4/label/dev::dkh \

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1076,6 +1076,12 @@ void export_mints(py::module& m) {
              "atom"_a, "omega"_a = 0.0, "factory"_a = nullptr)
         .def("ao_tei_deriv2", &MintsHelper::ao_tei_deriv2,
              "Hessian  of AO basis TEI integrals: returns (3 * natoms)^2 matrices", "atom1"_a, "atom2"_a)
+        .def("ao_metric_deriv1", &MintsHelper::ao_metric_deriv1,
+             "Gradient of AO basis metric integrals: returns 3 matrices",
+             "atom"_a, "aux_name"_a)
+        .def("ao_3center_deriv1", &MintsHelper::ao_3center_deriv1,
+             "Gradient of AO basis 3-center, density-fitted integrals: returns 3 matrices",
+             "atom"_a, "aux_name"_a)
         .def("mo_oei_deriv1", &MintsHelper::mo_oei_deriv1,
              "Gradient of MO basis OEI integrals: returns (3 * natoms) matrices",
              "oei_type"_a, "atom"_a, "C1"_a, "C2"_a)

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -202,6 +202,8 @@ class PSI_API MintsHelper {
                                             SharedMatrix C4);
     std::vector<SharedMatrix> mo_tei_deriv2(int atom1, int atom2, SharedMatrix C1, SharedMatrix C2, SharedMatrix C3,
                                             SharedMatrix C4);
+    std::vector<SharedMatrix> ao_metric_deriv1(int atom, const std::string& aux_name);
+    std::vector<SharedMatrix> ao_3center_deriv1(int atom, const std::string& aux_name);
 
     /// AO ERF Integrals
     SharedMatrix ao_erf_eri(double omega, std::shared_ptr<IntegralFactory> = nullptr);


### PR DESCRIPTION
## Description
Exactly what it says in the title. New `libmints` functions mean a @jturney ping, and new functions messing with integrals mean an @andysim ping.

Also, a positive LoC PR. Sad.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Metric derivatives and derivative of the 3-center integrals are now available to Python

## Checklist
- [x] I've tested that P4N DF-OMP2 gradients using these new functions match `dfocc` gradients to 6 decimal places, but that isn't suitable for the test suite. I'm open to suggestions on tests.

## Status
- [x] Ready for review
- [x] Ready for merge
