### PR TITLE
Fix method/basis bug with DiskDF

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1958,8 +1958,8 @@ def _cbs_gufunc(func, total_method_name, **kwargs):
         optstash = p4util.OptionsState(['BASIS'])
         core.set_global_option('BASIS', basis)
         ptype_value, wfn = func(method_name, return_wfn=True, molecule=molecule, **kwargs)
-        core.clean()
-
+        if core.get_option("SCF", "DF_INTS_IO") != "SAVE":
+            core.clean()
         optstash.restore()
 
         if return_wfn:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   fcidump
                   fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
-                  fnocc3 fnocc4 fnocc5 frac frac-ip-fitting frac-traverse ghosts gibbs
+                  fnocc3 fnocc4 fnocc5 fnocc6 frac frac-ip-fitting frac-traverse ghosts gibbs
                   lccd-grad1 lccd-grad2 matrix1 mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mcscf1 mcscf2 mcscf3
                   mints1 mints2 mints3 mints4 mints5 mints6 mints8 mints-benchmark mints-helper
                   mints9 mints10 mints15 molden1 molden2 mom mp2-1  mp2-def2 mp2-grad1 mp2-grad2 mp2-h
@@ -95,7 +95,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   options1 cubeprop-esp dft-smoke scf-hess1 scf-hess2 scf-hess3 scf-hess4 scf-hess5 scf-freq1 dft-jk scf-coverage
                   dft-custom-dhdf dft-custom-hybrid dft-custom-mgga dft-custom-gga
                   pywrap-bfs pywrap-align pywrap-align-chiral mints12 cc-module
-                  tdscf-1 tdscf-2 tdscf-3 tdscf-4
+                  tdscf-1 tdscf-2 tdscf-3 tdscf-4 tdscf-5
                   basis-ecp dft-pruning freq-masses sapt9 sapt10
 )
     add_subdirectory(${test_name})

--- a/tests/fnocc6/CMakeLists.txt
+++ b/tests/fnocc6/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(fnocc6 "psi;quicktests;fnocc")

--- a/tests/fnocc6/input.dat
+++ b/tests/fnocc6/input.dat
@@ -1,0 +1,18 @@
+#! Test method/basis with disk_df
+
+molecule {
+O
+H 1 r
+H 1 r 2 a
+
+r=0.958
+a=104.5
+
+symmetry c1
+}
+
+set scf_type disk_df
+set cc_type df
+set df_ints_io save
+eng, wfn = psi4.energy('hf/cc-pvdz', return_wfn=True)
+cc_eng = psi4.energy('ccsd/cc-pvdz', ref_wfn=wfn)

--- a/tests/tdscf-5/CMakeLists.txt
+++ b/tests/tdscf-5/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(tdscf-5 "psi;smoketests;tdscf")
+add_regression_test(tdscf-5 "psi;quicktests;tdscf")

--- a/tests/tdscf-5/CMakeLists.txt
+++ b/tests/tdscf-5/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(tdscf-5 "psi;smoketests;tdscf")

--- a/tests/tdscf-5/input.dat
+++ b/tests/tdscf-5/input.dat
@@ -1,25 +1,16 @@
 #! td-camb3lyp with DiskDF and method/basis specification
 from psi4.driver.procrouting.response.scf_response import tdscf_excitations
 
-molecule pna{
-0 1
+memory 280 mb
 
-C          8.64800        1.07500       -1.71100
-C          9.48200        0.43000       -0.80800
-C          9.39600        0.75000        0.53800
-C          8.48200        1.71200        0.99500
-C          7.65300        2.34500        0.05500
-C          7.73200        2.03100       -1.29200
-H         10.18300       -0.30900       -1.16400
-H         10.04400        0.25200        1.24700
-H          6.94200        3.08900        0.38900
-H          7.09700        2.51500       -2.01800
-N          8.40100        2.02500        2.32500
-N          8.73400        0.74100       -3.12900
-O          7.98000        1.33100       -3.90100
-O          9.55600       -0.11000       -3.46600
-H          7.74900        2.71100        2.65200
-H          8.99100        1.57500        2.99500
+molecule h2o {
+O
+H 1 r
+H 1 r 2 a
+
+r=0.958
+a=104.5
+
 symmetry c1
 }
 
@@ -30,5 +21,5 @@ set {
     e_convergence 8
     d_convergence 8
 }
-e, wfn = psi4.energy("cam-b3lyp/sto-3g", return_wfn=True, molecule=pna)
+e, wfn = psi4.energy("cam-b3lyp/aug-cc-pvtz", return_wfn=True, molecule=h2o)
 res = tdscf_excitations(wfn, states=1, tda=True)

--- a/tests/tdscf-5/input.dat
+++ b/tests/tdscf-5/input.dat
@@ -1,0 +1,34 @@
+#! td-camb3lyp with DiskDF and method/basis specification
+from psi4.driver.procrouting.response.scf_response import tdscf_excitations
+
+molecule pna{
+0 1
+
+C          8.64800        1.07500       -1.71100
+C          9.48200        0.43000       -0.80800
+C          9.39600        0.75000        0.53800
+C          8.48200        1.71200        0.99500
+C          7.65300        2.34500        0.05500
+C          7.73200        2.03100       -1.29200
+H         10.18300       -0.30900       -1.16400
+H         10.04400        0.25200        1.24700
+H          6.94200        3.08900        0.38900
+H          7.09700        2.51500       -2.01800
+N          8.40100        2.02500        2.32500
+N          8.73400        0.74100       -3.12900
+O          7.98000        1.33100       -3.90100
+O          9.55600       -0.11000       -3.46600
+H          7.74900        2.71100        2.65200
+H          8.99100        1.57500        2.99500
+symmetry c1
+}
+
+set {
+    scf_type disk_df
+    save_jk true
+    df_ints_io save
+    e_convergence 8
+    d_convergence 8
+}
+e, wfn = psi4.energy("cam-b3lyp/sto-3g", return_wfn=True, molecule=pna)
+res = tdscf_excitations(wfn, states=1, tda=True)


### PR DESCRIPTION
## Description
This PR fixes a bug when the `method/basis` specification is used in conjunction with DiskDF (i.e. when the reference wfn is passed on to, e.g. TDSCF or FNOCC).

Fixes #1604.

New test cases added that would trigger the original problem.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] fix
- [x] add tests

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
