### PR TITLE
odd gcc and atomic_point_charges segfault

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -462,7 +462,7 @@ Bibliography
 
 .. [Olsen:2010:3721]
    J. M. Olsen, K. Aidas, and J. Kongsted.
-   *J. Chem. Theory Comput.* **6**, 3721–3734 (2010).
+   *J. Chem. Theory Comput.* **6**, 3721-3734 (2010).
 
 .. [Dreuw:2014:82]
    A. Dreuw and M. Wormit.

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -638,7 +638,7 @@ PSI Variables by Alpha
 .. psivar:: DCT LAMBDA ENERGY
 
    An energy term in density cumulant theory [Eh]. This term is the
-   2-electron cumulant’s contribution contribution to the reduced
+   2-electron cumulant's contribution contribution to the reduced
    density matrix energy expression. Not recommended for interpretative
    use except by reduced density matrix specialists.
 

--- a/doc/sphinxman/source/manage_git.rst
+++ b/doc/sphinxman/source/manage_git.rst
@@ -319,7 +319,7 @@ can't work. To solve, pull tags and remake. ::
 How to fix "cannot import name 'core' from {top-level-psi4-dir}
 ---------------------------------------------------------------
 
-First, what's happening? ``sys.path`` (where modules can be imported from in python) starts with ``''``.  If you `export PYTHONPATH={objdir}/stage/{prefix}/lib/{pymod_lib_dir}:$PYTHONPATH` to make PsiAPI easy, that inserts starting in pos’n 1 (0-indexed), so ``''`` still at the head of ``sys.path``. Now, if you try to run a psiapi/python file from ``{top-level-psi4-dir}`` that contains ``import psi4``, it will find the source tree ``psi4/__init__.py`` and fail because there’s no ``core.so`` around. That is, it’s finding what looks to be the psi4 module dir structure ``.`` when the one it wants is what you inserted into PYTHONPATH at pos’n 1.
+First, what's happening? ``sys.path`` (where modules can be imported from in python) starts with ``''``.  If you `export PYTHONPATH={objdir}/stage/{prefix}/lib/{pymod_lib_dir}:$PYTHONPATH` to make PsiAPI easy, that inserts starting in pos'n 1 (0-indexed), so ``''`` still at the head of ``sys.path``. Now, if you try to run a psiapi/python file from ``{top-level-psi4-dir}`` that contains ``import psi4``, it will find the source tree ``psi4/__init__.py`` and fail because there's no ``core.so`` around. That is, it's finding what looks to be the psi4 module dir structure ``.`` when the one it wants is what you inserted into PYTHONPATH at pos'n 1.
 
 The way around this is to move the python file you're running to any other directory. Or, within the file, do ``sys.path.insert(0, {objdir}/stage/{prefix}/lib/{pymod_lib_dir}``.
 

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -483,7 +483,7 @@ GWH
     often less accurate than the core guess (see
     [Lehtola:2019:1593]_).
 HUCKEL
