### PR TITLE
Fix DF+Symmetry TD-SCF/Stability by Fixing JK

### DIFF
--- a/doc/sphinxman/source/tdscf.rst
+++ b/doc/sphinxman/source/tdscf.rst
@@ -133,7 +133,6 @@ Known limitations
 ~~~~~~~~~~~~~~~~~
 
 .. warning:: The implementation cannot currently handle the following cases:
-             - The use of symmetry with density-fitted two-electron integrals.
              - Excited states of triplet symmetry from a restricted DFT reference.
              - Excited states from an unrestricted reference other than HF or LDA.
 

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -423,7 +423,9 @@ void JK::USO2AO() {
     }
     delete[] temp;
 
-    // Transform C_right
+    // Transform the left-index of all C matrices from SO basis to AO basis.
+
+    // Transform C_left. Assumed totally symmetric.
     for (size_t N = 0; N < D_.size(); ++N) {
         // Input is already C1
         if (!input_symmetry_cast_map_[N]) {
@@ -446,7 +448,7 @@ void JK::USO2AO() {
         }
     }
 
-    // Transform C_left
+    // Transform C_right. Not assumed totally symmetric.
     for (size_t N = 0; (N < D_.size()) && (!lr_symmetric_); ++N) {
         // Input is already C1
         if (!input_symmetry_cast_map_[N]) {
@@ -457,14 +459,17 @@ void JK::USO2AO() {
         int offset = 0;
         int symm = D_[N]->symmetry();
         for (int h = 0; h < AO2USO_->nirrep(); ++h) {
+            // We MUST pack columns in the order in which they appear for totally symmetric C_left.
+            // This means we transform in order of h ^ symm, not in order of h.
             int nao = AO2USO_->rowspi()[0];
-            int nso = AO2USO_->colspi()[h];
+            int nso = AO2USO_->colspi()[h ^ symm];
             int ncol = C_right_ao_[N]->colspi()[0];
-            int ncolspi = C_right_[N]->colspi()[h ^ symm];
+            // Remember: colspi_[h] describes not the orbitals of block h, but the orbitals that transform as h.
+            int ncolspi = C_right_[N]->colspi()[h];
             if (nso == 0 || ncolspi == 0) continue;
-            double** Up = AO2USO_->pointer(h);
+            double** Up = AO2USO_->pointer(h ^ symm);
             double** CAOp = C_right_ao_[N]->pointer();
-            double** CSOp = C_right_[N]->pointer(h);
+            double** CSOp = C_right_[N]->pointer(h ^ symm);
             C_DGEMM('N', 'N', nao, ncolspi, nso, 1.0, Up[0], nso, CSOp[0], ncolspi, 0.0, &CAOp[0][offset], ncol);
             offset += ncolspi;
         }

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -115,9 +115,9 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     double*** matrix_;
     /// Number of irreps
     int nirrep_;
-    /// Rows per irrep array
+    /// Rows per irrep array. Element "h" is associated with matrix block h.
     Dimension rowspi_;
-    /// Columns per irrep array
+    /// Columns per irrep array. Element "h" is associated with matrix block h ^ symmetry_.
     Dimension colspi_;
     /// Name of the matrix
     std::string name_;


### PR DESCRIPTION
## Description
This PR fixes a bug causing TD-DFT and stability analysis to give incorrect results (or diverge) when used with density-fitting and symmetry : more generally, the bug occurs any time JK objects used back-transformed C matrices that weren't totally symmetric.

This is ultimately an issue of orbital indexing. When the left index of the generalized C matrix is back-transformed from SO to AO, the blocks need to be flattened together. The code previously combined the blocks from smallest h to lowest h. So columns of irrep `h ^ symmetry_` appear _in order of h ascending_, with the left C assumed totally symmetric. The matrices have different orbital indexing if your right C `symmetry_` is not totally symmetric! This produced inconsistencies when contracting quantities against each other that inherited this indexing.

The fix is simple: change the order we back-transform irreps of the right matrix, so the order of orbitals is consistent and `symmetry_`-independent.

Closes #2122.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Bugfix: Can now converge TD-SCF with DF and symmetry
- [x] Bugfix: Can now get correct stability analysis with DF and symmetry

## Checklist
- [x] Tests added for newly working TD-SCF - they pass
- [x] Quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
