### PR TITLE
Capitalize names of XC functionals

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -261,7 +261,7 @@ extern int read_options(const std::string& name, Options& options, bool suppress
 
 std::string to_upper(const std::string& key) {
     std::string nonconst_key = key;
-    std::transform(nonconst_key.begin(), nonconst_key.end(), nonconst_key.begin(), ::toupper);
+    to_upper(nonconst_key);
     return nonconst_key;
 }
 

--- a/psi4/src/create_new_plugin.cc
+++ b/psi4/src/create_new_plugin.cc
@@ -115,7 +115,7 @@ class PluginFileManager {
         std::string format_source_list = imploded.str();
         std::string format_plugin(plugin_name_);
         std::string format_PLUGIN = plugin_name_;
-        std::transform(format_PLUGIN.begin(), format_PLUGIN.end(), format_PLUGIN.begin(), ::toupper);
+        to_upper(format_PLUGIN);
         std::string format_ldflags(TOSTRING(PLUGIN_LDFLAGS));
 
         trim_spaces(format_source_list);

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -70,7 +70,7 @@
 #include "psi4/libmints/dipole.h"
 #include "psi4/libmints/overlap.h"
 #include "psi4/libmints/sieve.h"
-
+#include "psi4/libpsi4util/libpsi4util.h"
 #include <string>
 
 using namespace psi;
@@ -252,8 +252,8 @@ std::shared_ptr<Molecule> from_dict(py::dict molrec) {
         for (size_t iat = 0; iat < nat; ++iat) {
             std::string symbol = elem.at(iat);
             std::string label = elbl.at(iat);
-            std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
-            std::transform(label.begin(), label.end(), label.begin(), ::toupper);
+            to_upper(symbol);
+            to_upper(label);
             mol->add_unsettled_atom(elez.at(iat) * int(real.at(iat)), geom_unsettled.at(iat), symbol, mass.at(iat),
                                     elez.at(iat) * int(real.at(iat)), symbol + label, elea.at(iat));
         }
@@ -271,8 +271,8 @@ std::shared_ptr<Molecule> from_dict(py::dict molrec) {
         for (size_t iat = 0; iat < nat; ++iat) {
             std::string symbol = elem.at(iat);
             std::string label = elbl.at(iat);
-            std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
-            std::transform(label.begin(), label.end(), label.begin(), ::toupper);
+            to_upper(symbol);
+            to_upper(label);
             mol->add_atom(elez.at(iat) * int(real.at(iat)), geom.at(3 * iat), geom.at(3 * iat + 1), geom.at(3 * iat + 2),
                           symbol, mass.at(iat), elez.at(iat) * int(real.at(iat)), symbol + label, elea.at(iat));
         }

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -39,6 +39,8 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <algorithm>
+#include <cctype>
 
 // using namespace psi;
 
@@ -78,7 +80,10 @@ void SuperFunctional::common_init() {
 }
 std::shared_ptr<SuperFunctional> SuperFunctional::blank() { return std::make_shared<SuperFunctional>(); }
 std::shared_ptr<SuperFunctional> SuperFunctional::XC_build(std::string name, bool unpolarized) {
-    // Only allow build from full XC kernals
+    // Capitalize name for consistency
+    std::transform(name.begin(), name.end(), name.begin(), ::toupper);
+
+    // Only allow build from full XC kernels
     if (name.find("XC_") == std::string::npos) {
         throw PSIEXCEPTION("XC_build requires full XC_ functional names");
     }
@@ -144,7 +149,7 @@ std::shared_ptr<SuperFunctional> SuperFunctional::build_worker() {
 void SuperFunctional::print(std::string out, int level) const {
     if (level < 1) return;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    
+
     if (xclib_description_ != "") {
         printer->Printf("%s\n\n", xclib_description_.c_str());
     }

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -33,14 +33,13 @@
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libfock/cubature.h"
 #include "psi4/libfock/points.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "superfunctional.h"
 #include "functional.h"
 #include "LibXCfunctional.h"
 
 #include <cmath>
 #include <cstdlib>
-#include <algorithm>
-#include <cctype>
 
 // using namespace psi;
 
@@ -81,7 +80,7 @@ void SuperFunctional::common_init() {
 std::shared_ptr<SuperFunctional> SuperFunctional::blank() { return std::make_shared<SuperFunctional>(); }
 std::shared_ptr<SuperFunctional> SuperFunctional::XC_build(std::string name, bool unpolarized) {
     // Capitalize name for consistency
-    std::transform(name.begin(), name.end(), name.begin(), ::toupper);
+    to_upper(name);
 
     // Only allow build from full XC kernels
     if (name.find("XC_") == std::string::npos) {

--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -37,6 +37,7 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/psifiles.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "vector3.h"
 #include "molecule.h"
@@ -77,7 +78,7 @@ bool has_ending(std::string const &fullString, std::string const &ending) {
 
 std::string to_upper_copy(const std::string &original) {
     std::string upper = original;
-    std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+    to_upper(upper);
     return upper;
 }
 }  // namespace
@@ -513,7 +514,7 @@ std::string BasisSet::print_detail_cfour() const {
     char buffer[120];
     std::stringstream ss;
     std::string nameUpperCase = name_;
-    std::transform(nameUpperCase.begin(), nameUpperCase.end(), nameUpperCase.begin(), ::toupper);
+    to_upper(nameUpperCase);
 
     for (int uA = 0; uA < molecule_->nunique(); uA++) {
         const int A = molecule_->unique(uA);

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -38,6 +38,7 @@
 #include "psi4/libpsi4util/libpsi4util.h"  // Needed for Ref counting, string splitting, and conversions
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 namespace psi {
 
@@ -52,7 +53,7 @@ void DataType::changed() { changed_ = true; }
 
 void DataType::dechanged() { changed_ = false; }
 
-void DataType::to_upper(std::string& str) const { std::transform(str.begin(), str.end(), str.begin(), ::toupper); }
+void DataType::to_upper(std::string& str) const { psi::to_upper(str); }
 
 void DataType::add_choices(std::string str) {
     printf("I am here!\n");
@@ -513,7 +514,7 @@ void Options::set_current_module(const std::string s) {
     all_local_options_.clear();
 }
 
-void Options::to_upper(std::string& str) const { std::transform(str.begin(), str.end(), str.begin(), ::toupper); }
+void Options::to_upper(std::string& str) const { psi::to_upper(str); }
 
 void Options::validate_options() {
     std::map<std::string, Data>::const_iterator iter = locals_[current_module_].begin();

--- a/psi4/src/psi4/libplugin/load_plugin.cc
+++ b/psi4/src/psi4/libplugin/load_plugin.cc
@@ -36,6 +36,7 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 namespace psi {
 #ifdef HAVE_DLFCN_H
@@ -79,7 +80,7 @@ plugin_info plugin_load(std::string &plugin_pathname) {
     }
 
     // Uppercase and store the name of the plugin for read_options
-    std::transform(info.name.begin(), info.name.end(), info.name.begin(), [](unsigned char c) { return std::toupper(c); });
+    to_upper(info.name);
 
     // Get the plugin's options into the global space
     Process::environment.options.set_read_globals(true);

--- a/psi4/src/psi4/libpsio/filescfg.cc
+++ b/psi4/src/psi4/libpsio/filescfg.cc
@@ -33,6 +33,7 @@ PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include <string>
 #include <map>
@@ -58,7 +59,7 @@ std::string fullkwd(const char* kwdgrp, const char* kwd, int unit) {
 
     std::string fkwd = sep + kwdgrp + sep + "FILES" + sep + unitname + sep + kwd;
     // convert to upper case
-    std::transform(fkwd.begin(), fkwd.end(), fkwd.begin(), static_cast<int (*)(int)>(toupper));
+    to_upper(fkwd);
     return fkwd;
 }
 


### PR DESCRIPTION
## Description
This is a simple aesthetic cleanup to make the printout more systematic.

If I define the xc functional inline as e.g.
```
my_dft = {
    "name": "my lda",
    "x_functionals": {"lda_x": {}},
    "c_functionals": {"lda_c_pw": {}}
}
energy('scf', dft_functional=my_dft)
```
the capitalization is inconsistent in the output
```
   => Exchange Functionals <=

    1.0000         XC_lda_x

   => Correlation Functionals <=

    1.0000      XC_lda_c_pw
```
## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
