### PR TITLE
Restores debug symbols in Debug/RelWithDebInfo

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -13,6 +13,11 @@ if(${Fortran_ENABLED})
     enable_language(Fortran)
 endif()
 
+if (NOT MSVC)
+  set(CMAKE_C_FLAGS_DEBUG "-g -O0")
+  set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${PSI4_ROOT}/cmake)
 
 include(psi4OptionsTools)

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -20,7 +20,10 @@ target_link_libraries(core
     pybind11::windows_extras
 )
 pybind11_extension(core)
-pybind11_strip(core)
+if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+    # Strip unnecessary sections of the binary on Linux/macOS
+    pybind11_strip(core)
+endif()
 set_target_properties(core PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILITY_INLINES_HIDDEN 1)
 
 ### >> Go into psi4 subdirectory to compile libraries and modules <<


### PR DESCRIPTION
## Description
Debug symbols where being mistakenly striped from the core python module.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Debug symbols are back
- [x] Ability to break on line numbers is back.

## Checklist
- [x] Works for @JonathonMisiewicz and myself.  Doesn't affect any test cases.

## Status
- [x] Ready for review
- [x] Ready for merge
