### PR TITLE
Fixes get_amplitudes method when requesting frozen-core CC calculations

### DIFF
--- a/psi4/src/psi4/cc/amps.cc
+++ b/psi4/src/psi4/cc/amps.cc
@@ -50,15 +50,15 @@ std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
     std::vector<DPDMOSpace> spaces;
     if (dpd_list[0] == nullptr) {
         if (ref == "RHF") {
-            Dimension occpi_ = nalphapi_;
+            Dimension occpi_ = nalphapi_ - frzcpi_;
             Dimension virtpi_ = nmopi_ - nalphapi_;
             cachelist = cacheprep_rhf(options_.get_int("CACHELEVEL"), cachefiles.data());
             spaces = {DPDMOSpace{'o', "ijkl", occpi_}, DPDMOSpace{'v', "abcd", virtpi_}};
         } else if (ref == "ROHF") {
-            Dimension doccpi_ = nalphapi_;
-            Dimension soccpi_ = nbetapi_ - nalphapi_;
+            Dimension doccpi_ = nbetapi_ - frzcpi_;
+            Dimension soccpi_ = nalphapi_ - nbetapi_;
             Dimension occpi_ = doccpi_ + soccpi_;
-            Dimension virtpi_ = (nmopi_ - doccpi_) + soccpi_;
+            Dimension virtpi_ = nmopi_ - (occpi_ + frzcpi_);
             cachelist = cacheprep_rhf(options_.get_int("CACHELEVEL"), cachefiles.data());
             spaces = {DPDMOSpace{'o', "ijkl", occpi_}, DPDMOSpace{'v', "abcd", virtpi_}};
         } else /*UHF*/{

--- a/psi4/src/psi4/cc/amps.cc
+++ b/psi4/src/psi4/cc/amps.cc
@@ -32,19 +32,22 @@
 #include "psi4/libmints/dimension.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libmints/molecule.h"
 #include <memory>
-namespace psi {
-namespace ccenergy {
+namespace psi::ccenergy {
+
 std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
     // re-init dpd
     int** cachelist;
     auto cachefiles = std::vector<int>(PSIO_MAXUNIT);
+
     auto ref = options_.get_str("REFERENCE");
-    if (ref == "ROHF" && options_.get_bool("SEMICANONICAL")){
-      ref = "UHF";
-    }
+    if (ref == "ROHF" && options_.get_bool("SEMICANONICAL")) ref = "UHF";
+
+    const std::string pg = molecule_->sym_label();
+    if (nirrep_ > 1) throw InputException("Point-group symmetry must be c1", "symmetry", pg, __FILE__, __LINE__);
+
     std::vector<DPDMOSpace> spaces;
-    std::map<std::string, SharedMatrix> amps;
     if (dpd_list[0] == nullptr) {
         if (ref == "RHF") {
             Dimension occpi_ = nalphapi_;
@@ -59,8 +62,8 @@ std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
             cachelist = cacheprep_rhf(options_.get_int("CACHELEVEL"), cachefiles.data());
             spaces = {DPDMOSpace{'o', "ijkl", occpi_}, DPDMOSpace{'v', "abcd", virtpi_}};
         } else /*UHF*/{
-            Dimension aoccpi_ = nalphapi_;
-            Dimension boccpi_ = nbetapi_;
+            Dimension aoccpi_ = nalphapi_ - frzcpi_;
+            Dimension boccpi_ = nbetapi_ - frzcpi_;
             Dimension avirtpi_ = nmopi_ - nalphapi_;
             Dimension bvirtpi_ = nmopi_ - nbetapi_;
             cachelist = cacheprep_uhf(options_.get_int("CACHELEVEL"), cachefiles.data());
@@ -81,7 +84,8 @@ std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
         psio_open(PSIF_CC_TAMPS, PSIO_OPEN_OLD);
     }
 
-    // grab T1
+    // Grab T1 and T2 amplitudes
+    std::map<std::string, SharedMatrix> amps;
     dpdfile2 T1;
     dpdbuf4 T2;
     if (ref == "RHF") {
@@ -139,5 +143,4 @@ std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
     }
     return amps;
 }
-}  // namespace ccenergy
-}  // namespace psi
+}  // namespace psi::ccenergy

--- a/psi4/src/psi4/cc/amps.cc
+++ b/psi4/src/psi4/cc/amps.cc
@@ -34,7 +34,8 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include <memory>
-namespace psi::ccenergy {
+namespace psi {
+namespace ccenergy {
 
 std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
     // re-init dpd
@@ -143,4 +144,5 @@ std::map<std::string, SharedMatrix> CCEnergyWavefunction::get_amplitudes() {
     }
     return amps;
 }
-}  // namespace psi::ccenergy
+}  // namespace ccenergy
+}  // namespace psi

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -88,7 +88,7 @@ void CCEnergyWavefunction::get_params(Options &options) {
     // Allow user to force semicanonical
     if (options["SEMICANONICAL"].has_changed()) {
         params_.semicanonical = options.get_bool("SEMICANONICAL");
-        params_.ref = 2;
+        if (params_.semicanonical) params_.ref = 2;
     }
 
     params_.analyze = options.get_bool("ANALYZE");

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -112,7 +112,7 @@ class SphericalTransform {
    protected:
     std::vector<SphericalTransformComponent> components_;
     int l_;  // The angular momentum this transform is for.
-    int subl_;
+    int subl_;  // The sub angular momentum (default: l_)
 
     SphericalTransform();
 

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -415,7 +415,7 @@ void MintsHelper::one_body_ao_computer(std::vector<std::shared_ptr<OneBodyAOInt>
     std::shared_ptr<BasisSet> bs1 = ints[0]->basis1();
     std::shared_ptr<BasisSet> bs2 = ints[0]->basis2();
 
-    // Limit to the number of incoming onbody ints
+    // Limit to the number of incoming onebody ints
     size_t nthread = nthread_;
     if (nthread > ints.size()) {
         nthread = ints.size();

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -89,6 +89,16 @@ class PSI_API MintsHelper {
 
     void common_init();
 
+    /**
+     * @brief Compute a one-body operator matrix.
+     * 
+     * This function takes in a vector of OneBodyAOInt objects and outputs a matrix
+     * representation of the one-body operator.
+     * 
+     * @param[in] ints Vector of OneBodyAOInt integrals
+     * @param[out] out Matrix containing the one-body operator
+     * @param[in] symm Use symmetry flag
+    */
     void one_body_ao_computer(std::vector<std::shared_ptr<OneBodyAOInt>> ints, SharedMatrix out, bool symm);
     void grad_two_center_computer(std::vector<std::shared_ptr<OneBodyAOInt>> ints, SharedMatrix D, SharedMatrix out);
     /// Helper function to convert ao integrals to so and cache them

--- a/psi4/src/psi4/libmints/onebody.cc
+++ b/psi4/src/psi4/libmints/onebody.cc
@@ -62,6 +62,9 @@ static void transform1e_2(int am, SphericalTransformIter &sti, double *s, double
     memset(t, 0, nk * tl * sizeof(double));
 
     for (sti.first(); !sti.is_done(); sti.next()) {
+        // In the standard spherical transform, cartindex() inverses the order
+        // per shell (s + (L*(L-1)/2), s + (L*(L-1)/2) -1, ...), and
+        // pureindex() is just a sequence 0, 1, ..., 2*L + 1
         double *sptr = s + sti.cartindex();
         double *tptr = t + sti.pureindex();
         double coef = sti.coef();

--- a/psi4/src/psi4/libmints/transform.cc
+++ b/psi4/src/psi4/libmints/transform.cc
@@ -38,15 +38,13 @@ using namespace psi;
 
 extern void solidharmonic(int l, Matrix& coefmat);
 
-// there ordering here is arbitrary and doesn't have to match the
+// The ordering here is arbitrary and doesn't have to match the
 // basis set ordering
 static inline int ncart(int l) { return (l >= 0) ? ((((l) + 2) * ((l) + 1)) >> 1) : 0; }
 static inline int npure(int l) { return 2 * l + 1; }
 static inline int icart(int a, int b, int c) { return (((((a + b + c + 1) << 1) - a) * (a + 1)) >> 1) - b - 1; }
 
 void SphericalTransformComponent::init(int a, int b, int c, double coef, int cartindex, int pureindex) {
-    //    outfile->Printf( "a = %d, b = %d, c = %d, coef = %f, cartindex = %d, pureindex = %d\n", a, b, c, coef,
-    //    cartindex, pureindex);
     a_ = a;
     b_ = b;
     c_ = c;
@@ -67,7 +65,6 @@ SphericalTransform::SphericalTransform(int l, int subl) : l_(l) {
 }
 
 void SphericalTransform::init() {
-    //    outfile->Printf( "spher\n");
     int cartdim = INT_NCART(l_);
     Matrix coefmat(cartdim, cartdim);
     coefmat.zero();
@@ -75,23 +72,13 @@ void SphericalTransform::init() {
     // Compute the solid harmonic matrix elements
     solidharmonic(l_, coefmat);
 
-    //    outfile->Printf( "SphericalTransform: l = %d\n", l_);
-    //    coefmat.print();
-
     // Go through and grab the values.
     int pureindex = 0;
-    //int cartindex = 0; this is not used
 
     for (int i = 1; i <= (l_ - subl_) / 2; ++i) pureindex += npure(subl_ + 2 * i);
 
-    // There is npure and a INT_NPURE macro than do the same thing. Why is that?
+    // There is npure and an INT_NPURE macro that do the same thing.
     for (int p = 0; p < npure(subl_); ++p) {
-        //cartindex = 0;
-        //        for (int ii=0; ii<=l_; ++ii) {
-        //            int a = l_ - ii;
-        //            for (int jj=0; jj<=ii; ++jj) {
-        //                int b = ii - jj;
-        //                int c = jj;
         for (int a = 0; a <= l_; ++a) {
             for (int b = 0; (a + b) <= l_; ++b) {
                 int c = l_ - a - b;
@@ -99,7 +86,6 @@ void SphericalTransform::init() {
                 int cart1 = icart(a, b, c);
                 int cart2 = INT_CARTINDEX(a + b + c, a, b);
 
-                //                outfile->Printf( "cart1 = %d, p+pureindex=%d\n", cart1, p+pureindex);
                 double coef = coefmat(cart1, p + pureindex);
 
                 if (std::fabs(coef) > 1.0e-16) {
@@ -107,7 +93,6 @@ void SphericalTransform::init() {
                     component.init(a, b, c, coef, cart2, p);
                     components_.push_back(component);
                 }
-                //cartindex++;
             }
         }
     }
@@ -123,7 +108,6 @@ ISphericalTransform::ISphericalTransform(int l, int subl) : SphericalTransform(l
 }
 
 void ISphericalTransform::init() {
-    //    outfile->Printf( "ispher\n");
     int cartdim = ncart(l_);
     Matrix coefmat(cartdim, cartdim);
     coefmat.zero();
@@ -137,17 +121,10 @@ void ISphericalTransform::init() {
 
     // Go through and grab the values.
     int pureindex = 0;
-    int cartindex = 0;
 
     for (int i = 1; i <= (l_ - subl_) / 2; ++i) pureindex += npure(subl_ + 2 * i);
 
     for (int p = 0; p < npure(subl_); ++p) {
-        cartindex = 0;
-        //        for (int ii=0; ii<=l_; ++ii) {
-        //            int c = l_ - ii;
-        //            for (int jj=0; jj<=ii; ++jj) {
-        //                int b = ii - jj;
-        //                int a = jj;
         for (int a = 0; a <= l_; ++a) {
             for (int b = 0; (a + b) <= l_; ++b) {
                 int c = l_ - a - b;
@@ -162,7 +139,6 @@ void ISphericalTransform::init() {
                     component.init(a, b, c, coef, cart2, p);
                     components_.push_back(component);
                 }
-                cartindex++;
             }
         }
     }

--- a/psi4/src/psi4/libmints/transform.cc
+++ b/psi4/src/psi4/libmints/transform.cc
@@ -80,12 +80,13 @@ void SphericalTransform::init() {
 
     // Go through and grab the values.
     int pureindex = 0;
-    int cartindex = 0;
+    //int cartindex = 0; this is not used
 
     for (int i = 1; i <= (l_ - subl_) / 2; ++i) pureindex += npure(subl_ + 2 * i);
 
+    // There is npure and a INT_NPURE macro than do the same thing. Why is that?
     for (int p = 0; p < npure(subl_); ++p) {
-        cartindex = 0;
+        //cartindex = 0;
         //        for (int ii=0; ii<=l_; ++ii) {
         //            int a = l_ - ii;
         //            for (int jj=0; jj<=ii; ++jj) {
@@ -106,7 +107,7 @@ void SphericalTransform::init() {
                     component.init(a, b, c, coef, cart2, p);
                     components_.push_back(component);
                 }
-                cartindex++;
+                //cartindex++;
             }
         }
     }


### PR DESCRIPTION
## Description
This PR introduces a fix to the `get_amplitudes` method used to export T1 and T2 amplitudes to python, which allows the method to work properly when frozen-core coupled-cluster calculations are requested.

## Status
- [x] Ready for review
- [x] Ready for merge
