### PR TITLE
Simplify UDCT Fock Matrix Construction

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -82,6 +82,7 @@ jobs:
     displayName: "Add Conda to PATH"
 
   - bash: |
+      # When we drop 3.6, remove dataclasses install. It should be part of Python then
       conda create -q \
         -n p4env \
         python=$PYTHON_VER \
@@ -106,6 +107,7 @@ jobs:
         blas=*=mkl \
         mkl-include \
         networkx \
+        dataclasses \
         pytest \
         eigen \
         mpfr \

--- a/psi4/src/psi4/dct/dct.h
+++ b/psi4/src/psi4/dct/dct.h
@@ -447,10 +447,6 @@ class DCTSolver : public Wavefunction {
     SharedMatrix ao_s_;
     /// The one-electron integrals in the SO basis
     Matrix so_h_;
-    /// The alpha Fock matrix (without Tau contribution) in the MO basis
-    SharedMatrix moF0a_;
-    /// The beta Fock matrix (without Tau contribution) in the MO basis
-    SharedMatrix moF0b_;
     /// The alpha Fock matrix in the SO basis
     SharedMatrix Fa_;
     /// The beta Fock matrix in the SO basis
@@ -473,10 +469,6 @@ class DCTSolver : public Wavefunction {
     SharedMatrix kappa_so_a_;
     /// The beta kappa matrix in the SO basis
     SharedMatrix kappa_so_b_;
-    /// The alpha external potential in the SO basis
-    SharedMatrix g_tau_a_;
-    /// The beta external potential in the SO basis
-    SharedMatrix g_tau_b_;
     /// The alpha SCF error vector
     SharedMatrix scf_error_a_;
     /// The beta SCF error vector

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -145,11 +145,6 @@ void DCTSolver::run_twostep_dct() {
     // Set up the DIIS manager for the density cumulant and SCF iterations
     old_ca_->copy(Ca_);
     old_cb_->copy(Cb_);
-    // Save F0 = H + G * Kappa for the Fock intermediate update in lambda iterations
-    moF0a_->copy(Fa_);
-    moF0b_->copy(Fb_);
-    moF0a_->transform(Ca_);
-    moF0b_->transform(Cb_);
     // Just so the correct value is printed in the first macro iteration
     orbitals_convergence_ = compute_scf_error_vector();
     // Start macro-iterations
@@ -291,16 +286,8 @@ void DCTSolver::run_twostep_dct_orbital_updates() {
         Fb_->copy(so_h_);
         // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
         process_so_ints();
-        // Save F0 = H + G * Kappa for the Fock intermediate update in lambda iterations
-        moF0a_->copy(Fa_);
-        moF0b_->copy(Fb_);
-        moF0a_->transform(Ca_);
-        moF0b_->transform(Cb_);
         // Save old SCF energy
         old_total_energy_ = new_total_energy_;
-        // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-        Fa_->add(g_tau_a_);
-        Fb_->add(g_tau_b_);
         // Back up the SO basis Fock before it is symmetrically orthogonalized to transform it to the MO basis
         moFa_->copy(Fa_);
         moFb_->copy(Fb_);
@@ -414,11 +401,8 @@ void DCTSolver::run_simult_dct() {
             // Copy core hamiltonian into the Fock matrix array: F = H
             Fa_->copy(so_h_);
             Fb_->copy(so_h_);
-            // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
+            // Build the new Fock matrix from the SO integrals
             process_so_ints();
-            // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-            Fa_->add(g_tau_a_);
-            Fb_->add(g_tau_b_);
             // Back up the SO basis Fock before it is symmetrically orthogonalized to transform it to the MO basis
             moFa_->copy(Fa_);
             moFb_->copy(Fb_);

--- a/psi4/src/psi4/dct/dct_integrals_UHF.cc
+++ b/psi4/src/psi4/dct/dct_integrals_UHF.cc
@@ -765,7 +765,19 @@ void DCTSolver::build_gtau() {
     global_dpd_->file2_init(&T_VV, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "Tau <V|V>");
     global_dpd_->file2_init(&T_vv, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "Tau <v|v>");
 
-    global_dpd_->file2_init(&GT_VV, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GTau <V|V>");
+    auto OO_mat = Matrix(&T_OO);
+    OO_mat.add(kappa_mo_a_->get_block(slices_.at("ACTIVE_OCC_A")));
+    auto oo_mat = Matrix(&T_oo);
+    oo_mat.add(kappa_mo_b_->get_block(slices_.at("ACTIVE_OCC_B")));
+    global_dpd_->file2_close(&T_OO);
+    global_dpd_->file2_close(&T_oo);
+
+    global_dpd_->file2_init(&T_OO, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "Gamma <O|O>");
+    global_dpd_->file2_init(&T_oo, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "Gamma <o|o>");
+    OO_mat.write_to_dpdfile2(&T_OO);
+    oo_mat.write_to_dpdfile2(&T_oo);
+
+    global_dpd_->file2_init(&GT_VV, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GGamma <V|V>");
 
     // GT_AB = (AB|CD) Tau_CD
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[V,V]"), ID("[V,V]"), ID("[V>=V]+"), ID("[V>=V]+"), 0,
@@ -800,7 +812,7 @@ void DCTSolver::build_gtau() {
     global_dpd_->buf4_close(&I);
     global_dpd_->file2_close(&GT_VV);
 
-    global_dpd_->file2_init(&GT_vv, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GTau <v|v>");
+    global_dpd_->file2_init(&GT_vv, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GGamma <v|v>");
 
     // GT_ab = +(ab|cd) Tau_cd
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[v,v]"), ID("[v,v]"), ID("[v>=v]+"), ID("[v>=v]+"), 0,
@@ -835,7 +847,7 @@ void DCTSolver::build_gtau() {
     global_dpd_->buf4_close(&I);
     global_dpd_->file2_close(&GT_vv);
 
-    global_dpd_->file2_init(&GT_OO, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GTau <O|O>");
+    global_dpd_->file2_init(&GT_OO, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GGamma <O|O>");
     // GT_IJ = +(IJ|AB) Tau_AB
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>=O]+"), ID("[V>=V]+"), 0,
                            "MO Ints (OO|VV)");
@@ -869,7 +881,7 @@ void DCTSolver::build_gtau() {
     global_dpd_->buf4_close(&I);
     global_dpd_->file2_close(&GT_OO);
 
-    global_dpd_->file2_init(&GT_oo, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GTau <o|o>");
+    global_dpd_->file2_init(&GT_oo, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GGamma <o|o>");
     // GT_ij = +(ij|ab) Tau_ab
     global_dpd_->buf4_init(&I, PSIF_LIBTRANS_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>=o]+"), ID("[v>=v]+"), 0,
                            "MO Ints (oo|vv)");

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -87,8 +87,6 @@ void DCTSolver::init() {
     scf_error_b_ = std::make_shared<Matrix>("Beta SCF Error Vector", nirrep_, nsopi_, nsopi_);
     Fa_ = reference_wavefunction_->Fa()->clone();
     Fb_ = reference_wavefunction_->Fb()->clone();
-    moF0a_ = std::make_shared<Matrix>("Alpha MO F0 Matrix", nirrep_, nmopi_, nmopi_);
-    moF0b_ = std::make_shared<Matrix>("Beta MO F0 Matrix", nirrep_, nmopi_, nmopi_);
     Ftilde_a_ = std::make_shared<Matrix>("Alpha MO Ftilde Matrix", nirrep_, nmopi_, nmopi_);
     Ftilde_b_ = std::make_shared<Matrix>("Beta MO Ftilde Matrix", nirrep_, nmopi_, nmopi_);
     Ca_ = std::make_shared<Matrix>("Alpha MO Coefficients", nirrep_, nsopi_, nsopi_);
@@ -99,8 +97,6 @@ void DCTSolver::init() {
     old_cb_ = std::make_shared<Matrix>("Old Beta MO Coefficients", nirrep_, nsopi_, nsopi_);
     kappa_so_a_ = std::make_shared<Matrix>("Alpha Kappa Matrix", nirrep_, nsopi_, nsopi_);
     kappa_so_b_ = std::make_shared<Matrix>("Beta Kappa Matrix", nirrep_, nsopi_, nsopi_);
-    g_tau_a_ = std::make_shared<Matrix>("Alpha External Potential Matrix", nirrep_, nsopi_, nsopi_);
-    g_tau_b_ = std::make_shared<Matrix>("Beta External Potential Matrix", nirrep_, nsopi_, nsopi_);
     ao_s_ = std::make_shared<Matrix>("SO Basis Overlap Integrals", nirrep_, nsopi_, nsopi_);
     so_h_ = Matrix("SO basis one-electron integrals", nirrep_, nsopi_, nsopi_);
     s_half_inv_ = std::make_shared<Matrix>("SO Basis Inverse Square Root Overlap Matrix", nirrep_, nsopi_, nsopi_);
@@ -226,8 +222,6 @@ void DCTSolver::finalize() {
     old_cb_.reset();
     kappa_so_a_.reset();
     kappa_so_b_.reset();
-    g_tau_a_.reset();
-    g_tau_b_.reset();
     ao_s_.reset();
     s_half_inv_.reset();
 }

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -99,11 +99,8 @@ void DCTSolver::run_simult_dct_oo() {
             // Copy core hamiltonian into the Fock matrix array: F = H
             Fa_->copy(so_h_);
             Fb_->copy(so_h_);
-            // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
+            // Build the new Fock matrix from the SO integrals
             process_so_ints();
-            // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-            Fa_->add(g_tau_a_);
-            Fb_->add(g_tau_b_);
             // Back up the SO basis Fock before it is symmetrically orthogonalized to transform it to the MO basis
             moFa_->copy(Fa_);
             moFb_->copy(Fb_);

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -208,15 +208,6 @@ void DCTSolver::compute_orbital_gradient() {
     Fb_->copy(so_h_);
     // Build the new Fock matrix from the SO integrals: F += Gbar * Kappa
     process_so_ints();
-    // Form F0 matrix
-    moF0a_->copy(Fa_);
-    moF0b_->copy(Fb_);
-    // Transform the F0 matrix to the MO basis
-    moF0a_->transform(Ca_);
-    moF0b_->transform(Cb_);
-    // Add non-idempotent density contribution (Tau) to the Fock matrix: F += Gbar * Tau
-    Fa_->add(g_tau_a_);
-    Fb_->add(g_tau_b_);
     // Copy the SO basis Fock for the transformation to the MO basis
     moFa_->copy(Fa_);
     moFb_->copy(Fb_);

--- a/psi4/src/psi4/dct/dct_scf_UHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_UHF.cc
@@ -295,22 +295,20 @@ void DCTSolver::process_so_ints() {
 
     double *Da = init_array(ntriso_);
     double *Db = init_array(ntriso_);
-    double *Ta = init_array(ntriso_);
-    double *Tb = init_array(ntriso_);
     double *Ga = init_array(ntriso_);
     double *Gb = init_array(ntriso_);
-    double *Va = init_array(ntriso_);
-    double *Vb = init_array(ntriso_);
 
+    auto opdm_a = kappa_so_a_->clone();
+    opdm_a->add(tau_so_a_);
+    auto opdm_b = kappa_so_b_->clone();
+    opdm_b->add(tau_so_b_);
     int soOffset = 0;
     for (int h = 0; h < nirrep_; ++h) {
         for (int mu = 0; mu < nsopi_[h]; ++mu) {
             for (int nu = 0; nu <= mu; ++nu) {
                 int muNu = INDEX((nu + soOffset), (mu + soOffset));
-                Da[muNu] = kappa_so_a_->get(h, mu, nu);
-                Db[muNu] = kappa_so_b_->get(h, mu, nu);
-                Ta[muNu] = tau_so_a_->get(h, mu, nu);
-                Tb[muNu] = tau_so_b_->get(h, mu, nu);
+                Da[muNu] = opdm_a->get(h, mu, nu);
+                Db[muNu] = opdm_b->get(h, mu, nu);
             }
         }
         soOffset += nsopi_[h];
@@ -478,13 +476,9 @@ void DCTSolver::process_so_ints() {
             /* (pq|rs) */
             Ga[rsArr] += (Da[pqArr] + Db[pqArr]) * value;
             Gb[rsArr] += (Da[pqArr] + Db[pqArr]) * value;
-            Va[rsArr] += (Ta[pqArr] + Tb[pqArr]) * value;
-            Vb[rsArr] += (Ta[pqArr] + Tb[pqArr]) * value;
             if (q >= r) {
                 Ga[qrArr] -= Da[psArr] * value;
                 Gb[qrArr] -= Db[psArr] * value;
-                Va[qrArr] -= Ta[psArr] * value;
-                Vb[qrArr] -= Tb[psArr] * value;
             }
 
             if (p != q && r != s && pqArr != rsArr) {
@@ -492,237 +486,169 @@ void DCTSolver::process_so_ints() {
                 if (s >= r) {
                     Ga[srArr] += (Da[pqArr] + Db[pqArr]) * value;
                     Gb[srArr] += (Da[pqArr] + Db[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
-                    Vb[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
                     Gb[qsArr] -= Db[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
-                    Vb[qsArr] -= Tb[prArr] * value;
                 }
 
                 /* (qp|rs) */
                 if (r >= s) {
                     Ga[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
                     Gb[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
-                    Vb[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
                     Gb[prArr] -= Db[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
-                    Vb[prArr] -= Tb[qsArr] * value;
                 }
 
                 /* (qp|sr) */
                 if (s >= r) {
                     Ga[srArr] += (Da[qpArr] + Db[qpArr]) * value;
                     Gb[srArr] += (Da[qpArr] + Db[qpArr]) * value;
-                    Va[srArr] += (Ta[qpArr] + Tb[qpArr]) * value;
-                    Vb[srArr] += (Ta[qpArr] + Tb[qpArr]) * value;
                 }
                 if (p >= s) {
                     Ga[psArr] -= Da[qrArr] * value;
                     Gb[psArr] -= Db[qrArr] * value;
-                    Va[psArr] -= Ta[qrArr] * value;
-                    Vb[psArr] -= Tb[qrArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
                     Gb[spArr] -= Db[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
-                    Vb[spArr] -= Tb[rqArr] * value;
                 }
 
                 /* (sr|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[srArr] + Db[srArr]) * value;
                     Gb[pqArr] += (Da[srArr] + Db[srArr]) * value;
-                    Va[pqArr] += (Ta[srArr] + Tb[srArr]) * value;
-                    Vb[pqArr] += (Ta[srArr] + Tb[srArr]) * value;
                 }
                 if (r >= p) {
                     Ga[rpArr] -= Da[sqArr] * value;
                     Gb[rpArr] -= Db[sqArr] * value;
-                    Va[rpArr] -= Ta[sqArr] * value;
-                    Vb[rpArr] -= Tb[sqArr] * value;
                 }
 
                 /* (rs|qp) */
                 if (q >= p) {
                     Ga[qpArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[qpArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[qpArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[qpArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= q) {
                     Ga[sqArr] -= Da[rpArr] * value;
                     Gb[sqArr] -= Db[rpArr] * value;
-                    Va[sqArr] -= Ta[rpArr] * value;
-                    Vb[sqArr] -= Tb[rpArr] * value;
                 }
 
                 /* (sr|qp) */
                 if (q >= p) {
                     Ga[qpArr] += (Da[srArr] + Db[srArr]) * value;
                     Gb[qpArr] += (Da[srArr] + Db[srArr]) * value;
-                    Va[qpArr] += (Ta[srArr] + Tb[srArr]) * value;
-                    Vb[qpArr] += (Ta[srArr] + Tb[srArr]) * value;
                 }
                 if (r >= q) {
                     Ga[rqArr] -= Da[spArr] * value;
                     Gb[rqArr] -= Db[spArr] * value;
-                    Va[rqArr] -= Ta[spArr] * value;
-                    Vb[rqArr] -= Tb[spArr] * value;
                 }
             } else if (p != q && r != s && pqArr == rsArr) {
                 /* (pq|sr) */
                 if (s >= r) {
                     Ga[srArr] += (Da[pqArr] + Db[pqArr]) * value;
                     Gb[srArr] += (Da[pqArr] + Db[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
-                    Vb[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
                     Gb[qsArr] -= Db[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
-                    Vb[qsArr] -= Tb[prArr] * value;
                 }
                 /* (qp|rs) */
                 if (r >= s) {
                     Ga[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
                     Gb[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
-                    Vb[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
                     Gb[prArr] -= Db[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
-                    Vb[prArr] -= Tb[qsArr] * value;
                 }
 
                 /* (qp|sr) */
                 if (s >= r) {
                     Ga[srArr] += (Da[qpArr] + Db[qpArr]) * value;
                     Gb[srArr] += (Da[qpArr] + Db[qpArr]) * value;
-                    Va[srArr] += (Ta[qpArr] + Tb[qpArr]) * value;
-                    Vb[srArr] += (Ta[qpArr] + Tb[qpArr]) * value;
                 }
                 if (p >= s) {
                     Ga[psArr] -= Da[qrArr] * value;
                     Gb[psArr] -= Db[qrArr] * value;
-                    Va[psArr] -= Ta[qrArr] * value;
-                    Vb[psArr] -= Tb[qrArr] * value;
                 }
             } else if (p != q && r == s) {
                 /* (qp|rs) */
                 if (r >= s) {
                     Ga[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
                     Gb[rsArr] += (Da[qpArr] + Db[qpArr]) * value;
-                    Va[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
-                    Vb[rsArr] += (Ta[qpArr] + Tb[qpArr]) * value;
                 }
                 if (p >= r) {
                     Ga[prArr] -= Da[qsArr] * value;
                     Gb[prArr] -= Db[qsArr] * value;
-                    Va[prArr] -= Ta[qsArr] * value;
-                    Vb[prArr] -= Tb[qsArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
                     Gb[spArr] -= Db[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
-                    Vb[spArr] -= Tb[rqArr] * value;
                 }
 
                 /* (rs|qp) */
                 if (q >= p) {
                     Ga[qpArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[qpArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[qpArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[qpArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= q) {
                     Ga[sqArr] -= Da[rpArr] * value;
                     Gb[sqArr] -= Db[rpArr] * value;
-                    Va[sqArr] -= Ta[rpArr] * value;
-                    Vb[sqArr] -= Tb[rpArr] * value;
                 }
             } else if (p == q && r != s) {
                 /* (pq|sr) */
                 if (s >= r) {
                     Ga[srArr] += (Da[pqArr] + Db[pqArr]) * value;
                     Gb[srArr] += (Da[pqArr] + Db[pqArr]) * value;
-                    Va[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
-                    Vb[srArr] += (Ta[pqArr] + Tb[pqArr]) * value;
                 }
                 if (q >= s) {
                     Ga[qsArr] -= Da[prArr] * value;
                     Gb[qsArr] -= Db[prArr] * value;
-                    Va[qsArr] -= Ta[prArr] * value;
-                    Vb[qsArr] -= Tb[prArr] * value;
                 }
 
                 /* (rs|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
                     Gb[spArr] -= Db[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
-                    Vb[spArr] -= Tb[rqArr] * value;
                 }
 
                 /* (sr|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[srArr] + Db[srArr]) * value;
                     Gb[pqArr] += (Da[srArr] + Db[srArr]) * value;
-                    Va[pqArr] += (Ta[srArr] + Tb[srArr]) * value;
-                    Vb[pqArr] += (Ta[srArr] + Tb[srArr]) * value;
                 }
                 if (r >= p) {
                     Ga[rpArr] -= Da[sqArr] * value;
                     Gb[rpArr] -= Db[sqArr] * value;
-                    Va[rpArr] -= Ta[sqArr] * value;
-                    Vb[rpArr] -= Tb[sqArr] * value;
                 }
             } else if (p == q && r == s && pqArr != rsArr) {
                 /* (rs|pq) */
                 if (p >= q) {
                     Ga[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
                     Gb[pqArr] += (Da[rsArr] + Db[rsArr]) * value;
-                    Va[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
-                    Vb[pqArr] += (Ta[rsArr] + Tb[rsArr]) * value;
                 }
                 if (s >= p) {
                     Ga[spArr] -= Da[rqArr] * value;
                     Gb[spArr] -= Db[rqArr] * value;
-                    Va[spArr] -= Ta[rqArr] * value;
-                    Vb[spArr] -= Tb[rqArr] * value;
                 }
             }
         } /* end loop through current buffer */
@@ -814,27 +740,17 @@ void DCTSolver::process_so_ints() {
                 int muNu = INDEX((nu + soOffset), (mu + soOffset));
                 double aVal = Ga[muNu];
                 double bVal = Gb[muNu];
-                double aGTVal = Va[muNu];
-                double bGTVal = Vb[muNu];
                 Fa_->add(h, mu, nu, aVal);
                 Fb_->add(h, mu, nu, bVal);
-                g_tau_a_->set(h, mu, nu, aGTVal);
-                g_tau_b_->set(h, mu, nu, bGTVal);
                 if (mu != nu) {
                     Fa_->add(h, nu, mu, aVal);
                     Fb_->add(h, nu, mu, bVal);
-                    g_tau_a_->set(h, nu, mu, aGTVal);
-                    g_tau_b_->set(h, nu, mu, bGTVal);
                 }
             }
         }
         soOffset += nsopi_[h];
     }
 
-    free(Ta);
-    free(Tb);
-    free(Va);
-    free(Vb);
     free(Da);
     free(Db);
     free(Ga);
@@ -853,20 +769,22 @@ void DCTSolver::update_fock() {
 
     dpdfile2 Gtau;
 
-    // moF0 is the mean-field Fock matrix. We need to add the "correlation correction" to the 1RDM, tau.
-    moFa_->copy(moF0a_);
-    moFb_->copy(moF0b_);
+    moFa_->copy(so_h_);
+    moFa_->transform(Ca_);
+
+    moFb_->copy(so_h_);
+    moFb_->transform(Cb_);
 
     // We already have the gbar * tau contraction computed, so let's just add it in.
-    auto moG_tau = Matrix("GTau in the MO basis", nirrep_, nmopi_, nmopi_);
+    auto moG_tau = Matrix("GGamma in the MO basis", nirrep_, nmopi_, nmopi_);
 
     // Alpha occupied
-    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GTau <O|O>");
+    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GGamma <O|O>");
     moG_tau.set_block(slices_.at("ACTIVE_OCC_A"), Matrix(&Gtau));
     global_dpd_->file2_close(&Gtau);
 
     // Alpha virtual
-    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GTau <V|V>");
+    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GGamma <V|V>");
     moG_tau.set_block(slices_.at("ACTIVE_VIR_A"), Matrix(&Gtau));
     global_dpd_->file2_close(&Gtau);
 
@@ -874,12 +792,12 @@ void DCTSolver::update_fock() {
 
     // Beta occupied
     moG_tau.zero();
-    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GTau <o|o>");
+    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GGamma <o|o>");
     moG_tau.set_block(slices_.at("ACTIVE_OCC_B"), Matrix(&Gtau));
     global_dpd_->file2_close(&Gtau);
 
     // Beta virtual
-    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GTau <v|v>");
+    global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GGamma <v|v>");
     moG_tau.set_block(slices_.at("ACTIVE_VIR_B"), Matrix(&Gtau));
     global_dpd_->file2_close(&Gtau);
 
@@ -1018,24 +936,17 @@ void DCTSolver::build_AO_tensors() {
                            "tau2AO <nn|Oo>");
     global_dpd_->buf4_scm(&tau2_AO_ab, 0.0);
 
-    // Preparing Tau for the GTau terms
-    // This is where the SO-basis Tau will be
+    // Prepare to contract TEI against the 1RDM.
+
+    // Write SO basis gamma to disk as s1(temp)
     global_dpd_->file2_init(&s_aa_1, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s1(temp)A <n|n>");
     global_dpd_->file2_init(&s_bb_1, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s1(temp)B <n|n>");
-
-    // Write SO-basis Tau to disk
-    global_dpd_->file2_mat_init(&s_aa_1);
-    global_dpd_->file2_mat_init(&s_bb_1);
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < nsopi_[h]; ++i) {
-            for (int j = 0; j < nsopi_[h]; ++j) {
-                s_aa_1.matrix[h][i][j] = tau_so_a_->get(h, i, j);
-                s_bb_1.matrix[h][i][j] = tau_so_b_->get(h, i, j);
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&s_aa_1);
-    global_dpd_->file2_mat_wrt(&s_bb_1);
+    auto gamma_a = tau_so_a_->clone();
+    gamma_a->add(kappa_so_a_);
+    auto gamma_b = tau_so_b_->clone();
+    gamma_b->add(kappa_so_b_);
+    gamma_a->write_to_dpdfile2(&s_aa_1);
+    gamma_b->write_to_dpdfile2(&s_bb_1);
     global_dpd_->file2_close(&s_aa_1);
     global_dpd_->file2_close(&s_bb_1);
 
@@ -1043,7 +954,7 @@ void DCTSolver::build_AO_tensors() {
     global_dpd_->file2_init(&s_aa_1, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s1(temp)A <n|n>");
     global_dpd_->file2_init(&s_bb_1, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s1(temp)B <n|n>");
 
-    // This is where GTau contribution will be placed
+    // This is where GGamma contribution will be placed
     global_dpd_->file2_init(&s_aa_2, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s2(temp)A <n|n>");
     global_dpd_->file2_init(&s_bb_2, PSIF_DCT_DPD, 0, ID('n'), ID('n'), "s2(temp)B <n|n>");
     global_dpd_->file2_scm(&s_aa_2, 0.0);
@@ -1166,27 +1077,27 @@ void DCTSolver::build_AO_tensors() {
     global_dpd_->buf4_close(&tau2_AO_ab);
     global_dpd_->buf4_close(&tau_temp);
 
-    // Transform the GTau contribution from MO to SO basis for the future use in the Fock operator
+    // Transform the GGamma contribution from SO to MO basis for the future use in the Fock operator
     // Alpha occupied
-    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GTau <O|O>");
+    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GGamma <O|O>");
     global_dpd_->file2_scm(&tau, 0.0);
     file2_transform(&s_aa_2, &tau, aocc_c_, false);
     global_dpd_->file2_close(&tau);
 
     // Alpha virtual
-    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GTau <V|V>");
+    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "GGamma <V|V>");
     global_dpd_->file2_scm(&tau, 0.0);
     file2_transform(&s_aa_2, &tau, avir_c_, false);
     global_dpd_->file2_close(&tau);
 
     // Beta occupied
-    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GTau <o|o>");
+    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('o'), ID('o'), "GGamma <o|o>");
     global_dpd_->file2_scm(&tau, 0.0);
     file2_transform(&s_bb_2, &tau, bocc_c_, false);
     global_dpd_->file2_close(&tau);
 
     // Beta virtual
-    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GTau <v|v>");
+    global_dpd_->file2_init(&tau, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "GGamma <v|v>");
     global_dpd_->file2_scm(&tau, 0.0);
     file2_transform(&s_bb_2, &tau, bvir_c_, false);
     global_dpd_->file2_close(&tau);


### PR DESCRIPTION
## Description
The UHF version of #2171. The open-shell DCT code now adds two terms before contracting them against the two-electron integrals, rather than after. Unfortunately, this change was tightly coupled to surrounding code, making it unnecessarily complicated. This PR also removes that complexity. Again, I'd expect this code to be faster due to reduced random access in `process_so_integrals`, but I haven't run timings.

## Todos
- [x] More transparent code
- [x] 100 less lines code
- [x] Four fewer global variables 

## Checklist
- [x] DCT tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
