### PR TITLE
Misc. DCT Cleanup, `libmints` Function Variants

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -459,6 +459,8 @@ void export_mints(py::module& m) {
     typedef bool (Matrix::*matrix_load_psio1)(std::shared_ptr<psi::PSIO>&, size_t, const std::string&, int);
     typedef void (Matrix::*matrix_load_psio2)(std::shared_ptr<psi::PSIO>&, size_t, Matrix::SaveType);
     typedef const Dimension& (Matrix::*matrix_ret_dimension)() const;
+    typedef void (Matrix::*set_block_shared)(const Slice&, const Slice&, SharedMatrix);
+    typedef SharedMatrix (Matrix::*get_block_shared)(const Slice&, const Slice&);
 
     py::enum_<Matrix::SaveType>(m, "SaveType", "The layout of the matrix for saving")
         .value("Full", Matrix::SaveType::Full)
@@ -569,14 +571,14 @@ void export_mints(py::module& m) {
         .def("get", matrix_get3(&Matrix::get), "Returns a single element of a matrix in subblock h, row m, col n",
              "h"_a, "m"_a, "n"_a)
         .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", "m"_a, "n"_a)
-        .def("get_block", &Matrix::get_block, "Get a matrix block", "rows"_a, "cols"_a)
+        .def("get_block", get_block_shared(&Matrix::get_block), "Get a matrix block", "rows"_a, "cols"_a)
         .def("set", matrix_set1(&Matrix::set), "Sets every element of a matrix to val", "val"_a)
         .def("set", matrix_set3(&Matrix::set), "Sets a single element of a matrix to val at row m, col n", "m"_a, "n"_a,
              "val"_a)
         .def("set", matrix_set4(&Matrix::set),
              "Sets a single element of a matrix, subblock h, row m, col n, with value val", "h"_a, "m"_a, "n"_a,
              "val"_a)
-        .def("set_block", &Matrix::set_block, "Set a matrix block", "rows"_a, "cols"_a, "block"_a)
+        .def("set_block", set_block_shared(&Matrix::set_block), "Set a matrix block", "rows"_a, "cols"_a, "block"_a)
         // destroyed according to matrix.h file
         //.def("project_out", &Matrix::project_out, "docstring")
         .def("save", matrix_save(&Matrix::save),

--- a/psi4/src/psi4/dct/dct.h
+++ b/psi4/src/psi4/dct/dct.h
@@ -192,6 +192,7 @@ class DCTSolver : public Wavefunction {
     void compute_N_intermediate();
 
     // Orbital-optimized DCT
+    // Converge a DC-12 computation to obtain guess orbitals and double amplitudes
     void run_simult_dc_guess();
     double compute_orbital_residual();
     // Compute 2RDMs. These arise as intermediates in computing the
@@ -209,6 +210,8 @@ class DCTSolver : public Wavefunction {
     void compute_orbital_gradient_OV(bool separate_gbargamma);
     void compute_orbital_gradient_VO(bool separate_gbargamma);
     void compute_orbital_rotation_jacobi();
+    // target = old * exp(X)
+    void rotate_matrix(const Matrix& X, const Matrix& old, Matrix& target);
     void rotate_orbitals();
     Matrix construct_oo_density(const Matrix& occtau, const Matrix& virtau, const Matrix& kappa, const Matrix& C);
     // Three-particle cumulant contributions
@@ -475,10 +478,6 @@ class DCTSolver : public Wavefunction {
     SharedMatrix g_tau_a_;
     /// The beta external potential in the SO basis
     SharedMatrix g_tau_b_;
-    /// The alpha external potential in the MO basis (only needed in two-step algorithm)
-    SharedMatrix moG_tau_a_;
-    /// The beta external potential in the MO basis (only needed in two-step algorithm)
-    SharedMatrix moG_tau_b_;
     /// The alpha SCF error vector
     SharedMatrix scf_error_a_;
     /// The beta SCF error vector
@@ -507,13 +506,9 @@ class DCTSolver : public Wavefunction {
     SharedVector Q_;
     /// The subspace vector in the Davidson diagonalization procedure
     SharedMatrix b_;
-    /// Generator of the orbital rotations (Alpha) with respect to the orbitals from the previous update
-    SharedMatrix X_a_;
-    /// Generator of the orbital rotations (Beta) with respect to the orbitals from the previous update
-    SharedMatrix X_b_;
-    /// Generator of the orbital rotations (Alpha) with respect to the reference orbitals
+    /// Orbital parameters. Specifically, the generators of the orbital rotations with respect to
+    /// the reference orbitals. Dimension: nmo_ x nmo_.
     SharedMatrix Xtotal_a_;
-    /// Generator of the orbital rotations (Beta) with respect to the reference orbitals
     SharedMatrix Xtotal_b_;
 
     /// Used to align things in the output
@@ -614,6 +609,8 @@ class DCTSolver : public Wavefunction {
     /// MO-based Gamma <r|s>
     Matrix mo_gammaA_;
     Matrix mo_gammaB_;
+
+    std::map<std::string, Slice> slices_;
 };
 
 }  // namespace dct

--- a/psi4/src/psi4/dct/dct_integrals_RHF.cc
+++ b/psi4/src/psi4/dct/dct_integrals_RHF.cc
@@ -243,47 +243,23 @@ void DCTSolver::transform_core_integrals_RHF() {
     // Transform one-electron integrals to the MO basis and store them in the DPD file
     dpdfile2 H;
     Matrix aH(so_h_);
-    Matrix bH(so_h_);
     aH.transform(Ca_);
-    bH.transform(Cb_);
 
     global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('O'), "H <O|O>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < naoccpi_[h]; ++i) {
-            for (int j = 0; j < naoccpi_[h]; ++j) {
-                H.matrix[h][i][j] = aH.get(h, i, j);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_mat_close(&H);
+    const auto& O_slice = slices_.at("ACTIVE_OCC_A");
+    auto temp = *aH.get_block(O_slice);
+    temp.write_to_dpdfile2(&H);
     global_dpd_->file2_close(&H);
 
     global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('V'), ID('V'), "H <V|V>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int a = 0; a < navirpi_[h]; ++a) {
-            for (int b = 0; b < navirpi_[h]; ++b) {
-                H.matrix[h][a][b] = aH.get(h, naoccpi_[h] + a, naoccpi_[h] + b);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_mat_close(&H);
+    const auto &V_slice = slices_.at("ACTIVE_VIR_A");
+    temp = *aH.get_block(V_slice);
+    temp.write_to_dpdfile2(&H);
     global_dpd_->file2_close(&H);
 
     global_dpd_->file2_init(&H, PSIF_LIBTRANS_DPD, 0, ID('O'), ID('V'), "H <O|V>");
-    global_dpd_->file2_mat_init(&H);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < naoccpi_[h]; ++i) {
-            for (int j = 0; j < navirpi_[h]; ++j) {
-                H.matrix[h][i][j] = aH.get(h, i, naoccpi_[h] + j);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&H);
-    global_dpd_->file2_mat_close(&H);
+    temp = *aH.get_block(O_slice, V_slice);
+    temp.write_to_dpdfile2(&H);
     global_dpd_->file2_close(&H);
 }
 
@@ -298,10 +274,8 @@ void DCTSolver::build_denominators_RHF() {
     dpdbuf4 D;
     dpdfile2 F;
 
-    auto *aOccEvals = new double[nalpha_];
-    auto *bOccEvals = new double[nbeta_];
-    auto *aVirEvals = new double[navir_];
-    auto *bVirEvals = new double[nbvir_];
+    auto aOccEvals = std::vector<double>(nalpha_);
+    auto aVirEvals = std::vector<double>(navir_);
     // Pick out the diagonal elements of the Fock matrix, making sure that they are in the order
     // used by the DPD library, i.e. starting from zero for each space and ordering by irrep
     int aOccCount = 0, aVirCount = 0;
@@ -316,6 +290,8 @@ void DCTSolver::build_denominators_RHF() {
 
     // Diagonal elements of the Fock matrix
     // Alpha spin
+    aocc_c_ = Ca_->get_block(slices_.at("SO"), slices_.at("ACTIVE_OCC_A"));
+    avir_c_ = Ca_->get_block(slices_.at("SO"), slices_.at("ACTIVE_VIR_A"));
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
             if (!exact_tau_) {
@@ -323,7 +299,6 @@ void DCTSolver::build_denominators_RHF() {
             } else {
                 aOccEvals[aOccCount++] = moFa_->get(h, i, i) / (1.0 + 2.0 * T_OO.matrix[h][i][i]);
             }
-            for (int mu = 0; mu < nsopi_[h]; ++mu) aocc_c_->set(h, mu, i, Ca_->get(h, mu, i));
         }
 
         for (int a = 0; a < navirpi_[h]; ++a) {
@@ -333,7 +308,6 @@ void DCTSolver::build_denominators_RHF() {
                 aVirEvals[aVirCount++] =
                     moFa_->get(h, a + naoccpi_[h], a + naoccpi_[h]) / (1.0 - 2.0 * T_VV.matrix[h][a][a]);
             }
-            for (int mu = 0; mu < nsopi_[h]; ++mu) avir_c_->set(h, mu, a, Ca_->get(h, mu, naoccpi_[h] + a));
         }
     }
 
@@ -347,15 +321,12 @@ void DCTSolver::build_denominators_RHF() {
         // Alpha occupied
         global_dpd_->file2_init(&F, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "F <O|O>");
         global_dpd_->file2_mat_init(&F);
-        int offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
-            offset += frzcpi_[h];
             for (int i = 0; i < naoccpi_[h]; ++i) {
                 for (int j = 0; j < naoccpi_[h]; ++j) {
                     F.matrix[h][i][j] = moFa_->get(h, i, j);
                 }
             }
-            offset += nmopi_[h];
         }
         global_dpd_->file2_mat_wrt(&F);
         global_dpd_->file2_mat_close(&F);
@@ -364,15 +335,12 @@ void DCTSolver::build_denominators_RHF() {
         // Alpha Virtual
         global_dpd_->file2_init(&F, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "F <V|V>");
         global_dpd_->file2_mat_init(&F);
-        offset = 0;
         for (int h = 0; h < nirrep_; ++h) {
-            offset += naoccpi_[h];
             for (int i = 0; i < navirpi_[h]; ++i) {
                 for (int j = 0; j < navirpi_[h]; ++j) {
                     F.matrix[h][i][j] = moFa_->get(h, i + naoccpi_[h], j + naoccpi_[h]);
                 }
             }
-            offset += nmopi_[h] - naoccpi_[h];
         }
         global_dpd_->file2_mat_wrt(&F);
         global_dpd_->file2_mat_close(&F);
@@ -396,11 +364,6 @@ void DCTSolver::build_denominators_RHF() {
         global_dpd_->buf4_mat_irrep_close(&D, h);
     }
     global_dpd_->buf4_close(&D);
-
-    delete[] aOccEvals;
-    delete[] bOccEvals;
-    delete[] aVirEvals;
-    delete[] bVirEvals;
 
     dct_timer_off("DCTSolver::build_denominators()");
 }

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -70,6 +70,16 @@ void DCTSolver::init() {
     navir_ = navirpi_.sum();
     nbvir_ = nbvirpi_.sum();
 
+    auto zero = Dimension(nirrep_);
+    slices_ = {
+        {"SO",  Slice(zero, nsopi_)},
+        {"MO",  Slice(zero, nmopi_)},
+        {"ACTIVE_OCC_A",  Slice(frzcpi_, nalphapi_)},
+        {"ACTIVE_OCC_B",  Slice(frzcpi_, nbetapi_)},
+        {"ACTIVE_VIR_A",  Slice(nalphapi_, nalphapi_ + navirpi_)},
+        {"ACTIVE_VIR_B",  Slice(nbetapi_, nbetapi_ + nbvirpi_)}
+    };
+
     aocc_c_ = std::make_shared<Matrix>("Alpha Occupied MO Coefficients", nirrep_, nsopi_, naoccpi_);
     bocc_c_ = std::make_shared<Matrix>("Beta Occupied MO Coefficients", nirrep_, nsopi_, nboccpi_);
     avir_c_ = std::make_shared<Matrix>("Alpha Virtual MO Coefficients", nirrep_, nsopi_, navirpi_);
@@ -92,8 +102,6 @@ void DCTSolver::init() {
     kappa_so_b_ = std::make_shared<Matrix>("Beta Kappa Matrix", nirrep_, nsopi_, nsopi_);
     g_tau_a_ = std::make_shared<Matrix>("Alpha External Potential Matrix", nirrep_, nsopi_, nsopi_);
     g_tau_b_ = std::make_shared<Matrix>("Beta External Potential Matrix", nirrep_, nsopi_, nsopi_);
-    moG_tau_a_ = std::make_shared<Matrix>("GTau in the MO basis (Alpha)", nirrep_, nmopi_, nmopi_);
-    moG_tau_b_ = std::make_shared<Matrix>("GTau in the MO basis (Beta)", nirrep_, nmopi_, nmopi_);
     ao_s_ = std::make_shared<Matrix>("SO Basis Overlap Integrals", nirrep_, nsopi_, nsopi_);
     so_h_ = Matrix("SO basis one-electron integrals", nirrep_, nsopi_, nsopi_);
     s_half_inv_ = std::make_shared<Matrix>("SO Basis Inverse Square Root Overlap Matrix", nirrep_, nsopi_, nsopi_);
@@ -139,10 +147,6 @@ void DCTSolver::init() {
     if (options_.get_str("ALGORITHM") == "QC" || orbital_optimized_) {
         orbital_gradient_a_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Alpha)", nirrep_, nmopi_, nmopi_);
         orbital_gradient_b_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Beta)", nirrep_, nmopi_, nmopi_);
-        X_a_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. previous orbitals (Alpha)", nirrep_,
-                                        nmopi_, nmopi_);
-        X_b_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. previous orbitals (Beta)", nirrep_,
-                                        nmopi_, nmopi_);
         Xtotal_a_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. reference orbitals (Alpha)",
                                              nirrep_, nmopi_, nmopi_);
         Xtotal_b_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. reference orbitals (Beta)",

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -1899,13 +1899,14 @@ void DCTSolver::compute_orbital_rotation_nr() {
     int orbitals_address = 0;
     int idpcount = 0;
     // Alpha spin
+    auto X_a = Matrix("Alpha orbital step", nirrep_, nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = 0; a < navirpi_[h]; ++a) {
                 if (lookup_orbitals_[orbitals_address]) {
                     double value = X_->get(idpcount);
-                    X_a_->set(h, i, a + naoccpi_[h], value);
-                    X_a_->set(h, a + naoccpi_[h], i, (-1.0) * value);
+                    X_a.set(h, i, a + naoccpi_[h], value);
+                    X_a.set(h, a + naoccpi_[h], i, (-1.0) * value);
                     idpcount++;
                 }
                 orbitals_address++;
@@ -1914,13 +1915,14 @@ void DCTSolver::compute_orbital_rotation_nr() {
     }
 
     // Beta spin
+    auto X_b = Matrix("Beta orbital step", nirrep_, nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nboccpi_[h]; ++i) {
             for (int a = 0; a < nbvirpi_[h]; ++a) {
                 if (lookup_orbitals_[orbitals_address]) {
                     double value = X_->get(idpcount);
-                    X_b_->set(h, i, a + nboccpi_[h], value);
-                    X_b_->set(h, a + nboccpi_[h], i, (-1.0) * value);
+                    X_b.set(h, i, a + nboccpi_[h], value);
+                    X_b.set(h, a + nboccpi_[h], i, (-1.0) * value);
                     idpcount++;
                 }
                 orbitals_address++;
@@ -1928,8 +1930,8 @@ void DCTSolver::compute_orbital_rotation_nr() {
         }
     }
 
-    Xtotal_a_->add(X_a_);
-    Xtotal_b_->add(X_b_);
+    Xtotal_a_->add(X_a);
+    Xtotal_b_->add(X_b);
 }
 
 void DCTSolver::update_cumulant_nr() {

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -579,65 +579,14 @@ void DCTSolver::transform_tau_U() {
     global_dpd_->file2_init(&T_VV, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "Tau <V|V>");
     global_dpd_->file2_init(&T_vv, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "Tau <v|v>");
 
-    global_dpd_->file2_mat_init(&T_OO);
-    global_dpd_->file2_mat_init(&T_oo);
-    global_dpd_->file2_mat_init(&T_VV);
-    global_dpd_->file2_mat_init(&T_vv);
-    global_dpd_->file2_mat_rd(&T_OO);
-    global_dpd_->file2_mat_rd(&T_oo);
-    global_dpd_->file2_mat_rd(&T_VV);
-    global_dpd_->file2_mat_rd(&T_vv);
-
     // Zero SO tau arrays before computing it in the MO basis
     tau_so_a_->zero();
     tau_so_b_->zero();
 
-    for (int h = 0; h < nirrep_; ++h) {
-        if (nsopi_[h] == 0) continue;
-
-        double **temp = block_matrix(nsopi_[h], nsopi_[h]);
-        /*
-         * Backtransform the Tau matrices to the AO basis: soTau = C moTau Ct
-         * Attn: the forward MO->AO transformation would be: moTau = Ct S soTau S C
-         */
-        double **paOccC = aocc_c_->pointer(h);
-        double **pbOccC = bocc_c_->pointer(h);
-        double **paVirC = avir_c_->pointer(h);
-        double **pbVirC = bvir_c_->pointer(h);
-        double **pa_tau_ = tau_so_a_->pointer(h);
-        double **pb_tau_ = tau_so_b_->pointer(h);
-
-        // Alpha occupied
-        if (naoccpi_[h] && nsopi_[h]) {
-            C_DGEMM('n', 'n', nsopi_[h], naoccpi_[h], naoccpi_[h], 1.0, paOccC[0], naoccpi_[h], T_OO.matrix[h][0],
-                    naoccpi_[h], 0.0, temp[0], nsopi_[h]);
-            C_DGEMM('n', 't', nsopi_[h], nsopi_[h], naoccpi_[h], 1.0, temp[0], nsopi_[h], paOccC[0], naoccpi_[h], 1.0,
-                    pa_tau_[0], nsopi_[h]);
-        }
-        // Beta occupied
-        if (nboccpi_[h] && nsopi_[h]) {
-            C_DGEMM('n', 'n', nsopi_[h], nboccpi_[h], nboccpi_[h], 1.0, pbOccC[0], nboccpi_[h], T_oo.matrix[h][0],
-                    nboccpi_[h], 0.0, temp[0], nsopi_[h]);
-            C_DGEMM('n', 't', nsopi_[h], nsopi_[h], nboccpi_[h], 1.0, temp[0], nsopi_[h], pbOccC[0], nboccpi_[h], 1.0,
-                    pb_tau_[0], nsopi_[h]);
-        }
-        // Alpha virtual
-        if (navirpi_[h] && nsopi_[h]) {
-            C_DGEMM('n', 'n', nsopi_[h], navirpi_[h], navirpi_[h], 1.0, paVirC[0], navirpi_[h], T_VV.matrix[h][0],
-                    navirpi_[h], 0.0, temp[0], nsopi_[h]);
-            C_DGEMM('n', 't', nsopi_[h], nsopi_[h], navirpi_[h], 1.0, temp[0], nsopi_[h], paVirC[0], navirpi_[h], 1.0,
-                    pa_tau_[0], nsopi_[h]);
-        }
-        // Beta virtual
-        if (nbvirpi_[h] && nsopi_[h]) {
-            C_DGEMM('n', 'n', nsopi_[h], nbvirpi_[h], nbvirpi_[h], 1.0, pbVirC[0], nbvirpi_[h], T_vv.matrix[h][0],
-                    nbvirpi_[h], 0.0, temp[0], nsopi_[h]);
-            C_DGEMM('n', 't', nsopi_[h], nsopi_[h], nbvirpi_[h], 1.0, temp[0], nsopi_[h], pbVirC[0], nbvirpi_[h], 1.0,
-                    pb_tau_[0], nsopi_[h]);
-        }
-
-        free_block(temp);
-    }
+    tau_so_a_->add(linalg::triplet(*aocc_c_, Matrix(&T_OO), *aocc_c_, false, false, true));
+    tau_so_a_->add(linalg::triplet(*avir_c_, Matrix(&T_VV), *avir_c_, false, false, true));
+    tau_so_b_->add(linalg::triplet(*bocc_c_, Matrix(&T_oo), *bocc_c_, false, false, true));
+    tau_so_b_->add(linalg::triplet(*bvir_c_, Matrix(&T_vv), *bvir_c_, false, false, true));
 
     global_dpd_->file2_close(&T_OO);
     global_dpd_->file2_close(&T_oo);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -630,7 +630,19 @@ SharedMatrix Matrix::get_block(const Slice &rows, const Slice &cols) {
     return block;
 }
 
+SharedMatrix Matrix::get_block(const Slice &slice) {
+    return get_block(slice, slice);
+}
+
 void Matrix::set_block(const Slice &rows, const Slice &cols, SharedMatrix block) {
+    set_block(rows, cols, *block);
+}
+
+void Matrix::set_block(const Slice &slice, const Matrix& block) {
+    set_block(slice, slice, block);
+}
+
+void Matrix::set_block(const Slice &rows, const Slice &cols, const Matrix& block) {
     // check if slices are within bounds
     for (int h = 0; h < nirrep_; h++) {
         if (rows.end()[h] > rowspi_[h]) {
@@ -644,6 +656,12 @@ void Matrix::set_block(const Slice &rows, const Slice &cols, SharedMatrix block)
             throw PSIEXCEPTION(msg);
         }
     }
+    if (rows.end() - rows.begin() != block.rowspi()) {
+        throw PSIEXCEPTION("Invalid call to Matrix::set_block() row Slice doesn't match block's rows dimension.");
+    }
+    if (cols.end() - cols.begin() != block.colspi()) {
+        throw PSIEXCEPTION("Invalid call to Matrix::set_block() column Slice doesn't match block's columns dimension.");
+    }
     const Dimension &rows_begin = rows.begin();
     const Dimension &cols_begin = cols.begin();
     Dimension block_rows = rows.end() - rows.begin();
@@ -653,7 +671,7 @@ void Matrix::set_block(const Slice &rows, const Slice &cols, SharedMatrix block)
         int max_q = block_cols[h];
         for (int p = 0; p < max_p; p++) {
             for (int q = 0; q < max_q; q++) {
-                double value = block->get(h, p, q);
+                double value = block.get(h, p, q);
                 set(h, p + rows_begin[h], q + cols_begin[h], value);
             }
         }

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -486,6 +486,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @return SharedMatrix object
      */
     SharedMatrix get_block(const Slice& rows, const Slice& cols);
+    SharedMatrix get_block(const Slice& slice);
 
     /**
      * Set a matrix block
@@ -494,7 +495,9 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param cols Columns slice
      * @param block the SharedMatrix object block to set
      */
+    void set_block(const Slice& rows, const Slice& cols, const Matrix& block);
     void set_block(const Slice& rows, const Slice& cols, SharedMatrix block);
+    void set_block(const Slice& slice, const Matrix& block);
 
     /**
      * Returns the double** pointer to the h-th irrep block matrix


### PR DESCRIPTION
## Description
This is the first of what will likely be quite a few cleanup PRs in `dct`, in preparation for some features I'd like for 1.5.

This PR creates variants of existing constructors in `libmints`. We're no longer forced to use `SharedMatrix` in `set_block`, and we can now pass a single `Slice` object to `get_block` or `set_block` to use it for both rows and columns.

This PR can be moved to 1.5 if needed. I can also opt for fewer but longer PRs if needed.

## Checklist
- [x] `dct` test suite passes

## Status
- [x] Ready for review
- [x] Ready for merge
