### PR TITLE
Remove relax_tau

### DIFF
--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -197,29 +197,22 @@ int DCTSolver::run_twostep_dct_cumulant_updates() {
     while ((!cumulantDone_ || !energyConverged_) && nAmplitudeIterations++ < maxiter_) {
         std::string diisString;
         // Build new Tau from current Amplitude
-        if (options_.get_bool("RELAX_TAU")) {
-            build_d_U();
-            // Compute tau exactly if requested
-            if (exact_tau_) {
-                build_tau_U();
-            }
-            if (options_.get_str("AO_BASIS") == "DISK") {
-                // Transform new Tau to the SO basis
-                transform_tau_U();
-                // Build SO basis tensors for the <VV||VV>, <vv||vv>, and <Vv|Vv> terms in the G intermediate
-                build_AO_tensors();
-            } else {
-                // Compute GTau contribution for the Fock operator
-                build_gtau();
-            }
-            // Update Fock operator for the F intermediate
-            update_fock();
-        } else {
-            if (options_.get_str("AO_BASIS") == "DISK") {
-                // Build SO basis tensors for the <VV||VV>, <vv||vv>, and <Vv|Vv> terms in the G intermediate
-                build_AO_tensors();
-            }
+        build_d_U();
+        // Compute tau exactly if requested
+        if (exact_tau_) {
+            build_tau_U();
         }
+        if (options_.get_str("AO_BASIS") == "DISK") {
+            // Transform new Tau to the SO basis
+            transform_tau_U();
+            // Build SO basis tensors for the <VV||VV>, <vv||vv>, and <Vv|Vv> terms in the G intermediate
+            build_AO_tensors();
+        } else {
+            // Compute GTau contribution for the Fock operator
+            build_gtau();
+        }
+        // Update Fock operator for the F intermediate
+        update_fock();
         // Build G and F intermediates needed for the density cumulant residual equations and DCT energy computation
         build_cumulant_intermediates();
         // Compute the residuals for density cumulant equations

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1231,8 +1231,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- The maximum size of the subspace for the stability check. The program will terminate if this parameter is
            exceeded and the convergence (STABILITY_CONVERGENCE) is not satisfied !expert-*/
         options.add_int("STABILITY_MAX_SPACE_SIZE", 200);
-        /*- Controls whether to relax tau during the cumulant updates or not !expert-*/
-        options.add_bool("RELAX_TAU", true);
         /*- Chooses appropriate DCT method -*/
         options.add_str("DCT_FUNCTIONAL", "ODC-12", "DC-06 DC-12 ODC-06 ODC-12 ODC-13 CEPA0");
         /*- Whether to compute three-particle energy correction or not -*/


### PR DESCRIPTION
## Description
Another tiny one, in case anybody objects to my lack of deprecation.

The old keyword `relax_tau` in `dct` is eliminated. This was marked expert, was rarely a good idea to use, and wasn't consistently applied throughout the code. This keyword was implemented as a way to explore alternate convergence strategies that would have been done in P4N, nowadays.  Because this is fairly obscure code to boot, I'm eliminating it now with no formal deprecation strategy.

## Status
- [x] Ready for review
- [x] Ready for merge
