### PR TITLE
Remove Useless `occ` Code

### DIFF
--- a/psi4/src/psi4/occ/coord_grad.cc
+++ b/psi4/src/psi4/occ/coord_grad.cc
@@ -66,101 +66,10 @@ void OCCWave::coord_grad() {
     // OEPROP
     if (oeprop_ == "TRUE") oeprop();
 
-    dump_ints();
     outfile->Printf("\tWriting particle density matrices and GFM to disk...\n");
 
     dump_pdms();
 }  //
-
-//========================================================================
-//         Dump Molecular Integrals
-//========================================================================
-void OCCWave::dump_ints() {
-    // outfile->Printf("\n dump_ints is starting... \n");
-    dpdfile2 H;
-    dpdbuf4 K;
-
-    psio_->open(PSIF_LIBTRANS_DPD, PSIO_OPEN_OLD);
-
-    global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "H <O|O>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < occpiA[h]; ++i) {
-            for (int j = 0; j < occpiA[h]; ++j) {
-                H.matrix[h][i][j] = HmoA->get(h, i, j);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_close(&H);
-
-    global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "H <V|V>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int a = 0; a < virtpiA[h]; ++a) {
-            for (int b = 0; b < virtpiA[h]; ++b) {
-                H.matrix[h][a][b] = HmoA->get(h, a + occpiA[h], b + occpiA[h]);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_close(&H);
-
-    global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('V'), "H <O|V>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < occpiA[h]; ++i) {
-            for (int j = 0; j < virtpiA[h]; ++j) {
-                H.matrix[h][i][j] = HmoA->get(h, i, j + occpiA[h]);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_close(&H);
-
-    // Write beta-integrals if ref is UHF
-    if (reference_ == "UNRESTRICTED") {
-        global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('o'), "H <o|o>");
-        global_dpd_->file2_mat_init(&H);
-        for (int h = 0; h < nirrep_; ++h) {
-            for (int i = 0; i < occpiB[h]; ++i) {
-                for (int j = 0; j < occpiB[h]; ++j) {
-                    H.matrix[h][i][j] = HmoB->get(h, i, j);
-                }
-            }
-        }
-        global_dpd_->file2_mat_wrt(&H);
-        global_dpd_->file2_close(&H);
-
-        global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('v'), ID('v'), "H <v|v>");
-        global_dpd_->file2_mat_init(&H);
-        for (int h = 0; h < nirrep_; ++h) {
-            for (int a = 0; a < virtpiB[h]; ++a) {
-                for (int b = 0; b < virtpiB[h]; ++b) {
-                    H.matrix[h][a][b] = HmoB->get(h, a + occpiB[h], b + occpiB[h]);
-                }
-            }
-        }
-        global_dpd_->file2_mat_wrt(&H);
-        global_dpd_->file2_close(&H);
-
-        global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('o'), ID('v'), "H <o|v>");
-        global_dpd_->file2_mat_init(&H);
-        for (int h = 0; h < nirrep_; ++h) {
-            for (int i = 0; i < occpiB[h]; ++i) {
-                for (int j = 0; j < virtpiB[h]; ++j) {
-                    H.matrix[h][i][j] = HmoB->get(h, i, j + occpiB[h]);
-                }
-            }
-        }
-        global_dpd_->file2_mat_wrt(&H);
-        global_dpd_->file2_close(&H);
-    }  // end uhf
-
-    psio_->close(PSIF_LIBTRANS_DPD, 1);
-    // outfile->Printf("\n dump_ints done. \n");
-
-}  // end of dump_ints
 
 //========================================================================
 //         Dump PDMs

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -76,7 +76,6 @@ class OCCWave : public Wavefunction {
     void compute_sigma_vector();
     void orb_resp_pcg_rhf();
     void orb_resp_pcg_uhf();
-    void dump_ints();
     void denominators_rhf();
     void denominators_uhf();
     void gfock();


### PR DESCRIPTION
## Description
While cleaning out old branches, I noticed a small `occ` cleanup: the H integrals written to disk are no longer used. Accordingly, we can just remove the code responsible for it.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Removes code that isn't used

## Checklist
- [x] Every `occ` test I've tried passes

## Status
- [x] Ready for review
- [x] Ready for merge
