### PR TITLE
Major bugfix! Parallelization error in DF gradients

### DIFF
--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2469,11 +2469,12 @@ SharedMatrix MintsHelper::three_idx_grad(const std::string& aux_name, const std:
         auto idx3p = idx3_matrix->pointer();
 #pragma omp parallel for
         for (int aux = 0; aux < np; aux++) {
+            auto elt = &data[ntri * aux];
             for (int p = 0; p < nprim; p++) {
                 for (int q = 0; q <= p; q++) {
-                    idx3p[aux][p * nprim + q] = *data;
-                    idx3p[aux][q * nprim + p] = *data;
-                    data++;
+                    idx3p[aux][p * nprim + q] = *elt;
+                    idx3p[aux][q * nprim + p] = *elt;
+                    elt++;
                 }
             }
         }


### PR DESCRIPTION
## Description
Closes #2192 : a correctness error in threaded correlated DF gradients accidentally introduced during my refactoring. I recommend making a new release candidate sooner rather than later. Sorry, Lori.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Fix DF gradient paralellization error 

## Lessons Learned
- [ ] We could _really_ use a threaded pass of quicktests as part of the test suite
- [ ] The difficulty of compiling Psi4 can be a bottleneck in the dev process. In particular, the instructions to get Psi source-compiled on Linux don't work out of the box, and Mac clang compilers are still choking on programs that are five lines of code.

## Checklist
- [x] Threaded quicktests pass. @hokru found the only failure was the bug which this PR fixed, and the failing test cases pass now.

## Status
- [x] Ready for review
- [x] Ready for merge
