### PR TITLE
qcschema export bug fix

### DIFF
--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -306,13 +306,6 @@ def _convert_wavefunction(wfn, context=None):
                 arr = arr[ao_map[:, None]]
         return arr
 
-    def re1d(mat):
-        arr = np.array(mat)
-        if reorder:
-            arr = arr[ao_map]
-
-        return arr
-
     # get occupations in orbital-energy ordering
     def sort_occs(noccpi, epsilon):
         occs = []
@@ -349,10 +342,10 @@ def _convert_wavefunction(wfn, context=None):
         "scf_density_b": re2d(wfn.Db_subset("AO")),
         "scf_fock_a": re2d(wfn.Fa_subset("AO")),
         "scf_fock_b": re2d(wfn.Fa_subset("AO")),
-        "scf_eigenvalues_a": re1d(wfn.epsilon_a_subset("AO", "ALL")),
-        "scf_eigenvalues_b": re1d(wfn.epsilon_b_subset("AO", "ALL")),
-        "scf_occupations_a": re1d(sort_occs((wfn.doccpi() + wfn.soccpi()).to_tuple(), wfn.epsilon_a().nph)),
-        "scf_occupations_b": re1d(sort_occs(wfn.doccpi().to_tuple(), wfn.epsilon_b().nph)),
+        "scf_eigenvalues_a": wfn.epsilon_a_subset("AO", "ALL"),
+        "scf_eigenvalues_b": wfn.epsilon_b_subset("AO", "ALL"),
+        "scf_occupations_a": sort_occs((wfn.doccpi() + wfn.soccpi()).to_tuple(), wfn.epsilon_a().nph),
+        "scf_occupations_b": sort_occs(wfn.doccpi().to_tuple(), wfn.epsilon_b().nph),
     }
 
     return ret

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -149,10 +149,6 @@ def test_qcschema_wavefunction_scf_occupations_gs(result_data_fixture):
 
     ref_occupations_a = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
     ref_occupied_energies_a = np.array([-20.55785069,  -1.31618596,  -0.6770761,  -0.55872283,  -0.49037545])
