### PR TITLE
remove time test  for multithread

### DIFF
--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -1,29 +1,71 @@
 import pytest
 
+
+def pytest_configure(config):
+    # Register marks to avoid warnings in psi4.test()
+    # sync with setup.cfg
+    config.addinivalue_line("markers", "check_triplet")
+    config.addinivalue_line("markers", "dft")
+    config.addinivalue_line("markers", "gga")
+    config.addinivalue_line("markers", "hf")
+    config.addinivalue_line("markers", "hyb_gga")
+    config.addinivalue_line("markers", "hyb_gga_lrc")
+    config.addinivalue_line("markers", "lda")
+    config.addinivalue_line("markers", "long")
+    config.addinivalue_line("markers", "mdi")
+    config.addinivalue_line("markers", "mp2")
+    config.addinivalue_line("markers", "restricted_singlet")
+    config.addinivalue_line("markers", "restricted_triplet")
+    config.addinivalue_line("markers", "RPA")
+    config.addinivalue_line("markers", "scf")
+    config.addinivalue_line("markers", """slow: marks tests as slow (deselect with '-m "not slow"')""")
+    config.addinivalue_line("markers", "smoke")
+    config.addinivalue_line("markers", "solver")
+    config.addinivalue_line("markers", "stress")
+    config.addinivalue_line("markers", "TDA")
+    config.addinivalue_line("markers", "tdscf")
+    config.addinivalue_line("markers", "quick")
+    config.addinivalue_line("markers", "unittest")
+    config.addinivalue_line("markers", "unrestricted")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def set_up_overall(request):
     import psi4
+
     psi4.set_output_file("pytest_output.dat", False)
     request.addfinalizer(tear_down)
+
 
 @pytest.fixture(scope="function", autouse=True)
 def set_up():
     import psi4
+
     psi4.core.clean()
     psi4.core.clean_timers()
     psi4.core.clean_options()
     psi4.set_output_file("pytest_output.dat", True)
 
+
 def tear_down():
     import os
     import glob
     import psi4
+
     psi4.core.close_outfile()
-    patterns = ['cavity.*', 'grid*', 'pytest_output.*h5',
-                'pytest_output.dat',
-                'pytest_output.*grad',
-                '*pcmsolver.inp', 'PEDRA.OUT*', 'timer.dat',
-                'FCIDUMP_SCF', 'FCIDUMP_MP2','*.fchk']
+    patterns = [
+        "cavity.*",
+        "grid*",
+        "pytest_output.*h5",
+        "pytest_output.dat",
+        "pytest_output.*grad",
+        "*pcmsolver.inp",
+        "PEDRA.OUT*",
+        "timer.dat",
+        "FCIDUMP_SCF",
+        "FCIDUMP_MP2",
+        "*.fchk",
+    ]
     pytest_scratches = []
     for pat in patterns:
         pytest_scratches.extend(glob.glob(pat))

--- a/tests/pytests/test_triplet.py
+++ b/tests/pytests/test_triplet.py
@@ -1,8 +1,10 @@
+import os
 import numpy as np
 import pytest
 import time
 
 import psi4
+
 
 @pytest.mark.quick
 def test_triplet_speedup():
@@ -23,8 +25,10 @@ def test_triplet_speedup():
     S = psi4.core.doublet(S, C, False, False)
     time2 = time.time() - start
 
-    assert (time1 < time2)
+    if int(os.environ["PYTEST_XDIST_WORKER_COUNT"]) == 1:
+        assert time1 < time2
     assert psi4.compare_matrices(R, S, 8, "linalg::triplet speedup test")
+
 
 @pytest.mark.quick
 def test_triplet_normal_case():
@@ -43,10 +47,11 @@ def test_triplet_normal_case():
 
     assert psi4.compare_matrices(R, S, 8, "linalg::triplet avg_case test")
 
+
 @pytest.mark.quick
 def test_triplet_with_irreps():
     A = psi4.core.Matrix.from_array([np.random.rand(10000, 5), np.random.rand(5, 10000), np.random.rand(10000, 5)])
-    B = psi4.core.Matrix.from_array([np.random.rand(5, 10000), np.random.rand(10000, 5), np.random.rand(5, 10000)]) 
+    B = psi4.core.Matrix.from_array([np.random.rand(5, 10000), np.random.rand(10000, 5), np.random.rand(5, 10000)])
     C = psi4.core.Matrix.from_array([np.random.rand(10000, 5), np.random.rand(5, 10000), np.random.rand(10000, 5)])
 
     start = time.time()
@@ -58,8 +63,10 @@ def test_triplet_with_irreps():
     S = psi4.core.doublet(S, C, False, False)
     time2 = time.time() - start
 
-    assert (time1 < time2)
+    if int(os.environ["PYTEST_XDIST_WORKER_COUNT"]) == 1:
+        assert time1 < time2
     assert psi4.compare_matrices(R, S, 8, "linalg::triplet irrep test")
+
 
 @pytest.mark.quick
 def test_triplet_with_transpose():
@@ -76,5 +83,6 @@ def test_triplet_with_transpose():
     S = psi4.core.doublet(S, C, False, False)
     time2 = time.time() - start
 
-    assert (time1 < time2)
+    if int(os.environ["PYTEST_XDIST_WORKER_COUNT"]) == 1:
+        assert time1 < time2
     assert psi4.compare_matrices(R, S, 8, "linalg::triplet transpose test")


### PR DESCRIPTION
## Description
once more, try for a clean conda build

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] I think the conftest changes will eliminate the markers warnings for _installed_ psi4 pytest testing
- [x] the py36 conda build failed one of the time tests for @andyj10224's triplet tests. I couldn't get it to trigger again in a py39 env, but multithreaded tests and time assertions are always iffy, so skipping those

## Status
- [x] Ready for review
- [x] Ready for merge
