### PR TITLE
fix docs again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Patch Sphinx for Pybind11
       if: ${{ github.repository == 'psi4/psi4' }}
-      run: sed -i "s/lines = s\.expandtabs/lines = str(s).expandtabs/g" ${CONDA_PREFIX}/lib/python3.8/site-packages/sphinx/util/docstrings.py
+      run: sed -i "s/app\.add_autodoc_attrgetter/# app.add_autodoc_attrgetter/g" ${CONDA_PREFIX}/lib/python3.8/site-packages/sphinx_automodapi/autodoc_enhancements.py
 
     # docs are not Ninja ready
     - name: Configure with CMake (Conda Gnu + MKL)

--- a/doc/sphinxman/source/conf.py.in
+++ b/doc/sphinxman/source/conf.py.in
@@ -77,7 +77,6 @@ extensions = [
     @_jupyconf@  # nbsphinx
     # from Cloud
     'cloud_sptheme.ext.index_styling',
-    'cloud_sptheme.ext.escaped_samp_literals',
     # from Astropy
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.automodsumm',


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] With the release of Sphinx 4, a line in one of the cloud sphinx theme's extensions stopped working. Sphinx has long ago incorporated the extension's capability, so drop from list to allow newer Sphinx and fix the docs build workflow on master.
- [x] Further investigation on the "expandtabs" issue building the psi docs (https://github.com/pybind/pybind11/pull/2925), shows that neither of my first two fixes are any good. So let's `sed` a better file.

## Status
- [x] Ready for review
- [x] Ready for merge
