### PR TITLE
keep_intcos works for successful optimization

### DIFF
--- a/psi4/src/psi4/optking/optking.cc
+++ b/psi4/src/psi4/optking/optking.cc
@@ -418,8 +418,7 @@ OptReturnType optking(void) {
       p_Opt_data->reset_trust_radius();
       delete p_Opt_data;
       INTCO_EXCEPT::dynamic_level = options.get_int("DYNAMIC_LEVEL"); // reset for future optimizations
-      opt_intco_dat_remove(); // rm intco definitions
-      opt_io_remove();        // rm optimization data
+      opt_clean();
       mol1->write_geom();  // write geometry -> chkpt file (also output for QChem)
       print_end_out();
 


### PR DESCRIPTION
## Description
A minor bugfix in optking: internal coordinate files are now kept after a successful optimization.

I'm well-aware that the days of C-Optking are numbered, but I came across this when investigating a tangentially related bug report in forums, so I might as well fix it.

## Checklist
- [x] Code runs and keeps internal coordinate files when `keep_intcos` set to `true`

## Status
- [x] Ready for review
- [x] Ready for merge
