### PR TITLE
Bugfix and Test Shortening

### DIFF
--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -379,10 +379,16 @@ void DCTSolver::compute_orbital_gradient_OV(bool separate_gbargamma) {
         // All we need is (gbargamma)^i_p gamma^p_a.
         auto zero = Dimension(nirrep_);
         const auto& SO = slices_.at("SO");
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), SO);
-        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(zero, doccpi_), SO);
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), SO);
-        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), SO);
+        const auto& MO = slices_.at("MO");
+        // TODO: These slices grab blocks from the entire MO space.
+        // When I have frozen core, mo_gammaA_ should definitely be active indices only.
+        // This means I'll need a slice that grabs occ/vir from the active subspace, not the entire MO space.
+        // I don't know what mo_gbarGamma_A_ should look like then.
+        // I'll worry about how to implement this in the near future "add frozen core" PR.  JPM 04/23/21
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(slices_.at("ACTIVE_OCC_A"), MO);
+        auto gbar_beta_block = mo_gbarGamma_B_.get_block(slices_.at("ACTIVE_OCC_B"), MO);
+        auto gamma_alpha_block = mo_gammaA_.get_block(MO, slices_.at("ACTIVE_VIR_A"));
+        auto gamma_beta_block = mo_gammaB_.get_block(MO, slices_.at("ACTIVE_VIR_B"));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
         auto beta_jk = linalg::doublet(gbar_beta_block, gamma_beta_block, false, false);
 

