### PR TITLE
Simplify RDCT Fock Matrix Construction

### DIFF
--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -177,8 +177,6 @@ void DCTSolver::run_simult_dct_RHF() {
             // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
             process_so_ints_RHF();
 
-            // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-            Fa_->add(g_tau_a_);
             // Back up the SO basis Fock before it is symmetrically orthogonalized to transform it to the MO basis
             moFa_->copy(Fa_);
             // Transform the Fock matrix to the MO basis

--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -103,8 +103,6 @@ void DCTSolver::run_simult_dct_oo_RHF() {
             // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
             process_so_ints_RHF();
 
-            // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-            Fa_->add(g_tau_a_);
             // Back up the SO basis Fock before it is symmetrically orthogonalized to transform it to the MO basis
             moFa_->copy(Fa_);
             // Transform the Fock matrix to the MO basis

--- a/psi4/src/psi4/dct/dct_scf_RHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_RHF.cc
@@ -114,17 +114,16 @@ void DCTSolver::process_so_ints_RHF() {
     Value *valptr = iwl->values();
 
     double *Da = init_array(ntriso_);
-    double *Ta = init_array(ntriso_);
     double *Ga = init_array(ntriso_);
-    double *Va = init_array(ntriso_);
 
+    auto opdm = kappa_so_a_->clone();
+    opdm->add(tau_so_a_);
     int soOffset = 0;
     for (int h = 0; h < nirrep_; ++h) {
         for (int mu = 0; mu < nsopi_[h]; ++mu) {
             for (int nu = 0; nu <= mu; ++nu) {
                 int muNu = INDEX((nu + soOffset), (mu + soOffset));
-                Da[muNu] = kappa_so_a_->get(h, mu, nu);
-                Ta[muNu] = tau_so_a_->get(h, mu, nu);
+                Da[muNu] = opdm->get(h, mu, nu);
             }
         }
         soOffset += nsopi_[h];
@@ -218,181 +217,145 @@ void DCTSolver::process_so_ints_RHF() {
             qrArr = rqArr = INDEX(q, r);
 
             /* (pq|rs) */
-            Ga[rsArr] += (Da[pqArr] + Da[pqArr]) * value;
-            Va[rsArr] += (Ta[pqArr] + Ta[pqArr]) * value;
+            Ga[rsArr] += 2 * Da[pqArr] * value;
             if (q >= r) {
                 Ga[qrArr] -= Da[psArr] * value;
-                Va[qrArr] -= Ta[psArr] * value;
             }
 
             if (p != q && r != s && pqArr != rsArr) {
                 /* (pq|sr) */
                 if (s >= r) {
-                    Ga[srArr] += (Da[pqArr] + Da[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Ta[pqArr]) * value;
+                    Ga[srArr] += 2 * Da[pqArr] * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
                 }
 
                 /* (qp|rs) */
                 if (r >= s) {
-                    Ga[rsArr] += (Da[qpArr] + Da[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Ta[qpArr]) * value;
+                    Ga[rsArr] += 2 * Da[qpArr] * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
                 }
 
                 /* (qp|sr) */
                 if (s >= r) {
-                    Ga[srArr] += (Da[qpArr] + Da[qpArr]) * value;
-                    Va[srArr] += (Ta[qpArr] + Ta[qpArr]) * value;
+                    Ga[srArr] += 2 * Da[qpArr] * value;
                 }
                 if (p >= s) {
                     Ga[psArr] -= Da[qrArr] * value;
-                    Va[psArr] -= Ta[qrArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[pqArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
                 }
 
                 /* (sr|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[srArr] + Da[srArr]) * value;
-                    Va[pqArr] += (Ta[srArr] + Ta[srArr]) * value;
+                    Ga[pqArr] += 2 * Da[srArr] * value;
                 }
                 if (r >= p) {
                     Ga[rpArr] -= Da[sqArr] * value;
-                    Va[rpArr] -= Ta[sqArr] * value;
                 }
 
                 /* (rs|qp) */
                 if (q >= p) {
-                    Ga[qpArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[qpArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[qpArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= q) {
                     Ga[sqArr] -= Da[rpArr] * value;
-                    Va[sqArr] -= Ta[rpArr] * value;
                 }
 
                 /* (sr|qp) */
                 if (q >= p) {
-                    Ga[qpArr] += (Da[srArr] + Da[srArr]) * value;
-                    Va[qpArr] += (Ta[srArr] + Ta[srArr]) * value;
+                    Ga[qpArr] += 2 * Da[srArr] * value;
                 }
                 if (r >= q) {
                     Ga[rqArr] -= Da[spArr] * value;
-                    Va[rqArr] -= Ta[spArr] * value;
                 }
             } else if (p != q && r != s && pqArr == rsArr) {
                 /* (pq|sr) */
                 if (s >= r) {
-                    Ga[srArr] += (Da[pqArr] + Da[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Ta[pqArr]) * value;
+                    Ga[srArr] += 2 * Da[pqArr] * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
                 }
                 /* (qp|rs) */
                 if (r >= s) {
-                    Ga[rsArr] += (Da[qpArr] + Da[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Ta[qpArr]) * value;
+                    Ga[rsArr] += 2 * Da[qpArr] * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
                 }
 
                 /* (qp|sr) */
                 if (s >= r) {
-                    Ga[srArr] += (Da[qpArr] + Da[qpArr]) * value;
-                    Va[srArr] += (Ta[qpArr] + Ta[qpArr]) * value;
+                    Ga[srArr] += 2 * Da[qpArr] * value;
                 }
                 if (p >= s) {
                     Ga[psArr] -= Da[qrArr] * value;
-                    Va[psArr] -= Ta[qrArr] * value;
                 }
             } else if (p != q && r == s) {
                 /* (qp|rs) */
                 if (r >= s) {
-                    Ga[rsArr] += (Da[qpArr] + Da[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Ta[qpArr]) * value;
+                    Ga[rsArr] += 2 * Da[qpArr] * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[pqArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
                 }
 
                 /* (rs|qp) */
                 if (q >= p) {
-                    Ga[qpArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[qpArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[qpArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= q) {
                     Ga[sqArr] -= Da[rpArr] * value;
-                    Va[sqArr] -= Ta[rpArr] * value;
                 }
             } else if (p == q && r != s) {
                 /* (pq|sr) */
                 if (s >= r) {
-                    Ga[srArr] += (Da[pqArr] + Da[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Ta[pqArr]) * value;
+                    Ga[srArr] += 2 * Da[pqArr] * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[pqArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
                 }
 
                 /* (sr|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[srArr] + Da[srArr]) * value;
-                    Va[pqArr] += (Ta[srArr] + Ta[srArr]) * value;
+                    Ga[pqArr] += 2 * Da[srArr] * value;
                 }
                 if (r >= p) {
                     Ga[rpArr] -= Da[sqArr] * value;
-                    Va[rpArr] -= Ta[sqArr] * value;
                 }
             } else if (p == q && r == s && pqArr != rsArr) {
                 /* (rs|pq) */
                 if (p >= q) {
-                    Ga[pqArr] += (Da[rsArr] + Da[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Ta[rsArr]) * value;
+                    Ga[pqArr] += 2 * Da[rsArr] * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
                 }
             }
         } /* end loop through current buffer */
@@ -440,12 +403,9 @@ void DCTSolver::process_so_ints_RHF() {
             for (int nu = 0; nu <= mu; ++nu) {
                 int muNu = INDEX((nu + soOffset), (mu + soOffset));
                 double aVal = Ga[muNu];
-                double aGTVal = Va[muNu];
                 Fa_->add(h, mu, nu, aVal);
-                g_tau_a_->set(h, mu, nu, aGTVal);
                 if (mu != nu) {
                     Fa_->add(h, nu, mu, aVal);
-                    g_tau_a_->set(h, nu, mu, aGTVal);
                 }
             }
         }
@@ -453,10 +413,7 @@ void DCTSolver::process_so_ints_RHF() {
     }
 
     Fb_->copy(Fa_);
-    g_tau_b_->copy(g_tau_a_);
 
-    free(Ta);
-    free(Va);
     free(Da);
     free(Ga);
 


### PR DESCRIPTION
## Description
The next bite-sized DCT cleanup PR. To construct an intermediate `Fa_` and `Fb_`, previously, we'd divide the term in three parts, compute the three contributions separately, and then add them together. Making things more complicated, we add the pieces in different functions. In the RHF case, this PR combines two of those terms from the outset, so there are only two contributions to add.

As a result, we now construct fewer `double*`, use fewer class variables, and have less cause to worry about whether the intermediates `Fa_` and `Fb_` are completely or incompletely constructed. While I haven't run timings, this code should also be faster due to reduced random-access of arrays.

The UHF code is more complicated, so that's best saved for another PR. At that point, I hope to eliminate a few more class variables.

## Todos
- [x] More code cleanup

## Checklist
- [x] DCT tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
