### PR TITLE
Fix 2136

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -314,7 +314,7 @@ double CCEnergyWavefunction::compute_energy() {
     if (!done) {
         outfile->Printf("     ** Wave function not converged to %2.1e ** \n", params_.convergence);
 
-        if (params_.aobasis != "NONE") dpd_close(1);
+        if (params_.aobasis != "NONE" || params_.df) dpd_close(1);
         dpd_close(0);
         cleanup();
         timer_off("ccenergy");
@@ -481,7 +481,7 @@ double CCEnergyWavefunction::compute_energy() {
 
     if (params_.brueckner) Process::environment.globals["BRUECKNER CONVERGED"] = rotate();
 
-    if (params_.aobasis != "NONE") dpd_close(1);
+    if (params_.aobasis != "NONE" || params_.df) dpd_close(1);
     dpd_close(0);
 
     if (params_.ref == 2)

--- a/tests/pytests/test_gradients.py
+++ b/tests/pytests/test_gradients.py
@@ -21,7 +21,10 @@ data = {
          [0, -5.71563223e-03, -6.29920936e-03]]),
     "df-dct": np.array([[0, 0, 0.008477558394],
         [0,  0.005148825942, -0.004238779197],
-        [0, -0.005148825942, -0.004238779197]])
+        [0, -0.005148825942, -0.004238779197]]),
+    "df-cc2": np.array([[0, 0, 0.011903811700],
+        [0,  0.006730035450, -0.005951905850],
+        [0, -0.006730035450, -0.005951905850]])
     }
 
 @pytest.mark.slow
@@ -32,7 +35,8 @@ data = {
     pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df', 'num_frozen_uocc': 4}, 'ref': data["df-mp2 fv"]}, id='df-mp2 fv'),
     pytest.param({'name': 'mp2', 'options': {'mp2_type': 'df', 'freeze_core': 'true', 'num_frozen_uocc': 4}, 'ref': data["df-mp2 fc/fv"]}, id='df-omp2 fc/fv'),
     pytest.param({'name': 'dct', 'options': {'dct_type': 'df'}, 'ref': data["df-dct"]}, id='df-rdct'),
-    pytest.param({'name': 'dct', 'options': {'dct_type': 'df', 'reference': 'uhf'}, 'ref': data["df-dct"]}, id='df-udct')
+    pytest.param({'name': 'dct', 'options': {'dct_type': 'df', 'reference': 'uhf'}, 'ref': data["df-dct"]}, id='df-udct'),
+    pytest.param({'name': 'cc2', 'options': {'cc_type': 'df'}, 'ref': data["df-cc2"]}, id='df-cc2')
     ]
 )
 def test_gradient(inp):


### PR DESCRIPTION
## Description
Fixes #2136 by remembering to close a DPD file, because I'm a glutton for DF gradient bugs.

I'm impressed that these gradients are correct. I would have thought that the standard `libmints/deriv.cc` technology couldn't have gotten DF gradients right, but you can't argue with finite difference tests. I'll have to look into this at a later date.

## Todos
- [x] DF-CC2 gradients working

## Checklist
- [x] Tests added for newly working DF-CC2 gradients

## Status
- [x] Ready for review
- [x] Ready for merge
