### PR TITLE
Deprecate `legacy_wavefunction` getter and setter

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1021,7 +1021,11 @@ void py_psi_set_n_threads(size_t nthread, bool quiet) {
 
 int py_psi_get_n_threads() { return Process::environment.get_n_threads(); }
 
+PSI_DEPRECATED("Using core.legacy_wavefunction rather than setting return_wfn=True for a computation is deprecated, "
+        "and in 1.5, it will stop working.")
 std::shared_ptr<Wavefunction> py_psi_legacy_wavefunction() { return Process::environment.legacy_wavefunction(); }
+PSI_DEPRECATED("Using core.set_legacy_wavefunction rather than passing a wavefunction into a computation is deprecated, "
+        "and in 1.5, it will stop working.")
 void py_psi_set_legacy_wavefunction(SharedWavefunction wfn) { Process::environment.set_legacy_wavefunction(wfn); }
 
 void py_psi_print_variable_map() {


### PR DESCRIPTION
## Description
I was investigating the "memory not being released" problem that @fevangelista brought up at the developer meeting. For the case of a simple HF energy, the wavefunction object indeed persisted after the energy call. Investigation showed its lifetime was controlled by the fact that we had the legacy wavefunction stored, and garbage collection didn't occur until the legacy wavefunction changed.

Seeing as we don't actually use the legacy wavefunction machinery for anything in Psi, except part of a plugin interface where we tell people to prefer explicit wavefunction passing, this PR deprecates the commands for removal in 1.5, so we can collect garbage faster.

This PR doesn't explain Francesco's reports of _increasing_ memory consumption for FINDIF, but it at least is a start.

## Todos
- [x] Deprecates `legacy_wavefunction` and `set_legacy_wavefunction`

## Status
- [x] Ready for review
- [x] Ready for merge
