### PR TITLE
Update MDI support to version 1.2

### DIFF
--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_mdi})
-    find_package(mdi 1.1.6 CONFIG QUIET)
+    find_package(mdi 1.2.3 CONFIG QUIET)
 
     if(${mdi_FOUND})
         get_property(_loc TARGET mdi::mdi PROPERTY LOCATION)

--- a/external/upstream/mdi/CMakeLists.txt
+++ b/external/upstream/mdi/CMakeLists.txt
@@ -13,7 +13,7 @@ if(${ENABLE_mdi})
         include(ExternalProject)
         message(STATUS "Suitable mdi could not be located, ${Magenta}Building mdi${ColourReset} instead.")
         ExternalProject_Add(mdi_external
-            URL https://github.com/MolSSI-MDI/MDI_Library/archive/v1.1.6.tar.gz
+            URL https://github.com/MolSSI-MDI/MDI_Library/archive/v1.2.3.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -36,9 +36,9 @@ import qcelemental as qcel
 
 _have_mdi = False
 try:
-    from mdi import MDI_Init, MDI_Get_Intra_Code_MPI_Comm, MDI_Accept_Communicator, \
-        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
-        MDI_Register_Node, MDI_Register_Command
+    from mdi import MDI_Init, MDI_MPI_get_world_comm, MDI_Accept_communicator, \
+        MDI_Send, MDI_Recv, MDI_Recv_command, MDI_INT, MDI_DOUBLE, \
+        MDI_Register_node, MDI_Register_command
     _have_mdi = True
 except ImportError:
     pass
@@ -87,7 +87,7 @@ class MDIEngine():
 
         # Get correct intra-code MPI communicator
         if use_mpi4py:
-            self.mpi_world = MDI_Get_Intra_Code_MPI_Comm()
+            self.mpi_world = MDI_MPI_get_world_comm()
             self.world_rank = self.mpi_world.Get_rank()
 
             # Psi4 does not currently support multiple MPI ranks
@@ -95,7 +95,7 @@ class MDIEngine():
                 MPI.COMM_WORLD.Abort()
 
         # Accept a communicator to the driver code
-        self.comm = MDI_Accept_Communicator()
+        self.comm = MDI_Accept_communicator()
 
         # Ensure that the molecule is using c1 symmetry
         self.molecule.reset_point_group('c1')
@@ -131,9 +131,9 @@ class MDIEngine():
         }
 
         # Register all the supported commands
-        MDI_Register_Node("@DEFAULT")
+        MDI_Register_node("@DEFAULT")
         for command in self.commands.keys():
-            MDI_Register_Command("@DEFAULT", command)
+            MDI_Register_command("@DEFAULT", command)
 
     def length_conversion(self):
         """ Obtain the conversion factor between the geometry specification units and bohr
@@ -408,7 +408,7 @@ class MDIEngine():
 
         while not self.stop_listening:
             if self.world_rank == 0:
-                command = MDI_Recv_Command(self.comm)
+                command = MDI_Recv_command(self.comm)
             else:
                 command = None
             if use_mpi4py:
@@ -433,10 +433,7 @@ def mdi_init(mdi_arguments):
     Arguments:
         mdi_arguments: MDI configuration options
     """
-    mpi_world = None
-    if use_mpi4py:
-        mpi_world = MPI.COMM_WORLD
-    MDI_Init(mdi_arguments, mpi_world)
+    MDI_Init(mdi_arguments)
 
 
 def mdi_run(scf_method, **kwargs):


### PR DESCRIPTION
## Description
This PR updates the MDI integration to support version 1.2 of the MDI Library.

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
