### PR TITLE
Add some documentation for 1.4 release

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -533,3 +533,6 @@ Bibliography
     D. G. A. Smith, L. A. Burns, D. A. Sirianni, D. R. Nascimento, A. Kumar, A. M. James, J. B. Schriber, T. Zhang, B. Zhang, A. S. Abbott, E. J. Berquist, M. H. Lechner, L. A. Cunha, A. G. Heide, J. M. Waldrop, T. Y. Takeshita, A. Alenaizan, D. Neuhauser, R. A. King, A. C. Simmonett, J. M. Turney, H. F. Schaefer III, F. A. Evangelista, A. E. DePrince, T. D. Crawford, K. Patkowski, and C. D. Sherrill
     *J. Chem. Theory Comput.* **14**, 3504-3511 (2018).
 
+.. [Schriber:2021:234107]
+    J. B. Schriber, D. A. Sirianni, D. G. A. Smith, L. A. Burns, D. Sitkoff, D. L. Cheney, C. D. Sherrill
+    *J. Chem. Phys.* **154**, 234107 (2021).

--- a/doc/sphinxman/source/dftd3.rst
+++ b/doc/sphinxman/source/dftd3.rst
@@ -246,6 +246,41 @@ program is suppressed; to see it in the output file, set print > 2.
    | -DAS2010                            | Podeszwa & Szalewicz dispersion formula [#f9]_                        | |PSIfours| libdisp              | [:math:`s_6`]                                                                  |
    +-------------------------------------+-----------------------------------------------------------------------+---------------------------------+--------------------------------------------------------------------------------+
 
+
+Three-Body Dispersion Corrections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the previously discussed two-body dispersion corrections, 
+the ``dftd3``/|PSIfour| interface enables computations of three-body dispersion
+corrections. In ``DFT-D3``, three-body dispersion is approximated with the
+Axilrod-Teller-Muto model:
+
+.. math:: E_{disp}^{(3)}=-\frac{1}{6}\sum_{A\neqB\neqC}\frac{C_{9}^{ABC}(3\cos{\theta_a}\cos{\theta_b}\cos{\theta_c}+1)}{(r_{AB}r_{BC}r_{AC})^{3}}f_{damp}(\bar{r}_{ABC})
+ 
+where :math:`\theta_a` is the angle at atom A corresponding to the triangle formed by atoms A, B, and C,
+and :math:`\bar{r}_{ABC}` is the geometric mean of the corresponding atomic-pair distances.
+The dispersion coefficients are defined as
+
+.. math:: C_{9}^{ABC} = \sqrt{C_{6}^{AB}C_{6}^{BC}C_{6}^{AC}}
+
+See the `DFT-D3 documentation <https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3/man.pdf>`_ 
+for more details.
+
+For now, the three-body correction can be called by using the :py:func:`~qcdb.Molecule.run_dftd3`
+function with `d3-atmgr` as the passed functional string. 
+For example, the three-body ATM dispersion correction for a neon trimer could
+be computed with::
+
+   molecule ne3 {
+   Ne 0.0 0.0 0.0
+   Ne 0.0 0.0 1.0
+   Ne 0.0 1.0 1.0
+   }
+   ne.update_geometry()
+   energy = m.run_dftd3('d3-atmgr', dertype=0)
+   print(energy)
+
+
 .. rubric:: Footnotes
 
 .. [#f0] Note that there are functionals with these extensions (*e.g.*, wB97X-D) that, 

--- a/doc/sphinxman/source/oeprop.rst
+++ b/doc/sphinxman/source/oeprop.rst
@@ -171,7 +171,7 @@ manipulated using standard Python syntax.  For a complete demonstration of this
 utility, see the :srcsample:`props4` test case.
 
 
-..index:: ISA; MBIS
+.. index:: ISA; MBIS
 
 .. _`sec:oeprop_mbis`:
 
@@ -180,8 +180,15 @@ Minimal Basis Iterative Stockholder
 
 The Minimal Basis Iterative Stockholder (MBIS) method is one of many procedures
 that partitions a molecular one-particle density matrix into atomic electron densities.
-Running MBIS in |PSIfour| will calculate atomic charges, as well as dipoles, quadrupoles, and
-octupoles. The allowed number of iterations and convergence criteria for the stockholder 
+Running MBIS in |PSIfour| will calculate atomic valence charge widths, volume ratios,
+atomic charges, as well as dipoles, quadrupoles, and octupoles. 
+Additionally, all expectation values of radial moments of n-th order (:math:`<r^n>`) 
+are computed up to fourth order. Higher moments can be computed by specifying |globals__MAX_RADIAL_MOMENT|.
+The volume ratios are computed as the ratio between the volume of the atomic density
+(:math:`<r^3>`) and the volume of the free atom computed using the same level
+of theory, but with a potentially unrestricted reference.
+
+The allowed number of iterations and convergence criteria for the stockholder 
 algorithm is controlled by |globals__mbis_maxiter| and |globals__mbis_d_convergence|. Note 
 that the density is partitioned on a molecular quadrature grid, the details of which can be
 controlled with the keywords |globals__mbis_radial_points|, |globals__mbis_spherical_points|, and 

--- a/doc/sphinxman/source/oeprop.rst
+++ b/doc/sphinxman/source/oeprop.rst
@@ -183,7 +183,7 @@ that partitions a molecular one-particle density matrix into atomic electron den
 Running MBIS in |PSIfour| will calculate atomic valence charge widths, volume ratios,
 atomic charges, as well as dipoles, quadrupoles, and octupoles. 
 Additionally, all expectation values of radial moments of n-th order (:math:`<r^n>`) 
-are computed up to fourth order. Higher moments can be computed by specifying |globals__MAX_RADIAL_MOMENT|.
+are computed up to fourth order. Higher moments can be computed by specifying |globals__max_radial_moment|.
 The volume ratios are computed as the ratio between the volume of the atomic density
 (:math:`<r^3>`) and the volume of the free atom computed using the same level
 of theory, but with a potentially unrestricted reference.

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -61,7 +61,7 @@ SAPT: Symmetry-Adapted Perturbation Theory
 
 .. caution:: February 7, 2020, a missing term in :math:`E^{(30)}_{ind}` was added, causing
    possible discrepancies with prior versions of the code on the order of
-   0.01 kcal/mol. 
+   0.01 kcal/mol. See https://github.com/psi4/psi4/issues/1677
 
 Symmetry-adapted perturbation theory (SAPT) provides a means of directly
 computing the noncovalent interaction between two molecules, that is, the

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -933,3 +933,49 @@ S^inf Keywords
 
 .. include:: autodir_options_c/sapt__do_ind_exch_sinf.rst
 .. include:: autodir_options_c/sapt__do_disp_exch_sinf.rst
+
+.. _`sec:saptd`:
+
+SAPT0-D
+~~~~~~~
+
+In SAPT0, the computation of :math:`E_{disp}^{(20)} + E_{exch-disp}^{(20)}` represents
+the computational bottleneck. One can avoid this bottleneck by replacing these
+dispersion terms with the empirical D3 corrections developed by Grimme.
+  
+:ref:`Grimme's dispersion corrections are discussed here. <sec:dftd3>`
+
+The corresponding method, termed SAPT0-D, thus relies on empirically fit parameters
+specific to SAPT0/jun-cc-pVDZ. While SAPT0-D can be used with any of the -D 
+variants using default parameters optimized for Hartee--Fock interaction energies, 
+we recommend using the refit parameters with Becke-Johnson damping, as described in
+[Schriber:2021:234107]_. Again, use of SAPT0-D with a basis set other than
+jun-cc-pVDZ is not tested and not guaranteed to give meaningful results without
+refitting the dispersion parameters. 
+A simple water dimer computation using SAPT0-D may look like::
+
+	molecule water_dimer {
+	     0 1
+	     O  -1.551007  -0.114520   0.000000
+	     H  -1.934259   0.762503   0.000000
+	     H  -0.599677   0.040712   0.000000
+	     --
+	     0 1
+	     O   1.350625   0.111469   0.000000
+	     H   1.680398  -0.373741  -0.758561
+	     H   1.680398  -0.373741   0.758561
+	
+	     units angstrom
+	     no_reorient
+	     symmetry c1
+	}
+	
+	set basis jun-cc-pvdz
+
+	energy('sapt0-d3mbj') # runs the recommended dispersion correction
+    energy('sapt0-d3') # tests an alternative damping scheme/parameterization
+
+Given the naturally pairwise-atomic nature of these empirical dispersion corrections,
+integration with existing FSAPT functionality is also available simply by calling
+`energy("fsapt0-d3mbj")`. See `FSAPT <fisapt>` documentation for more details on using FSAPT
+for functional group analyses.

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -59,6 +59,10 @@ SAPT: Symmetry-Adapted Perturbation Theory
    wherever possible, according to literature recommendations.
    In early July 2016, some total SAPT energy psivars were renamed.
 
+.. caution:: February 7, 2020, a missing term in :math:`E^{(30)}_{ind}` was added, causing
+   possible discrepancies with prior versions of the code on the order of
+   0.01 kcal/mol. 
+
 Symmetry-adapted perturbation theory (SAPT) provides a means of directly
 computing the noncovalent interaction between two molecules, that is, the
 interaction energy is determined without computing the total energy of the

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -1686,7 +1686,7 @@ def frequency(name, **kwargs):
         :math:`a_1`, requesting only the totally symmetric modes.
         ``-1`` indicates a full frequency calculation.
 
-    .. note:: Analytic hessians are only available for RHF. For all other methods, Frequencies will
+    .. note:: Analytic hessians are only available for RHF and UHF. For all other methods, Frequencies will
         proceed through finite differences according to availability of gradients or energies.
 
     .. _`table:freq_gen`:


### PR DESCRIPTION
## Description
Updates the docs with any undocumented new features in 1.4

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] #1491 (ATM)
- [x] #842 (UHF Hess)
- [x] #1803 (E(30)ind bug fix)
- [x] #2056 (MBIS volumes)
- [x] #2081 (SAPT-D)
- [x] #2127 (MBIS volume ratios)

- [x] #1934 (cct3 plugin)
- [x] #1661 (mp2-d gradients)

I still have #1721 (Libint2 and shell screening), #1723 (QCSchema Interface), and #1728 (QCSchema Wavefunction Quantities) as being undocumented or incompletely documented. Let me know if I'm wrong here, and any suggestions (or volunteers) on how to complete them are welcome.

## Status
- [x] Ready for review
- [ ] Ready for merge