-    print(ref_occupations_a)
-    print(ret.wavefunction.scf_occupations_a)
-    print(ref_occupied_energies_a)
-    print(wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1])
 
     assert compare_arrays(ref_occupations_a, wfn.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
@@ -165,10 +161,6 @@ def test_qcschema_wavefunction_scf_occupations_es(result_data_fixture):
 
     ref_occupations_a = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
     ref_occupied_energies_a = np.array([-20.86710716,  -1.38875044,  -0.77442913,  -0.6598582,    1.10374473])
-    print(ref_occupations_a)
-    print(ret.wavefunction.scf_occupations_a)
-    print(ref_occupied_energies_a)
-    print(wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1])
 
     assert compare_arrays(ref_occupations_a, ret.wavefunction.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -147,11 +147,26 @@ def test_qcschema_wavefunction_scf_occupations_gs(result_data_fixture):
     ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
     wfn = ret.wavefunction
 
+    # correctness check
+
     ref_occupations_a = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
     ref_occupied_energies_a = np.array([-20.55785069,  -1.31618596,  -0.6770761,  -0.55872283,  -0.49037545])
 
     assert compare_arrays(ref_occupations_a, wfn.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
+
+    # consistency check
+
+    Ca = ret.wavefunction.scf_orbitals_a
+    Fa = ret.wavefunction.scf_fock_a
+    Da = ret.wavefunction.scf_density_a
+    ea = ret.wavefunction.scf_eigenvalues_a
+    na = ret.wavefunction.scf_occupations_a
+    Ca_occ = Ca[:, na == 1]
+
+    assert compare_arrays(ea, (Ca.T @ Fa @ Ca).diagonal(), 10, "Orbital Consistency")
+    assert compare_arrays(Da, Ca_occ @ Ca_occ.T, 10, "Occupied Orbital Consistency")
+
 
 def test_qcschema_wavefunction_scf_occupations_es(result_data_fixture):
     result_data_fixture["protocols"] = {"wavefunction": "all"}
@@ -159,9 +174,23 @@ def test_qcschema_wavefunction_scf_occupations_es(result_data_fixture):
     ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
     wfn = ret.wavefunction
 
+    # correctness check
+
     ref_occupations_a = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
     ref_occupied_energies_a = np.array([-20.86710716,  -1.38875044,  -0.77442913,  -0.6598582,    1.10374473])
 
     assert compare_arrays(ref_occupations_a, ret.wavefunction.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
+
+    # consistency check
+
+    Ca = ret.wavefunction.scf_orbitals_a
+    Fa = ret.wavefunction.scf_fock_a
+    Da = ret.wavefunction.scf_density_a
+    ea = ret.wavefunction.scf_eigenvalues_a
+    na = ret.wavefunction.scf_occupations_a
+    Ca_occ = Ca[:, na == 1]
+
+    assert compare_arrays(ea, (Ca.T @ Fa @ Ca).diagonal(), 10, "Orbital Consistency")
+    assert compare_arrays(Da, Ca_occ @ Ca_occ.T, 10, "Occupied Orbital Consistency")
 

--- a/tests/pytests/test_qcschema.py
+++ b/tests/pytests/test_qcschema.py
@@ -148,7 +148,11 @@ def test_qcschema_wavefunction_scf_occupations_gs(result_data_fixture):
     wfn = ret.wavefunction
 
     ref_occupations_a = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
-    ref_occupied_energies_a = np.array([-20.55785069,  -1.31618596,  -0.6770761,  -0.49037545,  -0.55872283])
+    ref_occupied_energies_a = np.array([-20.55785069,  -1.31618596,  -0.6770761,  -0.55872283,  -0.49037545])
+    print(ref_occupations_a)
+    print(ret.wavefunction.scf_occupations_a)
+    print(ref_occupied_energies_a)
+    print(wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1])
 
     assert compare_arrays(ref_occupations_a, wfn.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")
@@ -159,8 +163,12 @@ def test_qcschema_wavefunction_scf_occupations_es(result_data_fixture):
     ret = psi4.schema_wrapper.run_qcschema(result_data_fixture)
     wfn = ret.wavefunction
 
-    ref_occupations_a = np.array([1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
+    ref_occupations_a = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,])
     ref_occupied_energies_a = np.array([-20.86710716,  -1.38875044,  -0.77442913,  -0.6598582,    1.10374473])
+    print(ref_occupations_a)
+    print(ret.wavefunction.scf_occupations_a)
+    print(ref_occupied_energies_a)
+    print(wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1])
 
     assert compare_arrays(ref_occupations_a, ret.wavefunction.scf_occupations_a, 6, "Orbital Occupations")
     assert compare_arrays(ref_occupied_energies_a, wfn.scf_eigenvalues_a[wfn.scf_occupations_a == 1], 6, "Occupied Orbital Energies")


### PR DESCRIPTION
## Description
Fixes a bug that occurs when one runs `psi4 --qcschema` and requests that the wavefunction is returned. 

Before the orbitals / fock matrix / etc. are returned, all AO-indexed tensors are sorted according to CCA ordering: `Ca` and `Cb` are dimension [AO x MO], so their rows are sorted. `Fa`, `Fb`, `Da`, and `Db` are all dimension [AO x AO], so they are sorted by both row and column. `epsilon_a` and `epsilon_b` are not AO-indexed, so they shouldn't be sorted at all.

As an example, the following HF calculation has fewer MOs than AOs because of linear dependencies, and Psi4 will throw an error when `epsilon_a` is treated as if it were of length AO:
```
import psi4

ret = psi4.schema_wrapper.run_qcschema({
    "molecule": {
        "geometry": [
            0.0, 0.0, -0.1294769411935893,
            0.0, -1.494187339479985, 1.0274465079245698,
            0.0, 1.494187339479985, 1.0274465079245698
        ],  
        "symbols": ["O", "H", "H"],
    },  
    "driver": "energy",
    "model": {
        "method": "hf",
        "basis": "d-aug-cc-pvqz" # larger basis -> more lin deps
    },  
    "keywords": {
        "scf_type": "df",
        "s_tolerance" : 1e-4, # loosen lin dep cutoff
    },  
    "protocols": {
        "wavefunction" : "orbitals_and_eigenvalues",
    }   
    
})
print(ret.error)
```

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
