### PR TITLE
revert visibility change for symbols

### DIFF
--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(core
 )
 pybind11_extension(core)
 pybind11_strip(core)
-set_target_properties(core PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+set_target_properties(core PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILITY_INLINES_HIDDEN 1)
 
 ### >> Go into psi4 subdirectory to compile libraries and modules <<
 add_subdirectory(psi4)


### PR DESCRIPTION
## Description
Addresses a linker warning when building on OSX.
Original change in 703c8a07b238249134424fd938374eae01d8c5af.
related: https://stackoverflow.com/questions/9894961/strange-warnings-from-the-linker-ld

example of the warning:
```
ld: warning: direct access in function '__GLOBAL__sub_I_blas_diis.cc' from file 'psi4/psimrcc/libpsimrcc.a(blas_diis.cc.o)' to global weak symbol '__ZNSt6vectorISt4pairINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_ESaIS7_EED1Ev' from file 'CMakeFiles/core.dir/create_new_plugin.cc.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

## Checklist
- [x] quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
