### PR TITLE
Update to "Interface to Numpy"

### DIFF
--- a/doc/sphinxman/source/numpy.rst
+++ b/doc/sphinxman/source/numpy.rst
@@ -47,9 +47,9 @@ Basics
 Converting between the |PSIfour| Data classes and a NumPy array is easy through
 various helper functions as detailed in this section.  A quick overview NumPy
 functionality can be found `here
-<https://docs.scipy.org/doc/numpy-dev/user/quickstart.html>`_.  In addition,
+<https://numpy.org/doc/stable/user/quickstart.html>`_.  In addition,
 numerous example of hybrid NumPy and Psi4 can be found at the `Psi4Numpy
-project <https://github.com/dgasmith/psi4numpy>`_.  Currently only the Matrix
+project <https://github.com/psi4/psi4numpy>`_.  Currently only the Matrix
 and Vector objects support NumPy interfacing. Let us begin with a simple
 conversion from these objects to a NumPy array::
 
@@ -57,8 +57,8 @@ conversion from these objects to a NumPy array::
     >>> import numpy as np
 
     # Build the Psi4 data objects
-    >>> mat = psi4.Matrix(3, 3) 
-    >>> vec = psi4.Vector(3)
+    >>> mat = psi4.core.Matrix(3, 3) 
+    >>> vec = psi4.core.Vector(3)
 
     # Convert to a NumPy array
     >>> numpy_mat = np.array(mat)
@@ -67,8 +67,8 @@ conversion from these objects to a NumPy array::
 Here the data is copied into new NumPy arrays. NumPy arrays can be converted
 back to |PSIfour| objects using the ``from_array`` interface::
 
-    >>> new_mat = psi4.Matrix.from_array(mat)
-    >>> new_vec = psi4.Vector.from_array(vec)
+    >>> new_mat = psi4.core.Matrix.from_array(mat)
+    >>> new_vec = psi4.core.Vector.from_array(vec)
 
 
 NumPy Views
@@ -101,13 +101,14 @@ this operation is identical to the above.
 |PSIfour| Data Objects with Irreps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|PSIfour| data objects natively support multiple irreducible representations
+|PSIfour| data objects natively support multiple `irreducible representations
+<https://psicode.org/psi4manual/4.0b3/psithoninput.html#symmetry>`_
 which is quite useful for Quantum Chemistry. However, this is not fundamental
 to NumPy and some work around are required to natively support these
 operations. Take the following irreped Matrix::
 
-    >>> dim = psi4.Dimension.from_list([1, 2, 3])
-    >>> irreped_mat = psi4.Matrix("New Matrix", dim, dim)
+    >>> dim = psi4.core.Dimension.from_list([1, 2, 3])
+    >>> irreped_mat = psi4.core.Matrix("New Matrix", dim, dim)
 
     # Create a list of Psi4 arrays
     >>> list_of_arrays = irreped_mat.to_array()

--- a/doc/sphinxman/source/numpy.rst
+++ b/doc/sphinxman/source/numpy.rst
@@ -101,8 +101,8 @@ this operation is identical to the above.
 |PSIfour| Data Objects with Irreps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|PSIfour| data objects natively support multiple `irreducible representations
-<https://psicode.org/psi4manual/4.0b3/psithoninput.html#symmetry>`_
+|PSIfour| data objects natively support multiple :ref:`irreducible representations
+<sec:symmetry>`
 which is quite useful for Quantum Chemistry. However, this is not fundamental
 to NumPy and some work around are required to natively support these
 operations. Take the following irreped Matrix::
@@ -131,6 +131,5 @@ Matrix to Array
 A general function that converts NumPy arrays to |PSIfour| data objects.
 
 .. autofunction:: psi4.driver.p4util.numpy_helper._to_array
-
 
 

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -95,12 +95,12 @@ def array_to_matrix(self, arr, name="New Matrix", dim1=None, dim2=None):
     Examples
     --------
 
-    >>> data = np.random.rand(20)
-    >>> vector = array_to_matrix(data)
+    >>> data = np.random.rand(20,1)
+    >>> vector = psi4.core.Matrix.from_array(data)
 
     >>> irrep_data = [np.random.rand(2, 2), np.empty(shape=(0,3)), np.random.rand(4, 4)]
-    >>> matrix = array_to_matrix(irrep_data)
-    >>> print matrix.rowspi().to_tuple()
+    >>> matrix = psi4.core.Matrix.from_array(irrep_data)
+    >>> print(matrix.rowdim().to_tuple())
     (2, 0, 4)
     """
 

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -236,7 +236,7 @@ def _to_array(matrix, copy=True, dense=False):
     Examples
     --------
 
-    >>> data = psi4.Matrix(3, 3)
+    >>> data = psi4.core.Matrix(3, 3)
     >>> data.to_array()
     [[ 0.  0.  0.]
      [ 0.  0.  0.]


### PR DESCRIPTION
## Description
Address issue #2087. Specifically:

On `numpy.rst`:
  1) Updated Numpy quickstart guide link
  2) Updated Psi4Numpy Repo link
  3) Updated psi4.{Matrix, Vector, Dimension} -> psi4.core.{Matrix, Vector, Dimension}
  4) Added link to Psi4's Symmetry quick guide

On `numpy_helper.py`:
  1) Updated docstring example to `psi4.core.Matrix`. 

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ]

## Questions
- [ ] Section "Array to Matrix" and "Matrix to Array" print and run the docstring. For "Matrix to Array" the example can be run with no problem. But "Matrix to Array" can only be run by its own class. Should this example be updated as well? e.g. replace both examples of
https://github.com/psi4/psi4/blob/master/psi4/driver/p4util/numpy_helper.py#L99 with:

```
  >>> data = np.random.rand(20,1)
  >>> vector = psi4.core.Matrix.from_array(data)
```
My concern is that the example would not be calling the function directly. What would be the best way to proceed?

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