--- a/tests/dct-grad1/input.dat
+++ b/tests/dct-grad1/input.dat
@@ -1,20 +1,20 @@
-#! DCT DC-06 gradient for the O2 molecule with cc-pVDZ basis set
+#! Various DCT analytic gradients for the O2 molecule with 6-31G basis set
 
 ref_dc06 = psi4.Matrix.from_list([                                            #TEST
-                [ 0.000000000000,     0.000000000000,    -0.065140460923],    #TEST
-                [ 0.000000000000,     0.000000000000,     0.065140460923]     #TEST
+                [ 0.000000000000,     0.000000000000,     0.009067071330],    #TEST
+                [ 0.000000000000,     0.000000000000,    -0.009067071330]     #TEST
                 ])                                                            #TEST
 ref_odc06 = psi4.Matrix.from_list([                                           #TEST
-                [ 0.000000000000,     0.000000000000,    -0.056944434749],    #TEST
-                [ 0.000000000000,     0.000000000000,     0.056944434749]     #TEST
+                [ 0.000000000000,     0.000000000000,     0.015914392500],    #TEST
+                [ 0.000000000000,     0.000000000000,    -0.015914392500]     #TEST
                 ])                                                            #TEST
 ref_odc12 = psi4.Matrix.from_list([                                           #TEST
-                [ 0.000000000000,     0.000000000000,    -0.070863321661],    #TEST
-                [ 0.000000000000,     0.000000000000,     0.070863321661]     #TEST
+                [ 0.000000000000,     0.000000000000,     0.004052834155],    #TEST
+                [ 0.000000000000,     0.000000000000,    -0.004052834155]     #TEST
                 ])                                                            #TEST
 ref_odc13 = psi4.Matrix.from_list([                                           #TEST
-                [ 0.000000000000,     0.000000000000,    -0.077544709375 ],   #TEST
-                [ 0.000000000000,     0.000000000000,     0.077544709375 ]    #TEST
+                [ 0.000000000000,     0.000000000000,     0.002985330308],    #TEST
+                [ 0.000000000000,     0.000000000000,    -0.002985330308]     #TEST
                 ])                                                            #TEST
 
 molecule o2 {
@@ -27,8 +27,8 @@ R = 2.400
 }
 
 set {
-  basis           cc-pvdz
-  r_convergence   11
+  basis           6-31G
+  r_convergence   8
   diis_start_convergence 1e-2
   qc_coupling     true
   reference       uhf
@@ -39,71 +39,70 @@ set ao_basis        none
 set dct_functional dc-06
 set algorithm       simultaneous
 grad_sim = gradient('dct')
-compare_matrices(ref_dc06, grad_sim, 8, "DC-06 analytic gradient (simultaneous, ao_basis=none)")      #TEST
+compare_matrices(ref_dc06, grad_sim, 6, "DC-06 analytic gradient (simultaneous, ao_basis=none)")      #TEST
 
 set ao_basis        none
 set dct_functional dc-06
 set algorithm       qc
 grad_qc = gradient('dct')
-compare_matrices(ref_dc06, grad_qc, 8, "DC-06 analytic gradient (qc, ao_basis=none)")                 #TEST
+compare_matrices(ref_dc06, grad_qc, 6, "DC-06 analytic gradient (qc, ao_basis=none)")                 #TEST
 
 set ao_basis        none
 set dct_functional odc-06
 set algorithm simultaneous
 grad_odc06 = gradient('dct')
-compare_matrices(ref_odc06, grad_odc06, 8, "ODC-06 analytic gradient (simultaneous, ao_basis=none)")  #TEST
+compare_matrices(ref_odc06, grad_odc06, 6, "ODC-06 analytic gradient (simultaneous, ao_basis=none)")  #TEST
 
 set ao_basis        none
 set dct_functional odc-06
 set algorithm       qc
 grad_odc06 = gradient('dct')
-compare_matrices(ref_odc06, grad_odc06, 8, "ODC-06 analytic gradient (qc, ao_basis=none)")  #TEST
+compare_matrices(ref_odc06, grad_odc06, 6, "ODC-06 analytic gradient (qc, ao_basis=none)")  #TEST
 
 set ao_basis        none
 set dct_functional odc-12
 set algorithm       simultaneous
 grad_odc12 = gradient('dct')
-compare_matrices(ref_odc12, grad_odc12, 8, "ODC-12 analytic gradient (simultaneous, ao_basis=none)")  #TEST
+compare_matrices(ref_odc12, grad_odc12, 6, "ODC-12 analytic gradient (simultaneous, ao_basis=none)")  #TEST
 
 set ao_basis        none
 set dct_functional odc-12
 set algorithm       qc
 grad_odc12 = gradient('dct')
-compare_matrices(ref_odc12, grad_odc12, 8, "ODC-12 analytic gradient (qc, ao_basis=none)")  #TEST
+compare_matrices(ref_odc12, grad_odc12, 6, "ODC-12 analytic gradient (qc, ao_basis=none)")  #TEST
 
 set ao_basis        none
 set dct_functional odc-13
 set algorithm       simultaneous
 grad_odc13 = gradient('dct')
-compare_matrices(ref_odc13, grad_odc13, 8, "ODC-13 analytic gradient (simultaneous, ao_basis=none)")  #TEST
+compare_matrices(ref_odc13, grad_odc13, 6, "ODC-13 analytic gradient (simultaneous, ao_basis=none)")  #TEST
 
 set ao_basis        none
 set dct_functional odc-13
 set algorithm       qc
 grad_odc13 = gradient('dct')
-compare_matrices(ref_odc13, grad_odc13, 8, "ODC-13 analytic gradient (qc, ao_basis=none)")  #TEST
+compare_matrices(ref_odc13, grad_odc13, 6, "ODC-13 analytic gradient (qc, ao_basis=none)")  #TEST
 
-#AO_BASIS = DISK
+#AO_BASIS = DISK 
 set ao_basis        disk
 set dct_functional dc-06
 set algorithm       simultaneous
 grad_sim = gradient('dct')
-compare_matrices(ref_dc06, grad_sim, 8, "DC-06 analytic gradient (simultaneous, ao_basis=disk)")      #TEST
+compare_matrices(ref_dc06, grad_sim, 6, "DC-06 analytic gradient (simultaneous, ao_basis=disk)")      #TEST
 
 set ao_basis        disk
 set dct_functional odc-06
 set algorithm simultaneous
 grad_odc06 = gradient('dct')
-compare_matrices(ref_odc06, grad_odc06, 8, "ODC-06 analytic gradient (simultaneous, ao_basis=disk)")  #TEST
 
 set ao_basis        disk
 set dct_functional odc-12
 set algorithm       simultaneous
 grad_odc12 = gradient('dct')
-compare_matrices(ref_odc12, grad_odc12, 8, "ODC-12 analytic gradient (simultaneous, ao_basis=disk)")  #TEST
+compare_matrices(ref_odc12, grad_odc12, 6, "ODC-12 analytic gradient (simultaneous, ao_basis=disk)")  #TEST
 
 set ao_basis        disk
 set dct_functional odc-13
 set algorithm       simultaneous
 grad_odc13 = gradient('dct')
-compare_matrices(ref_odc13, grad_odc13, 8, "ODC-13 analytic gradient (simultaneous, ao_basis=disk)")  #TEST
+compare_matrices(ref_odc13, grad_odc13, 6, "ODC-13 analytic gradient (simultaneous, ao_basis=disk)")  #TEST

--- a/tests/dct6/input.dat
+++ b/tests/dct6/input.dat
@@ -1,19 +1,16 @@
-#! DCT calculation for the triplet O2 using DC-06, DC-12 and CEPA0 functionals. 
+#! DCT calculation for the triplet O2 using DC-06 and DC-12.
 #! Only two-step algorithm is tested.
 
-refscf      = -149.65367728294785   #TEST
-refmp2      = -150.17316961260252   #TEST
+refscf      = -149.604242662532   #TEST
+refmp2      = -149.921660679564   #TEST
 
 # DC-06
-refdctscf  = -149.08581589084218   #TEST
-refdct     = -150.190274002583237  #TEST
+refdctscf  = -149.246723409225   #TEST
+refdct     = -149.935859825526  #TEST
 
-# DC-12                             #TEST
-refdctxscf = -149.101073338708972  #TEST
-refdctx    = -150.185859013565732  #TEST
-
-#CEPA0
-refdctcepa = -150.188254445548893  #TEST
+# DC-12
+refdctxscf = -149.259033291563  #TEST
+refdctx    = -149.932306892090  #TEST
 
 molecule OO {
 0 3
@@ -29,7 +26,7 @@ set {
     d_convergence 12
     ao_basis    none
     algorithm   twostep
-    basis       cc-pcvtz
+    basis       cc-pvdz
     reference   uhf 
 }
 
@@ -46,4 +43,3 @@ energy('dct')
 
 compare_values(refdctxscf, variable("DCT SCF ENERGY"), 10, "DC-12 SCF Energy (two-step, ao_basis=none)");     #TEST
 compare_values(refdctx, variable("DCT TOTAL ENERGY"), 10, "DC-12 Energy (two-step, ao_basis=none)");                #TEST
-

--- a/tests/dct7/input.dat
+++ b/tests/dct7/input.dat
@@ -1,16 +1,16 @@
 #! DCT calculation for the triplet O2 using ODC-06 and ODC-12 functionals. 
 #! Only simultaneous algorithm is tested.
 
-refscf      = -149.65367728294785   #TEST
-refmp2      = -150.17316961260252   #TEST
+refscf      = -149.604242662532215   #TEST
+refmp2      = -149.921660679563871   #TEST
 
 # ODC-06
-refdctscf  = -149.074169972872937  #TEST
-refdct     = -150.194310452116127  #TEST
+refdctscf  = -149.239040008931511  #TEST
+refdct     = -149.938462434958325  #TEST
 
 # ODC-12                             #TEST
-refdctxscf = -149.090539944500989  #TEST
-refdctx    = -150.189699136183066  #TEST
+refdctxscf = -149.252176970263150  #TEST
+refdctx    = -149.934767334068425  #TEST
 
 molecule OO {
 0 3
@@ -26,7 +26,7 @@ set {
     d_convergence 12
     ao_basis    disk
     algorithm   simultaneous
-    basis       cc-pcvtz
+    basis       cc-pvdz
     reference   uhf
 }
 


### PR DESCRIPTION
## Description
Lori brought to my attention that my previous PR accidentally introduced a bug causing tests to fail. (It was an obvious indexing bug.) That is now fixed.

In the interests of making test-running less onerous, I've also changed the test cases so that I can run all `dct` tests faster. We're checking things less tightly and using smaller basis sets.

## Todos
- [x] Fix bug introduced in #2152 
- [x] Faster `dct` tests

## Checklist
- [x] `dct` tests pass, and in under two minutes

## Status
- [x] Ready for review
- [x] Ready for merge
