### PR TITLE
mcscf2 stability

### DIFF
--- a/tests/mcscf2/input.dat
+++ b/tests/mcscf2/input.dat
@@ -19,7 +19,7 @@ set mcscf {
     diis_max_vecs 4
     docc        [10, 1]
     socc        [ 0, 2]
-    maxiter     120
+    maxiter     140
 }
 
 thisenergy = energy('mcscf')


### PR DESCRIPTION
## Description
I've just watched this test take 84--120 iterations to converge over consecutive runs. Lately for py38 conda package it has needed 121, failing the whole thing. So I'm adding extra cushioning. The output.ref is 88, so nothing new. Also the MKL_CBWR=AVX seems on average to increase the iterations needed.

## Status
- [x] Ready for review
- [x] Ready for merge
