### PR TITLE
Print extra output from TDSCF / TDDFT calculations

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2839,7 +2839,8 @@ def run_tdscf_excitations(wfn,**kwargs):
                                                 r_convergence=r_convergence,
                                                 maxiter=core.get_option("SCF", "TDSCF_MAXITER"),
                                                 guess=core.get_option("SCF", "TDSCF_GUESS"),
-                                                verbose=core.get_option("SCF", "TDSCF_PRINT"))
+                                                verbose=core.get_option("SCF", "TDSCF_PRINT"),
+                                                coeff_cutoff=core.get_option("SCF", "TDSCF_COEFF_CUTOFF"))
 
     # Shove variables into global space
     for k, v in wfn.variables().items():

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2840,7 +2840,8 @@ def run_tdscf_excitations(wfn,**kwargs):
                                                 maxiter=core.get_option("SCF", "TDSCF_MAXITER"),
                                                 guess=core.get_option("SCF", "TDSCF_GUESS"),
                                                 verbose=core.get_option("SCF", "TDSCF_PRINT"),
-                                                coeff_cutoff=core.get_option("SCF", "TDSCF_COEFF_CUTOFF"))
+                                                coeff_cutoff=core.get_option("SCF", "TDSCF_COEFF_CUTOFF"),
+                                                tdm_print=core.get_option("SCF", "TDSCF_TDM_PRINT"))
 
     # Shove variables into global space
     for k, v in wfn.variables().items():

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -471,7 +471,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                 f"\nExcited State {i+1:4d} ({1 if x.spin_mult== 'singlet' else 3} {x.irrep_ES}):"
             )
             core.print_out(
-                f"{x.E_ex_au:> 10.5f} Ha   {E_ex_nm: >.2f} nm f = {x.f_length: >.4f}\n"
+                f"{x.E_ex_au:> 10.5f} au   {E_ex_nm: >.2f} nm f = {x.f_length: >.4f}\n"
             )
 
             if not restricted:

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -442,7 +442,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
             "what": lambda x: x.edtm_velocity,
         },
         "M_TDM": {
-            "title": "Magnetic Transition Dipole Moments (AU)",
+            "title": "Magnetic Transition Dipole Moments (au)",
             "what": lambda x: x.mdtm,
         },
     }

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -425,6 +425,126 @@ def _validate_tdscf(*, wfn, states, triplets, guess) -> None:
     if guess != "DENOMINATORS":
         raise ValidationError(f"TDSCF: Guess type {guess} is not valid")
 
