### PR TITLE
add Libxc printing

### DIFF
--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -25,6 +25,7 @@ dependencies:
   - nbsphinx
   - python-graphviz
   - sphinx >=3.5
+  - sphinx-autodoc-typehints
   - sphinx-automodapi
   - psi4/label/dev::sphinx-psi-theme
 

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -71,7 +71,7 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
         throw PSIEXCEPTION("Could not find required LibXC functional");
     }
     
-    xclib_description_ = "LibXC v" + std::string(xc_version_string()) + ", " + xc_reference() + "(" + xc_reference_doi() + ")";
+    xclib_description_ = "   => LibXC <=\n\n    Version " + std::string(xc_version_string()) + "\n    " + xc_reference() + " (" + xc_reference_doi() + ")";
 
     // Extract citation information
     name_ = xc_name;

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -70,6 +70,8 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
         outfile->Printf("Functional '%s' not found\n", xc_name.c_str());
         throw PSIEXCEPTION("Could not find required LibXC functional");
     }
+    
+    outfile->Printf("  ==> LibXC v%s, %s (%s) <==\n\n", xc_version_string(), xc_reference(), xc_reference_doi());
 
     // Extract citation information
     name_ = xc_name;

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -71,7 +71,7 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
         throw PSIEXCEPTION("Could not find required LibXC functional");
     }
     
-    outfile->Printf("  ==> LibXC v%s, %s (%s) <==\n\n", xc_version_string(), xc_reference(), xc_reference_doi());
+    xclib_description_ = "LibXC v" + std::string(xc_version_string()) + ", " + xc_reference() + "(" + xc_reference_doi() + ")";
 
     // Extract citation information
     name_ = xc_name;

--- a/psi4/src/psi4/libfunctional/functional.cc
+++ b/psi4/src/psi4/libfunctional/functional.cc
@@ -42,6 +42,7 @@ void Functional::common_init() {
     name_ = "";
     description_ = "";
     citation_ = "";
+    xclib_description_ = "";
     alpha_ = 1.0;
     omega_ = 0.0;
 

--- a/psi4/src/psi4/libfunctional/functional.h
+++ b/psi4/src/psi4/libfunctional/functional.h
@@ -61,6 +61,8 @@ class Functional {
     std::string description_;
     // Citations(s) defining functionals
     std::string citation_;
+    // Name, version, and citation of XC provider
+    std::string xclib_description_;
 
     // Is GGA?
     bool gga_;
@@ -118,6 +120,7 @@ class Functional {
     void set_name(const std::string &name) { name_ = name; }
     void set_description(const std::string &description) { description_ = description; }
     void set_citation(const std::string &citation) { citation_ = citation; }
+    void set_xclib_description(const std::string &description) { xclib_description_ = description; }
 
     void set_lsda_cutoff(double cut) { lsda_cutoff_ = cut; }
     void set_meta_cutoff(double cut) { meta_cutoff_ = cut; }
@@ -128,6 +131,7 @@ class Functional {
     std::string name() const { return name_; }
     std::string description() const { return description_; }
     std::string citation() const { return citation_; }
+    std::string xclib_description() const { return xclib_description_; }
 
     bool is_meta() const { return meta_; }
     bool is_gga() const { return gga_; }

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -142,6 +142,7 @@ std::shared_ptr<SuperFunctional> SuperFunctional::build_worker() {
 void SuperFunctional::print(std::string out, int level) const {
     if (level < 1) return;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
+    printer->Printf("   => %s <= \n\n", c_functionals_[0].get()->xclib_description().c_str());
     printer->Printf("   => Composite Functional: %s <= \n\n", name_.c_str());
 
     if (description_ != "") {

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -52,6 +52,7 @@ void SuperFunctional::common_init() {
     name_ = "";
     description_ = "";
     citation_ = "";
+    xclib_description_ = "";
 
     x_omega_ = 0.0;
     c_omega_ = 0.0;
@@ -92,6 +93,7 @@ std::shared_ptr<SuperFunctional> SuperFunctional::XC_build(std::string name, boo
     sup->set_name(xc_func->name());
     sup->set_description(xc_func->description());
     sup->set_citation(xc_func->citation());
+    sup->set_xclib_description(xc_func->xclib_description());
     sup->set_x_omega(xc_func->omega());
     sup->set_x_alpha(xc_func->global_exchange());
     sup->set_x_beta(xc_func->lr_exchange());
@@ -142,7 +144,11 @@ std::shared_ptr<SuperFunctional> SuperFunctional::build_worker() {
 void SuperFunctional::print(std::string out, int level) const {
     if (level < 1) return;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    printer->Printf("   => %s <= \n\n", c_functionals_[0].get()->xclib_description().c_str());
+    
+    if (xclib_description_ != "") {
+        printer->Printf("%s\n\n", xclib_description_.c_str());
+    }
+
     printer->Printf("   => Composite Functional: %s <= \n\n", name_.c_str());
 
     if (description_ != "") {

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -65,6 +65,7 @@ class SuperFunctional {
     std::string name_;
     std::string description_;
     std::string citation_;
+    std::string xclib_description_;
     bool locked_;
 
     // => Exchange-side DFA functionals <= //
@@ -175,6 +176,7 @@ class SuperFunctional {
     void set_name(const std::string& name) { name_ = name; }
     void set_description(const std::string& description) { description_ = description; }
     void set_citation(const std::string& citation) { citation_ = citation; }
+    void set_xclib_description(const std::string& description) { xclib_description_ = description; }
 
     void set_max_points(int max_points) { max_points_ = max_points; }
     void set_deriv(int deriv) { deriv_ = deriv; }
@@ -199,6 +201,7 @@ class SuperFunctional {
     std::string name() const { return name_; }
     std::string description() const { return description_; }
     std::string citation() const { return citation_; }
+    std::string xclib_description() const { return xclib_description_; }
 
     int ansatz() const;
     int max_points() const { return max_points_; }


### PR DESCRIPTION
## Description
See Libxc version and citation. looks like below. I'd have to add `xc.h` to another file to put the printing in a nicer place. @susilehtola 

```
  ==> Algorithm <==

  SCF Algorithm Type is DF.
  DIIS enabled.
  MOM disabled.
  Fractional occupation disabled.
  Guess Type is SAD.
  Energy threshold   = 1.00e-06
  Density threshold  = 1.00e-06
  Integral threshold = 1.00e-12

  ==> Primary Basis <==

  Basis Set: CC-PVDZ
    Blend: CC-PVDZ
    Number of shells: 12
    Number of basis functions: 24
    Number of Cartesian functions: 25
    Spherical Harmonics?: true
    Max angular momentum: 2

  ==> LibXC v5.1.2, S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002) <==

  ==> DFT Potential <==

   => Composite Functional: B3LYP <= 

    B3LYP Hyb-GGA Exchange-Correlation Functional

    P. J. Stephens, F. J. Devlin, C. F. Chabalowski, and M. J. Frisch, J. Phys. Chem. 98, 11623 (1994) (10.1021/j100096a001)

    Deriv               =              1
    GGA                 =           TRUE
    Meta                =          FALSE

    Exchange Hybrid     =           TRUE
    MP2 Hybrid          =          FALSE

   => Exchange Functionals <=

    0.0800   Slater exchange
    0.7200         Becke 88

   => Exact (HF) Exchange <=

    0.2000               HF 
```
## Status
- [x] Ready for review
- [x] Ready for merge **SQUASH**
