### PR TITLE
Remove evidence of defunct CHKPT

### DIFF
--- a/doc/sphinxman/source/external.rst
+++ b/doc/sphinxman/source/external.rst
@@ -103,17 +103,18 @@ the following code will do that::
     if scratch_dir:
         psi4_io.set_default_path(scratch_dir + '/')
 
-Individual files can be sent to specific locations.  For example, file 32 is
-the checkpoint file that the user might want to retain in the working directory
-(*i.e.*, where |PSIfour| was launched from) for restart purposes.  This is
+Individual files can be sent to specific locations.  For example, file 12
+contains information about the internal coordiantes of a geometry optimization.
+The user may want to retain this in the working directory
+(*i.e.*, where |PSIfour| was launched from) to analyze the optimization.  This is
 accomplished by the commands below::
 
-    psi4_io.set_specific_path(32, './')
-    psi4_io.set_specific_retention(32, True)
+    psi4_io.set_specific_path(12, './')
+    psi4_io.set_specific_retention(12, True)
 
     # equivalent to above
-    psi4_io.set_specific_path(PSIF_CHKPT, './')
-    psi4_io.set_specific_retention(PSIF_CHKPT, True)
+    psi4_io.set_specific_path(PSIF_INTCO, './')
+    psi4_io.set_specific_retention(PSIF_INTCO, True)
 
 A guide to the contents of individual scratch files may be found at :ref:`apdx:psiFiles`.
 To circumvent difficulties with running multiple jobs in the same scratch, the
@@ -176,14 +177,14 @@ To set up the scratch path from a variable ``$MYSCRATCH``::
     if scratch_dir:
         psi4_io.set_default_path(scratch_dir + '/')
 
-To set up a specific path for the checkpoint file and instruct |PSIfour| not to delete it::
+To set up a specific path for the internal coordinate file and instruct |PSIfour| not to delete it::
 
-    psi4_io.set_specific_path(32, './')
-    psi4_io.set_specific_retention(32, True)
+    psi4_io.set_specific_path(12, './')
+    psi4_io.set_specific_retention(12, True)
 
     # equivalent to above
-    psi4_io.set_specific_path(PSIF_CHKPT, './')
-    psi4_io.set_specific_retention(PSIF_CHKPT, True)
+    psi4_io.set_specific_path(PSIF_INTCO, './')
+    psi4_io.set_specific_retention(PSIF_INTCO, True)
 
 The Python interpreter will execute the contents of the
 |psirc| file in the current user's home area (if present) before performing any

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -1525,7 +1525,6 @@ PSI Variables by Alpha
    Deprecated in favor of :psivar:`SCF QUADRUPOLE`.
 
 .. psivar:: SCF TOTAL ENERGY
-   SCF TOTAL ENERGY (CHKPT)
 
    The total electronic energy [Eh] of the SCF stage of the calculation.
    The :samp:`{method} CORRELATION ENERGY` variables from subsequent stages of a

--- a/psi4/include/psi4/psifiles.h
+++ b/psi4/include/psi4/psifiles.h
@@ -57,7 +57,6 @@
 #define PSIF_INTCO               12   /*- internal coordinates file, currently is ASCII file like output.intco -*/
 #define PSIF_3INDEX              16   /*-  -*/
 #define PSIF_DSCF                31   /*-  -*/
-#define PSIF_CHKPT               32   /*- new libpsio checkpoint file number -*/
 #define PSIF_SO_TEI              33   /*-  -*/
 #define PSIF_SO_PK               34   /*-  -*/
 #define PSIF_OEI                 35   /*-  -*/
@@ -67,7 +66,6 @@
 #define PSIF_SO_R12T1            39   /*-  -*/
 #define PSIF_DERINFO             40   /*-  -*/
 #define PSIF_SO_PRESORT          41   /*-  -*/