+# Generate additional output from TDSCF caclulations
+def _analyze_tdscf_excitations(tdscf_results,
+                              wfn,
+                              tda,
+                              coeff_cutoff,
+                              tdm_print):
+
+    restricted = wfn.same_a_b_orbs()
+
+    if 'E_TDM_LEN' in tdm_print:
+    # Print out ETDM vectors (length representation)
+        core.print_out("\nElectric Transition Dipole Moments (Length) (AU):\nState      X          Y          Z\n")
+        for i, q in enumerate(tdscf_results):
+            x, y, z = q.edtm_length
+            core.print_out(f" {i+1: 4d} {x:< 10.6f} {y:< 10.6f} {z:< 10.6f}\n")
+    if 'E_TDM_VEL' in tdm_print:
+    # Print out ETDM vectors (velocity representation)
+        core.print_out("\nElectric Transition Dipole Moments (Velocity) (AU):\nState      X          Y          Z\n")
+        for i, q in enumerate(tdscf_results):
+            x, y, z = q.edtm_velocity
+            core.print_out(f" {i+1: 4d} {x:< 10.6f} {y:< 10.6f} {z:< 10.6f}\n")
+    if 'M_TDM' in tdm_print:
+    # Print out MTDM vectors
+        core.print_out("\nMagentic Transition Dipole Moments (AU):\nState      X          Y          Z\n")
+        for i, q in enumerate(tdscf_results):
+            x, y, z = q.mdtm
+            core.print_out(f" {i+1: 4d} {x:< 10.6f} {y:< 10.6f} {z:< 10.6f}\n")
+
+# Print contributing transitions...
+    core.print_out(f"\n\nContributing excitations{'' if tda else ' and de-excitations'}")
+#...only currently for C1 symmetry
+    if wfn.molecule().point_group().symbol() != 'c1':
+        core.print_out("...only curently available with C1 symmetry\n")
+    else:
+        core.print_out(f"\nOnly contributions with coefficients >{coeff_cutoff: .2e} will be printed:\n")
+        for i, x in enumerate(tdscf_results):
+            E_ex_nm = 1e9 / (constants.conversion_factor('hartree', 'm^-1') * x.E_ex_au)
+            core.print_out(f"\nExcited State {i+1:4d} ({1 if x.spin_mult== 'singlet' else 3} {x.irrep_ES}):")
+            core.print_out(f"{x.E_ex_au:> 10.5f} Ha   {E_ex_nm: >.2f} nm f = {x.f_length: >.4f}\n")
+
+            if not restricted:
+                core.print_out("Alpha orbitals:\n")
+# Extract contributing transitions from left and right eigenvectors from solver
+            if tda:
+                X = x.L_eigvec if restricted else x.L_eigvec[0]
+                Xssq = X.sum_of_squares()
+                core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}\n")
+            else:
+                L = x.L_eigvec if restricted else x.L_eigvec[0]
+                R = x.R_eigvec if restricted else x.R_eigvec[0]
+                X = L.clone()
+                X.add(R)
+                X.scale(0.5)
+                Y = R.clone()
+                Y.subtract(L)
+                Y.scale(0.5)
+                Xssq = X.sum_of_squares()
+                Yssq = Y.sum_of_squares()
+
+                core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}; Yssq = {Yssq: .6e}; Xssq - Yssq = {Xssq-Yssq: .6e}\n")
+
+            nocc = X.rows()
+            nvirt = X.cols()
+# Ignore any scaling for now
+            div = 1
+# Excitations
+            for row in range(nocc):
+                for col in range(nvirt):
+                    coef = X.get(row,col)/div
+                    if abs(coef) > coeff_cutoff:
+                        perc = 100 * coef**2
+                        core.print_out(f"   {row+1: 3} ->{col+1+nocc: 3}  {coef: 10.6f} ({perc: >6.3f}%)\n")
+# De-excitations if not using TDA
+            if not tda:
+                for row in range(nocc):
+                    for col in range(nvirt):
+                        coef = Y.get(row,col)/div
+                        if abs(coef) > coeff_cutoff:
+                            perc = 100 * coef**2
+                            core.print_out(f"   {row+1: 3} <-{col+1+nocc: 3}  {coef: 10.6f} ({perc: >6.3f}%)\n")
+# Now treat beta orbitals if needed
+            if not restricted:
+                core.print_out("Beta orbitals:\n")
+                if tda:
+                    X = x.L_eigvec if restricted else x.L_eigvec[1]
+                    Xssq = X.sum_of_squares()
+                    core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}\n")
+                else:
+                    L = x.L_eigvec if restricted else x.L_eigvec[1]
+                    R = x.R_eigvec if restricted else x.R_eigvec[1]
+                    X = L.clone()
+                    X.add(R)
+                    X.scale(0.5)
+                    Y = R.clone()
+                    Y.subtract(L)
+                    Y.scale(0.5)
+                    Xssq = X.sum_of_squares()
+                    Yssq = Y.sum_of_squares()
+
+                    core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}; Yssq = {Yssq: .6e}; Xssq - Yssq = {Xssq-Yssq: .6e}\n")
+
+                nocc = X.rows()
+                nvirt = X.cols()
+# Excitations
+                for row in range(nocc):
+                    for col in range(nvirt):
+                        coef = X.get(row,col)/div
+                        if abs(coef) > coeff_cutoff:
+                            perc = 100 * coef**2
+                            core.print_out(f"   {row+1: 3}B->{col+1+nocc: 3}B {coef: 10.6f} ({perc: >6.3f}%)\n")
+# De-excitations if not using TDA:
+                if not tda:
+                    for row in range(nocc):
+                        for col in range(nvirt):
+                            coef = Y.get(row,col)/div
+                            if abs(coef) > coeff_cutoff:
+                                perc = 100 * coef**2
+                                core.print_out(f"   {row+1: 3}B<-{col+1+nocc: 3}B {coef: 10.6f} ({perc: >6.3f}%)\n")
+    core.print_out("\n")
+
 
 def tdscf_excitations(wfn,
                       *,
@@ -435,7 +555,8 @@ def tdscf_excitations(wfn,
                       maxiter: int = 60,
                       guess: str = "DENOMINATORS",
                       verbose: int = 1,
-                      coeff_cutoff: float = 0.1):
+                      coeff_cutoff: float = 0.1,
+                      tdm_print: List[str]):
     """Compute excitations from a SCF(HF/KS) wavefunction
 
     Parameters
@@ -496,6 +617,13 @@ def tdscf_excitations(wfn,
     coeff_cutoff : float, optional.
        Cutoff for printing out excitation and deexcitation coefficients.
        Default: 0.1
+    tdm_print : list, optional.
+       List of transition dipole moments to print.
+       Valid options are:
+         - `ETDM_LEN`. Electric Transition Dipole Moments, length representation
+         - `ETDM_VEL`. Electric Transition Dipole Moments, velocity representation
+         - `MTDM`. Magnetic Transition Dipole Moments
+       Default: `none`
 
     Notes
     -----
@@ -684,102 +812,7 @@ def tdscf_excitations(wfn,
         )
 
     core.print_out("\n")
-
-# Print out TDM vectors just length representation for now: other forms could be added)
-    core.print_out("Electric Transition Dipole Moments (Length) (AU):\nState       X          Y          Z\n")
-    for i, x in enumerate(_results):
-        core.print_out(f" {i+1: 4} {x.edtm_length[0]:< 10.6f} {x.edtm_length[1]:< 10.6f} {x.edtm_length[2]:< 10.6f}\n")
-
-# Print contributing transitions...
-    core.print_out(f"\n\nContributing excitations{'' if tda else ' and deexcitations'}")
-#...only currently for C1 symmetry
-    if wfn.molecule().point_group().symbol() != 'c1':
-        core.print_out("...only curently available with C1 symmetry\n")
-    else:
-        core.print_out(f"\nOnly contributions with coefficients >{coeff_cutoff: .2e} will be printed:\n")
-        for i, x in enumerate(_results):
-            E_ex_nm = 1e9 / (constants.conversion_factor('hartree', 'm^-1') * x.E_ex_au)
-            core.print_out(f"\nExcited State {i+1:4} ({1 if x.spin_mult== 'singlet' else 3} {x.irrep_ES}):")
-            core.print_out(f"{x.E_ex_au:> 10.5f} Ha   {E_ex_nm: >.2f} nm f = {x.f_length: >.4f}\n")
-
-            if not restricted:
-                core.print_out("Alpha orbitals:\n")
-# Extract contributing transitions from left and right eigenvectors from solver
-            if tda:
-                X = x.L_eigvec if restricted else x.L_eigvec[0]
-                Xssq = X.sum_of_squares()
-                core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}\n")
-            else:
-                L = x.L_eigvec if restricted else x.L_eigvec[0]
-                R = x.R_eigvec if restricted else x.R_eigvec[0]
-                X = L.clone()
-                X.add(R)
-                X.scale(0.5)
-                Y = R.clone()
-                Y.subtract(L)
-                Y.scale(0.5)
-                Xssq = X.sum_of_squares()
-                Yssq = Y.sum_of_squares()
-
-                core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}; Yssq = {Yssq: .6e}; Xssq - Yssq = {Xssq-Yssq: .6e}\n")
-
-            nocc = X.rows()
-            nvirt = X.cols()
-# Ignore any scaling for now
-            div = 1
-# Excitations
-            for row in range(nocc):
-                for col in range(nvirt):
-                    coef = X.get(row,col)/div
-                    if abs(coef) > coeff_cutoff:
-                        perc = 100 * coef**2
-                        core.print_out(f"   {row+1: 3} ->{col+1+nocc: 3}  {coef: 10.6f} ({perc: >6.3f}%)\n")
-# Deexcitations if not using TDA
-            if not tda:
-                for row in range(nocc):
-                    for col in range(nvirt):
-                        coef = Y.get(row,col)/div
-                        if abs(coef) > coeff_cutoff:
-                            perc = 100 * coef**2
-                            core.print_out(f"   {row+1: 3} <-{col+1+nocc: 3}  {coef: 10.6f} ({perc: >6.3f}%)\n")
-# Now treat beta orbitals if needed
-            if not restricted:
-                core.print_out("Beta orbitals:\n")
-                if tda:
-                    X = x.L_eigvec if restricted else x.L_eigvec[1]
-                    Xssq = X.sum_of_squares()
-                    core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}\n")
-                else:
-                    L = x.L_eigvec if restricted else x.L_eigvec[1]
-                    R = x.R_eigvec if restricted else x.R_eigvec[1]
-                    X = L.clone()
-                    X.add(R)
-                    X.scale(0.5)
-                    Y = R.clone()
-                    Y.subtract(L)
-                    Y.scale(0.5)
-                    Xssq = X.sum_of_squares()
-                    Yssq = Y.sum_of_squares()
-
-                    core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}; Yssq = {Yssq: .6e}; Xssq - Yssq = {Xssq-Yssq: .6e}\n")
-
-                nocc = X.rows()
-                nvirt = X.cols()
-# Excitations
-                for row in range(nocc):
-                    for col in range(nvirt):
-                        coef = X.get(row,col)/div
-                        if abs(coef) > coeff_cutoff:
-                            perc = 100 * coef**2
-                            core.print_out(f"   {row+1: 3}B->{col+1+nocc: 3}B {coef: 10.6f} ({perc: >6.3f}%)\n")
-# Deexcitations if not using TDA:
-                if not tda:
-                    for row in range(nocc):
-                        for col in range(nvirt):
-                            coef = Y.get(row,col)/div
-                            if abs(coef) > coeff_cutoff:
-                                perc = 100 * coef**2
-                                core.print_out(f"   {row+1: 3}B<-{col+1+nocc: 3}B {coef: 10.6f} ({perc: >6.3f}%)\n")
-    core.print_out("\n")
+    
+    _analyze_tdscf_excitations(_results, wfn, tda, coeff_cutoff, tdm_print)
 
     return solver_results

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -636,7 +636,7 @@ def tdscf_excitations(wfn,
        How verbose should the solver be?
        Default: 1
     coeff_cutoff : float, optional.
-       Cutoff for printing out excitation and deexcitation coefficients.
+       Cutoff for printing out excitation and de-excitation coefficients.
        Default: 0.1
     tdm_print : list, optional.
        List of transition dipole moments to print.

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -758,12 +758,13 @@ def tdscf_excitations(wfn,
                     Y = R.clone()
                     Y.subtract(L)
                     Y.scale(0.5)
-                    nocc = X.rows()
-                    nvirt = X.cols()
                     Xssq = X.sum_of_squares()
                     Yssq = Y.sum_of_squares()
 
                     core.print_out(f"  Sums of squares: Xssq = {Xssq: .6e}; Yssq = {Yssq: .6e}; Xssq - Yssq = {Xssq-Yssq: .6e}\n")
+
+                nocc = X.rows()
+                nvirt = X.cols()
 # Excitations
                 for row in range(nocc):
                     for col in range(nvirt):

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -556,7 +556,7 @@ def tdscf_excitations(wfn,
                       guess: str = "DENOMINATORS",
                       verbose: int = 1,
                       coeff_cutoff: float = 0.1,
-                      tdm_print: List[str]):
+                      tdm_print: List[str] = []):
     """Compute excitations from a SCF(HF/KS) wavefunction
 
     Parameters

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -434,7 +434,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
     # Print out requested dipole moment vectors
     _printable = {
         "E_TDM_LEN": {
-            "title": "Electric Transition Dipole Moments (Length) (AU)",
+            "title": "Electric Transition Dipole Moments (Length) (au)",
             "what": lambda x: x.edtm_length,
         },
         "E_TDM_VEL": {

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -438,7 +438,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
             "what": lambda x: x.edtm_length,
         },
         "E_TDM_VEL": {
-            "title": "Electric Transition Dipole Moments (Velocity) (AU)",
+            "title": "Electric Transition Dipole Moments (Velocity) (au)",
             "what": lambda x: x.edtm_velocity,
         },
         "M_TDM": {

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1652,6 +1652,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("TDSCF_MAXITER", 60);
         /*- Verbosity level in TDSCF -*/
         options.add_int("TDSCF_PRINT", 1);
+        /*- Cutoff for printing excitations and deexcitations icontributing to each excited state -*/
+        options.add_double("TDSCF_COEFF_CUTOFF", 0.1);
 
         /*- combine omega exchange and Hartree--Fock exchange into
               one matrix for efficiency?

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1652,8 +1652,13 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("TDSCF_MAXITER", 60);
         /*- Verbosity level in TDSCF -*/
         options.add_int("TDSCF_PRINT", 1);
-        /*- Cutoff for printing excitations and deexcitations icontributing to each excited state -*/
+        /*- Cutoff for printing excitations and de-excitations icontributing to each excited state -*/
         options.add_double("TDSCF_COEFF_CUTOFF", 0.1);
+        /*- Which transition dipole moments to print out:
+            - E_TDM_LEN : electric transition dipole moments, length representation
+            - E_TDM_VEL : electric transition dipole moments, velocity representation
+            - M_TDM : magnetic transition dipole moments -*/
+        options.add("TDSCF_TDM_PRINT", new ArrayType());
 
         /*- combine omega exchange and Hartree--Fock exchange into
               one matrix for efficiency?


### PR DESCRIPTION
## Description
This adds further output to TDSCF and TDDFT calculations, including electric TDM vectors and the excitations and deexcitations that contribute to each excited state. Currently, excitations / deexcitations are only printed for C1 symmetry.

A new option TDSCF_COEFF_CUTOFF (default = 0.1) has been added that sets the cutoff for printing excitation / deexcitation coefficients.

## Todos
- [ ] Add support for symmetry
- [ ] Add further output (e.g. other transition dipoles, etc. I've only added what I'm usually after from these calculations)

## Questions
- [ ] How to construct excitations / deexcitations when symmetry is used?
- [ ] Does documentation for new options get built automatically or do I need to add something somewhere?

## Checklist
- [ ] Further comparisons could be added to the tdscf tests, e.g. TDM vectors
- [ ] All tdscf-? tests pass (although the output will be longer than the reference output; other tests still running - slow test machine - but should run as expected) 

## Status
- [x] Ready for review
- [ ] Ready for merge
