### PR TITLE
Simplify EFP routines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ ExternalProject_Add(psi4-core
               -DCMAKE_CXX_STANDARD=${psi4_CXX_STANDARD}
               -DCMAKE_CXX_STANDARD_REQUIRED=ON
               -DCMAKE_CXX_EXTENSIONS=OFF
+              -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
               -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
               -DCMAKE_Fortran_FLAGS=${CMAKE_Fortran_FLAGS}
               -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -25,6 +25,7 @@ else()
                    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                    -DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}
                    -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                   -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
                    -DNAMESPACE_INSTALL_INCLUDEDIR=/
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    # OpenMP irrelevant

--- a/psi4/driver/procrouting/scf_proc/CMakeLists.txt
+++ b/psi4/driver/procrouting/scf_proc/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 list(APPEND sources
-  efp
   scf_iterator
 )
 

--- a/psi4/driver/procrouting/solvent/CMakeLists.txt
+++ b/psi4/driver/procrouting/solvent/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 list(APPEND sources
+  efp
   pol_embed
 )
 

--- a/psi4/driver/procrouting/solvent/efp.py
+++ b/psi4/driver/procrouting/solvent/efp.py
@@ -26,8 +26,6 @@
 # @END LICENSE
 #
 
-from __future__ import division
-
 import numpy as np
 
 from psi4 import core
@@ -165,23 +163,6 @@ def modify_Fock_induced(efpobj, mints, verbose=1):
     val_id = (val_id + val_idt) * 0.5
 
     # EFP induced dipole contribution to the Fock Matrix
-    nbf = mints.basisset().nbf()
-    V2 = np.zeros((nbf, nbf))
-
-    # Cartesian basis one-electron EFP perturbation
-    field_ints = np.zeros((3, nbf, nbf))
-
-    for iid in range(nid):
-        origin = xyz_id[iid]
-
-        # get electric field integrals from Psi4
-        p4_field_ints = mints.electric_field(origin=origin)
-        for pole in range(3):
-            field_ints[pole] = np.asarray(p4_field_ints[pole])
-
-        # scale field integrals by induced dipole magnitudes. result goes into V
-        for pole in range(3):
-            field_ints[pole] *= -val_id[iid, pole]
-            V2 += field_ints[pole]
-
-    return V2
+    coords = core.Matrix.from_array(xyz_id)
+    V_ind = mints.induction_operator(coords, core.Matrix.from_array(val_id)).np
+    return V_ind


### PR DESCRIPTION
## Description
This PR refactors EFP routines such that they use the mints functions I implemented for PE a while ago.
Less code and a significant speed-up for the electric field integral evaluations.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Move `efp.py` to `solvent` folder
- [x] Refactor functions

## Questions
- [x] Question1

## Checklist
- [x] Tests added for any new features (already present)
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