-    An extended Hückel guess based on on-the-fly atomic UHF
+    An extended H\ |u_dots|\ ckel guess based on on-the-fly atomic UHF
     calculations alike SAD, see [Lehtola:2019:1593]_.
 READ
     Read the previous orbitals from a checkpoint file, casting from

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -968,6 +968,11 @@ void py_psi_set_gradient(SharedMatrix grad) { Process::environment.set_gradient(
 
 SharedMatrix py_psi_get_gradient() { return Process::environment.gradient(); }
 
+std::shared_ptr<Vector> py_psi_get_atomic_point_charges() {
+    auto empty = std::make_shared<psi::Vector>();
+    return empty;  // charges not added to process.h for environment - yet(?)
+}
+
 void py_psi_set_memory(size_t mem, bool quiet) {
     Process::environment.set_memory(mem);
     if (!quiet) {

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -1996,7 +1996,7 @@ MassPoint const *LebedevGridMgr::mk5810ptGrid() {
 
 class RadialGridMgr {
    private:
-    // See P. Gill and S. Chien,  J. Comput. Chem. 24 (2003) 732–740
+    // See P. Gill and S. Chien,  J. Comput. Chem. 24 (2003) 732-740
     static double multiexp_r(double x) { return -log(x); }
     static double multiexp_dr(double x) {
         double logx = log(x);
@@ -2609,7 +2609,7 @@ void StandardGridMgr::ReleaseMemory() {
 }
 
 void StandardGridMgr::Initialize_SG0() {
-    // See S. Chien and P. Gill,  J. Comput. Chem. 27 (2006) 730–739.
+    // See S. Chien and P. Gill,  J. Comput. Chem. 27 (2006) 730-739.
     // This is Table 1 from that paper, with {0,0} terminators at the end of each row.
     //
     // We need an 18-point rule; this is not a Lebedev rule, but we

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1988,7 +1988,7 @@ std::vector<SharedMatrix> compute_radial_moments(const std::shared_ptr<DFTGrid>&
     return rmoms;
 }
 
-// Minimal Basis Iterative Stockhplder (JCTC, 2016, p. 3894-3912, Verstraelen et al.)
+// Minimal Basis Iterative Stockholder (JCTC, 2016, p. 3894-3912, Verstraelen et al.)
 std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAnalysisCalc::compute_mbis_multipoles(
     bool print_output) {
     if (print_output) outfile->Printf("  ==> Computing MBIS Charges <==\n\n");

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1858,7 +1858,7 @@ void OEProp::compute_mbis_multipoles() {
     wfn_->set_array_variable("MBIS OCTUPOLES", opole);
 }
 
-/// Helper Methods for MBIS (JCTC, 2016, p. 3894–3912, Verstraelen et al.)
+/// Helper Methods for MBIS (JCTC, 2016, p. 3894-3912, Verstraelen et al.)
 
 // Proatomic density of a specific shell of an atom  (Equation 7 in Verstraelen et al.)
 double rho_ai_0(double n, double sigma, double distance) {
@@ -1988,7 +1988,7 @@ std::vector<SharedMatrix> compute_radial_moments(const std::shared_ptr<DFTGrid>&
     return rmoms;
 }
 
-// Minimal Basis Iterative Stockhplder (JCTC, 2016, p. 3894–3912, Verstraelen et al.)
+// Minimal Basis Iterative Stockhplder (JCTC, 2016, p. 3894-3912, Verstraelen et al.)
 std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAnalysisCalc::compute_mbis_multipoles(
     bool print_output) {
     if (print_output) outfile->Printf("  ==> Computing MBIS Charges <==\n\n");
@@ -2538,7 +2538,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> PopulationAna
     //    Note: The computed Mayer bond indices (MBI) will be different from the MBI values computed using
     //    some other program packages for the unrestricted case. The reason is that these programs left out
     //    the spin density contribution in the MBI equation for the unrestricted wavefunctions. As the result,
-    //    the MBI value will be underestimated. For example, the MBI value for the H–H bond of H2+
+    //    the MBI value will be underestimated. For example, the MBI value for the H-H bond of H2+
     //    is calculated to be 0.25 using the NBO program. The equation coded above gives the correct value of 0.5.
     //    For reference, see IJQC 29 (1986) P. 73 and IJQC 29 (1986) P. 477.
 


### PR DESCRIPTION
## Description
Even though Intel+defaults conda gcc7.3, azure gcc-s, and c-f conda gcc9 are perfectly fine with it, defaults conda gcc7.3 as primary compiler segfaults if the `py_psi_get_atomic_point_charges` fn is removed. I don't understand it, but I will appease it. All other changes are fixing stray non-ascii chars, since that's one of my routine steps when things don't make sense. Checking full tests locally.

EDIT: full tests clean

## Status
- [x] Ready for review
- [x] Ready for merge
