### PR TITLE
Deprecate `Matrix::SaveType::Full`

### DIFF
--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -586,7 +586,7 @@ void DFMP2::apply_gamma(size_t file, size_t naux, size_t nia) {
     // Tensor blocks
     auto Gia = std::make_shared<Matrix>("G(ia|Q)", max_nia, naux);
     auto Cia = std::make_shared<Matrix>("C(ia|Q)", max_nia, naux);
-    auto G = std::make_shared<Matrix>("g", naux, naux);
+    auto G = std::make_shared<Matrix>("G_PQ", naux, naux);
     double** Giap = Gia->pointer();
     double** Ciap = Cia->pointer();
     double** Gp = G->pointer();
@@ -618,7 +618,7 @@ void DFMP2::apply_gamma(size_t file, size_t naux, size_t nia) {
         timer_off("DFMP2 g");
     }
 
-    psio_->write_entry(file, "G_PQ", (char*)Gp[0], sizeof(double) * naux * naux);
+    G->save(psio_, file, Matrix::SaveType::SubBlocks);
 
     psio_->close(file, 1);
 }
@@ -1503,9 +1503,7 @@ void RDFMP2::form_AB_x_terms() {
     auto naux = ribasis_->nbf();
 
     auto V = std::make_shared<Matrix>("G_PQ", naux, naux);
-    psio_->open(PSIF_DFMP2_AIA, PSIO_OPEN_OLD);
-    V->load(psio_, PSIF_DFMP2_AIA, Matrix::SaveType::Full);
-    psio_->close(PSIF_DFMP2_AIA, 1);
+    V->load(psio_, PSIF_DFMP2_AIA, Matrix::SaveType::SubBlocks);
     V->hermitivitize();
     V->scale(2);
     std::map<std::string, SharedMatrix> densities = {{"(A|B)^x", V}};

--- a/psi4/src/psi4/libmints/eri.h
+++ b/psi4/src/psi4/libmints/eri.h
@@ -260,7 +260,7 @@ class Libint2TwoElectronInt : public TwoBodyAOInt {
     size_t compute_shell(const AOShellCombinationsIterator& shellIter) override;
 
     /// Compute ERIs between 4 shells. Result is stored in buffer.
-    size_t compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3, int s4, bool is_bra);
+    size_t compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3, int s4, bool is_bra) override;
 
     /// Compute ERIs between 4 shells. Result is stored in buffer.
     size_t compute_shell(int s1, int s2, int s3, int s4) override;

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -481,23 +481,22 @@ void Matrix::set(const double *const *const sq) {
         throw PSIEXCEPTION("Matrix::set called on a non-totally symmetric matrix.");
     }
 
-    int h, i, j, ii, jj;
-    int offset;
-
     if (sq == nullptr) {
         throw PSIEXCEPTION("Matrix::set: Set call with a nullptr double** matrix");
     }
-    offset = 0;
-    for (h = 0; h < nirrep_; ++h) {
-        for (i = 0; i < rowspi_[h]; ++i) {
-            ii = i + offset;
-            for (j = 0; j <= i; ++j) {
-                jj = j + offset;
+
+    int row_offset = 0;
+    int col_offset = 0;
+    for (int h = 0; h < nirrep_; ++h) {
+        for (int i = 0; i < rowspi_[h]; ++i) {
+            int ii = i + row_offset;
+            for (int j = 0; j < colspi_[h]; ++j) {
+                int jj = j + col_offset;
                 matrix_[h][i][j] = sq[ii][jj];
-                matrix_[h][j][i] = sq[jj][ii];
             }
         }
-        offset += rowspi_[h];
+        row_offset += rowspi_[h];
+        col_offset += colspi_[h];
     }
 }
 
@@ -3037,7 +3036,7 @@ void Matrix::load(psi::PSIO *const psio, size_t fileno, SaveType st) {
             psio->read_entry(fileno, name_.c_str(), (char *)fullblock[0], sizeof(double) * sizer * sizec);
 
         set(fullblock);
-        linalg::detail::free(fullblock);
+        free_block(fullblock);
     } else if (st == LowerTriangle) {
         double *lower = to_lower_triangle();
 

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -281,7 +281,11 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /// Copies data to the row specified. Assumes data is of correct length.
     void copy_to_row(int h, int row, double const* const data);
 
-    enum SaveType { Full, SubBlocks, LowerTriangle };
+    enum SaveType { Full
+    PSI_DEPRECATED(
+        "Using `Matrix::SaveType::Full` instead of `Matrix::SaveType::SubBlocks` is deprecated, "
+        "and in 1.5 it will stop working"),
+    SubBlocks, LowerTriangle };
 
     /**
      * @{

--- a/psi4/src/psi4/libmints/siminteri.h
+++ b/psi4/src/psi4/libmints/siminteri.h
@@ -58,7 +58,7 @@ class SimintTwoElectronInt : public TwoBodyAOInt {
     SimintTwoElectronInt(const SimintTwoElectronInt& rhs);
 
    private:
-    void create_blocks(void);
+    void create_blocks(void) override;
 
     size_t compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3, int s4, bool is_bra) override;
     int maxam_;


### PR DESCRIPTION
## Description
While working on some more DF technology, I discovered a bug when trying to load using `Matrix::SaveType::Full`. The code assumed the matrix was square. One of the things this PR does is have the code work when that assumption fails.

But the bigger problem is that `Matrix::SaveType::Full` is Psi3 era tech that shouldn't exist anymore. That SaveType reads/writes a matrix _where all elements of the wrong symmetry are replaced with zeros_. The better solution is to use `Matrix::SaveType::SubBlocks`, where those zero's are neither written nor read. Accordingly, I'm deprecating the Full save in favor of SubBlocks save.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] `Matrix::SaveType::Full` is deprecated
- [x] Fixed a correctness bug with loading from `Matrix::SaveType::Full`

## Checklist
- [x] quicktests, standard stuite, and dfmp2 all pass
- [ ] I didn't bother adding a new test that I actually fixed the bug, since I accessed the buggy code through a method that's going to be deprecated anyways. Any objections?

## Status
- [x] Ready for review
- [x] Ready for merge