-#define PSIF_OLD_CHKPT           42   /*- Until we have flexible PSIF_CHKPT this will store previous calculation info -*/
 #define PSIF_CIVECT              43   /*- CI vector from DETCI along with string and determinant info -*/
 
 #define PSIF_AO_DGDBX            44   /*- B-field derivative AO integrals over GIAO Gaussians -- only bra-ket permutational symmetry holds -*/

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -52,7 +52,7 @@ namespace ccdensity {
 
 /*
 ** get_moinfo():  Routine to obtain basic orbital information from
-** CHKPT and CC_INFO.
+** CC_INFO.
 **
 ** T. Daniel Crawford, October 1996.
 ** Modified by TDC, March 1999.

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -324,7 +324,6 @@ double CCEnergyWavefunction::compute_energy() {
     outfile->Printf("    SCF energy       (wfn)                    = %20.15f\n", moinfo_.escf);
     outfile->Printf("    Reference energy (file100)                = %20.15f\n", moinfo_.eref);
 
-    // Process::environment.globals["SCF TOTAL ENERGY (CHKPT)"] = moinfo.escf;
     // Process::environment.globals["SCF TOTAL ENERGY"] = moinfo.eref;
 
     if (params_.ref == 0 || params_.ref == 2) {

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -54,7 +54,7 @@ namespace ccenergy {
 
 /*
 ** get_moinfo():  Routine to obtain basic orbital information from
-** CHKPT and CC_INFO.
+** CC_INFO.
 **
 ** T. Daniel Crawford, October 1996
 ** Modified by TDC, March 1999

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -51,7 +51,7 @@ namespace cceom {
 
 /*
 ** get_moinfo():  Routine to obtain basic orbital information from
-** CHKPT and CC_INFO.
+** CC_INFO.
 **
 ** T. Daniel Crawford, October 1996
 ** Modified by TDC, March 1999

--- a/psi4/src/psi4/cc/cchbar/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cchbar/get_moinfo.cc
@@ -49,7 +49,7 @@ namespace cchbar {
 
 /*
 ** get_moinfo():  Routine to obtain basic orbital information from
-** CHKPT and CC_INFO.
+** CC_INFO.
 **
 ** T. Daniel Crawford, October 1996.
 ** Modified by TDC, March 1999.

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -51,7 +51,7 @@ namespace psi {
 namespace ccresponse {
 
 /* get_moinfo(): Routine to obtain basic orbital information from
-** CHKPT and CC_INFO.
+** CC_INFO.
 **
 ** T. Daniel Crawford, October 1996
 ** Modified for ccresponse by TDC May, 2003

--- a/psi4/src/psi4/cc/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cctriples/get_moinfo.cc
@@ -54,7 +54,7 @@ namespace cctriples {
 
 /*
  ** get_moinfo():  Routine to obtain basic orbital information from
- ** CHKPT and CC_INFO.
+ ** CC_INFO.
  **
  ** T. Daniel Crawford, October 1996.
  ** Modified by TDC, March 1999.

--- a/psi4/src/psi4/libpsio/init.cc
+++ b/psi4/src/psi4/libpsio/init.cc
@@ -103,7 +103,6 @@ PSIO::PSIO() {
     for (i = 1; i <= PSIO_MAXVOL; ++i) {
         char kwd[20];
         sprintf(kwd, "VOLUME%u", i);
-        filecfg_kwd("DEFAULT", kwd, PSIF_CHKPT, "./");
         filecfg_kwd("DEFAULT", kwd, -1, "/tmp/");
     }
     filecfg_kwd("DEFAULT", "NAME", -1, psi_file_prefix);


### PR DESCRIPTION
## Description
This PR removes the files `PSIF_CHKPT` and `PSIF_OLD_CHKPT`, as well as references to them elsewhere in the docs and the code. These were unused and caused some confusion in a [recent forum topic](http://forum.psicode.org/t/cannot-retain-scratch-file/2181/4).

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Remove `PSIF_CHKPT` and `PSIF_OLD_CHKPT`

## Checklist
- [x] [`ctest` passes](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
