### PR TITLE
GHA docs concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
       - master
       - gha-docs
 
+concurrency: 
+  group: latest-docs-group
+  cancel-in-progress: true
+  
 jobs:
 
   docs:

--- a/doc/sphinxman/source/build_faq.rst
+++ b/doc/sphinxman/source/build_faq.rst
@@ -137,7 +137,6 @@ Runtime Errors and Debugging
 #. :ref:`faq:gdblldb`
 #. :ref:`faq:setuptype`
 #. :ref:`faq:wrongpyfalse`
-.. #. :ref:`faq:erroreriam`
 
 Managing Code
 -------------
@@ -156,4 +155,5 @@ Miscellaneous
 .. #. :ref:`faq:getversion`
 .. #. :ref:`faq:binarypackage`
 .. #. :ref:`faq:getting-and-using-the-psi4dependencies-package`
+.. #. :ref:`faq:erroreriam`
 


### PR DESCRIPTION
## Description
* Fixes a line in docs that was causing a docs build fail
* Uses the new GHA concurrency feature to cancel previous docs job if new one presents itself. I've already seen it working correctly for the two commits of this branch.

## Status
- [x] Ready for review
- [x] Ready for merge **SQUASH**
