### PR TITLE
Remove more unused psifiles

### DIFF
--- a/psi4/include/psi4/psifiles.h
+++ b/psi4/include/psi4/psifiles.h
@@ -56,7 +56,6 @@
 #define PSIF_GRAD                11   /*- geometry optimization, geometry, and gradient; currently is an ASCII file like output.grad -*/
 #define PSIF_INTCO               12   /*- internal coordinates file, currently is ASCII file like output.intco -*/
 #define PSIF_3INDEX              16   /*-  -*/
-#define PSIF_DSCF                31   /*-  -*/
 #define PSIF_SO_TEI              33   /*-  -*/
 #define PSIF_SO_PK               34   /*-  -*/
 #define PSIF_OEI                 35   /*-  -*/
@@ -84,10 +83,6 @@
 #define PSIF_LIBTRANS_B_HT       63   /*- libtrans: Beta half-transformed integrals in DPD format -*/
 
 #define PSIF_LIBDIIS             64   /*- Storage for libdiis -*/
-#define PSIF_DFT_GRID            65   /*- Storage for DFT/pseudospectral grid -*/
-// DFCC 3-index files
-#define PSIF_DF_TENSOR           66   /*-  -*/
-#define PSIF_PS_TENSOR           67   /*-  -*/
 
 #define PSIF_TPDM_PRESORT        71   /*-  -*/
 #define PSIF_MO_TEI              72   /*-  -*/
@@ -96,8 +91,6 @@
 #define PSIF_MO_LAG              75   /*-  -*/
 #define PSIF_AO_OPDM             76   /*- PSIF_AO_OPDM also contains AO Lagrangian -*/
 #define PSIF_AO_TPDM             77   /*-  -*/
-
-#define PSIF_DBOC                78   /*- dboc: -*/
 
 #define PSIF_MO_R12              79   /*-  -*/
 #define PSIF_MO_R12T2            80   /*-  -*/
@@ -115,13 +108,6 @@
 #define PSIF_AA_PRESORT          87   /*- AA UHF twopdm presort file -*/
 #define PSIF_BB_PRESORT          88   /*- BB UHF twopdm presort file -*/
 #define PSIF_AB_PRESORT          89   /*- AB UHF twopdm presort file -*/
-/*
-** MO Hessian File (also contains specialized integral and Fock lists.
-** See programs STABLE and CPHF for more info.
-** -TDC, 7/00
-*/
-#define PSIF_MO_HESS             90   /*-  -*/
-#define PSIF_CPHF                91   /*-  -*/
 
 #define PSIF_SO_PKSUPER1         92   /*-  -*/
 #define PSIF_SO_PKSUPER2         93   /*-  -*/
@@ -130,10 +116,7 @@
 #define PSIF_HALFT0              94   /*-  -*/
 #define PSIF_HALFT1              95   /*-  -*/
 
-#define PSIF_DFSCF_A             96   /*- B Matrix containing 3-index tensor in AOs for use with DF-SCF -*/
 #define PSIF_DFSCF_BJ            97   /*- B Matrix containing 3-index tensor in AOs with J^-1/2 for use with DF-SCF -*/
-#define PSIF_DFSCF_K             98   /*- Exchange tensor for DF-SCF -*/
-#define PSIF_DFSCF_BJI           99   /*- The three-center integrals for DF-SCF -*/
 
 // The miscellaneous CC information file
 #define PSIF_CC_INFO             100  /*-  -*/
@@ -239,9 +222,6 @@
 #define PSIF_SAPT_TEMP           197  /*- SAPT Temporary worlds fastest code file -*/
 
 #define PSIF_SAPT_LRINTS         198  /*- SAPT0 2-Body linear response LDA integrals -*/
-
-#define PSIF_SO_D1OEI            199  /*- Derivative OEIs are stored in file 199 -*/
-#define PSIF_SO_D1ERI            200  /*- Derivative ERIs are stored in files 200, 201, 202, etc. File 200 -*/
 
 #define PSIF_3B_SAPT_TRIMER      220  /*- SAPT Three-Body Trimer -*/
 #define PSIF_3B_SAPT_DIMER_AB    221  /*- SAPT Three-Body Dimer AB -*/


### PR DESCRIPTION
## Description
Exactly what it says in the title.

There will need to be another docs cleanup to elaborate on the workings of `set_specific_retention` and orbital passing, but I think @hokru has a PR in the works that will be changing that.

## Checklist
- [x] `ctest` passes

## Status
- [x] Ready for review
- [x] Ready for merge
